### PR TITLE
docs: PRD e epics de go-live para produção

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,644 @@
+# e1p — "Empresa de 1 Pessoa" · Brownfield PRD — Go-Live para Produção
+
+> **Tipo:** Brownfield Enhancement PRD (produção-readiness / go-live).
+> **Escopo:** levar ao ar o produto JÁ CONSTRUÍDO (Fases 1–5). NÃO é um PRD de novas features de produto.
+> **Autor:** Morgan (@pm). **Modo de execução:** YOLO (autônomo — premissas documentadas na seção final).
+> **Data:** 2026-07-10.
+
+---
+
+## 1. Intro Project Analysis and Context
+
+### 1.1 Existing Project Overview
+
+#### Analysis Source
+Análise fresca baseada em documentação existente no repositório (IDE-based). Fontes primárias:
+- `CLAUDE.md` (memória viva — roadmap seção 6 e dívida técnica seção 6.1) — **material primário**.
+- `docs/decisions/0001-stack-e-infra.md` (ADR de stack/infra).
+- `docs/AWS-DEPLOYMENT.md` e `docs/HOSTINGER-DEPLOY.md` (dois caminhos de deploy documentados).
+- `README.md`, `infra/` (docker-compose dev/prod/traefik, Caddyfile, `.env.prod.example`).
+- Histórico git (últimos 20 commits — o mais recente, `59ff179`, adiciona o bundle de deploy Hostinger).
+
+> **Observação:** NÃO foi executada a task `document-project`. A documentação existente (CLAUDE.md +
+> ADR + guias de deploy) é rica o suficiente para dispensá-la neste ciclo. Recomenda-se rodá-la mais
+> tarde se for necessário um inventário técnico formal por módulo.
+
+#### Current Project State
+e1p é um **SaaS multi-tenant white-label** (`e1p.com`) para profissionais autônomos (advogados, médicos,
+consultores). Cada usuário é uma "empresa de 1 pessoa" com subdomínio próprio. Diferencial: **IA (Claude)
+como funcionário invisível** atravessando todos os módulos. Modelo de negócio: **split de pagamento**
+(40% produtos / 30% serviços / 20% recorrência).
+
+**Estado de construção:** Fases 1 a 5 implementadas. Módulos entregues: Auth/Tenant (RLS), Agenda
+(calendário + conflitos), CRM/Kanban, Cockpit, Super Admin (hierarquia + convites), Carteira/Split,
+Contas a Pagar/Receber (boleto PDF + webhook), Produtos/Checkout, Orçamentos, Propostas (link público),
+Contratos + assinatura/KYC, Ficha 360°, Marketing (Carrossel editorial, Funil de vendas com motor de
+automação, Estoque, Brand Kit, Sites/Páginas), Anexos (upload real), e Assistente Jurídico (21 skills,
+anonimizador + anti-alucinação). **~252 testes automatizados** + validações e2e no Postgres real.
+
+O produto está **funcionalmente completo para uso**; o que falta é o caminho de **produção-readiness**:
+integrações reais (dinheiro, comunicação), hardening de segurança/LGPD, storage durável e a esteira de
+deploy/observabilidade. Já existe um **começo de esforço de deploy** (commit Hostinger: `docker-compose.prod.yml`
+com Caddy próprio, `docker-compose.traefik.yml` para o Traefik compartilhado, `Caddyfile`, `.env.prod.example`,
+`initdb-prod/01-rls-enforce.sh`, guia `HOSTINGER-DEPLOY.md`).
+
+### 1.2 Available Documentation Analysis
+
+- [x] Tech Stack Documentation — `CLAUDE.md §2` + ADR 0001
+- [x] Source Tree/Architecture — `CLAUDE.md §4`, `docs/ARCHITECTURE.md`
+- [x] Coding Standards — `CLAUDE.md §3, §5, §8` (Regras de Ouro, fluxo de qualidade, convenções)
+- [x] API Documentation — contrato em `packages/shared-types` + OpenAPI do FastAPI (`/docs`)
+- [x] External API Documentation — parcial (integrações ainda em stub: WhatsApp, gateway, Google, e-mail)
+- [x] UX/UI Guidelines — design "Portal" (`packages/design-tokens`, cor `#5D44F8`)
+- [x] Technical Debt Documentation — `CLAUDE.md §6.0, §6.1` (dívida por módulo + TODO de segurança QA)
+- [x] Other: guias de deploy (`AWS-DEPLOYMENT.md`, `HOSTINGER-DEPLOY.md`), ADR 0001
+
+Documentação suficiente. **Não** é necessário rodar `document-project` para este PRD de go-live.
+
+### 1.3 Enhancement Scope Definition
+
+#### Enhancement Type
+- [x] Integration with New Systems (gateway de pagamento, WhatsApp Cloud API, provedor de e-mail, Google OAuth)
+- [x] Performance/Scalability Improvements (storage durável, backups, observabilidade)
+- [x] Bug Fix and Stability Improvements (hardening RLS `users`, validação CPF/CNPJ, idle timeout LGPD)
+- [x] Other: **Production readiness / Go-Live** (esteira de deploy, staging, CI na imagem, monitoramento)
+
+> Este NÃO é um "New Feature Addition". Toda a superfície de produto já existe. O enhancement é
+> **operacionalizar o que existe para produção segura**, trocando stubs por integrações reais e
+> fechando lacunas de segurança/compliance/infra.
+
+#### Enhancement Description
+Levar o e1p ao ar em produção com segurança: substituir os stubs por integrações reais (gateway de
+pagamento, WhatsApp Cloud API, e-mail transacional), fazer o hardening de segurança/LGPD exigido pela
+revisão de QA, migrar armazenamento de arquivos para storage durável, e estabelecer a esteira de
+deploy/observabilidade (staging, CI testando a imagem Docker, backups offsite, monitoramento). O ponto
+de partida é o bundle de deploy Hostinger já commitado (`59ff179`).
+
+#### Impact Assessment
+- [x] **Moderate to Significant Impact** — a maior parte é **aditiva** (trocar implementação por trás de
+  interfaces internas já validadas: `core/whatsapp`, `core/email`, webhook do gateway, camada de storage).
+  Alguns pontos exigem mudança de código existente com risco controlado: hardening de acesso à tabela
+  `users`, validação de CPF/CNPJ em múltiplos pontos de entrada, migração do storage de anexos
+  (bytes-no-Postgres → object storage). Nenhuma mudança arquitetural de fundo — a arquitetura (RLS,
+  anonimizador, 12-factor conteinerizado) permanece.
+
+### 1.4 Goals and Background Context
+
+#### Goals
+- Colocar o e1p no ar em produção, acessível por um domínio público com TLS, de forma estável e segura.
+- Fazer o dinheiro entrar de verdade: gateway real gerando boleto/Pix registrado e recebendo webhook confiável, com split creditado na Carteira.
+- Tornar verídicas as promessas de comunicação: e-mails transacionais (recuperação/convite) e notificações WhatsApp realmente entregues (hoje só `logged`).
+- Fechar as lacunas de segurança e LGPD bloqueantes identificadas pela revisão de QA antes de expor dados reais de clientes.
+- Estabelecer uma esteira de deploy repetível e segura (staging, CI na imagem Docker, backups offsite, monitoramento) para operar sem quebrar o que já funciona.
+- Separar com clareza o que é **bloqueante para o lançamento** do que pode ir para **backlog pós-lançamento**, para permitir um go-live enxuto sem escopo inflado.
+
+#### Background Context
+Fases 1–5 estão implementadas e testadas (~252 testes), com decisões de arquitetura sólidas (RLS como
+garantia única de isolamento, anonimizador antes da IA, 12-factor conteinerizado). Porém o produto foi
+construído com **stubs conscientes** em pontos que exigem credenciais/infra externa: pagamentos, WhatsApp,
+e-mail e Google são "logged"/manuais; anexos vivem como bytes no Postgres; e a revisão de QA catalogou uma
+lista explícita de dívida de segurança (§6.1 do CLAUDE.md) marcada como "endereçar antes de produção".
+O último commit (`59ff179`) já iniciou o esforço de deploy na VPS Hostinger (Caddy próprio e integração
+ao Traefik compartilhado em `e1p.doroeventos.com.br`). Este PRD organiza o caminho restante até o go-live,
+respeitando a Regra de Ouro nº 5 ("não quebrar o que já funciona") e o guard-rail de custo do projeto.
+
+### 1.5 Change Log
+
+| Change | Date | Version | Description | Author |
+|---|---|---|---|---|
+| Criação | 2026-07-10 | 1.0 | PRD brownfield de go-live/produção, derivado de CLAUDE.md §6/§6.1 e do bundle de deploy Hostinger | Morgan (@pm) |
+
+---
+
+## 2. Requirements
+
+> Requisitos derivados da dívida técnica documentada (CLAUDE.md §6.0, §6.1) e dos guias de deploy.
+> **Nada aqui é feature nova de produto** — tudo serve a operar em produção com segurança. Cada requisito
+> está classificado como **[BLOQUEANTE]** (para o lançamento) ou **[BACKLOG]** (pós-lançamento) na seção 6.
+
+### 2.1 Functional
+
+- **FR1:** Integrar um gateway de pagamento real (Asaas ou Mercado Pago) substituindo o stub: gerar boleto/Pix **registrado** (com registro bancário, não o layout-stub atual do `core/boleto.py`), e receber o **webhook real** de compensação em `POST /receivables/webhook`, protegido por `GATEWAY_WEBHOOK_SECRET`, creditando a Carteira com split (preservando idempotência e o lock `FOR UPDATE` contra baixa dupla já existentes).
+- **FR2:** Integrar um provedor de e-mail transacional (SMTP/SES) no `core/email.py`, entregando de verdade: link de recuperação de senha (`/auth/forgot-password`), senha temporária de convite de conta/funcionário (`/admin/accounts`, `/admin/accounts/{tenant_id}/users`) e demais mensagens. Em produção, **remover** o retorno de `dev_reset_token`/`temp_password` no corpo da resposta.
+- **FR3:** Integrar a WhatsApp Cloud API (Meta) no `core/whatsapp.py`, entregando as notificações hoje apenas `logged` (cobrança amigável com IA, mensagens de funil, `crm.client.moved`, vencimentos), usando um **campo de telefone do owner/destinatário** real (hoje o recipient usa o e-mail como placeholder). Exige `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID`.
+- **FR4:** Implementar validação real de CPF/CNPJ (dígito verificador + normalização + unicidade por tenant), aplicada em todos os pontos de entrada: `/register`, cadastro/convite de usuário, criação de cliente no CRM (`document`) e KYC/assinatura de contrato.
+- **FR5:** Fazer o hardening do acesso à tabela global `users` (sem RLS por ser login global): garantir que nenhum módulo de negócio consulte `users` via `get_db` sem escopo de tenant; e criar um **log de plataforma fora do tenant** para operações destrutivas (exclusão de conta), já que o delete purga os `audit_entries` do próprio tenant (LGPD).
+- **FR6:** Implementar o idle timeout LGPD de 30 minutos (hoje configurado mas não implementado — JWT stateless expira em 7 dias), via tracking de atividade / refresh token curto no frontend de auth.
+- **FR7:** Forçar troca de senha do Super Admin (Master) no primeiro login (hoje a senha semeada vale até troca manual).
+- **FR8:** Mover o armazenamento de arquivos para storage durável (S3-compatível): anexos hoje são `LargeBinary` no Postgres; logo/imagens de vários módulos (Brand Kit, propostas, carrossel, sites) são por URL. Migrar para upload real em object storage, mantendo isolamento por tenant.
+- **FR9:** Prover um ambiente de **staging** espelhando produção (mesma imagem, dados sintéticos) para validar cada deploy antes de promover para produção.
+- **FR10:** Estabelecer **CI automatizado** que rode a suíte de testes completa **dentro da imagem Docker de produção** (não só no venv local), fechando a brecha de drift venv↔produção documentada; o CI deve ser gate obrigatório antes do deploy.
+- **FR11:** Automatizar **backups do Postgres** (dump diário) com **cópia offsite** (S3/outro storage) e procedimento de **restauração testado** — hoje o guia sugere um cron, mas backup só na mesma VPS não protege contra perda do servidor.
+- **FR12:** Instrumentar **monitoramento e alertas** de disponibilidade: health da API (`/health`), validade do TLS (Caddy/Traefik), disco, e reinícios de container — com alerta acionável (ex.: Uptime Kuma + notificação).
+
+### 2.2 Non Functional
+
+- **NFR1:** O isolamento de tenant (RLS) deve permanecer a **garantia única** de isolamento (Regra de Ouro nº 1). Em produção a app **deve** conectar como papel NÃO-superusuário `e1p_app` (o `initdb-prod/01-rls-enforce.sh` já provisiona isso na VPS; na AWS/RDS o mesmo vale). Nenhuma regressão de isolamento é aceitável.
+- **NFR2:** O guard de produção (`app/config.py::_guard_production_secrets`) deve bloquear o boot com `JWT_SECRET` fraco/default (<32 chars), `ANTHROPIC_API_KEY` ausente ou `SUPER_ADMIN_PASSWORD` default. Isso deve ser verificado como parte do gate de release.
+- **NFR3:** Custo deve permanecer no alvo do projeto (~US$30–45/mês no plano AWS Fase A, ou 1 VPS Hostinger). Não introduzir serviço pago sem justificar (Regra de Ouro nº 4). Preferir Graviton/ARM, cache agressivo, S3 lifecycle.
+- **NFR4:** **Graceful degradation** obrigatória: módulos com integração não configurada (WhatsApp/gateway/e-mail sem chave) devem falhar fechado/`logged` e nunca derrubar a request (padrão já adotado nos stubs — deve ser preservado ao plugar os provedores reais).
+- **NFR5:** Todos os ~252 testes existentes devem continuar passando; cada integração real deve vir com testes + validação e2e no Postgres real (Regra de Ouro nº 5 + fluxo de qualidade §5). Automatizar o isolamento cross-tenant no CI com testcontainers (hoje é validado só manualmente).
+- **NFR6:** O webhook de pagamento deve ser **idempotente** e protegido; nenhuma baixa dupla nem crédito de split duplicado (preservar os locks `FOR UPDATE` existentes em Carteira/Contas a Receber).
+- **NFR7:** A Regra de Ouro nº 2 (anonimizador antes da IA) deve permanecer intacta: nenhum dado sensível (nomes/CPF/contas/peças jurídicas) vai para a API do Claude sem anonimização — nada neste go-live pode afrouxar isso.
+
+### 2.3 Compatibility Requirements
+
+- **CR1 (API):** Os endpoints e o contrato existentes (`packages/shared-types`) devem permanecer retrocompatíveis. Endpoints/campos das integrações reais são **aditivos**; o webhook do gateway reusa a rota `POST /receivables/webhook` já publicada.
+- **CR2 (DB schema):** Novas colunas/tabelas apenas via **migrations Alembic aditivas** (próximas após a 0029), sem mudanças destrutivas nos dados de tenant existentes; **toda nova tabela de negócio carrega `tenant_id` e política RLS** (Regra de Ouro nº 1). Ex.: campo de telefone do owner (FR3), campos de config de integração, ponteiros de object storage (FR8).
+- **CR3 (UI/UX):** O design "Portal" (cor `#5D44F8`, sidebar, layout) deve ser preservado. Novas telas (ex.: config de chaves de integração, campo de telefone do owner) seguem os padrões existentes de Configurações/Brand Kit.
+- **CR4 (integração):** A troca de stub por provedor real deve manter as **interfaces internas** (`core/whatsapp`, `core/email`, contrato do webhook, camada de storage) para que os chamadores e testes existentes não quebrem — a implementação muda por trás da interface.
+
+---
+
+## 3. User Interface Enhancement Goals
+
+> O go-live é majoritariamente backend/infra. As mudanças de UI são pontuais e devem reusar padrões existentes.
+
+### 3.1 Integration with Existing UI
+Novos elementos de UI reusam o design "Portal" e os componentes existentes (Configurações/Brand Kit,
+`Collapsible`, cards, toasts). Nenhuma revisão de design system.
+
+### 3.2 Modified/New Screens and Views
+- **Configurações → Integrações:** nova aba/seção para chaves de gateway, WhatsApp e e-mail (a própria §6.1 já lista "config de integrações (chaves) nesta tela" como dívida). Chaves sensíveis nunca expostas ao cliente; escopo de plataforma/tenant a definir.
+- **Perfil da empresa / owner:** campo de **telefone do owner** (necessário para FR3 — hoje inexistente).
+- **Configurações → Brand Kit e módulos com imagem:** trocar campos "URL da imagem/logo" por **upload real** (FR8), mantendo a prévia ao vivo.
+- **Tela de 1º acesso (Master):** forçar troca de senha (FR7) reusando o fluxo `FirstAccessPage`/`must_reset_password` já existente para usuários comuns.
+- **Auth:** tratamento de idle timeout (FR6) no `ProtectedLayout` (aviso + logout por inatividade).
+
+### 3.3 UI Consistency Requirements
+Manter cor `#5D44F8`, tipografia e espaçamento do design "Portal"; upload de arquivos reusa o componente
+`components/Attachments.tsx` já validado; mensagens de erro/estado em PT-BR (convenção §8).
+
+---
+
+## 4. Technical Constraints and Integration Requirements
+
+### 4.1 Existing Technology Stack
+**Languages:** Python 3.13 (backend), TypeScript (frontend).
+**Frameworks:** FastAPI, SQLAlchemy 2 + Alembic (backend); React 18 + Vite + Tailwind (frontend); design "Portal".
+**Database:** PostgreSQL 16 com Row-Level Security (banco único, `tenant_id` em toda tabela de negócio).
+**Infrastructure:** Monorepo pnpm (JS) + app Python isolado; 100% conteinerizado (Docker Compose). Deploy alvo atual: **VPS Hostinger** (Caddy próprio OU Traefik compartilhado — `e1p.doroeventos.com.br`); caminho AWS (EC2 Graviton → ECS Fargate, RDS, S3/CloudFront, SSM, SQS) documentado como evolução.
+**External Dependencies:** Anthropic SDK (`claude-opus-4-8`); pendentes de integração real: gateway (Asaas/Mercado Pago), WhatsApp Cloud API (Meta), e-mail (SMTP/SES), Google OAuth (Meet/Calendar), object storage (S3-compatível). OCR (tesseract) para o Jurídico — validar no build de produção.
+
+### 4.2 Integration Approach
+**Database Integration Strategy:** migrations Alembic aditivas a partir da 0029; toda nova tabela com `tenant_id` + RLS; app roda migrations e serve como papel non-superuser `e1p_app`. Automatizar teste de isolamento cross-tenant com testcontainers (Postgres real) no CI.
+**API Integration Strategy:** provedores externos plugados por trás das interfaces internas (`core/whatsapp`, `core/email`, webhook do gateway, camada de storage) — CR4. Webhook do gateway reusa `POST /receivables/webhook` protegido por `GATEWAY_WEBHOOK_SECRET`. Envios síncronos hoje no request (ex.: WhatsApp no move de card) devem migrar para fila (SQS) quando o worker durável existir.
+**Frontend Integration Strategy:** novas telas em `apps/web/src/features/*` seguindo o padrão módulo-por-pasta (§8); reuso de `Attachments.tsx`, Brand Kit e componentes "Portal".
+**Testing Integration Strategy:** manter `scripts/check.sh` (lint + types + testes) + os 3 agentes de QA (regression-tester, bug-hunter, dedup-checker) por mudança (§5). Adicionar CI que roda os testes **dentro da imagem Docker** (FR10) e e2e no Postgres real.
+
+### 4.3 Code Organization and Standards
+**File Structure Approach:** um módulo de negócio = uma pasta em `apps/api/app/modules/` + uma em `apps/web/src/features/`; integrações externas em `apps/api/app/core/*`.
+**Naming Conventions:** código/identificadores em inglês; domínio/comentários e UI em PT-BR (§8).
+**Coding Standards:** Regras de Ouro do CLAUDE.md §3 são inegociáveis (isolamento RLS, anonimizador antes da IA, rastro da IA, custo, não quebrar o existente). Conventional Commits; branch a partir de `main`.
+**Documentation Standards:** atualizar `CLAUDE.md` (memória viva) e ADRs (`docs/decisions/`) quando algo estrutural mudar (ex.: escolha do gateway, decisão de storage, alvo de deploy definitivo).
+
+### 4.4 Deployment and Operations
+**Build Process Integration:** imagens Docker das 3 apps (api/web/postgres-init) buildadas no deploy; migrations rodam no start do container `api` (mesmo comando do dev). CI deve buildar e testar a imagem antes de promover (FR10).
+**Deployment Strategy:** ponto de partida = bundle Hostinger (`docker-compose.prod.yml` com Caddy próprio OU `docker-compose.traefik.yml` na VPS com Traefik compartilhado). Introduzir **staging** (FR9) e um fluxo `git pull` + rebuild controlado (evoluir para CI/CD — hoje é manual na VPS). Manter o caminho AWS aberto (12-factor) sem acoplar à EC2 específica.
+**Monitoring and Logging:** hoje não há monitoramento (só `docker compose logs`). Introduzir uptime/health + alertas (FR12) e, quando houver worker, o `tick` do funil precisa de cron/worker durável (hoje é endpoint manual).
+**Configuration Management:** segredos via `.env.prod` (nunca commitado) na VPS / SSM Parameter Store na AWS. Guard de produção (`_guard_production_secrets`) bloqueia boot com segredo fraco/ausente (NFR2).
+
+### 4.5 Risk Assessment and Mitigation
+
+**Technical Risks:**
+- **Vazamento cross-tenant** se a app conectar como superusuário ou se algum módulo consultar `users` sem escopo — RLS seria ignorada. É o risco mais grave (Regra de Ouro nº 1).
+- **Drift venv↔produção** (documentado): versões divergentes esconderam um bug de rota 204 que só quebrou no container.
+- **Baixa dupla / crédito de split duplicado** no webhook do gateway real se a idempotência não for preservada.
+- **Perda de dados** — anexos como bytes no Postgres incham o banco e o backup; backup só na VPS não sobrevive à perda do servidor.
+- **PII vazando para a IA** se o anonimizador for contornado ao plugar integrações reais.
+
+**Integration Risks:**
+- Credenciais reais (Asaas/Mercado Pago, Meta WhatsApp, SMTP/SES, Google OAuth) dependem de contas/aprovações externas (ex.: WhatsApp Business exige aprovação de template pela Meta) — podem atrasar o go-live.
+- Boleto atual é layout-stub sem registro bancário; o boleto real exige homologação com o gateway.
+- OCR (tesseract) do Jurídico precisa estar presente na imagem de produção (já em requirements — validar no build).
+
+**Deployment Risks:**
+- Caddy/Let's Encrypt exige DNS apontado ANTES do boot (HTTP-01); na VPS com Traefik compartilhado, nenhum outro serviço pode disputar 80/443.
+- Wildcard por subdomínio de tenant (`*.e1p.com`) exige TLS via DNS-01 — ainda não configurado (afeta o white-label, ver premissa P4).
+- Sem staging, um deploy ruim vai direto para produção.
+
+**Mitigation Strategies:**
+- Papel `e1p_app` NOSUPERUSER dono das tabelas em prod (VPS `initdb-prod`; RDS papel dedicado) + teste e2e de isolamento no CI (testcontainers).
+- CI roda os testes DENTRO da imagem Docker (FR10) — mata o drift antes do deploy.
+- Preservar locks `FOR UPDATE` e idempotência do webhook; cobrir com teste de baixa concorrente.
+- Migrar anexos para object storage (FR8) + backup offsite testado (FR11).
+- Provisionar credenciais externas cedo (iniciar aprovações Meta/gateway no começo do épico); manter graceful degradation para permitir soft-launch mesmo com uma integração ainda pendente.
+- Staging (FR9) obrigatório antes de promover; runbook de rollback (`git checkout` da tag anterior + rebuild; migrations aditivas facilitam reversão).
+
+---
+
+## 5. Epic and Story Structure
+
+### 5.1 Epic Approach
+
+**Epic Structure Decision:** **Programa de Go-Live decomposto em 3 épicos bloqueantes + 1 épico de backlog pós-lançamento**, em vez de um único épico monolítico.
+
+**Rationale (baseado na análise real do projeto):** o template brownfield favorece um épico único, mas aqui os
+workstreams são **relacionados porém distintos**, cada um substancial e com donos/competências diferentes
+(segurança/backend, integrações externas, infra/devops). Agrupar tudo num épico só criaria um épico gigante e
+difícil de sequenciar. Ainda assim, eles compõem **um programa coeso** (o go-live) com dependências claras —
+por isso "Programa de Go-Live" e não iniciativas soltas. A **criação formal dos épicos é um passo seguinte**
+(via @pm `*create-epic`); aqui detalhamos o Epic 1 (o de maior risco e caminho crítico) com histórias, e
+listamos os demais em alto nível.
+
+**Sequenciamento recomendado (minimiza risco ao sistema existente):**
+1. **Epic 1 — Segurança & Compliance para Produção** (bloqueante, primeiro: nada vai ao ar com dados reais sem isso).
+2. **Epic 2 — Integrações Reais (Dinheiro & Comunicação)** (bloqueante: e-mail e gateway; WhatsApp em fast-follow).
+3. **Epic 3 — Deploy, Storage & Observabilidade** (bloqueante: staging, CI na imagem, backups, monitoramento; parte de storage pode ser faseada).
+4. **Epic 4 — Backlog Pós-Lançamento** (NÃO bloqueante: Google OAuth, dívidas menores por módulo, refinamentos).
+
+### 5.2 Classificação: Bloqueante para lançamento vs Backlog pós-lançamento
+
+| Item | Origem (CLAUDE.md) | Classificação | Épico |
+|---|---|---|---|
+| Gateway real (Asaas/MP) + boleto/Pix registrado + webhook real | §6.1 / Fase 2 | **BLOQUEANTE** (monetização) | Epic 2 |
+| Provedor de e-mail (SMTP/SES) — recuperação de senha + convites | §6 recuperação/convite | **BLOQUEANTE** (onboarding/reset) | Epic 2 |
+| WhatsApp Cloud API — entregar notificações hoje `logged` | §6 / Fase 4 | **BLOQUEANTE-LEVE** (degrada com graça; fast-follow) | Epic 2 |
+| Validação CPF/CNPJ (dígito verificador) | §6.1 | **BLOQUEANTE** (KYC/contratos) | Epic 1 |
+| Hardening RLS acesso à tabela `users` | §6.1 | **BLOQUEANTE** (segurança) | Epic 1 |
+| Log de plataforma p/ exclusão de conta (LGPD) | §6.1 Super Admin | **BLOQUEANTE** (LGPD) | Epic 1 |
+| Idle timeout LGPD (30 min) | §6.1 | **BLOQUEANTE** (LGPD) | Epic 1 |
+| Forçar troca de senha do Super Admin no 1º login | §6.1 Super Admin | **BLOQUEANTE** (segurança) | Epic 1 |
+| Guard de produção de segredos (validar no release) | §6.1 fundação | **BLOQUEANTE** (segurança) | Epic 1 |
+| CI testando a imagem Docker (drift venv↔prod) | §6.1 | **BLOQUEANTE** (deploy seguro) | Epic 3 |
+| Backups automatizados + offsite + restore testado | HOSTINGER-DEPLOY §6 | **BLOQUEANTE** (proteção de dados) | Epic 3 |
+| Monitoramento/alertas (uptime, TLS, disco) | HOSTINGER-DEPLOY dívida | **BLOQUEANTE-LEVE** (mínimo p/ operar) | Epic 3 |
+| Ambiente de staging vs produção | HOSTINGER-DEPLOY dívida | **BLOQUEANTE** (validar deploys) | Epic 3 |
+| Storage S3 p/ anexos (bytes no Postgres) | §6.1 Anexos | **BLOQUEANTE-LEVE** (risco de backup; faseável) | Epic 3 |
+| Upload real de logo/imagens (hoje URL) | §6 Brand Kit/Propostas/Sites | **BACKLOG** (URL funciona) | Epic 4 |
+| Google Meet/Calendar OAuth | §6 / módulo API Hub | **BACKLOG** (campo manual funciona) | Epic 4 |
+| Enumeração de e-mail no /register | §6.1 | **BACKLOG** (UX comum) | Epic 4 |
+| Geração de tipos TS via OpenAPI (vs manual) | §6.1 | **BACKLOG** (manutenção) | Epic 4 |
+| Rastro de IA propagado na Agenda | §6.1 | **BACKLOG** (sem ator de IA ainda) | Epic 4 |
+| Fuso por tenant (janela do dia / all-day) | §6.1 Cockpit/Agenda | **BACKLOG** (corrigido nas bordas críticas) | Epic 4 |
+| Cron/worker durável p/ tick do funil | §6 Fase 4 | **BACKLOG** (endpoint manual funciona) | Epic 4 |
+| Wildcard subdomínio por tenant (DNS-01) | HOSTINGER-DEPLOY dívida | **BACKLOG** (go-live em 1 domínio; ver P4) | Epic 4 |
+| Dívidas menores por módulo (estorno, OCR boleto, PDF assinado, régua de cobrança, etc.) | §6 por módulo | **BACKLOG** | Epic 4 |
+
+---
+
+## 6. Epic 1: Segurança & Compliance para Produção
+
+**Epic Goal:** fechar todas as lacunas de segurança e LGPD marcadas na revisão de QA como "endereçar antes
+de produção", garantindo que nenhum dado real de cliente seja exposto sem o hardening necessário — sem
+regressão de isolamento nem de funcionalidade existente.
+
+**Integration Requirements:** todo o hardening é aditivo por trás das interfaces existentes (auth, tenancy,
+admin). A garantia única de isolamento (RLS + papel `e1p_app` non-superuser) deve permanecer intacta; nenhum
+teste existente pode quebrar; validação e2e de isolamento no Postgres real.
+
+### Story 1.1 — Validação real de CPF/CNPJ
+As a **profissional que usa o e1p e seus clientes**,
+I want **que CPF/CNPJ sejam validados de verdade (dígito verificador, normalização, unicidade por tenant)**,
+so that **documentos inválidos não entrem no sistema e o KYC de contratos tenha valor**.
+
+#### Acceptance Criteria
+1. Um validador de CPF/CNPJ (dígito verificador + normalização) é aplicado em `/register`, cadastro/convite de usuário, criação de cliente no CRM (`document`) e KYC/assinatura de contrato.
+2. Documentos inválidos são rejeitados com 422 e mensagem clara em PT-BR; documentos válidos são normalizados (só dígitos) antes de persistir.
+3. Unicidade de `document` por tenant é garantida onde fizer sentido (owner/funcionário), respeitando a decisão de produto pendente sobre dedup de cliente (documentar a escolha).
+
+#### Integration Verification
+- IV1: Fluxos existentes de convite/assinatura continuam funcionando com documentos válidos (testes de convite/KYC passam).
+- IV2: A validação não consulta `users`/dados de outro tenant (respeita RLS); teste cross-tenant intacto.
+- IV3: Sem regressão de performance perceptível nos endpoints de cadastro.
+
+### Story 1.2 — Hardening de acesso à tabela global `users` + log de exclusão (LGPD)
+As a **operador da plataforma responsável por dados de clientes**,
+I want **garantir que nenhum módulo de negócio acesse `users` sem escopo de tenant e que exclusões de conta deixem rastro**,
+so that **não haja vazamento cross-tenant e a plataforma cumpra a LGPD mesmo em operações destrutivas**.
+
+#### Acceptance Criteria
+1. Auditoria do código confirma que nenhum módulo de negócio consulta `users` via `get_db` sem filtro de tenant; qualquer caso encontrado é corrigido (ou coberto por guarda explícita).
+2. A exclusão de conta grava um **log de plataforma fora do tenant** (não purgado com os `audit_entries` do tenant), registrando quem/quando/qual tenant.
+3. O comportamento de purga atômica dinâmica existente é preservado (sem conta-zumbi).
+
+#### Integration Verification
+- IV1: Delete de conta continua atômico e purga todas as tabelas de negócio do tenant (teste existente passa).
+- IV2: Isolamento cross-tenant permanece (e2e no Postgres real: João não vê dados da Maria).
+- IV3: O log de plataforma sobrevive à exclusão do tenant.
+
+### Story 1.3 — Idle timeout LGPD (30 min)
+As a **usuário logado no e1p**,
+I want **ser deslogado após 30 minutos de inatividade**,
+so that **sessões esquecidas não fiquem abertas, cumprindo a LGPD**.
+
+#### Acceptance Criteria
+1. Tracking de atividade / refresh token curto implementado; após 30 min sem atividade, a sessão é encerrada e o usuário é levado ao login.
+2. O frontend (`ProtectedLayout`) trata o timeout com aviso e logout limpo; a experiência não quebra fluxos ativos legítimos.
+3. A solução não afrouxa a segurança do JWT atual (7 dias) para os demais casos.
+
+#### Integration Verification
+- IV1: Login/logout e rotas protegidas continuam funcionando (testes de auth passam).
+- IV2: Não há impacto em endpoints públicos (propostas/contratos/páginas) que não exigem login.
+- IV3: Sem regressão de performance no fluxo de refresh.
+
+### Story 1.4 — Forçar troca de senha do Super Admin no 1º login + validar guard de segredos
+As a **administrador de plataforma (Master)**,
+I want **ser obrigado a trocar a senha semeada no primeiro acesso e ter o boot bloqueado com segredos fracos**,
+so that **a conta de maior privilégio não fique com credencial default em produção**.
+
+#### Acceptance Criteria
+1. O Super Admin semeado nasce com `must_reset_password=True`; o primeiro login bloqueia o app até a troca (reusa o fluxo `FirstAccessPage`/`change-password` já existente).
+2. O guard de produção (`_guard_production_secrets`) é verificado no gate de release: boot recusa `JWT_SECRET` fraco/default (<32), `ANTHROPIC_API_KEY` ausente e `SUPER_ADMIN_PASSWORD` default.
+3. Um item de checklist de release documenta essa verificação.
+
+#### Integration Verification
+- IV1: Login normal de usuários comuns e o fluxo de convite/1º acesso continuam funcionando.
+- IV2: Em dev (sem produção), o comportamento permissivo atual é preservado (não quebra o ciclo local).
+- IV3: Testes existentes de Super Admin e do guard de boot passam.
+
+---
+
+## 7. Epic 2: Integrações Reais (Dinheiro & Comunicação)
+
+**Epic Goal:** trocar os stubs conscientes por provedores reais para que o dinheiro entre de fato (gateway
+com boleto/Pix registrado e webhook confiável creditando o split) e as mensagens sejam realmente entregues
+(e-mail transacional e WhatsApp), tornando verídicas as promessas do produto — sem quebrar a graceful
+degradation nem os fluxos existentes.
+
+**Integration Requirements:** cada provedor é plugado **por trás das interfaces internas existentes**
+(`core/email.py`, `core/whatsapp.py`, contrato do webhook `POST /receivables/webhook`), preservando os
+chamadores e testes atuais (CR4). Idempotência e locks `FOR UPDATE` da Carteira/Contas a Receber devem
+permanecer intactos. Dependência externa (contas/aprovações Meta e gateway) deve ser iniciada cedo.
+
+### Story 2.1 — Provedor de e-mail transacional (SMTP/SES)
+As a **profissional e seus clientes/funcionários convidados**,
+I want **receber de verdade os e-mails de recuperação de senha e de convite (com a senha temporária)**,
+so that **o onboarding e a recuperação de acesso funcionem em produção sem expor tokens/senhas na resposta**.
+
+#### Acceptance Criteria
+1. `core/email.py` passa a enviar via provedor real (SMTP genérico ou SES), configurado por `SMTP_HOST` e credenciais em `.env.prod`/SSM; sem chave configurada, mantém o comportamento de log (graceful degradation).
+2. Os fluxos existentes passam a entregar por e-mail: link de recuperação (`/auth/forgot-password`) e senha temporária de convite de conta/funcionário (`/admin/accounts`, `/admin/accounts/{tenant_id}/users`).
+3. Em produção, o corpo da resposta **não** retorna mais `dev_reset_token` nem `temp_password` (só em dev).
+
+#### Integration Verification
+- IV1: Os fluxos de convite/1º acesso e recuperação de senha continuam funcionando ponta a ponta (testes existentes passam; token/senha deixam de vazar no corpo em prod).
+- IV2: Sem chave de e-mail configurada, os endpoints não quebram (falham fechado/log).
+- IV3: Sem regressão de latência perceptível nos endpoints de auth/convite.
+
+### Story 2.2 — Gateway de pagamento real (Asaas / Mercado Pago)
+As a **dono da empresa de 1 pessoa e a plataforma**,
+I want **gerar boleto/Pix registrado de verdade e receber o webhook real de compensação**,
+so that **o dinheiro entre e o split (40/30/20) seja creditado na Carteira automaticamente**.
+
+#### Acceptance Criteria
+1. Um gateway (Asaas ou Mercado Pago — decisão via ADR no início do épico) gera boleto/Pix **registrado** (substituindo o layout-stub do `core/boleto.py`), com linha digitável/QR válidos e vencimento correto.
+2. `POST /receivables/webhook` recebe o webhook real de compensação, valida `GATEWAY_WEBHOOK_SECRET`, e credita a Carteira com o split, liberando o valor para saque no Financeiro.
+3. A baixa é **idempotente** e protegida contra baixa dupla/crédito duplicado (preserva os locks `FOR UPDATE` existentes); pagamentos duplicados do gateway não geram dupla transação.
+4. Cada ocorrência recorrente gera seu próprio boleto/cobrança registrado (mantém o comportamento de recorrência atual).
+
+#### Integration Verification
+- IV1: O efeito dominó existente (orçamento/proposta aprovada → cobrança → contrato) e a recorrência continuam funcionando com o gateway real.
+- IV2: O split e os saldos da Carteira (disponível/a receber/sacado) e o `platform_earnings` batem após a baixa real (testes de Carteira/Contas a Receber passam).
+- IV3: Isolamento por tenant intacto; webhook não permite cruzar tenants nem baixar cobrança de outro tenant.
+
+### Story 2.3 — WhatsApp Cloud API
+As a **dono da empresa de 1 pessoa**,
+I want **que as notificações hoje apenas `logged` (cobrança com IA, funil, mover card, vencimentos) sejam entregues por WhatsApp**,
+so that **a comunicação com clientes aconteça de verdade e não seja uma promessa silenciosa**.
+
+#### Acceptance Criteria
+1. `core/whatsapp.py` passa a enviar via WhatsApp Cloud API (Meta), usando `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID`; sem chave, mantém o log (graceful degradation).
+2. É adicionado um **campo de telefone do owner/destinatário** (migration aditiva) — hoje o recipient usa o e-mail como placeholder; as notificações passam a usar o telefone real.
+3. As mensagens existentes (cobrança amigável com IA, mensagens de funil, `crm.client.moved`, vencimentos) são entregues com o conteúdo já gerado, respeitando o anonimizador quando a IA compõe o texto.
+
+#### Integration Verification
+- IV1: O barramento de notificações (`notifications`, `crm.client.moved`) e a "Cobrar com IA" continuam funcionando; sem chave, nada quebra (só loga).
+- IV2: Nenhum PII vai para a IA sem anonimização (Regra de Ouro nº 2 preservada na composição das mensagens).
+- IV3: Envio não derruba a request de origem em caso de falha do provedor (falha fechada/log; migração para fila fica no Epic 4).
+
+---
+
+## 8. Epic 3: Deploy, Storage & Observabilidade
+
+**Epic Goal:** transformar o bundle de deploy Hostinger já commitado (`59ff179`) numa esteira repetível e
+segura: validar cada deploy num staging antes de produção, garantir que os testes rodem dentro da imagem
+Docker (matando o drift venv↔prod), proteger os dados com backups offsite testados, e ter visibilidade
+mínima de disponibilidade — além de dar destino durável aos arquivos.
+
+**Integration Requirements:** manter 12-factor para não acoplar à VPS específica (caminho AWS aberto). A app
+sempre roda como papel non-superuser `e1p_app` (RLS válida). Nenhuma mudança pode quebrar os ~252 testes
+existentes; o CI passa a ser gate obrigatório antes do deploy.
+
+### Story 3.1 — Ambiente de staging espelhando produção
+As a **operador do go-live**,
+I want **um ambiente de staging com a mesma imagem de produção e dados sintéticos**,
+so that **cada deploy seja validado antes de ir para produção, sem risco ao dado real**.
+
+#### Acceptance Criteria
+1. Existe um staging que sobe a mesma imagem/compose de produção (`docker-compose.prod.yml` ou `.traefik.yml`), com `.env` próprio e dados sintéticos (seed), isolado da produção.
+2. O fluxo de release documenta: deploy em staging → validação (smoke test dos módulos-chave) → promoção para produção.
+3. Staging usa segredos próprios e nunca aponta para o banco/credenciais de produção.
+
+#### Integration Verification
+- IV1: Subir o staging roda `alembic upgrade head` + seed e responde no `/health` (mesma topologia do dev/prod).
+- IV2: O papel `e1p_app` non-superuser é criado no staging (RLS válida), igual à produção.
+- IV3: Nenhuma configuração de staging afeta produção (redes/volumes/segredos isolados).
+
+### Story 3.2 — CI testando a imagem Docker de produção
+As a **operador do go-live**,
+I want **um CI que rode a suíte de testes DENTRO da imagem Docker de produção e o e2e de isolamento cross-tenant**,
+so that **o drift venv↔produção seja pego antes do deploy e o isolamento RLS seja garantido automaticamente**.
+
+#### Acceptance Criteria
+1. O CI builda a imagem de produção e roda a suíte completa (`scripts/check.sh`/pytest) **dentro** dela, não só no venv local.
+2. O CI executa o teste de isolamento cross-tenant no Postgres real (testcontainers), hoje só validado manualmente.
+3. O CI é **gate obrigatório**: um deploy só é promovido se o CI passar; falha bloqueia o deploy.
+
+#### Integration Verification
+- IV1: Todos os ~252 testes existentes continuam passando na imagem de produção.
+- IV2: O teste de isolamento reproduz o cenário "João não vê dados da Maria" no Postgres real.
+- IV3: O gate não introduz falso-positivo que trave deploys legítimos (pipeline estável).
+
+### Story 3.3 — Backups automatizados + offsite + restore testado
+As a **dono do negócio**,
+I want **backups diários do Postgres copiados para fora da VPS, com restauração testada**,
+so that **os dados sobrevivam à perda do servidor inteiro**.
+
+#### Acceptance Criteria
+1. Um job diário faz `pg_dump` (gzip) do banco de produção (evoluindo o cron do `HOSTINGER-DEPLOY.md`).
+2. Os dumps são copiados para storage **offsite** (S3/outro), com retenção definida.
+3. Um procedimento de **restauração** é executado e validado ao menos uma vez (restore em staging a partir de um dump), documentado no runbook.
+
+#### Integration Verification
+- IV1: O backup roda sem interromper a aplicação em produção.
+- IV2: O restore em staging reconstrói o banco íntegro (RLS/papel `e1p_app` preservados).
+- IV3: A cópia offsite existe e é acessível (não fica só na VPS).
+
+### Story 3.4 — Monitoramento e alertas
+As a **operador do go-live**,
+I want **monitorar disponibilidade (health da API, TLS, disco, restart de container) com alerta acionável**,
+so that **eu saiba de uma queda antes do cliente e possa reagir**.
+
+#### Acceptance Criteria
+1. Há monitoramento de uptime/health da API (`/health`) e da validade do TLS (Caddy/Traefik), com alerta (ex.: Uptime Kuma + notificação).
+2. Sinais básicos de host são observados: disco e reinícios de container.
+3. Um alerta chega por um canal acionável (e-mail/WhatsApp/Telegram) quando um check falha.
+
+#### Integration Verification
+- IV1: O monitoramento não impacta a performance da aplicação (checks leves).
+- IV2: Um teste de queda simulada (parar o container) dispara o alerta.
+- IV3: Custo do monitoramento respeita o guard-rail (NFR3) — solução barata/self-hosted preferida.
+
+### Story 3.5 — Storage durável de anexos (object storage S3-compatível)
+As a **dono do negócio**,
+I want **mover os anexos de bytes-no-Postgres para object storage isolado por tenant**,
+so that **o banco/backup não inche e os arquivos escalem com segurança**.
+
+#### Acceptance Criteria
+1. O módulo de Anexos passa a persistir os arquivos em object storage S3-compatível (mantendo `owner_type`/`owner_id`/`label` e o isolamento por tenant), em vez de `LargeBinary` no Postgres.
+2. Upload, listagem, download e delete continuam funcionando pela mesma interface (componente `Attachments.tsx` e endpoints atuais inalterados no contrato — CR1/CR4).
+3. Anexos existentes são migrados (ou plano de migração documentado); o download de anexos antigos continua funcionando.
+
+#### Integration Verification
+- IV1: Contas a Pagar/Receber (boleto/contrato) e a Agenda (anexos do evento) continuam exibindo/baixando os arquivos.
+- IV2: Isolamento por tenant preservado (um tenant não acessa arquivo de outro).
+- IV3: O tamanho do dump do Postgres cai após a migração (validar no backup).
+
+---
+
+## 9. Epic 4: Backlog Pós-Lançamento (NÃO bloqueante)
+
+**Epic Goal:** consolidar as dívidas documentadas que **não impedem o go-live** para priorização depois do
+lançamento. Nenhuma destas histórias bloqueia produção; todas têm um comportamento atual aceitável (stub,
+campo manual, URL, ou endpoint manual). Escopo estritamente derivado do CLAUDE.md §6/§6.1.
+
+**Integration Requirements:** cada item é aditivo e opcional; ao ser puxado, deve seguir o fluxo de qualidade
+(§5) e não regredir o que já funciona.
+
+### Story 4.1 — Google Meet/Calendar OAuth
+As a **dono da empresa de 1 pessoa**,
+I want **gerar links de Meet automaticamente via OAuth Google (Calendar API)**,
+so that **eu não precise colar o link manualmente na Agenda**.
+
+#### Acceptance Criteria
+1. Fluxo OAuth Google (Cloud project + Calendar API) conecta a conta do owner quando ele fornecer as credenciais.
+2. Eventos da Agenda passam a gerar Meet automaticamente (substituindo o campo manual + botão que abre `meet.google.com/new`).
+3. Sem credenciais Google, o comportamento manual atual é preservado.
+
+#### Integration Verification
+- IV1: A Agenda (calendário, conflitos, detalhe do evento) continua funcionando sem Google conectado.
+- IV2: Nenhuma regressão nos eventos existentes (com link manual).
+- IV3: Credenciais Google tratadas como segredo (não expostas ao frontend).
+
+### Story 4.2 — Upload real de logo e imagens
+As a **dono da empresa de 1 pessoa**,
+I want **subir logo e imagens de verdade (Brand Kit, propostas, carrossel, sites) em vez de colar URL**,
+so that **eu não dependa de hospedar imagens externamente**.
+
+#### Acceptance Criteria
+1. Brand Kit, propostas, carrossel e sites aceitam upload real de imagem/logo (reusando a camada de storage do Epic 3.5), mantendo a prévia ao vivo.
+2. Campos de URL antigos continuam aceitos (retrocompatível) durante a transição.
+3. O reuso de Brand Kit (proposta/carrossel herdam cores/logo) continua funcionando com o upload real.
+
+#### Integration Verification
+- IV1: Propostas/carrosséis/sites existentes (com URL) continuam renderizando.
+- IV2: Isolamento por tenant no storage preservado.
+- IV3: Guarda de esquema de `<img src>` (segurança já existente) mantida.
+
+### Story 4.3 — Worker durável + fila (tick do funil + envios assíncronos)
+As a **operador da plataforma**,
+I want **um worker durável (cron/SQS) que processe o `tick` do funil e os envios assíncronos**,
+so that **as esperas do funil e as notificações não dependam de chamada manual nem bloqueiem a request**.
+
+#### Acceptance Criteria
+1. Um worker/cron durável dispara `POST /funnels/runs/tick` periodicamente (hoje é endpoint manual/tela), retomando esperas vencidas de forma idempotente.
+2. Os envios síncronos no request (ex.: WhatsApp ao mover card) migram para fila (SQS ou equivalente barato).
+3. Auto-enroll por evento (lead criado/tag aplicada via `core/events`) é avaliado como próximo passo (documentado, não obrigatório nesta story).
+
+#### Integration Verification
+- IV1: O motor de automação do funil (enroll→espera→tick→done) continua funcionando e idempotente.
+- IV2: Falha de envio não derruba a request de origem.
+- IV3: Custo do worker/fila respeita o guard-rail (NFR3).
+
+### Story 4.4 — Wildcard de subdomínio por tenant (TLS DNS-01)
+As a **plataforma white-label**,
+I want **servir cada tenant em seu subdomínio (`joaosilva.e1p.com`) com TLS wildcard**,
+so that **o white-label por subdomínio funcione em produção**.
+
+#### Acceptance Criteria
+1. TLS wildcard (`*.e1p.com`) via desafio DNS-01 (Caddy com plugin de provedor DNS) configurado.
+2. O roteamento por subdomínio resolve o tenant correto (mantendo o isolamento RLS).
+3. O go-live single-domain atual continua funcionando durante a transição.
+
+#### Integration Verification
+- IV1: O domínio único atual permanece acessível.
+- IV2: Isolamento por tenant preservado no roteamento por subdomínio.
+- IV3: Emissão/renovação de certificado wildcard validada.
+
+### Story 4.5 — Endurecimentos e refinamentos diversos
+As a **mantenedor do sistema**,
+I want **fechar as dívidas menores de segurança/manutenção não bloqueantes**,
+so that **o sistema fique mais robusto e coeso após o lançamento**.
+
+#### Acceptance Criteria
+1. Enumeração de e-mail no `/register` reavaliada (fluxo de confirmação de e-mail).
+2. Geração de tipos TS a partir do OpenAPI do FastAPI (elimina a manutenção manual do `shared-types`).
+3. Rastro da IA propagado na Agenda (`is_ai` real quando a camada de ações de IA existir) e normalização de fuso por tenant (janela do dia/`all_day`).
+
+#### Integration Verification
+- IV1: Cadastro/login e o contrato `shared-types` continuam funcionando (sem quebra do contrato).
+- IV2: As correções de fuso já feitas (all-day por data de calendário) não regridem.
+- IV3: Nenhuma regressão nos testes existentes.
+
+### Story 4.6 — Dívidas menores por módulo
+As a **product owner**,
+I want **um repositório organizado das dívidas específicas por módulo listadas no CLAUDE.md**,
+so that **elas sejam priorizadas por valor/risco após o lançamento**.
+
+#### Acceptance Criteria
+1. As dívidas por módulo do CLAUDE.md §6 são catalogadas como itens de backlog: estorno/reversão de `platform_earnings`, OCR de boleto, PDF assinado com hash/carimbo, régua de cobrança + juros/multa, antecipação de recebíveis, checkout público real, área de membros real, entrega automática de infoproduto, rate-limit em rotas públicas, PDF de orçamento, "Documentos" como conceito próprio na Ficha 360°, relatório .docx do Jurídico, versionamento de documentos jurídicos.
+2. Cada item recebe classificação valor/risco para priorização (via @po).
+3. Nenhum item é implementado nesta story (é catalogação); a implementação vira stories próprias quando priorizadas.
+
+#### Integration Verification
+- IV1: Nenhuma mudança de código nesta story (apenas backlog) — sem risco ao sistema existente.
+- IV2: O catálogo referencia a origem exata no CLAUDE.md §6 (rastreabilidade).
+- IV3: Itens já bloqueantes não são rebaixados para cá por engano (consistência com a seção 5.2).
+
+---
+
+## 10. Premissas e decisões do PM (modo YOLO — sem elicitação interativa)
+
+Este PRD foi gerado autonomamente. As decisões abaixo foram tomadas pelo PM e devem ser confirmadas pelo
+dono do produto; se alguma premissa estiver errada, o escopo/sequenciamento pode mudar.
+
+- **[AUTO-DECISION] Alvo de deploy para o go-live → VPS Hostinger** (com Traefik compartilhado em
+  `e1p.doroeventos.com.br`, per commit `59ff179` e `HOSTINGER-DEPLOY.md`). *Motivo:* é o esforço de deploy
+  mais recente e concreto; o caminho AWS (ADR 0001) permanece documentado como evolução futura, sem
+  bloquear o lançamento. Manter 12-factor para não acoplar à VPS.
+- **[AUTO-DECISION] Gateway de pagamento é BLOQUEANTE para go-live monetizado.** *Motivo:* o modelo de
+  negócio É o split de pagamento; sem gateway real o produto não captura receita. *Premissa:* existe a
+  opção de soft-launch dos módulos operacionais (Agenda/CRM/Jurídico/documentos) antes do gateway, dada a
+  graceful degradation — a decisão de faseamento fica com o dono do produto.
+- **[AUTO-DECISION] E-mail transacional é BLOQUEANTE.** *Motivo:* recuperação de senha e entrega de senha
+  temporária de convite dependem dele; hoje o token/senha volta no corpo da resposta (aceitável só em dev).
+- **[AUTO-DECISION] WhatsApp classificado como BLOQUEANTE-LEVE (fast-follow).** *Motivo:* as notificações
+  degradam com graça (`logged`); dá para ir ao ar sem entrega real e plugar logo em seguida, desde que a UI
+  não prometa entrega que não acontece. Também depende de aprovação de template pela Meta (risco de prazo).
+- **[AUTO-DECISION] Storage S3 para anexos classificado como BLOQUEANTE-LEVE/faseável.** *Motivo:* o prod
+  compose já usa volumes nomeados (`uploads_data`, `generated_data`); anexos-como-bytes-no-Postgres funciona
+  em baixo volume, mas incha o DB/backup. Recomendo migrar antes de crescer, mas não travar o go-live inicial
+  se o volume for baixo — monitorar o tamanho do backup.
+- **[AUTO-DECISION] Escolha específica do gateway (Asaas vs Mercado Pago) e do provedor de e-mail (SMTP
+  genérico vs SES) NÃO foi decidida aqui.** *Motivo:* exige input comercial/credenciais do dono; registrar
+  como decisão a formalizar em ADR no início do Epic 2.
+- **[AUTO-DECISION] White-label por subdomínio de tenant (`*.e1p.com`) fica FORA do go-live inicial (P4).**
+  *Motivo:* o `HOSTINGER-DEPLOY.md` faz o lançamento em 1 domínio único; wildcard TLS exige desafio DNS-01
+  (backlog). Confirmar se o go-live pode ser single-domain — se o subdomínio por tenant for requisito de
+  lançamento, isso vira bloqueante e sobe para o Epic 3.
+- **[AUTO-DECISION] Estrutura em 3 épicos bloqueantes + 1 de backlog** (em vez de épico único). *Motivo:*
+  workstreams substanciais e distintos; melhor sequenciamento e ownership. Contraria o default do template
+  (épico único) conscientemente.
+- **[AUTO-DECISION] `document-project` não foi executada.** *Motivo:* CLAUDE.md + ADR + guias de deploy dão
+  cobertura suficiente. Recomendo rodar depois se for preciso um inventário técnico formal por módulo.
+
+### Riscos/ambiguidades assumidos
+- **Ambiguidade de alvo de deploy (AWS vs Hostinger):** resolvida assumindo Hostinger como alvo de go-live
+  (P1). Se o dono preferir AWS Fase A, o Epic 3 muda de infra (mas o escopo lógico — staging, CI, backups,
+  monitoramento — permanece).
+- **Faseamento monetização vs soft-launch:** deixado como decisão do dono (pode ir ao ar operacional antes
+  do gateway).
+- **Escopo de chaves de integração (plataforma vs por tenant):** a tela de config de integrações precisa
+  definir se as chaves (gateway/WhatsApp) são globais da plataforma ou por tenant white-label — decisão de
+  produto pendente, sinalizada no Epic 2.

