### PR TITLE
Story 1.2 — Hardening de acesso a users + auditoria LGPD

### DIFF
--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -28,3 +28,52 @@ def record(db, *, tenant_id: str, actor: str, action: str, target: str = "", is_
     )
     db.add(entry)
     return entry
+
+
+class PlatformAuditEntry(Base, TimestampMixin):
+    """Log de PLATAFORMA (fora do tenant) para operações destrutivas do Master (LGPD).
+
+    Deliberadamente SEM ``TenantMixin``: assim `_business_table_names()` (descoberta dinâmica
+    via ``issubclass(mapper.class_, TenantMixin)`` em platform/service.py) NUNCA a inclui na
+    purga por tenant. Por isso o registro SOBREVIVE à exclusão da conta — resta o rastro de
+    quem/quando/qual tenant, que os `audit_entries` do próprio tenant (esses sim, purgados)
+    não conseguem preservar.
+
+    Guarda SNAPSHOTS (``actor_email``, ``target_tenant_slug``) porque o tenant-alvo é apagado
+    logo em seguida: não há como fazer FK/join depois. O ator é sempre o Master (não é apagado),
+    mas mantemos o e-mail como snapshot para o log ser autossuficiente.
+    """
+
+    __tablename__ = "platform_audit_entries"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    actor_user_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    actor_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    target_tenant_slug: Mapped[str] = mapped_column(String(63), nullable=False)
+    action: Mapped[str] = mapped_column(String(128), nullable=False)
+
+
+def record_platform(
+    db,
+    *,
+    actor_user_id: str,
+    actor_email: str,
+    target_tenant_id: str,
+    target_tenant_slug: str,
+    action: str,
+):
+    """Grava um log de PLATAFORMA (fora do tenant), que sobrevive à purga do tenant.
+
+    Use para operações destrutivas do Master (ex.: exclusão de conta), gravando na sessão
+    GLOBAL (`get_db`), NUNCA numa `tenant_session` do tenant que está sendo apagado.
+    """
+    entry = PlatformAuditEntry(
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_tenant_id=target_tenant_id,
+        target_tenant_slug=target_tenant_slug,
+        action=action,
+    )
+    db.add(entry)
+    return entry

--- a/apps/api/app/db/registry.py
+++ b/apps/api/app/db/registry.py
@@ -4,7 +4,7 @@ Usado pelo Alembic (autogenerate) e pelos testes (create_all). Sempre que criar 
 garanta que ele seja importado aqui (direta ou indiretamente).
 """
 # noqa: F401 — imports existem só para registrar as tabelas no metadata.
-from app.core.audit import AuditEntry  # noqa: F401
+from app.core.audit import AuditEntry, PlatformAuditEntry  # noqa: F401
 from app.db.base import Base
 from app.modules.agenda.models import AgendaEvent  # noqa: F401
 from app.modules.attachments.models import Attachment  # noqa: F401

--- a/apps/api/app/modules/contracts/router.py
+++ b/apps/api/app/modules/contracts/router.py
@@ -143,6 +143,9 @@ def cancel_contract(
 # ── Público (sem login) ─────────────────────────────────────────────────────
 @public_router.get("/{slug}", response_model=PublicContract)
 def public_view(slug: str, db: Session = Depends(get_db)) -> PublicContract:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_contracts`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicContract(**service.public_view(db, slug=slug))
     except service.ContractError as e:

--- a/apps/api/app/modules/pages/router.py
+++ b/apps/api/app/modules/pages/router.py
@@ -128,6 +128,9 @@ def delete_page(
 # ── Público (sem login) ─────────────────────────────────────────────────────
 @public_router.get("/{slug}", response_model=PublicPage)
 def public_view(slug: str, db: Session = Depends(get_db)) -> PublicPage:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_pages`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicPage(**service.public_view(db, slug=slug))
     except service.PageError as e:

--- a/apps/api/app/modules/platform/router.py
+++ b/apps/api/app/modules/platform/router.py
@@ -151,13 +151,15 @@ def delete_user(
 @router.delete("/accounts/{tenant_id}", status_code=204)
 def delete_account(
     tenant_id: str,
-    _admin: CurrentUser = Depends(require_platform_admin),
+    admin: CurrentUser = Depends(require_platform_admin),
     db: Session = Depends(get_db),
 ):
     from fastapi import Response
 
     try:
-        service.delete_account(db, tenant_id)
+        # `admin` (o Master autenticado) é repassado para gravar o log de plataforma da
+        # exclusão (quem/quando) — rastro que sobrevive à purga do tenant (LGPD, AC2).
+        service.delete_account(db, tenant_id, admin)
     except service.PlatformError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return Response(status_code=204)

--- a/apps/api/app/modules/platform/service.py
+++ b/apps/api/app/modules/platform/service.py
@@ -10,7 +10,9 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core import audit
 from app.core.security import hash_password
+from app.core.tenancy import CurrentUser
 from app.db.base import TenantMixin
 from app.db.registry import Base  # importa todos os modelos -> registra as tabelas
 from app.db.session import tenant_session
@@ -133,14 +135,26 @@ def update_account(db: Session, user_id: str, data: UpdateAccountRequest) -> Use
     return user
 
 
-def delete_account(db: Session, tenant_id: str) -> None:
+def delete_account(db: Session, tenant_id: str, actor: CurrentUser) -> None:
     """Exclui a conta de forma ATÔMICA: purga dados de negócio + remove tenant e usuários,
     tudo numa única transação. Bloqueia se houver qualquer administrador no tenant.
