### PR TITLE
Story 1.3 — Idle timeout LGPD (30 min, sliding session stateless)

### DIFF
--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -28,10 +28,34 @@ def verify_password(plain: str, hashed: str) -> bool:
         return False
 
 
-def create_access_token(claims: dict[str, Any]) -> str:
+# Claims de identidade preservados ao reemitir (deslizar) a sessão. NÃO inclui exp/iat/abs_exp,
+# que são recalculados a cada reemissão.
+_SESSION_IDENTITY_CLAIMS = ("sub", "tenant_id", "role", "allowed_modules", "is_platform_admin")
+
+
+def create_access_token(
+    claims: dict[str, Any],
+    *,
+    absolute_expiry: datetime | None = None,
+) -> str:
+    """Emite um token de sessão com DUAS camadas de expiração (idle timeout LGPD — Story 1.3).
+
+    - ``exp``: janela de INATIVIDADE (``session_idle_timeout_minutes``, ex. 30 min). É o que o
+      JWT valida automaticamente: passou disso sem atividade, o token morre (fail-closed). É
+      deslizado a cada atividade real do usuário via ``POST /auth/refresh``.
+    - ``abs_exp``: teto ABSOLUTO da sessão (``jwt_expire_minutes``, 7 dias). Preserva a garantia
+      de 7 dias do JWT como LIMITE MÁXIMO — a sessão nunca vive além disso, mesmo com atividade
+      contínua. Reduzir a janela de idle NÃO afrouxa os 7 dias (AC3): eles seguem como teto.
+
+    ``absolute_expiry`` é passado na reemissão para preservar o teto original do login.
+    """
+    now = datetime.now(UTC)
+    ceiling = absolute_expiry or (now + timedelta(minutes=settings.jwt_expire_minutes))
+    idle_expire = now + timedelta(minutes=settings.session_idle_timeout_minutes)
+    # A janela de inatividade nunca ultrapassa o teto absoluto da sessão.
+    expire = min(idle_expire, ceiling)
     to_encode = claims.copy()
-    expire = datetime.now(UTC) + timedelta(minutes=settings.jwt_expire_minutes)
-    to_encode.update({"exp": expire, "iat": datetime.now(UTC)})
+    to_encode.update({"exp": expire, "iat": now, "abs_exp": int(ceiling.timestamp())})
     return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
@@ -40,6 +64,31 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
         return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
     except JWTError:
         return None
+
+
+def refresh_access_token(payload: dict[str, Any]) -> str | None:
+    """Desliza a janela de inatividade de uma sessão, respeitando o teto absoluto de 7 dias.
+
+    Recebe o ``payload`` de um token AINDA VÁLIDO (quem chama já garantiu, via
+    ``decode_access_token``, que ele não expirou por inatividade). Retorna um novo token com a
+    janela de idle renovada, ou ``None`` se:
+    - o teto absoluto (``abs_exp``) já passou → a sessão atingiu o máximo de 7 dias; ou
+    - o token não carrega ``abs_exp`` legível (ex.: token legado pré-Story 1.3).
+
+    Fail-closed: na dúvida, recusa a reemissão (o usuário reloga). Não toca o banco.
+    """
+    abs_exp = payload.get("abs_exp")
+    if abs_exp is None:
+        return None
+    try:
+        ceiling_ts = float(abs_exp)
+    except (TypeError, ValueError):
+        return None
+    if datetime.now(UTC).timestamp() >= ceiling_ts:
+        return None
+    identity = {k: payload[k] for k in _SESSION_IDENTITY_CLAIMS if k in payload}
+    ceiling = datetime.fromtimestamp(ceiling_ts, tz=UTC)
+    return create_access_token(identity, absolute_expiry=ceiling)
 
 
 def generate_reset_token() -> tuple[str, str]:

--- a/apps/api/app/modules/auth/router.py
+++ b/apps/api/app/modules/auth/router.py
@@ -1,11 +1,11 @@
 """Rotas de autenticação e onboarding de tenant."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.core.security import create_access_token
+from app.core.security import create_access_token, decode_access_token, refresh_access_token
 from app.core.tenancy import CurrentUser, get_current_user
 from app.db.session import get_db
 from app.modules.auth.models import Tenant, User
@@ -14,6 +14,7 @@ from app.modules.auth.schemas import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
     LoginRequest,
+    RefreshedToken,
     RegisterRequest,
     ResetPasswordRequest,
     SessionInfo,
@@ -65,6 +66,27 @@ def login(data: LoginRequest, db: Session = Depends(get_db)) -> AuthToken:
     except AuthError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return _build_token(tenant, user)
+
+
+@router.post("/refresh", response_model=RefreshedToken)
+def refresh(
+    _current: CurrentUser = Depends(get_current_user),
+    authorization: str | None = Header(default=None),
+) -> RefreshedToken:
+    """Desliza a janela de inatividade da sessão (idle timeout LGPD — Story 1.3).
+
+    Depende de ``get_current_user``: um token já expirado por inatividade (>30 min sem chamar
+    /refresh) falha aqui com 401 (fail-closed), forçando novo login. O front chama isto enquanto
+    há atividade real do usuário. Não consulta o banco → leve, sem regressão de performance (IV3).
+    """
+    # get_current_user já validou header presente + token não expirado; decodificamos de novo
+    # apenas para ler ``abs_exp`` (não carregado em CurrentUser) e reemitir preservando o teto.
+    token = (authorization or "").split(" ", 1)[1]
+    payload = decode_access_token(token)
+    new_token = refresh_access_token(payload) if payload else None
+    if new_token is None:
+        raise HTTPException(status_code=401, detail="Sessão expirada — faça login novamente")
+    return RefreshedToken(access_token=new_token)
 
 
 @router.post("/forgot-password")

--- a/apps/api/app/modules/auth/schemas.py
+++ b/apps/api/app/modules/auth/schemas.py
@@ -104,3 +104,13 @@ class SessionInfo(BaseModel):
 class AuthToken(SessionInfo):
     access_token: str
     token_type: str = "bearer"  # noqa: S105 (não é senha, é o tipo do token OAuth)
+
+
+class RefreshedToken(BaseModel):
+    """Retorno de /auth/refresh — só a credencial renovada (desliza o idle timeout LGPD).
+
+    Não reenvia user/tenant (o cliente já os tem) nem toca o banco: mantém o refresh leve (IV3).
+    """
+
+    access_token: str
+    token_type: str = "bearer"  # noqa: S105 (não é senha, é o tipo do token OAuth)

--- a/apps/api/tests/test_idle_timeout.py
+++ b/apps/api/tests/test_idle_timeout.py
@@ -1,0 +1,129 @@
+"""Idle timeout LGPD (Story 1.3): expiração por inatividade + reemissão via /auth/refresh.
+
+O JWT ganha duas camadas: ``exp`` = janela de inatividade (30 min, deslizada por atividade) e
+``abs_exp`` = teto absoluto de 7 dias (preserva a garantia atual do JWT). Sem estado no banco.
+"""
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.core.security import (
+    create_access_token,
+    decode_access_token,
+    refresh_access_token,
+)
+
+VALID = {
+    "legal_name": "João Silva Advocacia",
+    "document": "12345678000190",
+    "slug": "joaosilva",
+    "email": "joao@example.com",
+    "name": "João Silva",
+    "password": "senha-super-secreta",
+}
+
+
+def _register(client: TestClient):
+    return client.post("/auth/register", json=VALID)
+
+
+# ── Unidade: estrutura do token (AC1, AC3) ───────────────────────────────────
+def test_token_has_idle_and_absolute_layers():
+    token = create_access_token({"sub": "u1", "tenant_id": "t1"})
+    payload = decode_access_token(token)
+    assert payload is not None
+    # A janela de inatividade (exp) é bem menor que o teto absoluto (abs_exp = 7 dias).
+    assert payload["exp"] < payload["abs_exp"]
+    idle_seconds = payload["exp"] - payload["iat"]
+    assert idle_seconds <= settings.session_idle_timeout_minutes * 60 + 5
+    # O teto absoluto continua sendo os 7 dias do JWT (AC3 — não afrouxado).
+    ceiling_seconds = payload["abs_exp"] - payload["iat"]
+    assert ceiling_seconds >= settings.jwt_expire_minutes * 60 - 5
+
+
+def test_refresh_slides_idle_window_preserving_ceiling():
+    original = create_access_token({"sub": "u1", "tenant_id": "t1", "role": "owner"})
+    payload = decode_access_token(original)
+    new_token = refresh_access_token(payload)
+    assert new_token is not None
+    new_payload = decode_access_token(new_token)
+    assert new_payload is not None
+    # Teto absoluto e identidade preservados na reemissão.
+    assert new_payload["abs_exp"] == payload["abs_exp"]
+    assert new_payload["sub"] == "u1"
+    assert new_payload["role"] == "owner"
+
+
+def test_refresh_returns_none_without_abs_exp():
+    # Token legado (pré-Story 1.3, sem abs_exp) não pode ser deslizado → fail-closed.
+    assert refresh_access_token({"sub": "u1", "tenant_id": "t1"}) is None
+
+
+def test_refresh_returns_none_after_absolute_cap():
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    payload = {"sub": "u1", "tenant_id": "t1", "abs_exp": int(past.timestamp())}
+    assert refresh_access_token(payload) is None
+
+
+def test_refresh_caps_new_window_at_ceiling():
+    # Se o teto está logo ali (20s) e o idle é 30 min, a nova janela não passa do teto.
+    ceiling = datetime.now(UTC) + timedelta(seconds=20)
+    payload = {"sub": "u1", "tenant_id": "t1", "abs_exp": int(ceiling.timestamp())}
+    new_token = refresh_access_token(payload)
+    assert new_token is not None
+    new_payload = decode_access_token(new_token)
+    assert new_payload is not None
+    assert new_payload["exp"] <= new_payload["abs_exp"]
+
+
+# ── Integração: endpoint /auth/refresh (AC1, IV1, IV3) ───────────────────────
+def test_refresh_endpoint_returns_working_token(client: TestClient):
+    token = _register(client).json()["access_token"]
+    r = client.post("/auth/refresh", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    new_token = r.json()["access_token"]
+    assert new_token
+    # O token renovado funciona numa rota protegida.
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {new_token}"})
+    assert me.status_code == 200
+
+
+def test_refresh_without_token_rejected(client: TestClient):
+    assert client.post("/auth/refresh").status_code == 401
+
+
+# ── Integração: expiração por inatividade é fail-closed (AC1) ─────────────────
+def test_idle_expired_token_is_rejected(client: TestClient, monkeypatch):
+    body = _register(client).json()
+    user, tenant = body["user"], body["tenant"]
+    # Simula 'última atividade' há muito tempo: idle negativo => token nasce expirado.
+    monkeypatch.setattr(settings, "session_idle_timeout_minutes", -1)
+    stale = create_access_token(
+        {
+            "sub": user["id"],
+            "tenant_id": tenant["id"],
+            "role": user["role"],
+            "allowed_modules": user["allowed_modules"],
+            "is_platform_admin": user["is_platform_admin"],
+        }
+    )
+    r = client.get("/auth/me", headers={"Authorization": f"Bearer {stale}"})
+    assert r.status_code == 401
+
+
+def test_idle_expired_token_cannot_refresh(client: TestClient, monkeypatch):
+    body = _register(client).json()
+    user, tenant = body["user"], body["tenant"]
+    monkeypatch.setattr(settings, "session_idle_timeout_minutes", -1)
+    stale = create_access_token({"sub": user["id"], "tenant_id": tenant["id"]})
+    # Token já expirado por inatividade não desliza a própria sessão (fail-closed).
+    r = client.post("/auth/refresh", headers={"Authorization": f"Bearer {stale}"})
+    assert r.status_code == 401
+
+
+# ── IV2: rotas públicas não são afetadas ─────────────────────────────────────
+def test_public_route_not_gated_by_idle(client: TestClient):
+    # Rota pública (sem login) NÃO passa por get_current_user → nunca 401 por sessão/inatividade.
+    r = client.get("/public/pages/inexistente-slug")
+    assert r.status_code != 401

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -28,7 +28,9 @@ import ProdutosPage from "../features/produtos/ProdutosPage";
 import PageBuilderPage from "../features/sites/PageBuilderPage";
 import PublicPage from "../features/sites/PublicPage";
 import SitesPage from "../features/sites/SitesPage";
+import IdleWarningModal from "../components/IdleWarningModal";
 import { AuthProvider, useAuth } from "../store/auth";
+import { useIdleTimeout } from "../store/useIdleTimeout";
 import { PageActionsProvider } from "../store/pageActions";
 import AppShell from "./AppShell";
 
@@ -83,6 +85,8 @@ function LoginRoute() {
 
 function ProtectedLayout() {
   const { isAuthenticated, user } = useAuth();
+  // Idle timeout LGPD (Story 1.3): hook sempre chamado (regra dos hooks); no-op quando deslogado.
+  const { showWarning, stayConnected } = useIdleTimeout();
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   // 1º acesso: bloqueia o app até o usuário trocar a senha temporária.
   if (user?.must_reset_password) return <FirstAccessPage />;
@@ -91,6 +95,7 @@ function ProtectedLayout() {
       <AppShell>
         <Outlet />
       </AppShell>
+      <IdleWarningModal open={showWarning} onStay={stayConnected} />
     </PageActionsProvider>
   );
 }

--- a/apps/web/src/components/IdleWarningModal.tsx
+++ b/apps/web/src/components/IdleWarningModal.tsx
@@ -1,0 +1,34 @@
+import { IDLE_WARNING_MINUTES } from "../lib/idleTimer";
+import Modal from "./Modal";
+
+/**
+ * Aviso de sessão prestes a expirar por inatividade (idle timeout LGPD — Story 1.3).
+ * Reaproveita o `Modal` do design "Portal". Fechar (X/fundo) ou clicar em "Continuar conectado"
+ * mantém a sessão; não fazer nada leva ao logout automático.
+ */
+export default function IdleWarningModal({
+  open,
+  onStay,
+}: {
+  open: boolean;
+  onStay: () => void;
+}) {
+  return (
+    <Modal title="Sessão prestes a expirar" open={open} onClose={onStay}>
+      <p className="text-sm text-neutral-600">
+        Por segurança (LGPD), sua sessão será encerrada em cerca de {IDLE_WARNING_MINUTES}{" "}
+        {IDLE_WARNING_MINUTES === 1 ? "minuto" : "minutos"} por inatividade. Deseja continuar
+        conectado?
+      </p>
+      <div className="mt-6 flex justify-end">
+        <button
+          type="button"
+          onClick={onStay}
+          className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700"
+        >
+          Continuar conectado
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,6 +20,20 @@ export const publicApi = axios.create({
   headers: { "Content-Type": "application/json" },
 });
 
+/**
+ * Desliza a sessão no backend (idle timeout LGPD — Story 1.3): reemite um access token com a
+ * janela de inatividade renovada. Retorna o novo token, ou `null` se a sessão não pôde ser
+ * renovada (401 → o interceptor já cuida do logout). Não lança.
+ */
+export async function refreshSession(): Promise<string | null> {
+  try {
+    const { data } = await api.post<{ access_token: string }>("/auth/refresh");
+    return data.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function apiErrorMessage(err: unknown): string {
   if (err instanceof AxiosError) {
     const data = err.response?.data as ApiError | undefined;

--- a/apps/web/src/lib/idleTimer.test.ts
+++ b/apps/web/src/lib/idleTimer.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IdleTimer } from "./idleTimer";
+
+describe("IdleTimer (idle timeout LGPD — Story 1.3)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const make = (over = {}) => {
+    const onWarn = vi.fn();
+    const onTimeout = vi.fn();
+    const onActive = vi.fn();
+    const timer = new IdleTimer({
+      idleMs: 30_000,
+      warningMs: 5_000,
+      onWarn,
+      onTimeout,
+      onActive,
+      ...over,
+    });
+    return { timer, onWarn, onTimeout, onActive };
+  };
+
+  it("avisa em (idle - warning) e desloga em idle sem atividade", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(25_000); // janela de aviso
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5_000); // esgota
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("atividade reinicia a contagem e evita o timeout (fluxo ativo legítimo — AC2)", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(20_000);
+    timer.activity(); // usuário interagiu (ex.: digitando um formulário longo)
+    vi.advanceTimersByTime(20_000); // 40s desde o start, mas só 20s desde a atividade
+
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("atividade após o aviso o esconde (onActive) e cancela o timeout", () => {
+    const { timer, onWarn, onTimeout, onActive } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(25_000);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+
+    timer.activity();
+    expect(onActive).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5_000); // teria estourado sem a atividade
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("stop() cancela timers pendentes", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+    timer.stop();
+    vi.advanceTimersByTime(60_000);
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/idleTimer.ts
+++ b/apps/web/src/lib/idleTimer.ts
@@ -1,0 +1,110 @@
+/**
+ * Idle timeout LGPD (Story 1.3).
+ *
+ * Camada de UX no cliente: avisa o usuário ANTES do logout por inatividade e desliza a sessão
+ * no backend (`POST /auth/refresh`) enquanto há atividade real. A EXPIRAÇÃO em si é garantida
+ * pelo backend (o access token expira por inatividade e o interceptor 401 desloga) — este timer
+ * é a experiência amigável em cima disso. Se cliente e backend divergirem, o backend ainda
+ * protege via 401 (fail-closed).
+ *
+ * A classe é pura (timers injetáveis) para ser testável sem DOM.
+ */
+
+/**
+ * Minutos de inatividade até o logout. DEVE espelhar `session_idle_timeout_minutes` do backend
+ * (apps/api/app/config.py). O backend é a fonte de verdade da expiração; este número controla
+ * apenas o momento do AVISO/logout do cliente.
+ */
+export const IDLE_TIMEOUT_MINUTES = 30;
+
+/** Antecedência (min) com que o aviso aparece antes do logout. */
+export const IDLE_WARNING_MINUTES = 1;
+
+/**
+ * Intervalo mínimo (min) entre chamadas a `/auth/refresh`. Evita reemitir a cada mousemove —
+ * mantém a sessão viva durante uso ativo sem gerar carga desnecessária na API (IV3).
+ */
+export const IDLE_REFRESH_INTERVAL_MINUTES = 5;
+
+type TimerId = ReturnType<typeof setTimeout>;
+
+export interface IdleTimerOptions {
+  /** Duração total da janela de inatividade em ms. */
+  idleMs: number;
+  /** Quanto antes do timeout mostrar o aviso, em ms. */
+  warningMs: number;
+  /** Chamado ao entrar na janela de aviso (idleMs - warningMs sem atividade). */
+  onWarn: () => void;
+  /** Chamado quando a janela total esgota sem atividade. */
+  onTimeout: () => void;
+  /** Chamado quando há atividade APÓS um aviso ter sido exibido (para escondê-lo). */
+  onActive?: () => void;
+  /** Injeção para testes. */
+  setTimer?: (cb: () => void, ms: number) => TimerId;
+  clearTimer?: (id: TimerId) => void;
+}
+
+export class IdleTimer {
+  private readonly idleMs: number;
+  private readonly warningMs: number;
+  private readonly onWarn: () => void;
+  private readonly onTimeout: () => void;
+  private readonly onActive: () => void;
+  private readonly setTimer: (cb: () => void, ms: number) => TimerId;
+  private readonly clearTimer: (id: TimerId) => void;
+
+  private warnId: TimerId | null = null;
+  private timeoutId: TimerId | null = null;
+  private warned = false;
+
+  constructor(opts: IdleTimerOptions) {
+    this.idleMs = opts.idleMs;
+    this.warningMs = Math.min(opts.warningMs, opts.idleMs);
+    this.onWarn = opts.onWarn;
+    this.onTimeout = opts.onTimeout;
+    this.onActive = opts.onActive ?? (() => {});
+    this.setTimer = opts.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimer = opts.clearTimer ?? ((id) => clearTimeout(id));
+  }
+
+  /** Inicia a contagem. */
+  start(): void {
+    this.schedule();
+  }
+
+  /** Para a contagem e limpa os timers pendentes. */
+  stop(): void {
+    this.clear();
+    this.warned = false;
+  }
+
+  /**
+   * Registra atividade do usuário: reinicia a contagem. Se um aviso estava visível, dispara
+   * `onActive` para escondê-lo.
+   */
+  activity(): void {
+    if (this.warned) {
+      this.warned = false;
+      this.onActive();
+    }
+    this.schedule();
+  }
+
+  private schedule(): void {
+    this.clear();
+    this.warnId = this.setTimer(() => {
+      this.warned = true;
+      this.onWarn();
+    }, this.idleMs - this.warningMs);
+    this.timeoutId = this.setTimer(() => {
+      this.onTimeout();
+    }, this.idleMs);
+  }
+
+  private clear(): void {
+    if (this.warnId !== null) this.clearTimer(this.warnId);
+    if (this.timeoutId !== null) this.clearTimer(this.timeoutId);
+    this.warnId = null;
+    this.timeoutId = null;
+  }
+}

--- a/apps/web/src/store/auth.tsx
+++ b/apps/web/src/store/auth.tsx
@@ -9,6 +9,7 @@ interface AuthContextValue {
   isAuthenticated: boolean;
   login: (token: string, user: User, tenant: Tenant) => void;
   updateUser: (user: User) => void;
+  updateToken: (token: string) => void;
   logout: () => void;
 }
 
@@ -46,6 +47,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(u);
   }, []);
 
+  // Substitui só a credencial (usado ao deslizar a sessão via /auth/refresh — idle timeout LGPD).
+  const updateToken = useCallback((t: string) => {
+    localStorage.setItem(TOKEN_KEY, t);
+    setToken(t);
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
@@ -69,7 +76,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ token, user, tenant, isAuthenticated: Boolean(token), login, updateUser, logout }}
+      value={{
+        token,
+        user,
+        tenant,
+        isAuthenticated: Boolean(token),
+        login,
+        updateUser,
+        updateToken,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/apps/web/src/store/useIdleTimeout.ts
+++ b/apps/web/src/store/useIdleTimeout.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { refreshSession } from "../lib/api";
+import {
+  IDLE_REFRESH_INTERVAL_MINUTES,
+  IDLE_TIMEOUT_MINUTES,
+  IDLE_WARNING_MINUTES,
+  IdleTimer,
+} from "../lib/idleTimer";
+import { useAuth } from "./auth";
+
+const ACTIVITY_EVENTS = [
+  "mousedown",
+  "mousemove",
+  "keydown",
+  "touchstart",
+  "scroll",
+  "click",
+] as const;
+
+const MIN = 60_000;
+
+/**
+ * Idle timeout LGPD (Story 1.3). Enquanto o usuário está logado:
+ * - conta 30 min de inatividade (qualquer interação — não só requests — reinicia a contagem,
+ *   cobrindo formulários longos sem quebrar fluxos ativos legítimos — AC2);
+ * - desliza a sessão no backend (`/auth/refresh`, com throttle) enquanto há atividade;
+ * - avisa 1 min antes e, ao esgotar, faz logout limpo.
+ *
+ * O backend é a proteção real (token expira por inatividade → 401 → interceptor desloga); este
+ * hook é a experiência amigável em cima disso.
+ */
+export function useIdleTimeout(): { showWarning: boolean; stayConnected: () => void } {
+  const { isAuthenticated, updateToken, logout } = useAuth();
+  const [showWarning, setShowWarning] = useState(false);
+  const timerRef = useRef<IdleTimer | null>(null);
+  const lastRefreshRef = useRef(0);
+
+  // Reemite o token no backend (throttle), atualizando a credencial guardada.
+  const doRefresh = useCallback(
+    async (force: boolean) => {
+      const now = Date.now();
+      if (!force && now - lastRefreshRef.current < IDLE_REFRESH_INTERVAL_MINUTES * MIN) return;
+      lastRefreshRef.current = now;
+      const token = await refreshSession();
+      if (token) updateToken(token);
+    },
+    [updateToken],
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setShowWarning(false);
+      return;
+    }
+
+    const timer = new IdleTimer({
+      idleMs: IDLE_TIMEOUT_MINUTES * MIN,
+      warningMs: IDLE_WARNING_MINUTES * MIN,
+      onWarn: () => setShowWarning(true),
+      onTimeout: () => {
+        setShowWarning(false);
+        // Fail-closed: sessão ociosa é encerrada (o token do backend já expirou em paralelo).
+        logout();
+      },
+      onActive: () => setShowWarning(false),
+    });
+    timerRef.current = timer;
+    timer.start();
+
+    const onActivity = () => {
+      timer.activity();
+      void doRefresh(false);
+    };
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, onActivity, { passive: true });
+    }
+
+    return () => {
+      timer.stop();
+      timerRef.current = null;
+      for (const evt of ACTIVITY_EVENTS) window.removeEventListener(evt, onActivity);
+    };
+  }, [isAuthenticated, doRefresh, logout]);
+
+  // Botão "Continuar conectado": reinicia a contagem e força uma reemissão imediata.
+  const stayConnected = useCallback(() => {
+    setShowWarning(false);
+    timerRef.current?.activity();
+    void doRefresh(true);
+  }, [doRefresh]);
+
+  return { showWarning, stayConnected };
+}

--- a/docs/stories/1.3.story.md
+++ b/docs/stories/1.3.story.md
@@ -1,7 +1,7 @@
 # Story 1.3: Idle timeout LGPD (30 min)
 
 ## Status
-Ready
+InReview
 
 ## Executor Assignment
 ```yaml
@@ -36,37 +36,37 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "vitest (apps
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Decisão de arquitetura para o mecanismo de idle timeout (AC: 1, 3)**
-  - [ ] **Esta story tem uma decisão de design em aberto que NÃO está resolvida nem no epic nem em CLAUDE.md** (ver Dev Notes → "Gap técnico identificado"). Antes de codar, o @dev deve escolher e documentar (no Dev Agent Record) uma das abordagens abaixo — ou outra equivalente — respeitando a AC3 (não afrouxar os 7 dias do JWT "para os demais casos"):
+- [x] **Task 1 — Decisão de arquitetura para o mecanismo de idle timeout (AC: 1, 3)**
+  - [x] **Esta story tem uma decisão de design em aberto que NÃO está resolvida nem no epic nem em CLAUDE.md** (ver Dev Notes → "Gap técnico identificado"). Antes de codar, o @dev deve escolher e documentar (no Dev Agent Record) uma das abordagens abaixo — ou outra equivalente — respeitando a AC3 (não afrouxar os 7 dias do JWT "para os demais casos"):
     - **Opção A — sliding refresh token curto** (mais alinhada à redação literal da AC1, "refresh token curto"): criar um `POST /auth/refresh` novo (não existe hoje) que emite um novo access token de vida curta a partir de um refresh token; o refresh token só é aceito se a última atividade foi há menos de `session_idle_timeout_minutes` (30); o frontend chama `/auth/refresh` periodicamente enquanto há atividade do usuário; se o refresh falhar (idle estourado), desloga.
     - **Opção B — tabela de sessão ativa server-side**: nova tabela (ex. `active_sessions`, chaveada por `user_id`/`jti` do JWT) atualizada a cada request autenticado com `last_activity_at`; uma dependency check (ex. em `get_current_user`) rejeita (401) requests cujo `last_activity_at` já passou de 30 min, mesmo com o JWT de 7 dias ainda tecnicamente válido.
-  - [ ] Qualquer que seja a opção, o JWT_SECRET/algoritmo/`jwt_expire_minutes=10080` (7 dias) usados hoje por `apps/api/app/core/security.py::create_access_token` **não devem ser reduzidos globalmente** — a AC3 pede que o idle timeout seja uma camada ADICIONAL, não uma troca do prazo de expiração do JWT em si (que continua valendo para os "demais casos" — ex. tokens de reset de senha usam mecanismo próprio via `hash_token`/sha256, não são afetados).
+  - [x] Qualquer que seja a opção, o JWT_SECRET/algoritmo/`jwt_expire_minutes=10080` (7 dias) usados hoje por `apps/api/app/core/security.py::create_access_token` **não devem ser reduzidos globalmente** — a AC3 pede que o idle timeout seja uma camada ADICIONAL, não uma troca do prazo de expiração do JWT em si (que continua valendo para os "demais casos" — ex. tokens de reset de senha usam mecanismo próprio via `hash_token`/sha256, não são afetados).
 
-- [ ] **Task 2 — Implementar o mecanismo de atividade/expiração no backend (AC: 1, 3)**
-  - [ ] Usar o config já existente `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`, hoje definido como `30  # LGPD` mas **NÃO referenciado em lugar nenhum do código** — é dead config, este é o ponto de entrada natural).
-  - [ ] Implementar a abordagem escolhida na Task 1 dentro de `apps/api/app/core/security.py` (primitivas) e `apps/api/app/core/tenancy.py::get_current_user`/nova dependency (ponto único onde toda rota autenticada já passa — ver Dev Notes para o fluxo exato hoje).
-  - [ ] Se a opção escolhida envolve nova tabela: nova migration em `apps/api/migrations/versions/` (coordenar numeração com Stories 1.1/1.2, que também adicionam migrations nesta mesma sequência de epic).
-  - [ ] Garantir que rotas PÚBLICAS (assinatura de contrato, aceite de proposta, página pública) continuam funcionando sem exigir sessão/atividade — elas já não usam `get_current_user`/`get_tenant_db` (usam `get_db` direto, ver Story 1.2 Task 1), então não devem ser afetadas por este mecanismo. Confirmar explicitamente com teste (IV2).
+- [x] **Task 2 — Implementar o mecanismo de atividade/expiração no backend (AC: 1, 3)**
+  - [x] Usar o config já existente `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`, hoje definido como `30  # LGPD` mas **NÃO referenciado em lugar nenhum do código** — é dead config, este é o ponto de entrada natural).
+  - [x] Implementar a abordagem escolhida na Task 1 dentro de `apps/api/app/core/security.py` (primitivas) e `apps/api/app/core/tenancy.py::get_current_user`/nova dependency (ponto único onde toda rota autenticada já passa — ver Dev Notes para o fluxo exato hoje).
+  - [x] Se a opção escolhida envolve nova tabela: nova migration em `apps/api/migrations/versions/` (coordenar numeração com Stories 1.1/1.2, que também adicionam migrations nesta mesma sequência de epic).
+  - [x] Garantir que rotas PÚBLICAS (assinatura de contrato, aceite de proposta, página pública) continuam funcionando sem exigir sessão/atividade — elas já não usam `get_current_user`/`get_tenant_db` (usam `get_db` direto, ver Story 1.2 Task 1), então não devem ser afetadas por este mecanismo. Confirmar explicitamente com teste (IV2).
 
-- [ ] **Task 3 — Frontend: `ProtectedLayout` trata o timeout (AC: 2)**
-  - [ ] `apps/web/src/app/App.tsx`, função `ProtectedLayout` (linhas ~84-96): hoje só verifica `isAuthenticated`/`must_reset_password`. Adicionar o tracking de atividade (eventos de mouse/teclado/click/scroll) com um timer de 30 min (mesmo valor do backend — idealmente expor `session_idle_timeout_minutes` para o frontend via `/me` ou config pública, para não hardcodar o número duas vezes).
-  - [ ] Ao estourar o idle: mostrar um aviso (ex. toast/modal — usar padrão de UI já existente no design "Portal") e então chamar `logout()` (já existe em `apps/web/src/store/auth.tsx`, limpa `localStorage` e state) — o próprio `AuthProvider` já redireciona pro `/login` quando `isAuthenticated` vira `false` via `ProtectedLayout`/`LoginRoute`, então basta chamar `logout()` corretamente.
-  - [ ] Reaproveitar o padrão já existente de logout automático em 401: `apps/web/src/store/auth.tsx` linhas ~58-68 já intercepta respostas 401 da API e desloga — se a Opção A/B do backend passar a devolver 401 quando a sessão expira por inatividade, esse interceptor JÁ cobre parte do fluxo; a Task 3 deve then focar em: (a) o AVISO amigável antes/no momento do logout (a AC pede "aviso", o interceptor sozinho não avisa, só desloga), e (b) o timer local para não depender só de uma request falhar para perceber o timeout.
-  - [ ] Não quebrar fluxos ativos legítimos (AC2): qualquer interação do usuário (não só requests à API) deve resetar o timer — cobrir digitação em formulários longos (ex. editor de contrato, editor de funil) mesmo que o usuário não dispare uma request por alguns minutos.
+- [x] **Task 3 — Frontend: `ProtectedLayout` trata o timeout (AC: 2)**
+  - [x] `apps/web/src/app/App.tsx`, função `ProtectedLayout` (linhas ~84-96): hoje só verifica `isAuthenticated`/`must_reset_password`. Adicionar o tracking de atividade (eventos de mouse/teclado/click/scroll) com um timer de 30 min (mesmo valor do backend — idealmente expor `session_idle_timeout_minutes` para o frontend via `/me` ou config pública, para não hardcodar o número duas vezes).
+  - [x] Ao estourar o idle: mostrar um aviso (ex. toast/modal — usar padrão de UI já existente no design "Portal") e então chamar `logout()` (já existe em `apps/web/src/store/auth.tsx`, limpa `localStorage` e state) — o próprio `AuthProvider` já redireciona pro `/login` quando `isAuthenticated` vira `false` via `ProtectedLayout`/`LoginRoute`, então basta chamar `logout()` corretamente.
+  - [x] Reaproveitar o padrão já existente de logout automático em 401: `apps/web/src/store/auth.tsx` linhas ~58-68 já intercepta respostas 401 da API e desloga — se a Opção A/B do backend passar a devolver 401 quando a sessão expira por inatividade, esse interceptor JÁ cobre parte do fluxo; a Task 3 deve then focar em: (a) o AVISO amigável antes/no momento do logout (a AC pede "aviso", o interceptor sozinho não avisa, só desloga), e (b) o timer local para não depender só de uma request falhar para perceber o timeout.
+  - [x] Não quebrar fluxos ativos legítimos (AC2): qualquer interação do usuário (não só requests à API) deve resetar o timer — cobrir digitação em formulários longos (ex. editor de contrato, editor de funil) mesmo que o usuário não dispare uma request por alguns minutos.
 
-- [ ] **Task 4 — Testes de regressão de auth (AC: 1, 2, 3; IV1)**
-  - [ ] Rodar/estender `apps/api/tests/test_auth.py` para cobrir: login/logout continuam funcionando; rota protegida ainda aceita token dentro da janela de atividade; rota protegida rejeita quando a "última atividade" simulada excede 30 min (ajustar `settings.session_idle_timeout_minutes` no teste para um valor pequeno, evitar testes lentos).
-  - [ ] Confirmar que o teste de guarda de configuração (`apps/api/tests/test_config.py`) não precisa mudar (idle timeout é comportamento de runtime, não de boot) — se a abordagem escolhida adicionar novo campo de config, avaliar se merece guard semelhante.
+- [x] **Task 4 — Testes de regressão de auth (AC: 1, 2, 3; IV1)**
+  - [x] Rodar/estender `apps/api/tests/test_auth.py` para cobrir: login/logout continuam funcionando; rota protegida ainda aceita token dentro da janela de atividade; rota protegida rejeita quando a "última atividade" simulada excede 30 min (ajustar `settings.session_idle_timeout_minutes` no teste para um valor pequeno, evitar testes lentos).
+  - [x] Confirmar que o teste de guarda de configuração (`apps/api/tests/test_config.py`) não precisa mudar (idle timeout é comportamento de runtime, não de boot) — se a abordagem escolhida adicionar novo campo de config, avaliar se merece guard semelhante.
 
-- [ ] **Task 5 — Validar não-impacto em endpoints públicos (AC: 2; IV2)**
-  - [ ] Testar manualmente/via `apps/api/tests/test_contracts.py`, `test_quotes.py`(?), `test_pages.py` que os fluxos públicos (assinatura de contrato, aceite de proposta, visualização de página) continuam funcionando sem exigir login/atividade — eles não passam por `get_current_user`.
+- [x] **Task 5 — Validar não-impacto em endpoints públicos (AC: 2; IV2)**
+  - [x] Testar manualmente/via `apps/api/tests/test_contracts.py`, `test_quotes.py`(?), `test_pages.py` que os fluxos públicos (assinatura de contrato, aceite de proposta, visualização de página) continuam funcionando sem exigir login/atividade — eles não passam por `get_current_user`.
 
-- [ ] **Task 6 — Validar performance do fluxo de refresh (AC: todas; IV3)**
-  - [ ] Se a Opção A (refresh token) for escolhida: confirmar que o novo `/auth/refresh` é leve (uma consulta simples, sem N+1) e que o polling do frontend não gera carga desnecessária na API (ex.: só chamar refresh quando há atividade real, não em intervalo fixo agressivo).
-  - [ ] Se a Opção B (sessão server-side) for escolhida: confirmar que a escrita de `last_activity_at` a cada request não gera contenção/lock desnecessário (ex.: usar `UPDATE` simples por PK, sem lock de linha compartilhado entre requests concorrentes do mesmo usuário além do necessário).
+- [x] **Task 6 — Validar performance do fluxo de refresh (AC: todas; IV3)**
+  - [x] Se a Opção A (refresh token) for escolhida: confirmar que o novo `/auth/refresh` é leve (uma consulta simples, sem N+1) e que o polling do frontend não gera carga desnecessária na API (ex.: só chamar refresh quando há atividade real, não em intervalo fixo agressivo).
+  - [x] Se a Opção B (sessão server-side) for escolhida: confirmar que a escrita de `last_activity_at` a cada request não gera contenção/lock desnecessário (ex.: usar `UPDATE` simples por PK, sem lock de linha compartilhado entre requests concorrentes do mesmo usuário além do necessário).
 
-- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
-  - [ ] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — CLAUDE.md §5.
+- [x] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [x] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — CLAUDE.md §5.
 
 ## Dev Notes
 
@@ -116,20 +116,59 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "vitest (apps
 |------|---------|-------------|--------|
 | 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
 | 2026-07-10 | 0.1.1 | Validated GO (8/10) — Status: Draft → Ready (fork de arquitetura Opção A/B delegado ao @dev/@architect na Task 1) | @po |
+| 2026-07-10 | 0.2 | Implementada (Opção A — sliding session stateless, sem tabela/migration). Backend: 262 pytest / ruff OK; Frontend: 4 vitest / tsc OK. Status: Ready → InReview | Dex (@dev) |
 
 ## Dev Agent Record
 
 ### Agent Model Used
-_(a preencher pelo @dev)_
+Dex (@dev) — Opus 4.8 (1M) — modo YOLO autônomo, worktree isolado `feature/1.3-idle-timeout-lgpd`.
 
 ### Debug Log References
-_(a preencher pelo @dev)_
+- Backend: `ruff check .` → All checks passed; `pytest -q` → **262 passed** (9 novos em `test_idle_timeout.py`, 0 regressões) — rodado em container `python:3.13-slim` (SQLite in-memory, sem Postgres, conforme conftest). Python não está instalado no host; suíte executada via Docker.
+- Frontend: `tsc --noEmit` → sem erros; `vitest run` → **4 passed** (`src/lib/idleTimer.test.ts`). `pnpm install` executado no worktree para habilitar typecheck/vitest.
+- Frontend eslint NÃO rodado: o repositório não tem `eslint.config.*` (flat config) presente — `scripts/check.sh` também não roda lint de frontend (só typecheck+vitest). Sem regressão introduzida.
 
 ### Completion Notes List
-_(a preencher pelo @dev — incluir obrigatoriamente a decisão de arquitetura tomada na Task 1 e o porquê)_
+
+**Decisão de arquitetura (Task 1) — OPÇÃO A (sliding session stateless), variante de token único. SEM tabela nova, SEM migration.**
+
+Mecanismo escolhido: o access token passa a carregar DUAS camadas de expiração, sem estado no servidor:
+- `exp` = janela de INATIVIDADE (`session_idle_timeout_minutes`, 30 min) — é o que o `jwt.decode` valida sozinho; passou disso sem atividade, o token morre e `get_current_user` retorna 401 (fail-closed, camada de segurança REAL, server-side).
+- `abs_exp` = teto ABSOLUTO da sessão (`jwt_expire_minutes`, 7 dias) — preserva a garantia atual do JWT como limite máximo.
+- Novo `POST /auth/refresh` desliza a janela de idle (reemite token com `exp` renovado) enquanto respeita `abs_exp`. O frontend o chama, com throttle, a cada atividade real do usuário. É stateless e NÃO toca o banco (leve — IV3).
+
+**Por que A e não B (tabela `active_sessions` server-side):**
+1. **Menor blast radius / zero coordenação de migration** — evita disputa de numeração Alembic com as Stories 1.1/1.2 em paralelo (o `0032` foi reservado mas NÃO foi necessário — não inventei tabela).
+2. **Preserva a arquitetura stateless atual** — `get_current_user` continua sem consulta ao banco; nenhuma escrita de `last_activity_at` por request (Opção B geraria contenção/escrita a cada request autenticado — pior para IV3/performance).
+3. **Atende a AC literal** ("refresh token curto") e a AC3 — `jwt_expire_minutes=10080` NÃO foi reduzido; ele agora é o teto `abs_exp`. Só o token de sessão de login é afetado (`create_access_token` só é chamado por login/register); tokens de reset de senha usam mecanismo próprio (`hash_token`/sha256) e ficam intactos.
+
+**Comportamento fail-closed:** token sem `abs_exp` legível (ex.: token legado emitido antes desta story) NÃO pode ser deslizado por `/auth/refresh` → força novo login. Aceitável: este epic é pré-go-live (sem usuários reais em produção ainda). Tokens legados seguem válidos até seu `exp` natural via `get_current_user`, sem idle enforcement, até relogin.
+
+**Frontend (AC2):** `ProtectedLayout` agora usa `useIdleTimeout`, que rastreia atividade de mouse/teclado/click/scroll/touch (qualquer interação — não só requests — reinicia a contagem, cobrindo formulários longos), desliza a sessão no backend com throttle (`/auth/refresh` no máx. a cada 5 min), avisa 1 min antes via `IdleWarningModal` (reusa o `Modal` do design Portal) e faz `logout()` limpo ao esgotar. O interceptor 401 já existente em `auth.tsx` é o backstop fail-closed.
+
+**IDS (reuso):** reusei `components/Modal.tsx` (aviso), o `logout()`/interceptor 401 de `store/auth.tsx`, o cliente `api` de `lib/api.ts`, e o config morto `session_idle_timeout_minutes` (agora vivo). Criei apenas o que não existia: `lib/idleTimer.ts` (timer puro testável), `store/useIdleTimeout.ts` (glue DOM), `components/IdleWarningModal.tsx`, e no backend `refresh_access_token` + endpoint `/auth/refresh`.
+
+**Desvios:** (1) nenhuma migration criada — a Opção A escolhida não precisa (o `0032` reservado no prompt fica livre). (2) Número de idle (30) mantido como constante no frontend (`IDLE_TIMEOUT_MINUTES`) espelhando o backend, em vez de expor via endpoint — o backend é a fonte de verdade da EXPIRAÇÃO (token `exp`); se divergir, o 401 ainda protege (fail-closed). Optei por menor superfície em vez de novo endpoint público de config.
 
 ### File List
-_(a preencher pelo @dev)_
+**Backend (alterados):**
+- `apps/api/app/core/security.py` — `create_access_token` agora emite `exp` (idle) + `abs_exp` (teto 7d); novo `refresh_access_token`.
+- `apps/api/app/modules/auth/router.py` — novo endpoint `POST /auth/refresh`.
+- `apps/api/app/modules/auth/schemas.py` — novo schema `RefreshedToken`.
+
+**Backend (novo):**
+- `apps/api/tests/test_idle_timeout.py` — 9 testes (unidade do token/refresh + integração /refresh + idle fail-closed + IV2 rota pública).
+
+**Frontend (alterados):**
+- `apps/web/src/app/App.tsx` — `ProtectedLayout` usa `useIdleTimeout` + renderiza `IdleWarningModal`.
+- `apps/web/src/store/auth.tsx` — novo `updateToken` no contexto de auth.
+- `apps/web/src/lib/api.ts` — novo helper `refreshSession()`.
+
+**Frontend (novo):**
+- `apps/web/src/lib/idleTimer.ts` — classe pura `IdleTimer` + constantes de config.
+- `apps/web/src/store/useIdleTimeout.ts` — hook que integra atividade DOM, refresh throttled, aviso e logout.
+- `apps/web/src/components/IdleWarningModal.tsx` — aviso reusando `Modal`.
+- `apps/web/src/lib/idleTimer.test.ts` — 4 testes (vitest) do timer.
 
 ## QA Results
 _(a preencher pelo @qa)_


### PR DESCRIPTION
## Resumo

Story 1.3 do Epic 1 (Segurança & Compliance): idle timeout LGPD de 30 minutos via sliding session stateless.

- Backend: `core/security.py` e `auth/router.py` implementam expiração deslizante por atividade no próprio JWT; novo schema em `auth/schemas.py`.
- Frontend: `idleTimer.ts` + `useIdleTimeout.ts` monitoram atividade, `IdleWarningModal.tsx` avisa antes do logout, integração em `App.tsx`, `store/auth.tsx` e `lib/api.ts`.
- Cobertura: `tests/test_idle_timeout.py` (backend) + `idleTimer.test.ts` (frontend).

## Arquitetura

- **Sem migration nova.** Decisão de arquitetura: sliding session stateless via JWT, sem tabela de sessão. Não altera a cadeia de migrations.

## Base

- PR empilhada sobre `docs/go-live-prd-epics-stories` (PR #1). Deve ser mergeada após/junto da PR #1.

## Referências

- Story: `docs/stories/1.3.story.md`
- Epic: `docs/prd/epic-1-seguranca-compliance.md`

## Testes

- `pytest`: 262 passed.
- `vitest`: 4 passed.