--- a/docs/prd/epic-1-seguranca-compliance.md
+++ b/docs/prd/epic-1-seguranca-compliance.md
@@ -1,0 +1,87 @@
+# Epic 1: Segurança & Compliance para Produção
+
+> **Classificação:** BLOQUEANTE para o lançamento. **Sequenciamento:** primeiro epic do go-live — nada vai
+> ao ar com dados reais de cliente antes deste hardening.
+> Fonte: `docs/prd.md` §6; dívida técnica em `CLAUDE.md` §6.1.
+
+## Contexto do sistema existente (para o @sm)
+e1p é um SaaS multi-tenant white-label (FastAPI + PostgreSQL 16 com Row-Level Security; React + Vite; design
+"Portal"). O produto está funcionalmente completo (Fases 1–5, ~252 testes). O isolamento entre tenants é
+garantido **apenas** por RLS no Postgres, com a app conectando como papel non-superuser `e1p_app` (super-
+usuário faz bypass de RLS). A tabela global `users` **não** tem RLS (login por e-mail é global). O fluxo de
+1º acesso (`must_reset_password` + `FirstAccessPage` + `POST /auth/change-password`) já existe para usuários
+comuns. O guard de produção `app/config.py::_guard_production_secrets` já bloqueia boot com segredos fracos.
+A revisão de QA catalogou (CLAUDE.md §6.1) um conjunto de dívidas de segurança/LGPD marcadas como "endereçar
+antes de produção" — este epic as fecha.
+
+## Epic Goal
+Fechar todas as lacunas de segurança e LGPD marcadas na revisão de QA como "endereçar antes de produção",
+garantindo que nenhum dado real de cliente seja exposto sem o hardening necessário — sem regressão de
+isolamento nem de funcionalidade existente.
+
+## Integration Requirements
+Todo o hardening é aditivo por trás das interfaces existentes (auth, tenancy, admin). A garantia única de
+isolamento (RLS + papel `e1p_app` non-superuser) deve permanecer intacta; nenhum teste existente pode
+quebrar; validação e2e de isolamento no Postgres real. Regras de Ouro do CLAUDE.md §3 são inegociáveis.
+
+---
+
+## Story 1.1 — Validação real de CPF/CNPJ
+As a **profissional que usa o e1p e seus clientes**,
+I want **que CPF/CNPJ sejam validados de verdade (dígito verificador, normalização, unicidade por tenant)**,
+so that **documentos inválidos não entrem no sistema e o KYC de contratos tenha valor**.
+
+### Acceptance Criteria
+1. Um validador de CPF/CNPJ (dígito verificador + normalização) é aplicado em `/register`, cadastro/convite de usuário, criação de cliente no CRM (`document`) e KYC/assinatura de contrato.
+2. Documentos inválidos são rejeitados com 422 e mensagem clara em PT-BR; documentos válidos são normalizados (só dígitos) antes de persistir.
+3. Unicidade de `document` por tenant é garantida onde fizer sentido (owner/funcionário), respeitando a decisão de produto pendente sobre dedup de cliente (documentar a escolha).
+
+### Integration Verification
+- IV1: Fluxos existentes de convite/assinatura continuam funcionando com documentos válidos (testes de convite/KYC passam).
+- IV2: A validação não consulta `users`/dados de outro tenant (respeita RLS); teste cross-tenant intacto.
+- IV3: Sem regressão de performance perceptível nos endpoints de cadastro.
+
+## Story 1.2 — Hardening de acesso à tabela global `users` + log de exclusão (LGPD)
+As a **operador da plataforma responsável por dados de clientes**,
+I want **garantir que nenhum módulo de negócio acesse `users` sem escopo de tenant e que exclusões de conta deixem rastro**,
+so that **não haja vazamento cross-tenant e a plataforma cumpra a LGPD mesmo em operações destrutivas**.
+
+### Acceptance Criteria
+1. Auditoria do código confirma que nenhum módulo de negócio consulta `users` via `get_db` sem filtro de tenant; qualquer caso encontrado é corrigido (ou coberto por guarda explícita).
+2. A exclusão de conta grava um **log de plataforma fora do tenant** (não purgado com os `audit_entries` do tenant), registrando quem/quando/qual tenant.
+3. O comportamento de purga atômica dinâmica existente é preservado (sem conta-zumbi).
+
+### Integration Verification
+- IV1: Delete de conta continua atômico e purga todas as tabelas de negócio do tenant (teste existente passa).
+- IV2: Isolamento cross-tenant permanece (e2e no Postgres real: João não vê dados da Maria).
+- IV3: O log de plataforma sobrevive à exclusão do tenant.
+
+## Story 1.3 — Idle timeout LGPD (30 min)
+As a **usuário logado no e1p**,
+I want **ser deslogado após 30 minutos de inatividade**,
+so that **sessões esquecidas não fiquem abertas, cumprindo a LGPD**.
+
+### Acceptance Criteria
+1. Tracking de atividade / refresh token curto implementado; após 30 min sem atividade, a sessão é encerrada e o usuário é levado ao login.
+2. O frontend (`ProtectedLayout`) trata o timeout com aviso e logout limpo; a experiência não quebra fluxos ativos legítimos.
+3. A solução não afrouxa a segurança do JWT atual (7 dias) para os demais casos.
+
+### Integration Verification
+- IV1: Login/logout e rotas protegidas continuam funcionando (testes de auth passam).
+- IV2: Não há impacto em endpoints públicos (propostas/contratos/páginas) que não exigem login.
+- IV3: Sem regressão de performance no fluxo de refresh.
+
+## Story 1.4 — Forçar troca de senha do Super Admin no 1º login + validar guard de segredos
+As a **administrador de plataforma (Master)**,
+I want **ser obrigado a trocar a senha semeada no primeiro acesso e ter o boot bloqueado com segredos fracos**,
+so that **a conta de maior privilégio não fique com credencial default em produção**.
+
+### Acceptance Criteria
+1. O Super Admin semeado nasce com `must_reset_password=True`; o primeiro login bloqueia o app até a troca (reusa o fluxo `FirstAccessPage`/`change-password` já existente).
+2. O guard de produção (`_guard_production_secrets`) é verificado no gate de release: boot recusa `JWT_SECRET` fraco/default (<32), `ANTHROPIC_API_KEY` ausente e `SUPER_ADMIN_PASSWORD` default.
+3. Um item de checklist de release documenta essa verificação.
+
+### Integration Verification
+- IV1: Login normal de usuários comuns e o fluxo de convite/1º acesso continuam funcionando.
+- IV2: Em dev (sem produção), o comportamento permissivo atual é preservado (não quebra o ciclo local).
+- IV3: Testes existentes de Super Admin e do guard de boot passam.