+
+    Ao final, grava um log de PLATAFORMA (fora do tenant) da exclusão — sobrevive à purga e
+    cumpre a exigência de rastro da LGPD (AC2). `actor` é o Master que executou a operação.
     """
-    if db.get(Tenant, tenant_id) is None:
+    tenant = db.get(Tenant, tenant_id)
+    if tenant is None:
         raise PlatformError("Conta não encontrada", 404)
     if _has_platform_admin(db, tenant_id):
         raise PlatformError("Não é possível excluir uma conta de administrador", 400)
+
+    # Snapshot ANTES da purga: depois do `DELETE FROM tenants` o slug some, e o log de
+    # plataforma precisa ser autossuficiente (sem FK/join para uma linha que deixará de existir).
+    # O ator (Master) vive em OUTRO tenant, então sua linha sobrevive; ainda assim capturamos o
+    # e-mail aqui para deixar o log completo num único snapshot.
+    target_tenant_slug = tenant.slug
+    actor_row = db.get(User, actor.user_id)
+    actor_email = actor_row.email if actor_row is not None else ""
 
     biz = _business_table_names()
     # Uma só transação (tenant_session commita ao sair) => sem estado órfão em falha parcial.
@@ -156,6 +170,23 @@ def delete_account(db: Session, tenant_id: str) -> None:
                 )
         tdb.execute(text("DELETE FROM users WHERE tenant_id = :tid"), {"tid": tenant_id})
         tdb.execute(text("DELETE FROM tenants WHERE id = :tid"), {"tid": tenant_id})
+
+    # A purga (bloco acima) já commitou com sucesso ao sair do `with` sem exceção. Só então
+    # gravamos o log na sessão GLOBAL `db` — NUNCA na `tenant_session` do tenant que acabou de
+    # sumir (seria uma escrita com RLS de um tenant inexistente, e é logicamente "fora do tenant").
+    # [AUTO-DECISION / Story Task 4] Logamos a exclusão que DE FATO ocorreu (após a purga). A
+    # atomicidade cross-sessão não é garantida entre os dois commits: uma falha rara entre eles
+    # deixaria a conta apagada sem log. É escolha consciente — logar uma exclusão que falhou no
+    # meio seria pior para auditoria/LGPD do que o risco raro de perder o log de uma que ocorreu.
+    audit.record_platform(
+        db,
+        actor_user_id=actor.user_id,
+        actor_email=actor_email,
+        target_tenant_id=tenant_id,
+        target_tenant_slug=target_tenant_slug,
+        action="account_deleted",
+    )
+    db.commit()
 
 
 # ── Hierarquia de usuários: Super Admin vê/edita/exclui todos ────────────────

--- a/apps/api/app/modules/quotes/router.py
+++ b/apps/api/app/modules/quotes/router.py
@@ -160,6 +160,9 @@ def reject_quote(
 def public_view(
     slug: str, password: str | None = Query(default=None), db: Session = Depends(get_db)
 ) -> PublicProposal:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_proposals`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicProposal(**service.public_view(db, slug=slug, password=password))
     except service.QuoteError as e:

--- a/apps/api/app/modules/wallet/router.py
+++ b/apps/api/app/modules/wallet/router.py
@@ -10,7 +10,7 @@ from app.core.tenancy import (
     require_module,
     require_platform_admin,
 )
-from app.db.session import get_db
+from app.db.session import get_db  # global (sem tenant): só rotas de Master abaixo (ver Story 1.2)
 from app.modules.wallet import service
 from app.modules.wallet.schemas import (
     PayoutResult,
@@ -79,6 +79,9 @@ def payout(
 
 
 # ── Master: ganhos da plataforma ───────────────────────
+# Uso LEGÍTIMO de `get_db` (Story 1.2, AC1): as rotas abaixo são de Master, guardadas por
+# `require_platform_admin`, e leem/gravam agregados GLOBAIS (platform_earnings/settings).
+# NÃO tocam `users` nem dados por tenant. Rotas de negócio deste módulo usam `get_tenant_db`.
 
 
 @router.get("/platform-earnings", response_model=PlatformEarningsSummary, tags=["platform-admin"])
@@ -86,6 +89,7 @@ def platform_earnings(
     _admin: CurrentUser = Depends(require_platform_admin),
     db: Session = Depends(get_db),
 ) -> PlatformEarningsSummary:
+    """Master: total de ganhos da plataforma (agregado global, sem escopo de tenant)."""
     return PlatformEarningsSummary(**service.platform_earnings(db))
 
 

--- a/apps/api/migrations/versions/0031_platform_audit_entries.py
+++ b/apps/api/migrations/versions/0031_platform_audit_entries.py
@@ -1,0 +1,50 @@
+"""platform_audit_entries: log de plataforma (fora do tenant) p/ exclusão de conta (LGPD)
+
+Tabela GLOBAL, deliberadamente SEM tenant_id / SEM RLS: registra operações destrutivas do
+Master (ex.: exclusão de conta) e SOBREVIVE à purga do tenant. Guarda snapshots (email do ator,
+slug do tenant) porque o tenant-alvo é apagado logo em seguida.
+
+Revision ID: 0031
+Revises: 0029
+Create Date: 2026-07-10
+
+NOTE (coordenação com Story 1.1): esta story roda em paralelo com a 1.1, que cria a migration
+`0030_*`. `down_revision` aqui aponta para `0029` porque a branch isolada desta story não tem
+acesso ao arquivo `0030`. No MERGE das duas branches pode ser necessário REBASE da cadeia
+`down_revision` (ex.: apontar esta para `0030`) para manter a sequência linear do Alembic.
+Isso é esperado e não é um erro de implementação desta story.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "platform_audit_entries",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("actor_user_id", sa.String(36), nullable=False),
+        sa.Column("actor_email", sa.String(255), nullable=False),
+        sa.Column("target_tenant_id", sa.String(36), nullable=False),
+        sa.Column("target_tenant_slug", sa.String(63), nullable=False),
+        sa.Column("action", sa.String(128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    # SEM RLS por design: tabela de plataforma, não de tenant. É o oposto das tabelas de negócio
+    # (que herdam TenantMixin e são purgadas na exclusão) — este log tem de sobreviver à purga.
+    op.create_index(
+        "ix_platform_audit_entries_target_tenant_id",
+        "platform_audit_entries",
+        ["target_tenant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("platform_audit_entries")

--- a/apps/api/tests/test_platform.py
+++ b/apps/api/tests/test_platform.py
@@ -1,10 +1,17 @@
 """Testes do Super Admin (Master). Delete real (purga) é coberto no e2e Docker (usa Postgres)."""
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.audit import PlatformAuditEntry
 from app.core.security import hash_password
+from app.modules.agenda.models import AgendaEvent
 from app.modules.auth.models import Tenant, User
+from app.modules.crm.models import Client
+from app.modules.platform import service as platform_service
 
 ADMIN_EMAIL = "master@e1p.com"
 ADMIN_PASS = "senha-do-master-123"
@@ -279,3 +286,95 @@ def test_users_requires_admin(client: TestClient):
     h = {"Authorization": f"Bearer {token}"}
     assert client.get("/admin/users", headers=h).status_code == 403
     assert client.get("/admin/users").status_code == 401
+
+
+# ── Exclusão de conta: purga atômica + log de plataforma sobrevivente (Story 1.2) ────
+# Baseline de regressão criada ANTES da mudança de comportamento (a story constatou que não
+# havia NENHUM teste automatizado para DELETE /admin/accounts/{tenant_id}). O delete real chama
+# `tenant_session` (Postgres, RLS) — em teste (SQLite) apontamos para a sessão compartilhada.
+
+
+@pytest.fixture()
+def _tenant_session_to_test_db(db: Session, monkeypatch):
+    """`delete_account` abre `tenant_session` (conexão Postgres dedicada) direto no service.
+
+    Em teste (SQLite, sem RLS) redirecionamos para a MESMA sessão compartilhada, exercitando a
+    purga + a gravação do log de plataforma sem precisar de Postgres real (RLS é validada no e2e).
+    """
+
+    @contextmanager
+    def _fake_tenant_session(_tenant_id: str):
+        yield db
+
+    monkeypatch.setattr(platform_service, "tenant_session", _fake_tenant_session)
+
+
+def _seed_business_data(db: Session, tenant_id: str) -> None:
+    """Dados em 2 módulos de negócio distintos, para provar que a purga por tenant funciona."""
+    db.add(Client(tenant_id=tenant_id, name="Lead a Purgar"))
+    db.add(
+        AgendaEvent(
+            tenant_id=tenant_id,
+            title="Reunião a Purgar",
+            kind="reuniao",
+            starts_at=datetime(2026, 7, 10, 10, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 7, 10, 11, 0, tzinfo=UTC),
+        )
+    )
+    db.commit()
+
+
+def test_delete_account_purges_and_writes_platform_log(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    created = client.post("/admin/accounts", json=_account_payload(), headers=admin_headers).json()
+    tid = created["tenant"]["id"]
+    _seed_business_data(db, tid)
+    assert db.query(Client).filter(Client.tenant_id == tid).count() == 1
+    assert db.query(AgendaEvent).filter(AgendaEvent.tenant_id == tid).count() == 1
+
+    resp = client.delete(f"/admin/accounts/{tid}", headers=admin_headers)
+    assert resp.status_code == 204, resp.text
+
+    # IV1 — purga: tabelas de negócio do tenant ficam vazias; tenant e usuários removidos
+    assert db.query(Client).filter(Client.tenant_id == tid).count() == 0
+    assert db.query(AgendaEvent).filter(AgendaEvent.tenant_id == tid).count() == 0
+    assert db.query(Tenant).filter(Tenant.id == tid).first() is None
+    assert db.query(User).filter(User.tenant_id == tid).count() == 0
+
+    # AC2 — log de plataforma criado com ator + snapshot do tenant corretos
+    master = db.query(User).filter(User.is_platform_admin.is_(True)).first()
+    logs = (
+        db.query(PlatformAuditEntry)
+        .filter(PlatformAuditEntry.target_tenant_id == tid)
+        .all()
+    )
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.action == "account_deleted"
+    assert log.target_tenant_slug == "clientepagante"
+    assert log.actor_user_id == master.id
+    assert log.actor_email == ADMIN_EMAIL
+
+    # IV3 — o log SOBREVIVE à exclusão: continua consultável mesmo sem o tenant/users
+    assert db.query(PlatformAuditEntry).filter(
+        PlatformAuditEntry.target_tenant_id == tid
+    ).count() == 1
+
+
+def test_delete_account_blocks_tenant_with_platform_admin(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    master = db.query(User).filter(User.is_platform_admin.is_(True)).first()
+    resp = client.delete(f"/admin/accounts/{master.tenant_id}", headers=admin_headers)
+    assert resp.status_code == 400
+    # exclusão bloqueada não gera log de exclusão
+    assert db.query(PlatformAuditEntry).count() == 0
+
+
+def test_delete_account_404_for_unknown_tenant(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    resp = client.delete("/admin/accounts/tenant-inexistente-1234", headers=admin_headers)
+    assert resp.status_code == 404
+    assert db.query(PlatformAuditEntry).count() == 0

--- a/apps/api/tests/test_tenancy_guard.py
+++ b/apps/api/tests/test_tenancy_guard.py
@@ -1,0 +1,57 @@
+"""Guarda de regressão ESTÁTICA (Story 1.2, Task 1 / AC1).
+
+Varre `apps/api/app/modules/**/router.py` e falha se algum módulo FORA da allowlist referenciar
+`get_db` (a sessão GLOBAL, sem tenant). Módulos de negócio comuns (agenda, crm, receivables,
+payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings,
+cockpit) DEVEM usar `get_tenant_db` (RLS) — nunca `get_db` — para não vazar dados cross-tenant.
+
+Não substitui a RLS; é uma rede de segurança barata (sem ferramenta externa) contra a regressão
+"alguém acessou `users`/dados sem escopo de tenant via get_db".
+
+Allowlist (usos legítimos, documentados com guarda explícita no próprio código):
+  - auth      → autenticação, inerentemente global sobre `users` (login por e-mail).
+  - platform  → Super Admin (Master), toda rota sob `require_platform_admin` (cross-tenant).
+  - contracts → só a rota pública `public_view` lê `published_contracts` (snapshot global).
+  - pages     → idem, `public_view` lê `published_pages`.
+  - quotes    → idem, aceite público lê `published_proposals`.
+  - wallet    → rotas de Master (earnings/split-rates) sob `require_platform_admin`.
+"""
+from __future__ import annotations
+
+import pathlib
+
+MODULES_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules"
+
+# Módulos onde `get_db` (sessão global) é um uso legítimo e já auditado (ver docstring acima).
+ALLOWLIST = {"auth", "platform", "contracts", "pages", "quotes", "wallet"}
+
+
+def _module_routers() -> list[pathlib.Path]:
+    routers = sorted(MODULES_DIR.glob("*/router.py"))
+    assert routers, f"Nenhum router.py encontrado em {MODULES_DIR} — teste desatualizado?"
+    return routers
+
+
+def test_no_business_module_uses_get_db():
+    """Nenhum módulo de negócio fora da allowlist pode referenciar `get_db`."""
+    offenders: list[str] = []
+    for router in _module_routers():
+        module = router.parent.name
+        if module in ALLOWLIST:
+            continue
+        source = router.read_text(encoding="utf-8")
+        if "get_db" in source:
+            offenders.append(module)
+
+    assert not offenders, (
+        "Módulo(s) de negócio referenciando get_db (sessão GLOBAL, sem tenant) — risco de "
+        f"vazamento cross-tenant: {sorted(offenders)}. Use get_tenant_db (RLS). Se o uso for "
+        "legítimo (rota pública sobre snapshot global / rota de Master), documente e adicione à "
+        "ALLOWLIST em tests/test_tenancy_guard.py."
+    )
+
+
+def test_allowlist_entries_still_exist():
+    """A allowlist não pode apodrecer: todo módulo listado deve existir como pasta real."""
+    missing = [m for m in ALLOWLIST if not (MODULES_DIR / m / "router.py").exists()]
+    assert not missing, f"Allowlist referencia módulos inexistentes: {sorted(missing)}"

--- a/docs/stories/1.2.story.md
+++ b/docs/stories/1.2.story.md
@@ -1,7 +1,7 @@
 # Story 1.2: Hardening de acesso à tabela global `users` + log de exclusão (LGPD)
 
 ## Status
-Ready
+InReview
 
 ## Executor Assignment
 ```yaml
@@ -36,8 +36,8 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Auditoria formal de acesso a `users` via `get_db` (AC: 1)**
-  - [ ] Confirmar (e documentar no Dev Agent Record) o levantamento já feito nesta story — todo arquivo em `apps/api/app/modules/**` e `apps/api/app/core/**` que importa `get_db` de `app.db.session`:
+- [x] **Task 1 — Auditoria formal de acesso a `users` via `get_db` (AC: 1)**
+  - [x] Confirmar (e documentar no Dev Agent Record) o levantamento já feito nesta story — todo arquivo em `apps/api/app/modules/**` e `apps/api/app/core/**` que importa `get_db` de `app.db.session`:
     - `apps/api/app/modules/auth/router.py` — LEGÍTIMO: é o próprio módulo de autenticação (register/login/forgot-password/reset-password/change-password), inerentemente global sobre `users` por design. Não é "módulo de negócio".
     - `apps/api/app/modules/platform/router.py` — LEGÍTIMO: é o módulo do Super Admin (Master); toda rota é protegida por `Depends(require_platform_admin)`, propositalmente cross-tenant sobre `users`/`tenants`.
     - `apps/api/app/modules/contracts/router.py:145,157` — usa `get_db` só nas rotas `public_view`/assinatura pública (sem login) para ler `published_contracts` (snapshot GLOBAL sem RLS) — **NÃO toca `users`**.
@@ -45,39 +45,39 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
     - `apps/api/app/modules/quotes/router.py:161,173` — idem, aceite público de proposta lê `published_proposals` — **NÃO toca `users`**.
     - `apps/api/app/modules/wallet/router.py:86,94,103` — protegidas por `Depends(require_platform_admin)` (`_admin`), consultam `platform_earnings` (agregado global) — **NÃO toca `users`** e já é guardado.
     - `apps/api/app/core/tenancy.py` — a própria dependência de resolução de tenant/usuário atual (`get_current_user`) precisa consultar `users` globalmente a partir do claim do JWT (é o mecanismo, não um módulo de negócio).
-  - [ ] Nenhum módulo de negócio "comum" (agenda, crm, receivables, payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings, cockpit) usa `get_db` hoje — todos usam `get_tenant_db` (RLS). Confirmar isso permanece true rodando um grep de auditoria (`grep -rln "get_db" apps/api/app/modules/`) e comparando com esta lista.
-  - [ ] Adicionar comentário/docstring explícito nos poucos usos legítimos acima (contracts/pages/quotes `public_view`, wallet admin routes) explicando POR QUE é seguro (não toca `users`, ou é protegido por `require_platform_admin`) — cumpre a exigência de "guarda explícita" da AC1.
-  - [ ] Criar um teste de regressão estático simples (novo arquivo `apps/api/tests/test_tenancy_guard.py`) que varre `apps/api/app/modules/**/router.py` e falha se algum arquivo fora da allowlist (auth, platform, e as rotas públicas específicas já mapeadas) importar `get_db` — protege contra regressão futura sem exigir ferramenta externa de lint.
+  - [x] Nenhum módulo de negócio "comum" (agenda, crm, receivables, payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings, cockpit) usa `get_db` hoje — todos usam `get_tenant_db` (RLS). Confirmar isso permanece true rodando um grep de auditoria (`grep -rln "get_db" apps/api/app/modules/`) e comparando com esta lista.
+  - [x] Adicionar comentário/docstring explícito nos poucos usos legítimos acima (contracts/pages/quotes `public_view`, wallet admin routes) explicando POR QUE é seguro (não toca `users`, ou é protegido por `require_platform_admin`) — cumpre a exigência de "guarda explícita" da AC1.
+  - [x] Criar um teste de regressão estático simples (novo arquivo `apps/api/tests/test_tenancy_guard.py`) que varre `apps/api/app/modules/**/router.py` e falha se algum arquivo fora da allowlist (auth, platform, e as rotas públicas específicas já mapeadas) importar `get_db` — protege contra regressão futura sem exigir ferramenta externa de lint.
 
-- [ ] **Task 2 — Criar o modelo de log de plataforma (fora do tenant) (AC: 2, 3)**
-  - [ ] Adicionar `PlatformAuditEntry` em `apps/api/app/core/audit.py` (mesmo arquivo do `AuditEntry` já existente, mesma convenção de módulo) — **deliberadamente `Base` + `TimestampMixin`, SEM `TenantMixin`**, para que `_business_table_names()` (`apps/api/app/modules/platform/service.py`, descoberta dinâmica via `issubclass(mapper.class_, TenantMixin)`) NUNCA a inclua na purga por tenant.
-  - [ ] Campos sugeridos: `id`, `actor_user_id: str`, `actor_email: str` (snapshot — o ator é sempre o Master, que não é apagado), `target_tenant_id: str`, `target_tenant_slug: str` (snapshot — o tenant será apagado, não dá pra fazer FK/join depois), `action: str` (ex.: `"account_deleted"`), `created_at` (via `TimestampMixin`).
-  - [ ] Nova migration em `apps/api/migrations/versions/` — usar o próximo número livre após a última migration existente (`0029_user_invite_fields.py`; se a Story 1.1 já tiver criado `0030_*`, esta deve ser `0031_*` — **coordenar numeração sequencial com a Story 1.1 antes de gerar o arquivo**, alembic é sequencial por `down_revision`).
+- [x] **Task 2 — Criar o modelo de log de plataforma (fora do tenant) (AC: 2, 3)**
+  - [x] Adicionar `PlatformAuditEntry` em `apps/api/app/core/audit.py` (mesmo arquivo do `AuditEntry` já existente, mesma convenção de módulo) — **deliberadamente `Base` + `TimestampMixin`, SEM `TenantMixin`**, para que `_business_table_names()` (`apps/api/app/modules/platform/service.py`, descoberta dinâmica via `issubclass(mapper.class_, TenantMixin)`) NUNCA a inclua na purga por tenant.
+  - [x] Campos sugeridos: `id`, `actor_user_id: str`, `actor_email: str` (snapshot — o ator é sempre o Master, que não é apagado), `target_tenant_id: str`, `target_tenant_slug: str` (snapshot — o tenant será apagado, não dá pra fazer FK/join depois), `action: str` (ex.: `"account_deleted"`), `created_at` (via `TimestampMixin`).
+  - [x] Nova migration em `apps/api/migrations/versions/` — usar o próximo número livre após a última migration existente (`0029_user_invite_fields.py`; se a Story 1.1 já tiver criado `0030_*`, esta deve ser `0031_*` — **coordenar numeração sequencial com a Story 1.1 antes de gerar o arquivo**, alembic é sequencial por `down_revision`).
 
-- [ ] **Task 3 — Capturar o ator e o snapshot do tenant antes da purga (AC: 2)**
-  - [ ] `apps/api/app/modules/platform/service.py::delete_account` hoje tem assinatura `delete_account(db: Session, tenant_id: str) -> None` e não recebe quem está executando a ação. Alterar para `delete_account(db: Session, tenant_id: str, actor: User) -> None`.
-  - [ ] `apps/api/app/modules/platform/router.py` (rota `DELETE /accounts/{tenant_id}`, linhas ~151-160): hoje o admin autenticado vem como `_admin: CurrentUser = Depends(require_platform_admin)` e é ignorado (prefixo `_`); passar esse `_admin` (renomear para `admin`) para `service.delete_account(db, tenant_id, admin)`.
-  - [ ] Antes de qualquer `DELETE` dentro de `delete_account`, capturar `tenant.slug`/`tenant.legal_name` (o objeto `Tenant` já é buscado no início da função para o guard 404 — reaproveitar) para usar no log, já que depois do `DELETE FROM tenants` essa informação some.
+- [x] **Task 3 — Capturar o ator e o snapshot do tenant antes da purga (AC: 2)**
+  - [x] `apps/api/app/modules/platform/service.py::delete_account` hoje tem assinatura `delete_account(db: Session, tenant_id: str) -> None` e não recebe quem está executando a ação. Alterar para `delete_account(db: Session, tenant_id: str, actor: User) -> None`.
+  - [x] `apps/api/app/modules/platform/router.py` (rota `DELETE /accounts/{tenant_id}`, linhas ~151-160): hoje o admin autenticado vem como `_admin: CurrentUser = Depends(require_platform_admin)` e é ignorado (prefixo `_`); passar esse `_admin` (renomear para `admin`) para `service.delete_account(db, tenant_id, admin)`.
+  - [x] Antes de qualquer `DELETE` dentro de `delete_account`, capturar `tenant.slug`/`tenant.legal_name` (o objeto `Tenant` já é buscado no início da função para o guard 404 — reaproveitar) para usar no log, já que depois do `DELETE FROM tenants` essa informação some.
 
-- [ ] **Task 4 — Gravar o log de plataforma de forma que sobreviva à purga (AC: 2, 3)**
-  - [ ] A purga de negócio roda dentro de `with tenant_session(tenant_id) as tdb:` (que abre uma conexão dedicada com o GUC `app.current_tenant_id` setado para o tenant SENDO APAGADO — ver CLAUDE.md §3, nota sobre `tenant_session` e conexão dedicada). O log de plataforma NÃO deve ser gravado nessa sessão (seria uma escrita com RLS do tenant que está sumindo, e é logicamente "fora do tenant").
-  - [ ] **[AUTO-DECISION]** Gravar o `PlatformAuditEntry` na sessão GLOBAL `db` (a mesma recebida pelo endpoint via `Depends(get_db)`), **DEPOIS** que o bloco `with tenant_session(tenant_id) as tdb:` sair sem exceção (ou seja, depois que a purga já commitou com sucesso), e então dar `db.commit()` na sessão global antes de retornar. Reason: a AC2 pede rastro da exclusão que de fato aconteceu — logar uma tentativa que falhou no meio geraria um registro de "conta excluída" para algo que não ocorreu de fato, pior para fins de auditoria/LGPD do que o risco (raro) de falha entre os dois commits. Documentar essa limitação de atomicidade cross-sessão no Dev Agent Record (é uma escolha consciente, não um bug).
-  - [ ] Confirmar manualmente (ou via teste, ver Task 5) que a linha em `platform_audit_entries` (ou nome escolhido para a tabela) continua existindo depois que `tenants`/`users`/tabelas de negócio do tenant já foram apagadas — IV3.
+- [x] **Task 4 — Gravar o log de plataforma de forma que sobreviva à purga (AC: 2, 3)**
+  - [x] A purga de negócio roda dentro de `with tenant_session(tenant_id) as tdb:` (que abre uma conexão dedicada com o GUC `app.current_tenant_id` setado para o tenant SENDO APAGADO — ver CLAUDE.md §3, nota sobre `tenant_session` e conexão dedicada). O log de plataforma NÃO deve ser gravado nessa sessão (seria uma escrita com RLS do tenant que está sumindo, e é logicamente "fora do tenant").
+  - [x] **[AUTO-DECISION]** Gravar o `PlatformAuditEntry` na sessão GLOBAL `db` (a mesma recebida pelo endpoint via `Depends(get_db)`), **DEPOIS** que o bloco `with tenant_session(tenant_id) as tdb:` sair sem exceção (ou seja, depois que a purga já commitou com sucesso), e então dar `db.commit()` na sessão global antes de retornar. Reason: a AC2 pede rastro da exclusão que de fato aconteceu — logar uma tentativa que falhou no meio geraria um registro de "conta excluída" para algo que não ocorreu de fato, pior para fins de auditoria/LGPD do que o risco (raro) de falha entre os dois commits. Documentar essa limitação de atomicidade cross-sessão no Dev Agent Record (é uma escolha consciente, não um bug).
+  - [x] Confirmar manualmente (ou via teste, ver Task 5) que a linha em `platform_audit_entries` (ou nome escolhido para a tabela) continua existindo depois que `tenants`/`users`/tabelas de negócio do tenant já foram apagadas — IV3.
 
-- [ ] **Task 5 — Testes de regressão para `delete_account` (AC: 3; IV1, IV3)**
-  - [ ] **Risco identificado:** hoje **não existe nenhum teste automatizado** cobrindo `DELETE /admin/accounts/{tenant_id}` em `apps/api/tests/test_platform.py` (nem em nenhum outro arquivo de teste) — apesar de CLAUDE.md descrever esse fluxo como "já corrigido"/"validado e2e". A validação existente foi manual (Docker + Postgres real), não há regressão automatizada em CI. Esta story deve criar esse teste ANTES de alterar `delete_account`, para ter uma baseline confiável.
-  - [ ] Novo(s) teste(s) em `apps/api/tests/test_platform.py` (ou novo arquivo `test_platform_delete.py`) cobrindo:
+- [x] **Task 5 — Testes de regressão para `delete_account` (AC: 3; IV1, IV3)**
+  - [x] **Risco identificado:** hoje **não existe nenhum teste automatizado** cobrindo `DELETE /admin/accounts/{tenant_id}` em `apps/api/tests/test_platform.py` (nem em nenhum outro arquivo de teste) — apesar de CLAUDE.md descrever esse fluxo como "já corrigido"/"validado e2e". A validação existente foi manual (Docker + Postgres real), não há regressão automatizada em CI. Esta story deve criar esse teste ANTES de alterar `delete_account`, para ter uma baseline confiável.
+  - [x] Novo(s) teste(s) em `apps/api/tests/test_platform.py` (ou novo arquivo `test_platform_delete.py`) cobrindo:
     - Criar uma conta (tenant + owner) com dados em pelo menos 2 módulos de negócio diferentes (ex.: um `Client` do CRM e um `AgendaEvent`); excluir via `DELETE /admin/accounts/{tenant_id}`; confirmar que as tabelas de negócio desse tenant ficam vazias (purga funcionou).
     - Confirmar bloqueio (400) ao tentar excluir um tenant que contém um `is_platform_admin`.
     - Confirmar 404 ao excluir tenant inexistente.
     - Confirmar que a exclusão cria uma linha em `PlatformAuditEntry` com o `target_tenant_id`/`slug` corretos e o `actor_user_id` do Master que executou.
     - Confirmar que essa linha de log **continua consultável** depois do delete (a tabela não tem FK/cascata para `tenants`, é independente) — cobre IV3.
 
-- [ ] **Task 6 — Validação manual de isolamento cross-tenant (IV2)**
-  - [ ] Não há e2e automatizado no repositório (RLS só é exercitada com Postgres real — ver CLAUDE.md §6.1 "Teste de isolamento cross-tenant"). Validar manualmente via Docker (`docker compose -f infra/docker-compose.yml up -d --build`) que, após as mudanças desta story, um usuário de um tenant continua sem conseguir ver dados de outro tenant (cenário "João não vê dados da Maria", já citado como baseline no epic e em CLAUDE.md §3).
+- [ ] **Task 6 — Validação manual de isolamento cross-tenant (IV2)** — PENDENTE (manual, requer Postgres real)
+  - [ ] Não há e2e automatizado no repositório (RLS só é exercitada com Postgres real — ver CLAUDE.md §6.1 "Teste de isolamento cross-tenant"). Validar manualmente via Docker (`docker compose -f infra/docker-compose.yml up -d --build`) que, após as mudanças desta story, um usuário de um tenant continua sem conseguir ver dados de outro tenant (cenário "João não vê dados da Maria", já citado como baseline no epic e em CLAUDE.md §3). **NÃO executado neste worktree isolado** (sem stack Postgres/Docker compose ativa); as mudanças desta story NÃO alteram políticas RLS nem `tenant_session`, então o comportamento de isolamento existente é preservado por construção. Requer execução manual pelo quality gate (@architect) antes do merge.
 
-- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
-  - [ ] Rodar `bash scripts/check.sh` (lint + testes) — CLAUDE.md §5.
+- [x] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [x] Rodar lint + testes do backend (`ruff check .` + `pytest` em `apps/api`) — equivalente à parte backend de `scripts/check.sh`. Resultado: ruff OK, **257 passed**. Frontend (`@e1p/web`) não é tocado por esta story (backend-only), então typecheck/vitest do front não se aplicam.
 
 ## Dev Notes
 
@@ -125,20 +125,56 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 |------|---------|-------------|--------|
 | 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
 | 2026-07-10 | 0.1.1 | Validated GO (9/10) — Status: Draft → Ready | @po |
+| 2026-07-10 | 0.2 | Implementação Tasks 1-5,7 (Task 6 manual pendente) — Status: Ready → InReview | Dex (@dev) |
 
 ## Dev Agent Record
 
 ### Agent Model Used
-_(a preencher pelo @dev)_
+claude-opus-4-8 (Dex / @dev), modo YOLO autônomo.
 
 ### Debug Log References
-_(a preencher pelo @dev)_
+- Backend sem Python no host Windows; lint+testes rodados em container `python:3.13-slim` (mesma imagem do `apps/api/Dockerfile`), montando `apps/api`.
+- `ruff check .` → All checks passed.
+- `python -m pytest -q` → **257 passed, 0 failed** (~70s). Baseline anterior + 5 testes novos desta story (2 em `test_tenancy_guard.py`, 3 em `test_platform.py`).
 
 ### Completion Notes List
-_(a preencher pelo @dev)_
+
+**IDS (Search → Decide → Log):**
+- `PlatformAuditEntry`: ADAPT de `AuditEntry` (mesmo arquivo `core/audit.py`, mesma convenção), MENOS `TenantMixin` — decisão central da story.
+- `record_platform()`: CREATE, espelhando o helper `record()` já existente (consistência).
+- Log de guarda estático (`test_tenancy_guard.py`): CREATE — segue o espírito de `test_config.py` (invariante de segurança por asserção, sem mocks), sem precedente exato.
+- Testes de `delete_account`: CREATE em `test_platform.py` (overlap conhecido com Story 1.1 nesse arquivo — esperado, resolvido no merge).
+
+**Decisões / desvios em relação à story:**
+- **[AUTO-DECISION] Tipo do `actor`**: a story sugeriu `delete_account(..., actor: User)`, mas o router só dispõe do `CurrentUser` (de `require_platform_admin`), que NÃO tem `email`. Optei por `actor: CurrentUser` e resolvo `actor_email` via `db.get(User, actor.user_id)` dentro do service (o Master vive em outro tenant, sua linha sobrevive à purga). Evita um fetch-e-repassa artificial no router. Reason: fidelidade ao que o endpoint realmente tem + snapshot de e-mail correto.
+- **[AUTO-DECISION] Momento da gravação do log (Task 4)**: log gravado na sessão GLOBAL `db` APÓS a purga sair sem exceção, com `db.commit()` ao final. Limitação consciente de atomicidade cross-sessão (falha rara entre os dois commits deixaria conta apagada sem log) — preferível a logar exclusão que não ocorreu. Documentado em comentário no `service.py`.
+- **Migration `0031`**: `down_revision = "0029"` (a branch isolada não tem acesso ao `0030` da Story 1.1). O arquivo carrega NOTE explícita de que pode ser necessário REBASE da cadeia `down_revision` no merge — esperado, não é erro.
+- **Task 6 (IV2, e2e cross-tenant)**: NÃO executado — requer Postgres/Docker compose ativo, indisponível neste worktree. As mudanças não alteram RLS nem `tenant_session`, então o isolamento existente é preservado por construção. Deixado para o quality gate (@architect) validar antes do merge.
+- **Task 7**: rodei o equivalente backend de `scripts/check.sh` (ruff + pytest em `apps/api`); frontend não é tocado por esta story.
+
+**Verificação das ACs:**
+- AC1: guardas explícitas (docstrings) nos usos legítimos de `get_db` (contracts/pages/quotes `public_view`, wallet Master) + teste estático `test_tenancy_guard.py` que falha se módulo de negócio fora da allowlist usar `get_db`.
+- AC2: `PlatformAuditEntry` gravado fora do tenant, com ator + snapshot (slug/email); coberto por `test_delete_account_purges_and_writes_platform_log`.
+- AC3 / IV1: purga dinâmica preservada (assinatura e corpo do loop intactos); teste confirma tabelas de negócio vazias pós-delete.
+- IV3: teste confirma que o log continua consultável após a purga (tabela sem FK/cascata para `tenants`).
 
 ### File List
-_(a preencher pelo @dev)_
+
+**Alterados:**
+- `apps/api/app/core/audit.py` — novo modelo `PlatformAuditEntry` (sem `TenantMixin`) + helper `record_platform()`.
+- `apps/api/app/db/registry.py` — importa `PlatformAuditEntry` (metadata/create_all).
+- `apps/api/app/modules/platform/service.py` — `delete_account` nova assinatura (`actor: CurrentUser`), snapshot pré-purga, gravação do log de plataforma pós-purga.
+- `apps/api/app/modules/platform/router.py` — repassa `admin` autenticado ao service.
+- `apps/api/app/modules/contracts/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/pages/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/quotes/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/wallet/router.py` — comentário/docstring de guarda nas rotas de Master.
+- `apps/api/tests/test_platform.py` — 3 testes novos de `delete_account` (baseline de regressão) + imports.
+- `docs/stories/1.2.story.md` — Status, checkboxes, Dev Agent Record.
+
+**Novos:**
+- `apps/api/migrations/versions/0031_platform_audit_entries.py` — cria `platform_audit_entries` (global, sem RLS).
+- `apps/api/tests/test_tenancy_guard.py` — teste estático de guarda de `get_db`.
 
 ## QA Results
 _(a preencher pelo @qa)_


### PR DESCRIPTION
## Resumo

Story 1.2 do Epic 1 (Segurança & Compliance): hardening de acesso a `users` e trilha de auditoria de exclusão de plataforma (LGPD).

- Novo `apps/api/app/core/audit.py` para registro de eventos sensíveis.
- `platform/service.py` e `platform/router.py` registram log de exclusão de plataforma.
- Reforço de tenancy guard nos routers de contracts, pages, quotes e wallet.
- Cobertura: `tests/test_tenancy_guard.py` (novo) + ampliação de `tests/test_platform.py`.

## Migration

- Adiciona `0031_platform_audit_entries` (down_revision = `0029`).
- Coordenação: a Story 1.1 criou em paralelo a migration `0030` também com `down_revision = 0029`. Dois heads sobre 0029 — a cadeia precisará de **rebase manual da revision** antes do merge final em `main`. Esperado, não é bug.

## Overlap conhecido

- `apps/api/tests/test_platform.py` foi alterado tanto aqui quanto na Story 1.1. Merge das duas PRs exigirá reconciliar esse arquivo (edições complementares, sem conflito lógico esperado).

## Base

- PR empilhada sobre `docs/go-live-prd-epics-stories` (PR #1) — nasceu dessa branch. Deve ser mergeada após/junto da PR #1.

## Referências

- Story: `docs/stories/1.2.story.md`
- Epic: `docs/prd/epic-1-seguranca-compliance.md`

## Testes

- `pytest`: 257 passed.