--- a/docs/prd/epic-2-integracoes-reais.md
+++ b/docs/prd/epic-2-integracoes-reais.md
@@ -1,0 +1,80 @@
+# Epic 2: Integrações Reais (Dinheiro & Comunicação)
+
+> **Classificação:** BLOQUEANTE para o lançamento (WhatsApp é bloqueante-leve/fast-follow).
+> **Sequenciamento:** segundo epic do go-live. **Dependência externa:** contas/aprovações (Meta, gateway) —
+> iniciar cedo, pois podem atrasar. Fonte: `docs/prd.md` §7; dívida em `CLAUDE.md` §6/§6.1.
+
+## Contexto do sistema existente (para o @sm)
+O e1p foi construído com **stubs conscientes** nos pontos que exigem credenciais/infra externa:
+- **Pagamento:** existe `core/boleto.py` (fpdf2) que gera um boleto **layout-stub sem registro bancário**;
+  o pagamento entra por `POST /receivables/webhook` (público, protegido por `GATEWAY_WEBHOOK_SECRET`), que
+  credita a Carteira com split (40/30/20) usando locks `FOR UPDATE` contra baixa dupla. Falta o gateway
+  real (Asaas/Mercado Pago) gerando boleto/Pix registrado e enviando o webhook de verdade.
+- **E-mail:** `core/email.py` é stub (em dev vira log; o token de reset e a senha temporária de convite
+  voltam no corpo da resposta — `dev_reset_token`/`temp_password`). Recuperação de senha e convite de
+  conta/funcionário dependem de entrega real.
+- **WhatsApp:** `core/whatsapp.py` é stub — as notificações (cobrança com IA, funil, `crm.client.moved`,
+  vencimentos) ficam apenas `logged`. Não há campo de telefone do owner (recipient usa o e-mail como
+  placeholder). Precisa `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID` (Meta Cloud API).
+Todos os stubs adotam **graceful degradation** (sem chave → log, sem quebrar a request) — comportamento a
+ser preservado. A composição de mensagens por IA passa pelo **anonimizador** (Regra de Ouro nº 2).
+
+## Epic Goal
+Trocar os stubs conscientes por provedores reais para que o dinheiro entre de fato (gateway com boleto/Pix
+registrado e webhook confiável creditando o split) e as mensagens sejam realmente entregues (e-mail
+transacional e WhatsApp), tornando verídicas as promessas do produto — sem quebrar a graceful degradation
+nem os fluxos existentes.
+
+## Integration Requirements
+Cada provedor é plugado **por trás das interfaces internas existentes** (`core/email.py`, `core/whatsapp.py`,
+contrato do webhook `POST /receivables/webhook`), preservando os chamadores e testes atuais. Idempotência e
+locks `FOR UPDATE` da Carteira/Contas a Receber devem permanecer intactos. Escolha específica do gateway e
+do provedor de e-mail deve ser formalizada em ADR no início do epic.
+
+---
+
+## Story 2.1 — Provedor de e-mail transacional (SMTP/SES)
+As a **profissional e seus clientes/funcionários convidados**,
+I want **receber de verdade os e-mails de recuperação de senha e de convite (com a senha temporária)**,
+so that **o onboarding e a recuperação de acesso funcionem em produção sem expor tokens/senhas na resposta**.
+
+### Acceptance Criteria
+1. `core/email.py` passa a enviar via provedor real (SMTP genérico ou SES), configurado por `SMTP_HOST` e credenciais em `.env.prod`/SSM; sem chave configurada, mantém o comportamento de log (graceful degradation).
+2. Os fluxos existentes passam a entregar por e-mail: link de recuperação (`/auth/forgot-password`) e senha temporária de convite de conta/funcionário (`/admin/accounts`, `/admin/accounts/{tenant_id}/users`).
+3. Em produção, o corpo da resposta **não** retorna mais `dev_reset_token` nem `temp_password` (só em dev).
+
+### Integration Verification
+- IV1: Os fluxos de convite/1º acesso e recuperação de senha continuam funcionando ponta a ponta (testes existentes passam; token/senha deixam de vazar no corpo em prod).
+- IV2: Sem chave de e-mail configurada, os endpoints não quebram (falham fechado/log).
+- IV3: Sem regressão de latência perceptível nos endpoints de auth/convite.
+
+## Story 2.2 — Gateway de pagamento real (Asaas / Mercado Pago)
+As a **dono da empresa de 1 pessoa e a plataforma**,
+I want **gerar boleto/Pix registrado de verdade e receber o webhook real de compensação**,
+so that **o dinheiro entre e o split (40/30/20) seja creditado na Carteira automaticamente**.
+
+### Acceptance Criteria
+1. Um gateway (Asaas ou Mercado Pago — decisão via ADR no início do épico) gera boleto/Pix **registrado** (substituindo o layout-stub do `core/boleto.py`), com linha digitável/QR válidos e vencimento correto.
+2. `POST /receivables/webhook` recebe o webhook real de compensação, valida `GATEWAY_WEBHOOK_SECRET`, e credita a Carteira com o split, liberando o valor para saque no Financeiro.
+3. A baixa é **idempotente** e protegida contra baixa dupla/crédito duplicado (preserva os locks `FOR UPDATE` existentes); pagamentos duplicados do gateway não geram dupla transação.
+4. Cada ocorrência recorrente gera seu próprio boleto/cobrança registrado (mantém o comportamento de recorrência atual).
+
+### Integration Verification
+- IV1: O efeito dominó existente (orçamento/proposta aprovada → cobrança → contrato) e a recorrência continuam funcionando com o gateway real.
+- IV2: O split e os saldos da Carteira (disponível/a receber/sacado) e o `platform_earnings` batem após a baixa real (testes de Carteira/Contas a Receber passam).
+- IV3: Isolamento por tenant intacto; webhook não permite cruzar tenants nem baixar cobrança de outro tenant.
+
+## Story 2.3 — WhatsApp Cloud API
+As a **dono da empresa de 1 pessoa**,
+I want **que as notificações hoje apenas `logged` (cobrança com IA, funil, mover card, vencimentos) sejam entregues por WhatsApp**,
+so that **a comunicação com clientes aconteça de verdade e não seja uma promessa silenciosa**.
+
+### Acceptance Criteria
+1. `core/whatsapp.py` passa a enviar via WhatsApp Cloud API (Meta), usando `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID`; sem chave, mantém o log (graceful degradation).
+2. É adicionado um **campo de telefone do owner/destinatário** (migration aditiva) — hoje o recipient usa o e-mail como placeholder; as notificações passam a usar o telefone real.
+3. As mensagens existentes (cobrança amigável com IA, mensagens de funil, `crm.client.moved`, vencimentos) são entregues com o conteúdo já gerado, respeitando o anonimizador quando a IA compõe o texto.
+
+### Integration Verification
+- IV1: O barramento de notificações (`notifications`, `crm.client.moved`) e a "Cobrar com IA" continuam funcionando; sem chave, nada quebra (só loga).
+- IV2: Nenhum PII vai para a IA sem anonimização (Regra de Ouro nº 2 preservada na composição das mensagens).
+- IV3: Envio não derruba a request de origem em caso de falha do provedor (falha fechada/log; migração para fila fica no Epic 4).

--- a/docs/prd/epic-3-deploy-storage-observabilidade.md
+++ b/docs/prd/epic-3-deploy-storage-observabilidade.md
@@ -1,0 +1,106 @@
+# Epic 3: Deploy, Storage & Observabilidade
+
+> **Classificação:** BLOQUEANTE para o lançamento (monitoramento e storage-S3 são bloqueante-leve/faseáveis).
+> **Sequenciamento:** terceiro epic do go-live. Fonte: `docs/prd.md` §8; guias `docs/HOSTINGER-DEPLOY.md` e
+> `docs/AWS-DEPLOYMENT.md`; dívida em `CLAUDE.md` §6.1.
+
+## Contexto do sistema existente (para o @sm)
+A app é 100% conteinerizada (12-factor). Já existe um **bundle de deploy commitado** (`59ff179`) para VPS
+Hostinger: `infra/docker-compose.prod.yml` (Caddy próprio, TLS Let's Encrypt), `infra/docker-compose.traefik.yml`
+(integra ao Traefik compartilhado da VPS de produção `e1p.doroeventos.com.br`), `infra/Caddyfile`,
+`infra/.env.prod.example`, `infra/docker/initdb-prod/01-rls-enforce.sh` (cria o papel non-superuser `e1p_app`
+essencial pro RLS) e o guia `docs/HOSTINGER-DEPLOY.md`. O container `api` roda `alembic upgrade head` + seed
+no boot. Lacunas conhecidas: **não há staging**, **não há CI** rodando os testes na imagem de produção (houve
+um bug de drift venv↔produção — versão do FastAPI divergente escondeu um erro de rota 204 que só quebrou no
+container), **backup** é só um cron sugerido na própria VPS (sem cópia offsite nem restore testado),
+**não há monitoramento/alertas**, e o teste de isolamento cross-tenant (RLS é Postgres-only) só foi validado
+manualmente. Anexos hoje são `LargeBinary` no Postgres (módulo Anexos, componente `Attachments.tsx`),
+incham banco/backup. O caminho AWS (EC2 Graviton → ECS Fargate, RDS, S3/CloudFront) é a evolução documentada.
+
+## Epic Goal
+Transformar o bundle de deploy Hostinger já commitado numa esteira repetível e segura: validar cada deploy
+num staging antes de produção, garantir que os testes rodem dentro da imagem Docker (matando o drift
+venv↔prod), proteger os dados com backups offsite testados, ter visibilidade mínima de disponibilidade, e
+dar destino durável aos arquivos.
+
+## Integration Requirements
+Manter 12-factor para não acoplar à VPS específica (caminho AWS aberto). A app sempre roda como papel
+non-superuser `e1p_app` (RLS válida). Nenhuma mudança pode quebrar os ~252 testes existentes; o CI passa a
+ser gate obrigatório antes do deploy. Custo respeita o guard-rail (soluções baratas/self-hosted).
+
+---
+
+## Story 3.1 — Ambiente de staging espelhando produção
+As a **operador do go-live**,
+I want **um ambiente de staging com a mesma imagem de produção e dados sintéticos**,
+so that **cada deploy seja validado antes de ir para produção, sem risco ao dado real**.
+
+### Acceptance Criteria
+1. Existe um staging que sobe a mesma imagem/compose de produção (`docker-compose.prod.yml` ou `.traefik.yml`), com `.env` próprio e dados sintéticos (seed), isolado da produção.
+2. O fluxo de release documenta: deploy em staging → validação (smoke test dos módulos-chave) → promoção para produção.
+3. Staging usa segredos próprios e nunca aponta para o banco/credenciais de produção.
+
+### Integration Verification
+- IV1: Subir o staging roda `alembic upgrade head` + seed e responde no `/health` (mesma topologia do dev/prod).
+- IV2: O papel `e1p_app` non-superuser é criado no staging (RLS válida), igual à produção.
+- IV3: Nenhuma configuração de staging afeta produção (redes/volumes/segredos isolados).
+
+## Story 3.2 — CI testando a imagem Docker de produção
+As a **operador do go-live**,
+I want **um CI que rode a suíte de testes DENTRO da imagem Docker de produção e o e2e de isolamento cross-tenant**,
+so that **o drift venv↔produção seja pego antes do deploy e o isolamento RLS seja garantido automaticamente**.
+
+### Acceptance Criteria
+1. O CI builda a imagem de produção e roda a suíte completa (`scripts/check.sh`/pytest) **dentro** dela, não só no venv local.
+2. O CI executa o teste de isolamento cross-tenant no Postgres real (testcontainers), hoje só validado manualmente.
+3. O CI é **gate obrigatório**: um deploy só é promovido se o CI passar; falha bloqueia o deploy.
+
+### Integration Verification
+- IV1: Todos os ~252 testes existentes continuam passando na imagem de produção.
+- IV2: O teste de isolamento reproduz o cenário "João não vê dados da Maria" no Postgres real.
+- IV3: O gate não introduz falso-positivo que trave deploys legítimos (pipeline estável).
+
+## Story 3.3 — Backups automatizados + offsite + restore testado
+As a **dono do negócio**,
+I want **backups diários do Postgres copiados para fora da VPS, com restauração testada**,
+so that **os dados sobrevivam à perda do servidor inteiro**.
+
+### Acceptance Criteria
+1. Um job diário faz `pg_dump` (gzip) do banco de produção (evoluindo o cron do `HOSTINGER-DEPLOY.md`).
+2. Os dumps são copiados para storage **offsite** (S3/outro), com retenção definida.
+3. Um procedimento de **restauração** é executado e validado ao menos uma vez (restore em staging a partir de um dump), documentado no runbook.
+
+### Integration Verification
+- IV1: O backup roda sem interromper a aplicação em produção.
+- IV2: O restore em staging reconstrói o banco íntegro (RLS/papel `e1p_app` preservados).
+- IV3: A cópia offsite existe e é acessível (não fica só na VPS).
+
+## Story 3.4 — Monitoramento e alertas
+As a **operador do go-live**,
+I want **monitorar disponibilidade (health da API, TLS, disco, restart de container) com alerta acionável**,
+so that **eu saiba de uma queda antes do cliente e possa reagir**.
+
+### Acceptance Criteria
+1. Há monitoramento de uptime/health da API (`/health`) e da validade do TLS (Caddy/Traefik), com alerta (ex.: Uptime Kuma + notificação).
+2. Sinais básicos de host são observados: disco e reinícios de container.
+3. Um alerta chega por um canal acionável (e-mail/WhatsApp/Telegram) quando um check falha.
+
+### Integration Verification
+- IV1: O monitoramento não impacta a performance da aplicação (checks leves).
+- IV2: Um teste de queda simulada (parar o container) dispara o alerta.
+- IV3: Custo do monitoramento respeita o guard-rail (NFR3) — solução barata/self-hosted preferida.
+
+## Story 3.5 — Storage durável de anexos (object storage S3-compatível)
+As a **dono do negócio**,
+I want **mover os anexos de bytes-no-Postgres para object storage isolado por tenant**,
+so that **o banco/backup não inche e os arquivos escalem com segurança**.
+
+### Acceptance Criteria
+1. O módulo de Anexos passa a persistir os arquivos em object storage S3-compatível (mantendo `owner_type`/`owner_id`/`label` e o isolamento por tenant), em vez de `LargeBinary` no Postgres.
+2. Upload, listagem, download e delete continuam funcionando pela mesma interface (componente `Attachments.tsx` e endpoints atuais inalterados no contrato).
+3. Anexos existentes são migrados (ou plano de migração documentado); o download de anexos antigos continua funcionando.
+
+### Integration Verification
+- IV1: Contas a Pagar/Receber (boleto/contrato) e a Agenda (anexos do evento) continuam exibindo/baixando os arquivos.
+- IV2: Isolamento por tenant preservado (um tenant não acessa arquivo de outro).
+- IV3: O tamanho do dump do Postgres cai após a migração (validar no backup).

--- a/docs/prd/epic-4-backlog-pos-lancamento.md
+++ b/docs/prd/epic-4-backlog-pos-lancamento.md
@@ -1,0 +1,117 @@
+# Epic 4: Backlog Pós-Lançamento (NÃO bloqueante)
+
+> **Classificação:** NÃO bloqueante para o go-live. **Sequenciamento:** puxar após o lançamento, priorizado
+> por valor/risco (via @po). Fonte: `docs/prd.md` §9; dívida por módulo em `CLAUDE.md` §6/§6.1.
+
+## Contexto do sistema existente (para o @sm)
+Todas as histórias deste epic têm um **comportamento atual aceitável** que não impede produção: stub, campo
+manual, URL de imagem, ou endpoint manual. Referências ao estado atual:
+- **Google Meet/Calendar:** hoje é campo manual + botão que abre `meet.google.com/new` (é o módulo 6 / API Hub).
+- **Logo/imagens:** vários módulos (Brand Kit, propostas, carrossel, sites) aceitam apenas **URL**, não upload.
+- **Funil:** o motor de automação existe (`funnels/engine.py`, enroll→espera→tick→done), mas o `tick` é
+  disparado por endpoint/tela (`POST /funnels/runs/tick`) — sem worker durável; envios são síncronos no request.
+- **White-label por subdomínio:** o go-live é single-domain; wildcard `*.e1p.com` exige TLS via desafio DNS-01.
+- **Refinamentos:** enumeração de e-mail no `/register`; `shared-types` mantido à mão (vs OpenAPI); `is_ai`
+  placeholder na Agenda; janela do dia/`all_day` ancorada em meia-noite UTC (dívida de fuso por tenant).
+- **Dívidas por módulo:** estorno/reversão de `platform_earnings`, OCR de boleto, PDF assinado com hash/carimbo,
+  régua de cobrança + juros/multa, antecipação de recebíveis, checkout público real, área de membros real, etc.
+
+## Epic Goal
+Consolidar as dívidas documentadas que não impedem o go-live para priorização depois do lançamento. Nenhuma
+destas histórias bloqueia produção.
+
+## Integration Requirements
+Cada item é aditivo e opcional; ao ser puxado, deve seguir o fluxo de qualidade (§5 do CLAUDE.md) e não
+regredir o que já funciona.
+
+---
+
+## Story 4.1 — Google Meet/Calendar OAuth
+As a **dono da empresa de 1 pessoa**,
+I want **gerar links de Meet automaticamente via OAuth Google (Calendar API)**,
+so that **eu não precise colar o link manualmente na Agenda**.
+
+### Acceptance Criteria
+1. Fluxo OAuth Google (Cloud project + Calendar API) conecta a conta do owner quando ele fornecer as credenciais.
+2. Eventos da Agenda passam a gerar Meet automaticamente (substituindo o campo manual + botão que abre `meet.google.com/new`).
+3. Sem credenciais Google, o comportamento manual atual é preservado.
+
+### Integration Verification
+- IV1: A Agenda (calendário, conflitos, detalhe do evento) continua funcionando sem Google conectado.
+- IV2: Nenhuma regressão nos eventos existentes (com link manual).
+- IV3: Credenciais Google tratadas como segredo (não expostas ao frontend).
+
+## Story 4.2 — Upload real de logo e imagens
+As a **dono da empresa de 1 pessoa**,
+I want **subir logo e imagens de verdade (Brand Kit, propostas, carrossel, sites) em vez de colar URL**,
+so that **eu não dependa de hospedar imagens externamente**.
+
+### Acceptance Criteria
+1. Brand Kit, propostas, carrossel e sites aceitam upload real de imagem/logo (reusando a camada de storage do Epic 3.5), mantendo a prévia ao vivo.
+2. Campos de URL antigos continuam aceitos (retrocompatível) durante a transição.
+3. O reuso de Brand Kit (proposta/carrossel herdam cores/logo) continua funcionando com o upload real.
+
+### Integration Verification
+- IV1: Propostas/carrosséis/sites existentes (com URL) continuam renderizando.
+- IV2: Isolamento por tenant no storage preservado.
+- IV3: Guarda de esquema de `<img src>` (segurança já existente) mantida.
+
+## Story 4.3 — Worker durável + fila (tick do funil + envios assíncronos)
+As a **operador da plataforma**,
+I want **um worker durável (cron/SQS) que processe o `tick` do funil e os envios assíncronos**,
+so that **as esperas do funil e as notificações não dependam de chamada manual nem bloqueiem a request**.
+
+### Acceptance Criteria
+1. Um worker/cron durável dispara `POST /funnels/runs/tick` periodicamente (hoje é endpoint manual/tela), retomando esperas vencidas de forma idempotente.
+2. Os envios síncronos no request (ex.: WhatsApp ao mover card) migram para fila (SQS ou equivalente barato).
+3. Auto-enroll por evento (lead criado/tag aplicada via `core/events`) é avaliado como próximo passo (documentado, não obrigatório nesta story).
+
+### Integration Verification
+- IV1: O motor de automação do funil (enroll→espera→tick→done) continua funcionando e idempotente.
+- IV2: Falha de envio não derruba a request de origem.
+- IV3: Custo do worker/fila respeita o guard-rail (NFR3).
+
+## Story 4.4 — Wildcard de subdomínio por tenant (TLS DNS-01)
+As a **plataforma white-label**,
+I want **servir cada tenant em seu subdomínio (`joaosilva.e1p.com`) com TLS wildcard**,
+so that **o white-label por subdomínio funcione em produção**.
+
+### Acceptance Criteria
+1. TLS wildcard (`*.e1p.com`) via desafio DNS-01 (Caddy com plugin de provedor DNS) configurado.
+2. O roteamento por subdomínio resolve o tenant correto (mantendo o isolamento RLS).
+3. O go-live single-domain atual continua funcionando durante a transição.
+
+### Integration Verification
+- IV1: O domínio único atual permanece acessível.
+- IV2: Isolamento por tenant preservado no roteamento por subdomínio.
+- IV3: Emissão/renovação de certificado wildcard validada.
+
+## Story 4.5 — Endurecimentos e refinamentos diversos
+As a **mantenedor do sistema**,
+I want **fechar as dívidas menores de segurança/manutenção não bloqueantes**,
+so that **o sistema fique mais robusto e coeso após o lançamento**.
+
+### Acceptance Criteria
+1. Enumeração de e-mail no `/register` reavaliada (fluxo de confirmação de e-mail).
+2. Geração de tipos TS a partir do OpenAPI do FastAPI (elimina a manutenção manual do `shared-types`).
+3. Rastro da IA propagado na Agenda (`is_ai` real quando a camada de ações de IA existir) e normalização de fuso por tenant (janela do dia/`all_day`).
+
+### Integration Verification
+- IV1: Cadastro/login e o contrato `shared-types` continuam funcionando (sem quebra do contrato).
+- IV2: As correções de fuso já feitas (all-day por data de calendário) não regridem.
+- IV3: Nenhuma regressão nos testes existentes.
+
+## Story 4.6 — Dívidas menores por módulo
+As a **product owner**,
+I want **um repositório organizado das dívidas específicas por módulo listadas no CLAUDE.md**,
+so that **elas sejam priorizadas por valor/risco após o lançamento**.
+
+### Acceptance Criteria
+1. As dívidas por módulo do CLAUDE.md §6 são catalogadas como itens de backlog: estorno/reversão de `platform_earnings`, OCR de boleto, PDF assinado com hash/carimbo, régua de cobrança + juros/multa, antecipação de recebíveis, checkout público real, área de membros real, entrega automática de infoproduto, rate-limit em rotas públicas, PDF de orçamento, "Documentos" como conceito próprio na Ficha 360°, relatório .docx do Jurídico, versionamento de documentos jurídicos.
+2. Cada item recebe classificação valor/risco para priorização (via @po).
+3. Nenhum item é implementado nesta story (é catalogação); a implementação vira stories próprias quando priorizadas.
+
+### Integration Verification
+- IV1: Nenhuma mudança de código nesta story (apenas backlog) — sem risco ao sistema existente.
+- IV2: O catálogo referencia a origem exata no CLAUDE.md §6 (rastreabilidade).
+- IV3: Itens já bloqueantes não são rebaixados para cá por engano (consistência com a seção 5.2 do PRD).

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -1,0 +1,37 @@
+# e1p — Brownfield PRD (Go-Live) — Índice de Epics
+
+> Shard do PRD `docs/prd.md` (Brownfield Enhancement PRD — Go-Live para Produção).
+> Cada arquivo de epic é **autocontido**: traz o contexto do sistema existente, o goal do epic e as stories
+> completas com Acceptance Criteria + Integration Verification. O @sm deve ler **apenas o arquivo do epic**
+> para gerar cada story formal via `create-next-story.md`.
+
+## Resumo do produto
+SaaS multi-tenant white-label (`e1p.com`) para profissionais autônomos, com IA (Claude) como funcionário
+invisível e modelo de split de pagamento (40% produtos / 30% serviços / 20% recorrência). Fases 1–5
+implementadas e testadas (~252 testes). Este PRD trata **exclusivamente do caminho até o go-live** do que já
+foi construído — não há features novas de produto.
+
+## Stack (resumo)
+FastAPI (Python 3.13) + SQLAlchemy 2/Alembic + PostgreSQL 16 com Row-Level Security (isolamento de tenant).
+React 18 + Vite + TS + Tailwind (design "Portal", cor `#5D44F8`). Monorepo pnpm + app Python. 100%
+conteinerizado (Docker). Alvo de deploy do go-live: VPS Hostinger (Caddy próprio ou Traefik compartilhado);
+caminho AWS documentado como evolução.
+
+## Regras de Ouro (inegociáveis — valem para toda story)
+1. Isolamento de tenant é sagrado (RLS; app conecta como papel non-superuser `e1p_app`).
+2. Anonimizador antes da IA (nenhum PII vai para o Claude).
+3. Rastro da IA (toda ação da IA é logada).
+4. Custo importa (soluções baratas; sem serviço pago sem justificar).
+5. Não quebrar o que já funciona (testes + agentes de QA a cada mudança).
+
+## Epics
+
+| Epic | Arquivo | Classificação | Stories |
+|---|---|---|---|
+| Epic 1 — Segurança & Compliance para Produção | [epic-1-seguranca-compliance.md](./epic-1-seguranca-compliance.md) | BLOQUEANTE | 4 |
+| Epic 2 — Integrações Reais (Dinheiro & Comunicação) | [epic-2-integracoes-reais.md](./epic-2-integracoes-reais.md) | BLOQUEANTE | 3 |
+| Epic 3 — Deploy, Storage & Observabilidade | [epic-3-deploy-storage-observabilidade.md](./epic-3-deploy-storage-observabilidade.md) | BLOQUEANTE | 5 |
+| Epic 4 — Backlog Pós-Lançamento | [epic-4-backlog-pos-lancamento.md](./epic-4-backlog-pos-lancamento.md) | NÃO bloqueante | 6 |
+
+**Sequenciamento recomendado:** Epic 1 → Epic 2 → Epic 3 → (Epic 4 pós-lançamento).
+PRD completo (com Requirements FR/NFR/CR, constraints técnicas e premissas do PM): [`../prd.md`](../prd.md).

--- a/docs/stories/1.1.story.md
+++ b/docs/stories/1.1.story.md
@@ -1,0 +1,141 @@
+# Story 1.1: Validação real de CPF/CNPJ
+
+## Status
+Ready
+
+## Executor Assignment
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual security review", "validação manual e2e no Postgres real (docker compose)"]
+```
+> [AUTO-DECISION] Executor/quality_gate não vieram pré-preenchidos pelo @pm no epic file → mapeados autonomamente como "Code/Features/Logic" (backend, validação de schema Pydantic) conforme a tabela de Executor Assignment do template → executor=@dev, quality_gate=@architect (reason: story é lógica de validação/backend pura, sem mudança de infraestrutura ou design de schema complexo que justifique @data-engineer/@architect como executor).
+
+## Story
+**As a** profissional que usa o e1p e seus clientes,
+**I want** que CPF/CNPJ sejam validados de verdade (dígito verificador, normalização, unicidade por tenant),
+**so that** documentos inválidos não entrem no sistema e o KYC de contratos tenha valor.
+
+## Acceptance Criteria
+1. Um validador de CPF/CNPJ (dígito verificador + normalização) é aplicado em `/register`, cadastro/convite de usuário, criação de cliente no CRM (`document`) e KYC/assinatura de contrato.
+2. Documentos inválidos são rejeitados com 422 e mensagem clara em PT-BR; documentos válidos são normalizados (só dígitos) antes de persistir.
+3. Unicidade de `document` por tenant é garantida onde fizer sentido (owner/funcionário), respeitando a decisão de produto pendente sobre dedup de cliente (documentar a escolha).
+
+### Integration Verification
+- IV1: Fluxos existentes de convite/assinatura continuam funcionando com documentos válidos (testes de convite/KYC passam).
+- IV2: A validação não consulta `users`/dados de outro tenant (respeita RLS); teste cross-tenant intacto.
+- IV3: Sem regressão de performance perceptível nos endpoints de cadastro.
+
+## 🤖 CodeRabbit Integration
+
+> **CodeRabbit Integration**: Disabled
+>
+> Este projeto (e1p, brownfield sem `.aiox-core` próprio) não tem `coderabbit_integration.enabled` configurado localmente. Por instrução explícita do orquestrador desta missão, foi tratado como `false`.
+> Quality validation will use manual review process only (ver `quality_gate_tools` acima e `scripts/check.sh`).
+> To enable, set `coderabbit_integration.enabled: true` em um `core-config.yaml` próprio do projeto.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Criar validador central de CPF/CNPJ (AC: 1, 2)**
+  - [ ] Criar `apps/api/app/core/validators.py` (novo arquivo — segue o padrão de módulos utilitários já existente em `apps/api/app/core/`, ver `core/security.py`, `core/tenancy.py`) com:
+    - `normalize_document(raw: str) -> str` — remove tudo que não é dígito.
+    - `validate_cpf(digits: str) -> bool` — 11 dígitos, rejeita sequências repetidas (`"00000000000"`, `"11111111111"`, etc.), valida os 2 dígitos verificadores pelo algoritmo padrão do CPF.
+    - `validate_cnpj(digits: str) -> bool` — 14 dígitos, mesma lógica com o algoritmo do CNPJ.
+    - `validate_document(raw: str) -> str` — normaliza, decide CPF (11) vs CNPJ (14) pelo tamanho após normalização, valida, e retorna a string só-dígitos; levanta `ValueError` com mensagem em PT-BR (`"CPF inválido"` / `"CNPJ inválido"` / `"documento deve ter 11 (CPF) ou 14 (CNPJ) dígitos"`) se inválido.
+  - [ ] Criar `apps/api/tests/test_validators.py` cobrindo: CPF válido, CPF com todos os dígitos iguais (inválido), CPF com DV errado, CNPJ válido, CNPJ com DV errado, string vazia, tamanho incorreto (ex.: 10 ou 12 dígitos), documento já formatado com pontuação/traço/barra normaliza corretamente antes de validar.
+
+- [ ] **Task 2 — Aplicar no `/register` (AC: 1, 2)**
+  - [ ] `apps/api/app/modules/auth/schemas.py::RegisterRequest` (campo `document`, linha ~19): adicionar `@field_validator("document")` chamando `validate_document`, seguindo o MESMO padrão já usado no mesmo arquivo para `valid_slug` (linha ~25-33) e `normalize_email` (linha ~35-38). Pydantic converte `ValueError` do validator automaticamente em 422.
+
+- [ ] **Task 3 — Aplicar no cadastro/convite de usuário (funcionário e dono) (AC: 1, 2)**
+  - [ ] `apps/api/app/modules/platform/schemas.py::CreateStaffRequest.document` (campo próprio, linha ~69, hoje só `Field(min_length=11, max_length=18)` sem validação de DV): adicionar o mesmo `@field_validator("document")`.
+  - [ ] `CreateAccountRequest` herda de `RegisterRequest` (linha ~11) — já coberto pela Task 2, apenas confirmar em teste que o validator herdado dispara.
+
+- [ ] **Task 4 — Aplicar na criação de cliente do CRM (AC: 1, 2)**
+  - [ ] `apps/api/app/modules/crm/schemas.py` — campo `document: str | None` é OPCIONAL em pelo menos 3 pontos (linhas ~49, ~101, ~125: criação/update/out). Adicionar `@field_validator("document")` que só valida quando o valor não é `None`/vazio (não tornar obrigatório — mudança de obrigatoriedade não está no escopo desta AC).
+
+- [ ] **Task 5 — Aplicar no KYC/assinatura pública de contrato (AC: 1, 2)**
+  - [ ] `apps/api/app/modules/contracts/schemas.py` — `signer_document` (linha ~75, hoje `Field(min_length=3, max_length=32)`, usado no endpoint público de assinatura sem login) — ajustar `Field` e adicionar o mesmo validator. Esse é o único ponto de KYC citado na AC1; conferir `apps/api/app/modules/contracts/service.py` (função de assinatura pública, ~linha 304-327) para garantir que o documento normalizado (só dígitos) é o que fica gravado em `c.signer_document`.
+
+- [ ] **Task 6 — Unicidade de `document` por tenant (AC: 3)**
+  - [ ] `apps/api/app/modules/auth/models.py::User.document` (linha ~23, hoje `String(18) nullable=False` sem constraint de unicidade): criar nova migration em `apps/api/migrations/versions/0030_*.py` (última existente é `0029_user_invite_fields.py`) adicionando `UNIQUE(tenant_id, document)` — **composto**, nunca `document` sozinho, porque `users` é tabela GLOBAL sem RLS (múltiplos tenants podem legitimamente ter o mesmo CPF em teoria, mas dentro do MESMO tenant owner+funcionários não devem duplicar documento).
+  - [ ] Tratar a nova `IntegrityError` como 409 no endpoint de convite/registro, no mesmo padrão já usado para e-mail duplicado no `/register` (ver CLAUDE.md §6.0 "Já corrigidos na fundação: IntegrityError→409 no register (race)").
+  - [ ] **[AUTO-DECISION]** Não adicionar constraint de unicidade em `crm.Client.document` nesta story → decisão de produto sobre dedup de cliente permanece EM ABERTO, exatamente como a AC3 do epic prevê ("respeitando a decisão de produto pendente sobre dedup de cliente") e como já documentado em CLAUDE.md §6.1 ("Unicidade de e-mail de cliente: ... decisão de produto — confirmar se deve deduplicar" — mesma dívida se estende a `document`). Documentar essa decisão explicitamente no PR/Dev Agent Record.
+  - [ ] **Risco identificado (não quebrar o tenant interno "platform"):** o tenant interno `platform` é semeado por `apps/api/app/seed.py` com `document="00000000000"` (sentinela, não é CPF/CNPJ real) — construído via ORM direto, não passa pelo `RegisterRequest`, então NÃO é afetado pela validação de schema. Confirmar que a nova validação (Task 1-5) vive só na camada Pydantic (schemas), e que a nova `UNIQUE(tenant_id, document)` (Task 6) não vira um `CHECK` de formato no banco — senão quebra o seed interno.
+
+- [ ] **Task 7 — Atualizar fixtures de teste com documentos fake inválidos (AC: 1, 2, todas as ACs indiretamente)**
+  - [ ] **Risco identificado nos testes existentes:** os seguintes arquivos usam documentos fake que NÃO têm dígito verificador válido e vão passar a falhar com 422 assim que a validação real entrar:
+    - `apps/api/tests/test_platform.py:6` e `:39` — `"document": "12345678000190"` (CNPJ, DV a confirmar/provavelmente inválido).
+    - `apps/api/tests/test_platform.py:152` — `"document": "11122233344"` (CPF, DV inválido).
+    - `apps/api/tests/test_platform.py:15`, `apps/api/tests/test_wallet.py:145,214` — `Tenant(document="00000000000")` para o tenant `platform` interno de teste (sequência repetida, sempre inválida como CPF).
+    - `apps/api/tests/test_wallet.py:12` — `"document": "44555666000133"` (CNPJ, DV a confirmar).
+  - [ ] Trocar esses valores por CPF/CNPJ de teste com DV **realmente válido** (gerar programaticamente com o próprio `validate_cpf`/`validate_cnpj` novo, ou usar um exemplo publicamente conhecido como válido, ex. CPF `529.982.247-25` — sempre CONFERIR contra o validador antes de commitar, não assumir).
+  - [ ] Para os casos de `Tenant(document="00000000000")` do tenant interno de teste `platform`: como esse objeto é criado via ORM direto nos testes (não via `RegisterRequest`), não é obrigatoriamente afetado pela validação Pydantic — mas revisar se algum teste futuro passa a validar `Tenant.document` também, e nesse caso usar um CPF/CNPJ de teste válido em vez do sentinela.
+  - [ ] Rodar toda a suíte `apps/api/tests/test_auth.py`, `test_platform.py`, `test_contracts.py`, `test_crm.py`, `test_wallet.py` e confirmar 100% verde.
+
+- [ ] **Task 8 — Checklist de qualidade (AC: todas)**
+  - [ ] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — ver CLAUDE.md §5, obrigatório antes de considerar a story concluída.
+  - [ ] Validar manualmente (não há e2e automatizado — ver Dev Notes/Testing) que o fluxo de convite de funcionário e a assinatura pública de contrato continuam funcionando ponta-a-ponta no Docker com Postgres real.
+
+## Dev Notes
+
+### Contexto do sistema (fonte: CLAUDE.md / epic)
+- e1p é multi-tenant com isolamento **exclusivamente via RLS** no Postgres; a app conecta como papel non-superuser `e1p_app`. Regra de Ouro nº 1: nunca adicionar filtro manual de tenant redundante — a RLS é a única garantia. [Source: CLAUDE.md#3]
+- Dívida técnica catalogada explicitamente: "Validação de CPF/CNPJ: hoje só valida tamanho; falta dígito verificador + normalização + unicidade por tenant." [Source: CLAUDE.md#6.1]
+- Mesma dívida se repete na seção de pendências do CRM: "Validação de CPF (`document`): reutiliza a dívida global (sem dígito verificador)." [Source: CLAUDE.md#6.1]
+- Testes unitários do backend rodam em **SQLite**, não exercitam RLS real; isolamento cross-tenant é validado manualmente via Docker/Postgres real (não há e2e automatizado no CI ainda). [Source: CLAUDE.md#6.1 "Teste de isolamento cross-tenant"]
+
+### Arquivos e padrões relevantes (verificado diretamente no código, não apenas nos docs)
+- Padrão de `@field_validator` para normalização/validação de campo já existe e deve ser seguido: `apps/api/app/modules/auth/schemas.py` (`valid_slug`, `normalize_email` na classe `RegisterRequest`).
+- Pontos exatos onde `document`/`signer_document` aparecem hoje (todos SEM validação de dígito verificador):
+  - `apps/api/app/modules/auth/schemas.py:19` — `RegisterRequest.document` (`Field(min_length=11, max_length=18)`).
+  - `apps/api/app/modules/auth/models.py:23` — `User.document: String(18) nullable=False`.
+  - `apps/api/app/modules/platform/schemas.py:69` — `CreateStaffRequest.document` (`Field(min_length=11, max_length=18)`).
+  - `apps/api/app/modules/crm/models.py:58` e `apps/api/app/modules/crm/schemas.py:49,101,125` — `Client.document` opcional (`String(18) | None`).
+  - `apps/api/app/modules/contracts/schemas.py:75` — `signer_document: Field(min_length=3, max_length=32)` (KYC de assinatura pública).
+  - `apps/api/app/modules/contracts/models.py:47` — `Contract.signer_document: String(32) default=""`.
+- Núcleo utilitário (`apps/api/app/core/`) hoje tem `ai.py, anonymizer.py, audit.py, boleto.py, email.py, events.py, extract.py, recurrence.py, security.py, tenancy.py, whatsapp.py` — **não existe `validators.py` ainda**; criar seguindo essa mesma convenção de módulo.
+- Última migration existente: `apps/api/migrations/versions/0029_user_invite_fields.py` → a nova migration desta story deve ser `0030_*`.
+- Padrão de tratamento de erro de unicidade já validado no projeto: `IntegrityError` → 409 no `/register` para e-mail duplicado (race condition). [Source: CLAUDE.md#6.0 "Já corrigidos na fundação"]
+
+### File Locations (novos/alterados)
+- NOVO: `apps/api/app/core/validators.py`
+- NOVO: `apps/api/tests/test_validators.py`
+- NOVO: `apps/api/migrations/versions/0030_document_unique_constraint.py` (nome sugerido)
+- ALTERAR: `apps/api/app/modules/auth/schemas.py`, `apps/api/app/modules/platform/schemas.py`, `apps/api/app/modules/crm/schemas.py`, `apps/api/app/modules/contracts/schemas.py`
+- ALTERAR (se necessário para normalizar antes de persistir): `apps/api/app/modules/contracts/service.py`
+
+### Technical Constraints
+- Idioma de mensagens de erro voltadas ao usuário: PT-BR (convenção do produto). [Source: CLAUDE.md#8]
+- Nenhuma query de aplicação deve filtrar tenant manualmente — a nova constraint de unicidade deve ser `UNIQUE(tenant_id, document)`, nunca `UNIQUE(document)` sozinho, para não violar a Regra de Ouro nº 1 nem quebrar o design de `users` como tabela global sem RLS. [Source: docs/prd/epic-1-seguranca-compliance.md + CLAUDE.md#3]
+- Não introduzir validação de CPF/CNPJ como `CHECK` constraint de banco (quebraria o seed do tenant interno `platform`, que usa um documento sentinela não-válido) — validar apenas na camada de schema Pydantic dos endpoints públicos/administrativos.
+
+### Testing
+- Framework backend: `pytest` (`apps/api/tests`, banco SQLite em teste — RLS não é exercitada em unit test).
+- Testes novos obrigatórios: `apps/api/tests/test_validators.py` (validação pura, sem I/O).
+- Testes existentes que DEVEM continuar passando após a mudança (ver Task 7 para os fixtures que precisam de CPF/CNPJ válido): `test_auth.py`, `test_platform.py`, `test_contracts.py`, `test_crm.py`, `test_wallet.py`.
+- Validação manual e2e (Postgres real, Docker) exigida pela IV2 (RLS/cross-tenant): não há suíte automatizada de e2e no repositório hoje — seguir o procedimento manual descrito em CLAUDE.md §9 ("Como rodar local") e validar que o convite/KYC funcionam ponta-a-ponta com documento real válido, e que a nova constraint de unicidade não vaza entre tenants.
+- Nenhuma orientação técnica específica encontrada nos docs disponíveis sobre métricas/threshold formal de performance para IV3 — tratar como "sem regressão perceptível" qualitativa (validador é O(1), não deve introduzir I/O extra).
+
+## Change Log
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
+| 2026-07-10 | 0.1.1 | Validated GO (9/10) — Status: Draft → Ready | @po |
+
+## Dev Agent Record
+
+### Agent Model Used
+_(a preencher pelo @dev)_
+
+### Debug Log References
+_(a preencher pelo @dev)_
+
+### Completion Notes List
+_(a preencher pelo @dev)_
+
+### File List
+_(a preencher pelo @dev)_
+
+## QA Results
+_(a preencher pelo @qa)_

--- a/docs/stories/1.2.story.md
+++ b/docs/stories/1.2.story.md
@@ -1,0 +1,144 @@
+# Story 1.2: Hardening de acesso à tabela global `users` + log de exclusão (LGPD)
+
+## Status
+Ready
+
+## Executor Assignment
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual security review", "validação manual e2e no Postgres real (docker compose)"]
+```
+> [AUTO-DECISION] Mesmo raciocínio da Story 1.1: story é lógica de auditoria de código + hardening de backend, sem mudança de infraestrutura → executor=@dev, quality_gate=@architect.
+
+## Story
+**As a** operador da plataforma responsável por dados de clientes,
+**I want** garantir que nenhum módulo de negócio acesse `users` sem escopo de tenant e que exclusões de conta deixem rastro,
+**so that** não haja vazamento cross-tenant e a plataforma cumpra a LGPD mesmo em operações destrutivas.
+
+## Acceptance Criteria
+1. Auditoria do código confirma que nenhum módulo de negócio consulta `users` via `get_db` sem filtro de tenant; qualquer caso encontrado é corrigido (ou coberto por guarda explícita).
+2. A exclusão de conta grava um **log de plataforma fora do tenant** (não purgado com os `audit_entries` do tenant), registrando quem/quando/qual tenant.
+3. O comportamento de purga atômica dinâmica existente é preservado (sem conta-zumbi).
+
+### Integration Verification
+- IV1: Delete de conta continua atômico e purga todas as tabelas de negócio do tenant (teste existente passa).
+- IV2: Isolamento cross-tenant permanece (e2e no Postgres real: João não vê dados da Maria).
+- IV3: O log de plataforma sobrevive à exclusão do tenant.
+
+## 🤖 CodeRabbit Integration
+
+> **CodeRabbit Integration**: Disabled
+>
+> Este projeto (e1p, brownfield sem `.aiox-core` próprio) não tem `coderabbit_integration.enabled` configurado localmente. Tratado como `false` por instrução explícita do orquestrador desta missão.
+> Quality validation will use manual review process only (ver `quality_gate_tools` acima e `scripts/check.sh`).
+> To enable, set `coderabbit_integration.enabled: true` em um `core-config.yaml` próprio do projeto.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Auditoria formal de acesso a `users` via `get_db` (AC: 1)**
+  - [ ] Confirmar (e documentar no Dev Agent Record) o levantamento já feito nesta story — todo arquivo em `apps/api/app/modules/**` e `apps/api/app/core/**` que importa `get_db` de `app.db.session`:
+    - `apps/api/app/modules/auth/router.py` — LEGÍTIMO: é o próprio módulo de autenticação (register/login/forgot-password/reset-password/change-password), inerentemente global sobre `users` por design. Não é "módulo de negócio".
+    - `apps/api/app/modules/platform/router.py` — LEGÍTIMO: é o módulo do Super Admin (Master); toda rota é protegida por `Depends(require_platform_admin)`, propositalmente cross-tenant sobre `users`/`tenants`.
+    - `apps/api/app/modules/contracts/router.py:145,157` — usa `get_db` só nas rotas `public_view`/assinatura pública (sem login) para ler `published_contracts` (snapshot GLOBAL sem RLS) — **NÃO toca `users`**.
+    - `apps/api/app/modules/pages/router.py:130` — idem, `public_view` lê `published_pages` — **NÃO toca `users`**.
+    - `apps/api/app/modules/quotes/router.py:161,173` — idem, aceite público de proposta lê `published_proposals` — **NÃO toca `users`**.
+    - `apps/api/app/modules/wallet/router.py:86,94,103` — protegidas por `Depends(require_platform_admin)` (`_admin`), consultam `platform_earnings` (agregado global) — **NÃO toca `users`** e já é guardado.
+    - `apps/api/app/core/tenancy.py` — a própria dependência de resolução de tenant/usuário atual (`get_current_user`) precisa consultar `users` globalmente a partir do claim do JWT (é o mecanismo, não um módulo de negócio).
+  - [ ] Nenhum módulo de negócio "comum" (agenda, crm, receivables, payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings, cockpit) usa `get_db` hoje — todos usam `get_tenant_db` (RLS). Confirmar isso permanece true rodando um grep de auditoria (`grep -rln "get_db" apps/api/app/modules/`) e comparando com esta lista.
+  - [ ] Adicionar comentário/docstring explícito nos poucos usos legítimos acima (contracts/pages/quotes `public_view`, wallet admin routes) explicando POR QUE é seguro (não toca `users`, ou é protegido por `require_platform_admin`) — cumpre a exigência de "guarda explícita" da AC1.
+  - [ ] Criar um teste de regressão estático simples (novo arquivo `apps/api/tests/test_tenancy_guard.py`) que varre `apps/api/app/modules/**/router.py` e falha se algum arquivo fora da allowlist (auth, platform, e as rotas públicas específicas já mapeadas) importar `get_db` — protege contra regressão futura sem exigir ferramenta externa de lint.
+
+- [ ] **Task 2 — Criar o modelo de log de plataforma (fora do tenant) (AC: 2, 3)**
+  - [ ] Adicionar `PlatformAuditEntry` em `apps/api/app/core/audit.py` (mesmo arquivo do `AuditEntry` já existente, mesma convenção de módulo) — **deliberadamente `Base` + `TimestampMixin`, SEM `TenantMixin`**, para que `_business_table_names()` (`apps/api/app/modules/platform/service.py`, descoberta dinâmica via `issubclass(mapper.class_, TenantMixin)`) NUNCA a inclua na purga por tenant.
+  - [ ] Campos sugeridos: `id`, `actor_user_id: str`, `actor_email: str` (snapshot — o ator é sempre o Master, que não é apagado), `target_tenant_id: str`, `target_tenant_slug: str` (snapshot — o tenant será apagado, não dá pra fazer FK/join depois), `action: str` (ex.: `"account_deleted"`), `created_at` (via `TimestampMixin`).
+  - [ ] Nova migration em `apps/api/migrations/versions/` — usar o próximo número livre após a última migration existente (`0029_user_invite_fields.py`; se a Story 1.1 já tiver criado `0030_*`, esta deve ser `0031_*` — **coordenar numeração sequencial com a Story 1.1 antes de gerar o arquivo**, alembic é sequencial por `down_revision`).
+
+- [ ] **Task 3 — Capturar o ator e o snapshot do tenant antes da purga (AC: 2)**
+  - [ ] `apps/api/app/modules/platform/service.py::delete_account` hoje tem assinatura `delete_account(db: Session, tenant_id: str) -> None` e não recebe quem está executando a ação. Alterar para `delete_account(db: Session, tenant_id: str, actor: User) -> None`.
+  - [ ] `apps/api/app/modules/platform/router.py` (rota `DELETE /accounts/{tenant_id}`, linhas ~151-160): hoje o admin autenticado vem como `_admin: CurrentUser = Depends(require_platform_admin)` e é ignorado (prefixo `_`); passar esse `_admin` (renomear para `admin`) para `service.delete_account(db, tenant_id, admin)`.
+  - [ ] Antes de qualquer `DELETE` dentro de `delete_account`, capturar `tenant.slug`/`tenant.legal_name` (o objeto `Tenant` já é buscado no início da função para o guard 404 — reaproveitar) para usar no log, já que depois do `DELETE FROM tenants` essa informação some.
+
+- [ ] **Task 4 — Gravar o log de plataforma de forma que sobreviva à purga (AC: 2, 3)**
+  - [ ] A purga de negócio roda dentro de `with tenant_session(tenant_id) as tdb:` (que abre uma conexão dedicada com o GUC `app.current_tenant_id` setado para o tenant SENDO APAGADO — ver CLAUDE.md §3, nota sobre `tenant_session` e conexão dedicada). O log de plataforma NÃO deve ser gravado nessa sessão (seria uma escrita com RLS do tenant que está sumindo, e é logicamente "fora do tenant").
+  - [ ] **[AUTO-DECISION]** Gravar o `PlatformAuditEntry` na sessão GLOBAL `db` (a mesma recebida pelo endpoint via `Depends(get_db)`), **DEPOIS** que o bloco `with tenant_session(tenant_id) as tdb:` sair sem exceção (ou seja, depois que a purga já commitou com sucesso), e então dar `db.commit()` na sessão global antes de retornar. Reason: a AC2 pede rastro da exclusão que de fato aconteceu — logar uma tentativa que falhou no meio geraria um registro de "conta excluída" para algo que não ocorreu de fato, pior para fins de auditoria/LGPD do que o risco (raro) de falha entre os dois commits. Documentar essa limitação de atomicidade cross-sessão no Dev Agent Record (é uma escolha consciente, não um bug).
+  - [ ] Confirmar manualmente (ou via teste, ver Task 5) que a linha em `platform_audit_entries` (ou nome escolhido para a tabela) continua existindo depois que `tenants`/`users`/tabelas de negócio do tenant já foram apagadas — IV3.
+
+- [ ] **Task 5 — Testes de regressão para `delete_account` (AC: 3; IV1, IV3)**
+  - [ ] **Risco identificado:** hoje **não existe nenhum teste automatizado** cobrindo `DELETE /admin/accounts/{tenant_id}` em `apps/api/tests/test_platform.py` (nem em nenhum outro arquivo de teste) — apesar de CLAUDE.md descrever esse fluxo como "já corrigido"/"validado e2e". A validação existente foi manual (Docker + Postgres real), não há regressão automatizada em CI. Esta story deve criar esse teste ANTES de alterar `delete_account`, para ter uma baseline confiável.
+  - [ ] Novo(s) teste(s) em `apps/api/tests/test_platform.py` (ou novo arquivo `test_platform_delete.py`) cobrindo:
+    - Criar uma conta (tenant + owner) com dados em pelo menos 2 módulos de negócio diferentes (ex.: um `Client` do CRM e um `AgendaEvent`); excluir via `DELETE /admin/accounts/{tenant_id}`; confirmar que as tabelas de negócio desse tenant ficam vazias (purga funcionou).
+    - Confirmar bloqueio (400) ao tentar excluir um tenant que contém um `is_platform_admin`.
+    - Confirmar 404 ao excluir tenant inexistente.
+    - Confirmar que a exclusão cria uma linha em `PlatformAuditEntry` com o `target_tenant_id`/`slug` corretos e o `actor_user_id` do Master que executou.
+    - Confirmar que essa linha de log **continua consultável** depois do delete (a tabela não tem FK/cascata para `tenants`, é independente) — cobre IV3.
+
+- [ ] **Task 6 — Validação manual de isolamento cross-tenant (IV2)**
+  - [ ] Não há e2e automatizado no repositório (RLS só é exercitada com Postgres real — ver CLAUDE.md §6.1 "Teste de isolamento cross-tenant"). Validar manualmente via Docker (`docker compose -f infra/docker-compose.yml up -d --build`) que, após as mudanças desta story, um usuário de um tenant continua sem conseguir ver dados de outro tenant (cenário "João não vê dados da Maria", já citado como baseline no epic e em CLAUDE.md §3).
+
+- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [ ] Rodar `bash scripts/check.sh` (lint + testes) — CLAUDE.md §5.
+
+## Dev Notes
+
+### Previous Story Insights (Story 1.1)
+- Story 1.1 também adiciona uma migration nova (sugerida como `0030_*`) em `apps/api/migrations/versions/`. Como as migrations do Alembic são sequenciais (`down_revision`), confirmar a ordem real de merge antes de numerar a migration desta story — não assumir `0031` cegamente.
+- Story 1.1 mexe em `apps/api/app/modules/auth/models.py` (constraint em `User.document`) — sem sobreposição direta com esta story, mas ambas tocam o módulo `auth`/`platform`; revisar conflitos de migration/merge ao final.
+
+### Contexto do sistema (fonte: CLAUDE.md / epic)
+- `users` é uma tabela GLOBAL, **sem RLS** (login por e-mail é global) — é a única tabela de negócio/identidade que foge da regra "toda tabela de negócio tem `tenant_id` + RLS". [Source: docs/prd/epic-1-seguranca-compliance.md — "Contexto do sistema existente"]
+- Regra de Ouro nº 1 (isolamento de tenant é sagrado, via RLS) continua valendo — o hardening desta story é sobre o único ponto de exceção conhecido e documentado (`users`). [Source: CLAUDE.md#3]
+- O delete de conta hoje já é "ATÔMICO (transação única, sem conta-zumbi)" e a purga de tabelas é "dinâmica" (descobre subclasses de `TenantMixin`) — comportamento EXISTENTE que esta story deve preservar, não redesenhar. [Source: CLAUDE.md#6.1 "Já corrigidos no Super Admin"]
+- Dívida explicitamente listada: "Log de exclusão (LGPD): o delete de conta purga também `audit_entries` do tenant — não sobra registro da própria exclusão. Criar um log de plataforma (fora do tenant) da operação destrutiva." [Source: CLAUDE.md#6.1 "Super Admin — pendências"]
+- Nota de arquitetura sobre `tenant_session`: o GUC do tenant é setado em escopo de SESSÃO (`set_config(..., false)`), a sessão prende-se a UMA conexão dedicada por request/operação, e reseta o GUC no `finally` — relevante para decidir onde a nova escrita de log (fora do tenant) deve acontecer. [Source: CLAUDE.md#3, nota de rodapé sobre `tenant_session`]
+
+### Arquivos e padrões relevantes (verificado diretamente no código)
+- `apps/api/app/modules/platform/service.py`:
+  - `_business_table_names()` (linha ~27-37): descobre tabelas de negócio dinamicamente via `issubclass(mapper.class_, TenantMixin)` — a nova tabela de log de plataforma DEVE ficar fora dessa descoberta (não herdar `TenantMixin`).
+  - `delete_account(db, tenant_id)` (linha ~136-158): purga dentro de `with tenant_session(tenant_id) as tdb:`; deleta `users WHERE tenant_id = :tid` e depois `tenants WHERE id = :tid`, tudo na mesma transação dedicada.
+- `apps/api/app/core/audit.py`: já existe `AuditEntry(Base, TenantMixin, TimestampMixin)` com `actor`, `is_ai`, `action`, `target` — modelo de referência direta para o novo `PlatformAuditEntry` (mesmo arquivo, mesma convenção, MENOS o `TenantMixin`).
+- `apps/api/app/modules/platform/router.py` (linhas ~151-160): rota `DELETE /accounts/{tenant_id}`, hoje `_admin: CurrentUser = Depends(require_platform_admin)` não é repassado ao service.
+- Última migration existente: `apps/api/migrations/versions/0029_user_invite_fields.py`.
+- Testes unitários rodam em SQLite (`apps/api/tests/conftest.py`), não exercitam RLS real de verdade — confirmar isolamento cross-tenant apenas manualmente no Postgres (Docker).
+
+### File Locations (novos/alterados)
+- ALTERAR: `apps/api/app/core/audit.py` (novo modelo `PlatformAuditEntry`)
+- ALTERAR: `apps/api/app/modules/platform/service.py` (`delete_account`, nova assinatura + gravação de log)
+- ALTERAR: `apps/api/app/modules/platform/router.py` (repassar `admin` autenticado)
+- NOVO: `apps/api/migrations/versions/00XX_platform_audit_entries.py`
+- NOVO: `apps/api/tests/test_tenancy_guard.py` (Task 1)
+- ALTERAR/NOVO: `apps/api/tests/test_platform.py` ou `apps/api/tests/test_platform_delete.py` (Task 5)
+
+### Technical Constraints
+- A nova tabela de log de plataforma NÃO pode herdar `TenantMixin` (senão vira "tabela de negócio" e é purgada junto com o tenant — o oposto do que a AC2 pede).
+- Não redesenhar a purga dinâmica existente (AC3 exige preservar o comportamento, não substituí-lo).
+- `users`/`tenants` continuam sendo tabelas globais sem RLS por design deste projeto — esta story não adiciona RLS a `users` (fora de escopo; o hardening é sobre acesso via código, não sobre política de banco).
+
+### Testing
+- Framework backend: `pytest` (`apps/api/tests`, SQLite em teste).
+- **Gap identificado**: não existe hoje teste automatizado para `DELETE /admin/accounts/{tenant_id}` — criar como parte desta story (Task 5), antes de alterar o comportamento, para servir de baseline de regressão (IV1).
+- Teste estático de guarda de `get_db` (Task 1) é uma novidade nesta story — não há precedente exato no repo, mas segue o espírito dos testes de config já existentes (`test_config.py`, que também valida invariantes de segurança via asserção direta, sem mocks).
+- Validação manual e2e cross-tenant (IV2): sem suíte automatizada — seguir CLAUDE.md §9 ("Como rodar local").
+
+## Change Log
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
+| 2026-07-10 | 0.1.1 | Validated GO (9/10) — Status: Draft → Ready | @po |
+
+## Dev Agent Record
+
+### Agent Model Used
+_(a preencher pelo @dev)_
+
+### Debug Log References
+_(a preencher pelo @dev)_
+
+### Completion Notes List
+_(a preencher pelo @dev)_
+
+### File List
+_(a preencher pelo @dev)_
+
+## QA Results
+_(a preencher pelo @qa)_

--- a/docs/stories/1.3.story.md
+++ b/docs/stories/1.3.story.md
@@ -1,0 +1,135 @@
+# Story 1.3: Idle timeout LGPD (30 min)
+
+## Status
+Ready
+
+## Executor Assignment
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "vitest (apps/web)", "manual security review", "validação manual e2e no Postgres real (docker compose)"]
+```
+> [AUTO-DECISION] Story é full-stack (backend: mecanismo de expiração/atividade; frontend: `ProtectedLayout`) mas a natureza é lógica de autenticação/segurança, não design visual → executor=@dev, quality_gate=@architect. (reason: mesmo critério das Stories 1.1/1.2; não há trabalho de UI/UX novo, é hardening de sessão.)
+
+## Story
+**As a** usuário logado no e1p,
+**I want** ser deslogado após 30 minutos de inatividade,
+**so that** sessões esquecidas não fiquem abertas, cumprindo a LGPD.
+
+## Acceptance Criteria
+1. Tracking de atividade / refresh token curto implementado; após 30 min sem atividade, a sessão é encerrada e o usuário é levado ao login.
+2. O frontend (`ProtectedLayout`) trata o timeout com aviso e logout limpo; a experiência não quebra fluxos ativos legítimos.
+3. A solução não afrouxa a segurança do JWT atual (7 dias) para os demais casos.
+
+### Integration Verification
+- IV1: Login/logout e rotas protegidas continuam funcionando (testes de auth passam).
+- IV2: Não há impacto em endpoints públicos (propostas/contratos/páginas) que não exigem login.
+- IV3: Sem regressão de performance no fluxo de refresh.
+
+## 🤖 CodeRabbit Integration
+
+> **CodeRabbit Integration**: Disabled
+>
+> Este projeto (e1p, brownfield sem `.aiox-core` próprio) não tem `coderabbit_integration.enabled` configurado localmente. Tratado como `false` por instrução explícita do orquestrador desta missão.
+> Quality validation will use manual review process only (ver `quality_gate_tools` acima e `scripts/check.sh`).
+> To enable, set `coderabbit_integration.enabled: true` em um `core-config.yaml` próprio do projeto.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Decisão de arquitetura para o mecanismo de idle timeout (AC: 1, 3)**
+  - [ ] **Esta story tem uma decisão de design em aberto que NÃO está resolvida nem no epic nem em CLAUDE.md** (ver Dev Notes → "Gap técnico identificado"). Antes de codar, o @dev deve escolher e documentar (no Dev Agent Record) uma das abordagens abaixo — ou outra equivalente — respeitando a AC3 (não afrouxar os 7 dias do JWT "para os demais casos"):
+    - **Opção A — sliding refresh token curto** (mais alinhada à redação literal da AC1, "refresh token curto"): criar um `POST /auth/refresh` novo (não existe hoje) que emite um novo access token de vida curta a partir de um refresh token; o refresh token só é aceito se a última atividade foi há menos de `session_idle_timeout_minutes` (30); o frontend chama `/auth/refresh` periodicamente enquanto há atividade do usuário; se o refresh falhar (idle estourado), desloga.
+    - **Opção B — tabela de sessão ativa server-side**: nova tabela (ex. `active_sessions`, chaveada por `user_id`/`jti` do JWT) atualizada a cada request autenticado com `last_activity_at`; uma dependency check (ex. em `get_current_user`) rejeita (401) requests cujo `last_activity_at` já passou de 30 min, mesmo com o JWT de 7 dias ainda tecnicamente válido.
+  - [ ] Qualquer que seja a opção, o JWT_SECRET/algoritmo/`jwt_expire_minutes=10080` (7 dias) usados hoje por `apps/api/app/core/security.py::create_access_token` **não devem ser reduzidos globalmente** — a AC3 pede que o idle timeout seja uma camada ADICIONAL, não uma troca do prazo de expiração do JWT em si (que continua valendo para os "demais casos" — ex. tokens de reset de senha usam mecanismo próprio via `hash_token`/sha256, não são afetados).
+
+- [ ] **Task 2 — Implementar o mecanismo de atividade/expiração no backend (AC: 1, 3)**
+  - [ ] Usar o config já existente `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`, hoje definido como `30  # LGPD` mas **NÃO referenciado em lugar nenhum do código** — é dead config, este é o ponto de entrada natural).
+  - [ ] Implementar a abordagem escolhida na Task 1 dentro de `apps/api/app/core/security.py` (primitivas) e `apps/api/app/core/tenancy.py::get_current_user`/nova dependency (ponto único onde toda rota autenticada já passa — ver Dev Notes para o fluxo exato hoje).
+  - [ ] Se a opção escolhida envolve nova tabela: nova migration em `apps/api/migrations/versions/` (coordenar numeração com Stories 1.1/1.2, que também adicionam migrations nesta mesma sequência de epic).
+  - [ ] Garantir que rotas PÚBLICAS (assinatura de contrato, aceite de proposta, página pública) continuam funcionando sem exigir sessão/atividade — elas já não usam `get_current_user`/`get_tenant_db` (usam `get_db` direto, ver Story 1.2 Task 1), então não devem ser afetadas por este mecanismo. Confirmar explicitamente com teste (IV2).
+
+- [ ] **Task 3 — Frontend: `ProtectedLayout` trata o timeout (AC: 2)**
+  - [ ] `apps/web/src/app/App.tsx`, função `ProtectedLayout` (linhas ~84-96): hoje só verifica `isAuthenticated`/`must_reset_password`. Adicionar o tracking de atividade (eventos de mouse/teclado/click/scroll) com um timer de 30 min (mesmo valor do backend — idealmente expor `session_idle_timeout_minutes` para o frontend via `/me` ou config pública, para não hardcodar o número duas vezes).
+  - [ ] Ao estourar o idle: mostrar um aviso (ex. toast/modal — usar padrão de UI já existente no design "Portal") e então chamar `logout()` (já existe em `apps/web/src/store/auth.tsx`, limpa `localStorage` e state) — o próprio `AuthProvider` já redireciona pro `/login` quando `isAuthenticated` vira `false` via `ProtectedLayout`/`LoginRoute`, então basta chamar `logout()` corretamente.
+  - [ ] Reaproveitar o padrão já existente de logout automático em 401: `apps/web/src/store/auth.tsx` linhas ~58-68 já intercepta respostas 401 da API e desloga — se a Opção A/B do backend passar a devolver 401 quando a sessão expira por inatividade, esse interceptor JÁ cobre parte do fluxo; a Task 3 deve then focar em: (a) o AVISO amigável antes/no momento do logout (a AC pede "aviso", o interceptor sozinho não avisa, só desloga), e (b) o timer local para não depender só de uma request falhar para perceber o timeout.
+  - [ ] Não quebrar fluxos ativos legítimos (AC2): qualquer interação do usuário (não só requests à API) deve resetar o timer — cobrir digitação em formulários longos (ex. editor de contrato, editor de funil) mesmo que o usuário não dispare uma request por alguns minutos.
+
+- [ ] **Task 4 — Testes de regressão de auth (AC: 1, 2, 3; IV1)**
+  - [ ] Rodar/estender `apps/api/tests/test_auth.py` para cobrir: login/logout continuam funcionando; rota protegida ainda aceita token dentro da janela de atividade; rota protegida rejeita quando a "última atividade" simulada excede 30 min (ajustar `settings.session_idle_timeout_minutes` no teste para um valor pequeno, evitar testes lentos).
+  - [ ] Confirmar que o teste de guarda de configuração (`apps/api/tests/test_config.py`) não precisa mudar (idle timeout é comportamento de runtime, não de boot) — se a abordagem escolhida adicionar novo campo de config, avaliar se merece guard semelhante.
+
+- [ ] **Task 5 — Validar não-impacto em endpoints públicos (AC: 2; IV2)**
+  - [ ] Testar manualmente/via `apps/api/tests/test_contracts.py`, `test_quotes.py`(?), `test_pages.py` que os fluxos públicos (assinatura de contrato, aceite de proposta, visualização de página) continuam funcionando sem exigir login/atividade — eles não passam por `get_current_user`.
+
+- [ ] **Task 6 — Validar performance do fluxo de refresh (AC: todas; IV3)**
+  - [ ] Se a Opção A (refresh token) for escolhida: confirmar que o novo `/auth/refresh` é leve (uma consulta simples, sem N+1) e que o polling do frontend não gera carga desnecessária na API (ex.: só chamar refresh quando há atividade real, não em intervalo fixo agressivo).
+  - [ ] Se a Opção B (sessão server-side) for escolhida: confirmar que a escrita de `last_activity_at` a cada request não gera contenção/lock desnecessário (ex.: usar `UPDATE` simples por PK, sem lock de linha compartilhado entre requests concorrentes do mesmo usuário além do necessário).
+
+- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [ ] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — CLAUDE.md §5.
+
+## Dev Notes
+
+### Previous Story Insights (Stories 1.1 / 1.2)
+- Ambas as stories anteriores também adicionam migrations novas em `apps/api/migrations/versions/` — se esta story precisar de uma nova tabela (Opção B da Task 1), coordenar a numeração sequencial (Alembic é linear via `down_revision`) com o que já foi mergeado.
+- Padrão de `IntegrityError`→409 e de guardas explícitas (Story 1.2) reforça a convenção de segurança "fail-closed" do projeto — aplicar o mesmo espírito aqui: se o mecanismo de idle timeout falhar/estiver mal configurado, o comportamento default deve ser DESLOGAR (fail-closed), nunca manter a sessão aberta silenciosamente.
+
+### Gap técnico identificado (não inventar — decisão de arquitetura em aberto)
+- Nem o epic nem o CLAUDE.md especificam O MECANISMO exato de "tracking de atividade / refresh token curto" — apenas o comportamento externo desejado (30 min, LGPD) e a restrição (não afrouxar o JWT de 7 dias "para os demais casos"). Esta ambiguidade é real e deve ser resolvida pelo @dev/@architect na Task 1, documentando a escolha — **não é uma lacuna desta story, é uma decisão de implementação explicitamente delegada pelo epic** ("Tracking de atividade / refresh token curto implementado" deixa a forma exata em aberto).
+- Confirmado por inspeção de código (não é invenção): hoje NÃO existe nenhum endpoint `/auth/refresh`, nenhuma tabela de sessão/atividade, e `get_current_user` (`apps/api/app/core/tenancy.py:31-43`) é **100% stateless** — só decodifica o JWT, sem nenhuma consulta ao banco (exceto em `require_platform_admin`, que revalida `is_active`/`is_platform_admin` a cada request). Isso significa que hoje NADA detecta inatividade — o JWT vale os 7 dias inteiros independente de uso.
+- `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`) já existe com valor `30` e comentário `# LGPD`, mas está **morto** (não é lido em nenhum outro lugar do código) — é exatamente o "configurado mas não implementado" citado em CLAUDE.md §6.1.
+
+### Contexto do sistema (fonte: CLAUDE.md / epic)
+- "Idle timeout LGPD (30min): configurado mas não implementado (JWT é stateless, expira em 7 dias). Implementar tracking de atividade / refresh curto quando o frontend de auth entrar." [Source: CLAUDE.md#6.1]
+- JWT hoje: `jwt_expire_minutes: int = 10080  # 7 dias` (`apps/api/app/config.py:23`), usado por `create_access_token` em `apps/api/app/core/security.py`. [Source: CLAUDE.md + inspeção direta de `apps/api/app/config.py`]
+
+### Arquivos e padrões relevantes (verificado diretamente no código)
+- Backend:
+  - `apps/api/app/config.py` — `session_idle_timeout_minutes: int = 30` (linha 24, dead config), `jwt_expire_minutes: int = 10080` (linha 23).
+  - `apps/api/app/core/security.py` — `create_access_token`/`decode_access_token` (JWT via `python-jose`), sem qualquer estado server-side hoje.
+  - `apps/api/app/core/tenancy.py` — `get_current_user` (linhas 31-43, stateless), `require_platform_admin` (linhas 46-59, único ponto que já revalida no banco a cada request — modelo de referência caso a Opção B seja escolhida), `get_tenant_db` (linhas 62-65, usado por toda rota de módulo de negócio).
+  - `apps/api/app/modules/auth/router.py` — endpoints existentes: `/register`, `/login`, `/forgot-password`, `/reset-password`, `/change-password`, `/me`. **Não existe `/refresh`.**
+- Frontend:
+  - `apps/web/src/app/App.tsx` — `ProtectedLayout` (linhas 84-96, citado nominalmente na AC2), rotas públicas fora do `ProtectedLayout`: `/login`, `/orcamento/:slug`, `/contrato/:slug`, `/p/:slug` (relevante para IV2).
+  - `apps/web/src/store/auth.tsx` — `AuthProvider`/`useAuth`; token/user/tenant em `localStorage` (`e1p_token`, `e1p_user`, `e1p_tenant`); `logout()` já limpa tudo; já existe um interceptor de resposta 401 (linhas 58-68) que desloga automaticamente — ponto de reuso natural.
+  - `apps/web/src/lib/api.ts` — cliente axios único (`api`), injeta `Authorization: Bearer` via interceptor de request; `publicApi` separado para rotas públicas (sem token) — usado pelas páginas públicas (`PublicContractPage`, `PublicProposalPage`, `PublicPage`).
+
+### File Locations (novos/alterados, dependendo da opção escolhida na Task 1)
+- ALTERAR: `apps/api/app/core/security.py`, `apps/api/app/core/tenancy.py`
+- POSSÍVEL NOVO: endpoint `/auth/refresh` em `apps/api/app/modules/auth/router.py` + `apps/api/app/modules/auth/service.py`
+- POSSÍVEL NOVO: migration para tabela de sessão (se Opção B)
+- ALTERAR: `apps/web/src/app/App.tsx` (`ProtectedLayout`)
+- POSSÍVEL NOVO: hook/util de tracking de atividade em `apps/web/src/store/` ou `apps/web/src/lib/`
+
+### Technical Constraints
+- Não reduzir `jwt_expire_minutes` global (7 dias) — a AC3 exige que os "demais casos" não sejam afetados.
+- Rotas públicas (`get_db` direto, sem `get_current_user`) não devem ganhar nenhuma dependência nova de sessão/atividade (IV2).
+- Fail-closed: qualquer erro/ambiguidade no cálculo de idle deve resultar em logout, nunca em sessão indefinidamente aberta (alinhado à Regra de Ouro nº 1 e à postura de segurança já adotada no projeto — RLS fail-closed, guard de produção fail-fast).
+
+### Testing
+- Framework backend: `pytest` (`apps/api/tests`).
+- Framework frontend: `vitest` (`apps/web/package.json` tem `"test": "vitest run"`) — **hoje não há nenhum arquivo de teste frontend no repositório** (`*.test.*`/`*.spec.*` não encontrados em `apps/web/src`); esta pode ser a primeira suíte de teste do frontend do projeto — se o @dev decidir testar `ProtectedLayout`/o timer de atividade automaticamente, será preciso montar a infraestrutura básica de teste do zero (não há precedente para copiar).
+- Sem e2e automatizado (Playwright não está configurado no repositório apesar de citado como aspiração em CLAUDE.md §5) — validar manualmente o fluxo completo (login → esperar/simular 30 min de inatividade → confirmar logout com aviso) no ambiente Docker local.
+
+## Change Log
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
+| 2026-07-10 | 0.1.1 | Validated GO (8/10) — Status: Draft → Ready (fork de arquitetura Opção A/B delegado ao @dev/@architect na Task 1) | @po |
+
+## Dev Agent Record
+
+### Agent Model Used
+_(a preencher pelo @dev)_
+
+### Debug Log References
+_(a preencher pelo @dev)_
+
+### Completion Notes List
+_(a preencher pelo @dev — incluir obrigatoriamente a decisão de arquitetura tomada na Task 1 e o porquê)_
+
+### File List
+_(a preencher pelo @dev)_
+
+## QA Results
+_(a preencher pelo @qa)_

--- a/docs/stories/1.4.story.md
+++ b/docs/stories/1.4.story.md
@@ -1,0 +1,120 @@
+# Story 1.4: Forçar troca de senha do Super Admin no 1º login + validar guard de segredos
+
+## Status
+Ready
+
+## Executor Assignment
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual security review", "validação manual do fluxo de 1º acesso do Master"]
+```
+> [AUTO-DECISION] Mesmo raciocínio das Stories 1.1-1.3: lógica de backend (seed + guard de config), sem trabalho de UI/UX novo (reusa fluxo existente) → executor=@dev, quality_gate=@architect.
+
+## Story
+**As a** administrador de plataforma (Master),
+**I want** ser obrigado a trocar a senha semeada no primeiro acesso e ter o boot bloqueado com segredos fracos,
+**so that** a conta de maior privilégio não fique com credencial default em produção.
+
+## Acceptance Criteria
+1. O Super Admin semeado nasce com `must_reset_password=True`; o primeiro login bloqueia o app até a troca (reusa o fluxo `FirstAccessPage`/`change-password` já existente).
+2. O guard de produção (`_guard_production_secrets`) é verificado no gate de release: boot recusa `JWT_SECRET` fraco/default (<32), `ANTHROPIC_API_KEY` ausente e `SUPER_ADMIN_PASSWORD` default.
+3. Um item de checklist de release documenta essa verificação.
+
+### Integration Verification
+- IV1: Login normal de usuários comuns e o fluxo de convite/1º acesso continuam funcionando.
+- IV2: Em dev (sem produção), o comportamento permissivo atual é preservado (não quebra o ciclo local).
+- IV3: Testes existentes de Super Admin e do guard de boot passam.
+
+## 🤖 CodeRabbit Integration
+
+> **CodeRabbit Integration**: Disabled
+>
+> Este projeto (e1p, brownfield sem `.aiox-core` próprio) não tem `coderabbit_integration.enabled` configurado localmente. Tratado como `false` por instrução explícita do orquestrador desta missão.
+> Quality validation will use manual review process only (ver `quality_gate_tools` acima e `scripts/check.sh`).
+> To enable, set `coderabbit_integration.enabled: true` em um `core-config.yaml` próprio do projeto.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Semear o Super Admin com `must_reset_password=True` (AC: 1)**
+  - [ ] `apps/api/app/seed.py::seed_super_admin` (linhas ~18-46): o `User(...)` criado para o admin (linhas ~32-41) hoje NÃO passa `must_reset_password` — o default do modelo é `False` (`apps/api/app/modules/auth/models.py:50`, `must_reset_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)`). Adicionar `must_reset_password=True` explicitamente na construção do `User` do admin.
+  - [ ] **Confirmado por inspeção de código: nenhuma outra mudança é necessária para o restante do fluxo.** O caminho já existe ponta-a-ponta e é genérico (não depende de `role`/`is_platform_admin`):
+    - `POST /auth/login` (`apps/api/app/modules/auth/router.py:61-67`) devolve `AuthToken.user` via `UserOut.model_validate(user)`, que já inclui `must_reset_password` (`apps/api/app/modules/auth/schemas.py:87`).
+    - `apps/web/src/app/App.tsx::ProtectedLayout` (linha 88) já checa `user?.must_reset_password` e renderiza `FirstAccessPage` para QUALQUER usuário com a flag ativa — sem tratamento especial de admin, já cobre o Master automaticamente.
+    - `POST /auth/change-password` (`apps/api/app/modules/auth/router.py:91-103`) usa `get_current_user` (não `require_platform_admin`, não tem restrição de módulo/role) + `set_own_password` (`apps/api/app/modules/auth/service.py:95-104`, genérico, limpa `must_reset_password=False` para qualquer `User`) — funciona para o Master sem alteração.
+
+- [ ] **Task 2 — Confirmar o guard de produção já existente (AC: 2)**
+  - [ ] `apps/api/app/config.py::_guard_production_secrets` (linhas ~50-64) **já implementa exatamente** o que a AC2 pede: bloqueia boot em produção se `jwt_secret` for o default OU tiver menos de 32 chars, se `anthropic_api_key` estiver vazio, ou se `super_admin_password` for o default (`_DEFAULT_ADMIN_PASSWORD = "trocar-no-primeiro-acesso"`).
+  - [ ] **Não há trabalho de implementação aqui** — apenas verificação/confirmação (ver Task 4, testes já existem e passam). Se algum dos 3 casos da AC2 não estiver coberto ao rodar os testes existentes, ajustar `_guard_production_secrets` para fechar a lacuna.
+
+- [ ] **Task 3 — Adicionar item ao checklist de release (AC: 3)**
+  - [ ] `docs/HOSTINGER-DEPLOY.md`, seção `## 4. Validar` (linhas ~76-79, já menciona "Login com `SUPER_ADMIN_EMAIL` / `SUPER_ADMIN_PASSWORD` do `.env.prod`"): adicionar um item explícito confirmando (a) que o boot falhou/falharia com segredos fracos (referenciar o guard `_guard_production_secrets` e seus 3 testes) e (b) que o primeiro login do Master força a troca de senha (Task 1).
+  - [ ] Repetir o mesmo item em `docs/AWS-DEPLOYMENT.md` se houver seção equivalente de validação pós-deploy (hoje o arquivo é mais uma referência de infraestrutura/custo do que um checklist passo-a-passo — avaliar se cabe um item novo ou uma nota apontando para `HOSTINGER-DEPLOY.md#4-validar`).
+  - [ ] **[AUTO-DECISION]** Não criar um novo documento dedicado `docs/RELEASE-CHECKLIST.md` nesta story — o Epic 3 (Deploy, Storage & Observabilidade, fora do escopo desta missão) é o dono natural de um checklist de release mais formal; aqui basta satisfazer a AC3 adicionando o item ao(s) documento(s) de deploy já existente(s). Reason: evitar inventar estrutura de documentação fora do escopo do Epic 1 e duplicar conteúdo que o Epic 3 provavelmente vai formalizar.
+
+- [ ] **Task 4 — Testes (AC: 1, 2, 3; IV1, IV2, IV3)**
+  - [ ] **Gap identificado:** não existe hoje nenhum teste cobrindo `seed_super_admin` (`apps/api/tests` não tem nenhum arquivo `test_seed*.py` nem referência a `seed_super_admin`). Criar `apps/api/tests/test_seed.py` cobrindo: o admin semeado nasce com `must_reset_password=True`; rodar o seed duas vezes é idempotente (já é o comportamento hoje — `existing = db.scalar(...); if existing: return`).
+  - [ ] Confirmar que os testes já existentes em `apps/api/tests/test_config.py` (6 testes: `test_production_rejects_default_secret`, `test_production_rejects_short_secret`, `test_production_requires_anthropic_key`, `test_production_rejects_default_admin_password`, `test_production_ok_with_strong_secret`, `test_development_allows_defaults`) continuam passando — cobrem IV3 e a AC2 quase integralmente já.
+  - [ ] Rodar `apps/api/tests/test_platform.py`/`test_auth.py` para confirmar que login de usuário comum e fluxo de convite/1º acesso (funcionário/dono, que já usam `must_reset_password=True` desde a Story de convite existente) continuam passando — IV1.
+  - [ ] Validar manualmente (dev, sem produção) que o comportamento permissivo atual (defaults funcionam, boot não falha) continua intacto — IV2, já coberto por `test_development_allows_defaults`.
+
+- [ ] **Task 5 — Checklist de qualidade (AC: todas)**
+  - [ ] Rodar `bash scripts/check.sh` (lint + testes) — CLAUDE.md §5.
+
+## Dev Notes
+
+### Previous Story Insights (Stories 1.1 - 1.3)
+- Nenhuma dependência direta com as stories anteriores do epic — 1.4 é a mais isolada tecnicamente (toca `seed.py` e `config.py`, módulos não alterados pelas Stories 1.1-1.3). Pode ser desenvolvida em paralelo se necessário, mas o sequenciamento do epic (1.1→1.2→1.3→1.4) deve ser respeitado para criação/QA das stories.
+
+### Contexto do sistema (fonte: CLAUDE.md / epic)
+- "Forçar troca de senha no 1º login do super admin (hoje a senha semeada vale até ser trocada manualmente)." [Source: CLAUDE.md#6.1 "Super Admin — pendências"]
+- "Já corrigidos no Super Admin (revisão QA): guarda de produção p/ senha default do admin [...]" — ou seja, o GUARD (AC2) já é tratado como resolvido pelo próprio CLAUDE.md; o que falta é especificamente o item AC1 (forçar troca no 1º login). [Source: CLAUDE.md#6.1]
+- "Já corrigidos na fundação: guarda de boot p/ JWT_SECRET fraco em produção [...]" — confirma que o guard de JWT_SECRET já é dado como certo. [Source: CLAUDE.md#6.1]
+- O fluxo de 1º acesso (`must_reset_password` + `FirstAccessPage` + `POST /auth/change-password`) "já existe para usuários comuns" — a story é sobre REUSAR esse fluxo para o Master, não recriar. [Source: docs/prd/epic-1-seguranca-compliance.md — "Contexto do sistema existente"]
+
+### Arquivos e padrões relevantes (verificado diretamente no código)
+- `apps/api/app/seed.py` (linhas 18-46) — `seed_super_admin()`, idempotente (`if existing: return`), constrói `Tenant` "platform" + `User(is_platform_admin=True)` sem `must_reset_password` explícito hoje.
+- `apps/api/app/config.py` (linhas 50-64) — `_guard_production_secrets`, já implementa a AC2 por completo (`model_validator(mode="after")` do Pydantic Settings); `_DEV_SECRET`/`_DEFAULT_ADMIN_PASSWORD` são os sentinelas comparados.
+- `apps/api/tests/test_config.py` — 6 testes já cobrindo o guard (ver Task 4), todos passando hoje.
+- `apps/api/app/modules/auth/router.py` (linhas 91-103) — `change_password`, genérico, sem restrição de role.
+- `apps/api/app/modules/auth/service.py` (linhas 95-104) — `set_own_password`, genérico.
+- `apps/web/src/app/App.tsx` (linha 88) — `ProtectedLayout` já trata `must_reset_password` de forma role-agnostic.
+- `docs/HOSTINGER-DEPLOY.md` (linhas 76-79, seção "4. Validar") — já menciona login do Super Admin pós-deploy; ponto natural para o item de checklist da AC3.
+
+### File Locations (novos/alterados)
+- ALTERAR: `apps/api/app/seed.py` (1 linha: `must_reset_password=True`)
+- NOVO: `apps/api/tests/test_seed.py`
+- ALTERAR: `docs/HOSTINGER-DEPLOY.md` (e possivelmente `docs/AWS-DEPLOYMENT.md`)
+
+### Technical Constraints
+- Não afrouxar/alterar o comportamento de `_guard_production_secrets` para `environment != "production"` — IV2 exige que o comportamento permissivo em dev continue intacto (o guard já só roda `if self.is_production:`).
+- Não introduzir tratamento especial de `is_platform_admin` em `set_own_password`/`change_password` — manter o fluxo genérico é o que torna esta story de baixo risco (menos código novo = menos superfície de regressão).
+
+### Testing
+- Framework backend: `pytest` (`apps/api/tests`).
+- Testes novos: `apps/api/tests/test_seed.py` (Task 4) — não há teste hoje para `seed.py`.
+- Testes existentes que já cobrem boa parte da AC2/IV3: `apps/api/tests/test_config.py` (6 testes, listados na Task 4) — apenas confirmar que continuam verdes, não é esperado que precisem mudar.
+- Nenhuma orientação técnica específica encontrada nos docs disponíveis sobre um teste automatizado de ponta-a-ponta do fluxo "login do Master → FirstAccessPage → change-password" — validar esse trecho manualmente (não há e2e automatizado no projeto, mesma limitação já registrada nas Stories 1.1-1.3).
+
+## Change Log
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
+| 2026-07-10 | 0.1.1 | Validated GO (9/10) — Status: Draft → Ready | @po |
+
+## Dev Agent Record
+
+### Agent Model Used
+_(a preencher pelo @dev)_
+
+### Debug Log References
+_(a preencher pelo @dev)_
+
+### Completion Notes List
+_(a preencher pelo @dev)_
+
+### File List
+_(a preencher pelo @dev)_
+
+## QA Results
+_(a preencher pelo @qa)_


### PR DESCRIPTION
## Objetivo

Documentação de planejamento do processo de ir a produção. Não altera código de produto — apenas adiciona PRD, epics e stories em `docs/`.

## Conteúdo

- **`docs/prd.md`** — PRD completo do go-live.
- **`docs/prd/`** — índice + 4 epics:
  - Epic 1: Segurança & Compliance
  - Epic 2: Integrações Reais
  - Epic 3: Deploy, Storage & Observabilidade
  - Epic 4: Backlog Pós-Lançamento
- **`docs/stories/`** — 4 stories do Epic 1 (1.1 a 1.4), já validadas pelo PO.

## Escopo

- Somente arquivos de documentação (`.md`).
- Nenhuma mudança em `apps/`, `packages/` ou infra.
- Base para code review antes de qualquer implementação do go-live.