### PR TITLE
Epic 1 — Stories 1.2, 1.3, 1.4 (consolidado com 1.1)

### DIFF
--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -28,3 +28,52 @@ def record(db, *, tenant_id: str, actor: str, action: str, target: str = "", is_
     )
     db.add(entry)
     return entry
+
+
+class PlatformAuditEntry(Base, TimestampMixin):
+    """Log de PLATAFORMA (fora do tenant) para operações destrutivas do Master (LGPD).
+
+    Deliberadamente SEM ``TenantMixin``: assim `_business_table_names()` (descoberta dinâmica
+    via ``issubclass(mapper.class_, TenantMixin)`` em platform/service.py) NUNCA a inclui na
+    purga por tenant. Por isso o registro SOBREVIVE à exclusão da conta — resta o rastro de
+    quem/quando/qual tenant, que os `audit_entries` do próprio tenant (esses sim, purgados)
+    não conseguem preservar.
+
+    Guarda SNAPSHOTS (``actor_email``, ``target_tenant_slug``) porque o tenant-alvo é apagado
+    logo em seguida: não há como fazer FK/join depois. O ator é sempre o Master (não é apagado),
+    mas mantemos o e-mail como snapshot para o log ser autossuficiente.
+    """
+
+    __tablename__ = "platform_audit_entries"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    actor_user_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    actor_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    target_tenant_slug: Mapped[str] = mapped_column(String(63), nullable=False)
+    action: Mapped[str] = mapped_column(String(128), nullable=False)
+
+
+def record_platform(
+    db,
+    *,
+    actor_user_id: str,
+    actor_email: str,
+    target_tenant_id: str,
+    target_tenant_slug: str,
+    action: str,
+):
+    """Grava um log de PLATAFORMA (fora do tenant), que sobrevive à purga do tenant.
+
+    Use para operações destrutivas do Master (ex.: exclusão de conta), gravando na sessão
+    GLOBAL (`get_db`), NUNCA numa `tenant_session` do tenant que está sendo apagado.
+    """
+    entry = PlatformAuditEntry(
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_tenant_id=target_tenant_id,
+        target_tenant_slug=target_tenant_slug,
+        action=action,
+    )
+    db.add(entry)
+    return entry

--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -28,10 +28,34 @@ def verify_password(plain: str, hashed: str) -> bool:
         return False
 
 
-def create_access_token(claims: dict[str, Any]) -> str:
+# Claims de identidade preservados ao reemitir (deslizar) a sessão. NÃO inclui exp/iat/abs_exp,
+# que são recalculados a cada reemissão.
+_SESSION_IDENTITY_CLAIMS = ("sub", "tenant_id", "role", "allowed_modules", "is_platform_admin")
+
+
+def create_access_token(
+    claims: dict[str, Any],
+    *,
+    absolute_expiry: datetime | None = None,
+) -> str:
+    """Emite um token de sessão com DUAS camadas de expiração (idle timeout LGPD — Story 1.3).
+
+    - ``exp``: janela de INATIVIDADE (``session_idle_timeout_minutes``, ex. 30 min). É o que o
+      JWT valida automaticamente: passou disso sem atividade, o token morre (fail-closed). É
+      deslizado a cada atividade real do usuário via ``POST /auth/refresh``.
+    - ``abs_exp``: teto ABSOLUTO da sessão (``jwt_expire_minutes``, 7 dias). Preserva a garantia
+      de 7 dias do JWT como LIMITE MÁXIMO — a sessão nunca vive além disso, mesmo com atividade
+      contínua. Reduzir a janela de idle NÃO afrouxa os 7 dias (AC3): eles seguem como teto.
+
+    ``absolute_expiry`` é passado na reemissão para preservar o teto original do login.
+    """
+    now = datetime.now(UTC)
+    ceiling = absolute_expiry or (now + timedelta(minutes=settings.jwt_expire_minutes))
+    idle_expire = now + timedelta(minutes=settings.session_idle_timeout_minutes)
+    # A janela de inatividade nunca ultrapassa o teto absoluto da sessão.
+    expire = min(idle_expire, ceiling)
     to_encode = claims.copy()
-    expire = datetime.now(UTC) + timedelta(minutes=settings.jwt_expire_minutes)
-    to_encode.update({"exp": expire, "iat": datetime.now(UTC)})
+    to_encode.update({"exp": expire, "iat": now, "abs_exp": int(ceiling.timestamp())})
     return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
@@ -40,6 +64,31 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
         return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
     except JWTError:
         return None
+
+
+def refresh_access_token(payload: dict[str, Any]) -> str | None:
+    """Desliza a janela de inatividade de uma sessão, respeitando o teto absoluto de 7 dias.
+
+    Recebe o ``payload`` de um token AINDA VÁLIDO (quem chama já garantiu, via
+    ``decode_access_token``, que ele não expirou por inatividade). Retorna um novo token com a
+    janela de idle renovada, ou ``None`` se:
+    - o teto absoluto (``abs_exp``) já passou → a sessão atingiu o máximo de 7 dias; ou
+    - o token não carrega ``abs_exp`` legível (ex.: token legado pré-Story 1.3).
+
+    Fail-closed: na dúvida, recusa a reemissão (o usuário reloga). Não toca o banco.
+    """
+    abs_exp = payload.get("abs_exp")
+    if abs_exp is None:
+        return None
+    try:
+        ceiling_ts = float(abs_exp)
+    except (TypeError, ValueError):
+        return None
+    if datetime.now(UTC).timestamp() >= ceiling_ts:
+        return None
+    identity = {k: payload[k] for k in _SESSION_IDENTITY_CLAIMS if k in payload}
+    ceiling = datetime.fromtimestamp(ceiling_ts, tz=UTC)
+    return create_access_token(identity, absolute_expiry=ceiling)
 
 
 def generate_reset_token() -> tuple[str, str]:

--- a/apps/api/app/db/registry.py
+++ b/apps/api/app/db/registry.py
@@ -4,7 +4,7 @@ Usado pelo Alembic (autogenerate) e pelos testes (create_all). Sempre que criar 
 garanta que ele seja importado aqui (direta ou indiretamente).
 """
 # noqa: F401 — imports existem só para registrar as tabelas no metadata.
-from app.core.audit import AuditEntry  # noqa: F401
+from app.core.audit import AuditEntry, PlatformAuditEntry  # noqa: F401
 from app.db.base import Base
 from app.modules.agenda.models import AgendaEvent  # noqa: F401
 from app.modules.attachments.models import Attachment  # noqa: F401

--- a/apps/api/app/modules/auth/router.py
+++ b/apps/api/app/modules/auth/router.py
@@ -1,11 +1,11 @@
 """Rotas de autenticação e onboarding de tenant."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.core.security import create_access_token
+from app.core.security import create_access_token, decode_access_token, refresh_access_token
 from app.core.tenancy import CurrentUser, get_current_user
 from app.db.session import get_db
 from app.modules.auth.models import Tenant, User
@@ -14,6 +14,7 @@ from app.modules.auth.schemas import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
     LoginRequest,
+    RefreshedToken,
     RegisterRequest,
     ResetPasswordRequest,
     SessionInfo,
@@ -65,6 +66,27 @@ def login(data: LoginRequest, db: Session = Depends(get_db)) -> AuthToken:
     except AuthError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return _build_token(tenant, user)
+
+
+@router.post("/refresh", response_model=RefreshedToken)
+def refresh(
+    _current: CurrentUser = Depends(get_current_user),
+    authorization: str | None = Header(default=None),
+) -> RefreshedToken:
+    """Desliza a janela de inatividade da sessão (idle timeout LGPD — Story 1.3).
+
+    Depende de ``get_current_user``: um token já expirado por inatividade (>30 min sem chamar
+    /refresh) falha aqui com 401 (fail-closed), forçando novo login. O front chama isto enquanto
+    há atividade real do usuário. Não consulta o banco → leve, sem regressão de performance (IV3).
+    """
+    # get_current_user já validou header presente + token não expirado; decodificamos de novo
+    # apenas para ler ``abs_exp`` (não carregado em CurrentUser) e reemitir preservando o teto.
+    token = (authorization or "").split(" ", 1)[1]
+    payload = decode_access_token(token)
+    new_token = refresh_access_token(payload) if payload else None
+    if new_token is None:
+        raise HTTPException(status_code=401, detail="Sessão expirada — faça login novamente")
+    return RefreshedToken(access_token=new_token)
 
 
 @router.post("/forgot-password")

--- a/apps/api/app/modules/auth/schemas.py
+++ b/apps/api/app/modules/auth/schemas.py
@@ -104,3 +104,13 @@ class SessionInfo(BaseModel):
 class AuthToken(SessionInfo):
     access_token: str
     token_type: str = "bearer"  # noqa: S105 (não é senha, é o tipo do token OAuth)
+
+
+class RefreshedToken(BaseModel):
+    """Retorno de /auth/refresh — só a credencial renovada (desliza o idle timeout LGPD).
+
+    Não reenvia user/tenant (o cliente já os tem) nem toca o banco: mantém o refresh leve (IV3).
+    """
+
+    access_token: str
+    token_type: str = "bearer"  # noqa: S105 (não é senha, é o tipo do token OAuth)

--- a/apps/api/app/modules/contracts/router.py
+++ b/apps/api/app/modules/contracts/router.py
@@ -143,6 +143,9 @@ def cancel_contract(
 # ── Público (sem login) ─────────────────────────────────────────────────────
 @public_router.get("/{slug}", response_model=PublicContract)
 def public_view(slug: str, db: Session = Depends(get_db)) -> PublicContract:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_contracts`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicContract(**service.public_view(db, slug=slug))
     except service.ContractError as e:

--- a/apps/api/app/modules/pages/router.py
+++ b/apps/api/app/modules/pages/router.py
@@ -128,6 +128,9 @@ def delete_page(
 # ── Público (sem login) ─────────────────────────────────────────────────────
 @public_router.get("/{slug}", response_model=PublicPage)
 def public_view(slug: str, db: Session = Depends(get_db)) -> PublicPage:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_pages`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicPage(**service.public_view(db, slug=slug))
     except service.PageError as e:

--- a/apps/api/app/modules/platform/router.py
+++ b/apps/api/app/modules/platform/router.py
@@ -151,13 +151,15 @@ def delete_user(
 @router.delete("/accounts/{tenant_id}", status_code=204)
 def delete_account(
     tenant_id: str,
-    _admin: CurrentUser = Depends(require_platform_admin),
+    admin: CurrentUser = Depends(require_platform_admin),
     db: Session = Depends(get_db),
 ):
     from fastapi import Response
 
     try:
-        service.delete_account(db, tenant_id)
+        # `admin` (o Master autenticado) é repassado para gravar o log de plataforma da
+        # exclusão (quem/quando) — rastro que sobrevive à purga do tenant (LGPD, AC2).
+        service.delete_account(db, tenant_id, admin)
     except service.PlatformError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return Response(status_code=204)

--- a/apps/api/app/modules/platform/service.py
+++ b/apps/api/app/modules/platform/service.py
@@ -10,7 +10,9 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core import audit
 from app.core.security import hash_password
+from app.core.tenancy import CurrentUser
 from app.db.base import TenantMixin
 from app.db.registry import Base  # importa todos os modelos -> registra as tabelas
 from app.db.session import tenant_session
@@ -133,14 +135,26 @@ def update_account(db: Session, user_id: str, data: UpdateAccountRequest) -> Use
     return user
 
 
-def delete_account(db: Session, tenant_id: str) -> None:
+def delete_account(db: Session, tenant_id: str, actor: CurrentUser) -> None:
     """Exclui a conta de forma ATÔMICA: purga dados de negócio + remove tenant e usuários,
     tudo numa única transação. Bloqueia se houver qualquer administrador no tenant.
+
+    Ao final, grava um log de PLATAFORMA (fora do tenant) da exclusão — sobrevive à purga e
+    cumpre a exigência de rastro da LGPD (AC2). `actor` é o Master que executou a operação.
     """
-    if db.get(Tenant, tenant_id) is None:
+    tenant = db.get(Tenant, tenant_id)
+    if tenant is None:
         raise PlatformError("Conta não encontrada", 404)
     if _has_platform_admin(db, tenant_id):
         raise PlatformError("Não é possível excluir uma conta de administrador", 400)
+
+    # Snapshot ANTES da purga: depois do `DELETE FROM tenants` o slug some, e o log de
+    # plataforma precisa ser autossuficiente (sem FK/join para uma linha que deixará de existir).
+    # O ator (Master) vive em OUTRO tenant, então sua linha sobrevive; ainda assim capturamos o
+    # e-mail aqui para deixar o log completo num único snapshot.
+    target_tenant_slug = tenant.slug
+    actor_row = db.get(User, actor.user_id)
+    actor_email = actor_row.email if actor_row is not None else ""
 
     biz = _business_table_names()
     # Uma só transação (tenant_session commita ao sair) => sem estado órfão em falha parcial.
@@ -156,6 +170,23 @@ def delete_account(db: Session, tenant_id: str) -> None:
                 )
         tdb.execute(text("DELETE FROM users WHERE tenant_id = :tid"), {"tid": tenant_id})
         tdb.execute(text("DELETE FROM tenants WHERE id = :tid"), {"tid": tenant_id})
+
+    # A purga (bloco acima) já commitou com sucesso ao sair do `with` sem exceção. Só então
+    # gravamos o log na sessão GLOBAL `db` — NUNCA na `tenant_session` do tenant que acabou de
+    # sumir (seria uma escrita com RLS de um tenant inexistente, e é logicamente "fora do tenant").
+    # [AUTO-DECISION / Story Task 4] Logamos a exclusão que DE FATO ocorreu (após a purga). A
+    # atomicidade cross-sessão não é garantida entre os dois commits: uma falha rara entre eles
+    # deixaria a conta apagada sem log. É escolha consciente — logar uma exclusão que falhou no
+    # meio seria pior para auditoria/LGPD do que o risco raro de perder o log de uma que ocorreu.
+    audit.record_platform(
+        db,
+        actor_user_id=actor.user_id,
+        actor_email=actor_email,
+        target_tenant_id=tenant_id,
+        target_tenant_slug=target_tenant_slug,
+        action="account_deleted",
+    )
+    db.commit()
 
 
 # ── Hierarquia de usuários: Super Admin vê/edita/exclui todos ────────────────

--- a/apps/api/app/modules/quotes/router.py
+++ b/apps/api/app/modules/quotes/router.py
@@ -160,6 +160,9 @@ def reject_quote(
 def public_view(
     slug: str, password: str | None = Query(default=None), db: Session = Depends(get_db)
 ) -> PublicProposal:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `published_proposals`, um snapshot
+    GLOBAL sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design
+    (guarda explícita exigida pela Story 1.2, AC1)."""
     try:
         return PublicProposal(**service.public_view(db, slug=slug, password=password))
     except service.QuoteError as e:

--- a/apps/api/app/modules/wallet/router.py
+++ b/apps/api/app/modules/wallet/router.py
@@ -10,7 +10,7 @@ from app.core.tenancy import (
     require_module,
     require_platform_admin,
 )
-from app.db.session import get_db
+from app.db.session import get_db  # global (sem tenant): só rotas de Master abaixo (ver Story 1.2)
 from app.modules.wallet import service
 from app.modules.wallet.schemas import (
     PayoutResult,
@@ -79,6 +79,9 @@ def payout(
 
 
 # ── Master: ganhos da plataforma ───────────────────────
+# Uso LEGÍTIMO de `get_db` (Story 1.2, AC1): as rotas abaixo são de Master, guardadas por
+# `require_platform_admin`, e leem/gravam agregados GLOBAIS (platform_earnings/settings).
+# NÃO tocam `users` nem dados por tenant. Rotas de negócio deste módulo usam `get_tenant_db`.
 
 
 @router.get("/platform-earnings", response_model=PlatformEarningsSummary, tags=["platform-admin"])
@@ -86,6 +89,7 @@ def platform_earnings(
     _admin: CurrentUser = Depends(require_platform_admin),
     db: Session = Depends(get_db),
 ) -> PlatformEarningsSummary:
+    """Master: total de ganhos da plataforma (agregado global, sem escopo de tenant)."""
     return PlatformEarningsSummary(**service.platform_earnings(db))
 
 

--- a/apps/api/app/seed.py
+++ b/apps/api/app/seed.py
@@ -38,6 +38,9 @@ def seed_super_admin() -> None:
             allowed_modules=[],
             is_active=True,
             is_platform_admin=True,
+            # Força troca da senha semeada no 1º login (reusa o fluxo FirstAccessPage /
+            # POST /auth/change-password, igual aos usuários convidados). Story 1.4.
+            must_reset_password=True,
         )
         db.add(admin)
         db.commit()

--- a/apps/api/migrations/versions/0031_platform_audit_entries.py
+++ b/apps/api/migrations/versions/0031_platform_audit_entries.py
@@ -5,14 +5,8 @@ Master (ex.: exclusão de conta) e SOBREVIVE à purga do tenant. Guarda snapshot
 slug do tenant) porque o tenant-alvo é apagado logo em seguida.
 
 Revision ID: 0031
-Revises: 0029
+Revises: 0030
 Create Date: 2026-07-10
-
-NOTE (coordenação com Story 1.1): esta story roda em paralelo com a 1.1, que cria a migration
-`0030_*`. `down_revision` aqui aponta para `0029` porque a branch isolada desta story não tem
-acesso ao arquivo `0030`. No MERGE das duas branches pode ser necessário REBASE da cadeia
-`down_revision` (ex.: apontar esta para `0030`) para manter a sequência linear do Alembic.
-Isso é esperado e não é um erro de implementação desta story.
 """
 from collections.abc import Sequence
 
@@ -20,7 +14,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0031"
-down_revision: str | None = "0029"
+down_revision: str | None = "0030"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/api/migrations/versions/0031_platform_audit_entries.py
+++ b/apps/api/migrations/versions/0031_platform_audit_entries.py
@@ -1,0 +1,50 @@
+"""platform_audit_entries: log de plataforma (fora do tenant) p/ exclusão de conta (LGPD)
+
+Tabela GLOBAL, deliberadamente SEM tenant_id / SEM RLS: registra operações destrutivas do
+Master (ex.: exclusão de conta) e SOBREVIVE à purga do tenant. Guarda snapshots (email do ator,
+slug do tenant) porque o tenant-alvo é apagado logo em seguida.
+
+Revision ID: 0031
+Revises: 0029
+Create Date: 2026-07-10
+
+NOTE (coordenação com Story 1.1): esta story roda em paralelo com a 1.1, que cria a migration
+`0030_*`. `down_revision` aqui aponta para `0029` porque a branch isolada desta story não tem
+acesso ao arquivo `0030`. No MERGE das duas branches pode ser necessário REBASE da cadeia
+`down_revision` (ex.: apontar esta para `0030`) para manter a sequência linear do Alembic.
+Isso é esperado e não é um erro de implementação desta story.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "platform_audit_entries",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("actor_user_id", sa.String(36), nullable=False),
+        sa.Column("actor_email", sa.String(255), nullable=False),
+        sa.Column("target_tenant_id", sa.String(36), nullable=False),
+        sa.Column("target_tenant_slug", sa.String(63), nullable=False),
+        sa.Column("action", sa.String(128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    # SEM RLS por design: tabela de plataforma, não de tenant. É o oposto das tabelas de negócio
+    # (que herdam TenantMixin e são purgadas na exclusão) — este log tem de sobreviver à purga.
+    op.create_index(
+        "ix_platform_audit_entries_target_tenant_id",
+        "platform_audit_entries",
+        ["target_tenant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("platform_audit_entries")

--- a/apps/api/tests/test_idle_timeout.py
+++ b/apps/api/tests/test_idle_timeout.py
@@ -1,0 +1,129 @@
+"""Idle timeout LGPD (Story 1.3): expiração por inatividade + reemissão via /auth/refresh.
+
+O JWT ganha duas camadas: ``exp`` = janela de inatividade (30 min, deslizada por atividade) e
+``abs_exp`` = teto absoluto de 7 dias (preserva a garantia atual do JWT). Sem estado no banco.
+"""
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.core.security import (
+    create_access_token,
+    decode_access_token,
+    refresh_access_token,
+)
+
+VALID = {
+    "legal_name": "João Silva Advocacia",
+    "document": "12345678000190",
+    "slug": "joaosilva",
+    "email": "joao@example.com",
+    "name": "João Silva",
+    "password": "senha-super-secreta",
+}
+
+
+def _register(client: TestClient):
+    return client.post("/auth/register", json=VALID)
+
+
+# ── Unidade: estrutura do token (AC1, AC3) ───────────────────────────────────
+def test_token_has_idle_and_absolute_layers():
+    token = create_access_token({"sub": "u1", "tenant_id": "t1"})
+    payload = decode_access_token(token)
+    assert payload is not None
+    # A janela de inatividade (exp) é bem menor que o teto absoluto (abs_exp = 7 dias).
+    assert payload["exp"] < payload["abs_exp"]
+    idle_seconds = payload["exp"] - payload["iat"]
+    assert idle_seconds <= settings.session_idle_timeout_minutes * 60 + 5
+    # O teto absoluto continua sendo os 7 dias do JWT (AC3 — não afrouxado).
+    ceiling_seconds = payload["abs_exp"] - payload["iat"]
+    assert ceiling_seconds >= settings.jwt_expire_minutes * 60 - 5
+
+
+def test_refresh_slides_idle_window_preserving_ceiling():
+    original = create_access_token({"sub": "u1", "tenant_id": "t1", "role": "owner"})
+    payload = decode_access_token(original)
+    new_token = refresh_access_token(payload)
+    assert new_token is not None
+    new_payload = decode_access_token(new_token)
+    assert new_payload is not None
+    # Teto absoluto e identidade preservados na reemissão.
+    assert new_payload["abs_exp"] == payload["abs_exp"]
+    assert new_payload["sub"] == "u1"
+    assert new_payload["role"] == "owner"
+
+
+def test_refresh_returns_none_without_abs_exp():
+    # Token legado (pré-Story 1.3, sem abs_exp) não pode ser deslizado → fail-closed.
+    assert refresh_access_token({"sub": "u1", "tenant_id": "t1"}) is None
+
+
+def test_refresh_returns_none_after_absolute_cap():
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    payload = {"sub": "u1", "tenant_id": "t1", "abs_exp": int(past.timestamp())}
+    assert refresh_access_token(payload) is None
+
+
+def test_refresh_caps_new_window_at_ceiling():
+    # Se o teto está logo ali (20s) e o idle é 30 min, a nova janela não passa do teto.
+    ceiling = datetime.now(UTC) + timedelta(seconds=20)
+    payload = {"sub": "u1", "tenant_id": "t1", "abs_exp": int(ceiling.timestamp())}
+    new_token = refresh_access_token(payload)
+    assert new_token is not None
+    new_payload = decode_access_token(new_token)
+    assert new_payload is not None
+    assert new_payload["exp"] <= new_payload["abs_exp"]
+
+
+# ── Integração: endpoint /auth/refresh (AC1, IV1, IV3) ───────────────────────
+def test_refresh_endpoint_returns_working_token(client: TestClient):
+    token = _register(client).json()["access_token"]
+    r = client.post("/auth/refresh", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    new_token = r.json()["access_token"]
+    assert new_token
+    # O token renovado funciona numa rota protegida.
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {new_token}"})
+    assert me.status_code == 200
+
+
+def test_refresh_without_token_rejected(client: TestClient):
+    assert client.post("/auth/refresh").status_code == 401
+
+
+# ── Integração: expiração por inatividade é fail-closed (AC1) ─────────────────
+def test_idle_expired_token_is_rejected(client: TestClient, monkeypatch):
+    body = _register(client).json()
+    user, tenant = body["user"], body["tenant"]
+    # Simula 'última atividade' há muito tempo: idle negativo => token nasce expirado.
+    monkeypatch.setattr(settings, "session_idle_timeout_minutes", -1)
+    stale = create_access_token(
+        {
+            "sub": user["id"],
+            "tenant_id": tenant["id"],
+            "role": user["role"],
+            "allowed_modules": user["allowed_modules"],
+            "is_platform_admin": user["is_platform_admin"],
+        }
+    )
+    r = client.get("/auth/me", headers={"Authorization": f"Bearer {stale}"})
+    assert r.status_code == 401
+
+
+def test_idle_expired_token_cannot_refresh(client: TestClient, monkeypatch):
+    body = _register(client).json()
+    user, tenant = body["user"], body["tenant"]
+    monkeypatch.setattr(settings, "session_idle_timeout_minutes", -1)
+    stale = create_access_token({"sub": user["id"], "tenant_id": tenant["id"]})
+    # Token já expirado por inatividade não desliza a própria sessão (fail-closed).
+    r = client.post("/auth/refresh", headers={"Authorization": f"Bearer {stale}"})
+    assert r.status_code == 401
+
+
+# ── IV2: rotas públicas não são afetadas ─────────────────────────────────────
+def test_public_route_not_gated_by_idle(client: TestClient):
+    # Rota pública (sem login) NÃO passa por get_current_user → nunca 401 por sessão/inatividade.
+    r = client.get("/public/pages/inexistente-slug")
+    assert r.status_code != 401

--- a/apps/api/tests/test_idle_timeout.py
+++ b/apps/api/tests/test_idle_timeout.py
@@ -16,7 +16,7 @@ from app.core.security import (
 
 VALID = {
     "legal_name": "João Silva Advocacia",
-    "document": "12345678000190",
+    "document": "12345678000195",
     "slug": "joaosilva",
     "email": "joao@example.com",
     "name": "João Silva",

--- a/apps/api/tests/test_platform.py
+++ b/apps/api/tests/test_platform.py
@@ -1,10 +1,17 @@
 """Testes do Super Admin (Master). Delete real (purga) é coberto no e2e Docker (usa Postgres)."""
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.audit import PlatformAuditEntry
 from app.core.security import hash_password
+from app.modules.agenda.models import AgendaEvent
 from app.modules.auth.models import Tenant, User
+from app.modules.crm.models import Client
+from app.modules.platform import service as platform_service
 
 ADMIN_EMAIL = "master@e1p.com"
 ADMIN_PASS = "senha-do-master-123"
@@ -279,3 +286,95 @@ def test_users_requires_admin(client: TestClient):
     h = {"Authorization": f"Bearer {token}"}
     assert client.get("/admin/users", headers=h).status_code == 403
     assert client.get("/admin/users").status_code == 401
+
+
+# ── Exclusão de conta: purga atômica + log de plataforma sobrevivente (Story 1.2) ────
+# Baseline de regressão criada ANTES da mudança de comportamento (a story constatou que não
+# havia NENHUM teste automatizado para DELETE /admin/accounts/{tenant_id}). O delete real chama
+# `tenant_session` (Postgres, RLS) — em teste (SQLite) apontamos para a sessão compartilhada.
+
+
+@pytest.fixture()
+def _tenant_session_to_test_db(db: Session, monkeypatch):
+    """`delete_account` abre `tenant_session` (conexão Postgres dedicada) direto no service.
+
+    Em teste (SQLite, sem RLS) redirecionamos para a MESMA sessão compartilhada, exercitando a
+    purga + a gravação do log de plataforma sem precisar de Postgres real (RLS é validada no e2e).
+    """
+
+    @contextmanager
+    def _fake_tenant_session(_tenant_id: str):
+        yield db
+
+    monkeypatch.setattr(platform_service, "tenant_session", _fake_tenant_session)
+
+
+def _seed_business_data(db: Session, tenant_id: str) -> None:
+    """Dados em 2 módulos de negócio distintos, para provar que a purga por tenant funciona."""
+    db.add(Client(tenant_id=tenant_id, name="Lead a Purgar"))
+    db.add(
+        AgendaEvent(
+            tenant_id=tenant_id,
+            title="Reunião a Purgar",
+            kind="reuniao",
+            starts_at=datetime(2026, 7, 10, 10, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 7, 10, 11, 0, tzinfo=UTC),
+        )
+    )
+    db.commit()
+
+
+def test_delete_account_purges_and_writes_platform_log(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    created = client.post("/admin/accounts", json=_account_payload(), headers=admin_headers).json()
+    tid = created["tenant"]["id"]
+    _seed_business_data(db, tid)
+    assert db.query(Client).filter(Client.tenant_id == tid).count() == 1
+    assert db.query(AgendaEvent).filter(AgendaEvent.tenant_id == tid).count() == 1
+
+    resp = client.delete(f"/admin/accounts/{tid}", headers=admin_headers)
+    assert resp.status_code == 204, resp.text
+
+    # IV1 — purga: tabelas de negócio do tenant ficam vazias; tenant e usuários removidos
+    assert db.query(Client).filter(Client.tenant_id == tid).count() == 0
+    assert db.query(AgendaEvent).filter(AgendaEvent.tenant_id == tid).count() == 0
+    assert db.query(Tenant).filter(Tenant.id == tid).first() is None
+    assert db.query(User).filter(User.tenant_id == tid).count() == 0
+
+    # AC2 — log de plataforma criado com ator + snapshot do tenant corretos
+    master = db.query(User).filter(User.is_platform_admin.is_(True)).first()
+    logs = (
+        db.query(PlatformAuditEntry)
+        .filter(PlatformAuditEntry.target_tenant_id == tid)
+        .all()
+    )
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.action == "account_deleted"
+    assert log.target_tenant_slug == "clientepagante"
+    assert log.actor_user_id == master.id
+    assert log.actor_email == ADMIN_EMAIL
+
+    # IV3 — o log SOBREVIVE à exclusão: continua consultável mesmo sem o tenant/users
+    assert db.query(PlatformAuditEntry).filter(
+        PlatformAuditEntry.target_tenant_id == tid
+    ).count() == 1
+
+
+def test_delete_account_blocks_tenant_with_platform_admin(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    master = db.query(User).filter(User.is_platform_admin.is_(True)).first()
+    resp = client.delete(f"/admin/accounts/{master.tenant_id}", headers=admin_headers)
+    assert resp.status_code == 400
+    # exclusão bloqueada não gera log de exclusão
+    assert db.query(PlatformAuditEntry).count() == 0
+
+
+def test_delete_account_404_for_unknown_tenant(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    resp = client.delete("/admin/accounts/tenant-inexistente-1234", headers=admin_headers)
+    assert resp.status_code == 404
+    assert db.query(PlatformAuditEntry).count() == 0

--- a/apps/api/tests/test_seed.py
+++ b/apps/api/tests/test_seed.py
@@ -1,0 +1,61 @@
+"""Testes do seed do Super Admin (Master). Story 1.4.
+
+Cobre:
+- o admin semeado nasce com `must_reset_password=True` (força troca no 1º login);
+- o seed é idempotente (rodar 2x não duplica o admin nem sobe erro).
+
+O seed usa seu próprio `SessionLocal` (Postgres em produção); aqui apontamos esse
+`SessionLocal` para um SQLite em memória (StaticPool, compartilhado entre sessões).
+"""
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.seed as seed_module
+from app.config import settings
+from app.db.registry import Base
+from app.modules.auth.models import User
+
+
+@pytest.fixture()
+def seed_session(monkeypatch):
+    """SQLite em memória com as tabelas criadas, plugado no SessionLocal do seed."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    monkeypatch.setattr(seed_module, "SessionLocal", TestSession)
+    try:
+        yield TestSession
+    finally:
+        Base.metadata.drop_all(engine)
+
+
+def _admin(session_factory) -> User | None:
+    with session_factory() as db:
+        return db.scalar(select(User).where(User.is_platform_admin.is_(True)))
+
+
+def test_seed_creates_admin_with_must_reset_password(seed_session):
+    seed_module.seed_super_admin()
+
+    admin = _admin(seed_session)
+    assert admin is not None
+    assert admin.is_platform_admin is True
+    assert admin.email == settings.super_admin_email.lower()
+    # AC1: a conta de maior privilégio nasce obrigada a trocar a senha no 1º acesso.
+    assert admin.must_reset_password is True
+
+
+def test_seed_is_idempotent(seed_session):
+    seed_module.seed_super_admin()
+    seed_module.seed_super_admin()  # segunda passada não pode duplicar nem falhar
+
+    with seed_session() as db:
+        admins = db.scalars(select(User).where(User.is_platform_admin.is_(True))).all()
+    assert len(admins) == 1
+    assert admins[0].must_reset_password is True

--- a/apps/api/tests/test_tenancy_guard.py
+++ b/apps/api/tests/test_tenancy_guard.py
@@ -1,0 +1,57 @@
+"""Guarda de regressão ESTÁTICA (Story 1.2, Task 1 / AC1).
+
+Varre `apps/api/app/modules/**/router.py` e falha se algum módulo FORA da allowlist referenciar
+`get_db` (a sessão GLOBAL, sem tenant). Módulos de negócio comuns (agenda, crm, receivables,
+payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings,
+cockpit) DEVEM usar `get_tenant_db` (RLS) — nunca `get_db` — para não vazar dados cross-tenant.
+
+Não substitui a RLS; é uma rede de segurança barata (sem ferramenta externa) contra a regressão
+"alguém acessou `users`/dados sem escopo de tenant via get_db".
+
+Allowlist (usos legítimos, documentados com guarda explícita no próprio código):
+  - auth      → autenticação, inerentemente global sobre `users` (login por e-mail).
+  - platform  → Super Admin (Master), toda rota sob `require_platform_admin` (cross-tenant).
+  - contracts → só a rota pública `public_view` lê `published_contracts` (snapshot global).
+  - pages     → idem, `public_view` lê `published_pages`.
+  - quotes    → idem, aceite público lê `published_proposals`.
+  - wallet    → rotas de Master (earnings/split-rates) sob `require_platform_admin`.
+"""
+from __future__ import annotations
+
+import pathlib
+
+MODULES_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules"
+
+# Módulos onde `get_db` (sessão global) é um uso legítimo e já auditado (ver docstring acima).
+ALLOWLIST = {"auth", "platform", "contracts", "pages", "quotes", "wallet"}
+
+
+def _module_routers() -> list[pathlib.Path]:
+    routers = sorted(MODULES_DIR.glob("*/router.py"))
+    assert routers, f"Nenhum router.py encontrado em {MODULES_DIR} — teste desatualizado?"
+    return routers
+
+
+def test_no_business_module_uses_get_db():
+    """Nenhum módulo de negócio fora da allowlist pode referenciar `get_db`."""
+    offenders: list[str] = []
+    for router in _module_routers():
+        module = router.parent.name
+        if module in ALLOWLIST:
+            continue
+        source = router.read_text(encoding="utf-8")
+        if "get_db" in source:
+            offenders.append(module)
+
+    assert not offenders, (
+        "Módulo(s) de negócio referenciando get_db (sessão GLOBAL, sem tenant) — risco de "
+        f"vazamento cross-tenant: {sorted(offenders)}. Use get_tenant_db (RLS). Se o uso for "
+        "legítimo (rota pública sobre snapshot global / rota de Master), documente e adicione à "
+        "ALLOWLIST em tests/test_tenancy_guard.py."
+    )
+
+
+def test_allowlist_entries_still_exist():
+    """A allowlist não pode apodrecer: todo módulo listado deve existir como pasta real."""
+    missing = [m for m in ALLOWLIST if not (MODULES_DIR / m / "router.py").exists()]
+    assert not missing, f"Allowlist referencia módulos inexistentes: {sorted(missing)}"

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -28,7 +28,9 @@ import ProdutosPage from "../features/produtos/ProdutosPage";
 import PageBuilderPage from "../features/sites/PageBuilderPage";
 import PublicPage from "../features/sites/PublicPage";
 import SitesPage from "../features/sites/SitesPage";
+import IdleWarningModal from "../components/IdleWarningModal";
 import { AuthProvider, useAuth } from "../store/auth";
+import { useIdleTimeout } from "../store/useIdleTimeout";
 import { PageActionsProvider } from "../store/pageActions";
 import AppShell from "./AppShell";
 
@@ -83,6 +85,8 @@ function LoginRoute() {
 
 function ProtectedLayout() {
   const { isAuthenticated, user } = useAuth();
+  // Idle timeout LGPD (Story 1.3): hook sempre chamado (regra dos hooks); no-op quando deslogado.
+  const { showWarning, stayConnected } = useIdleTimeout();
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   // 1º acesso: bloqueia o app até o usuário trocar a senha temporária.
   if (user?.must_reset_password) return <FirstAccessPage />;
@@ -91,6 +95,7 @@ function ProtectedLayout() {
       <AppShell>
         <Outlet />
       </AppShell>
+      <IdleWarningModal open={showWarning} onStay={stayConnected} />
     </PageActionsProvider>
   );
 }

--- a/apps/web/src/components/IdleWarningModal.tsx
+++ b/apps/web/src/components/IdleWarningModal.tsx
@@ -1,0 +1,34 @@
+import { IDLE_WARNING_MINUTES } from "../lib/idleTimer";
+import Modal from "./Modal";
+
+/**
+ * Aviso de sessão prestes a expirar por inatividade (idle timeout LGPD — Story 1.3).
+ * Reaproveita o `Modal` do design "Portal". Fechar (X/fundo) ou clicar em "Continuar conectado"
+ * mantém a sessão; não fazer nada leva ao logout automático.
+ */
+export default function IdleWarningModal({
+  open,
+  onStay,
+}: {
+  open: boolean;
+  onStay: () => void;
+}) {
+  return (
+    <Modal title="Sessão prestes a expirar" open={open} onClose={onStay}>
+      <p className="text-sm text-neutral-600">
+        Por segurança (LGPD), sua sessão será encerrada em cerca de {IDLE_WARNING_MINUTES}{" "}
+        {IDLE_WARNING_MINUTES === 1 ? "minuto" : "minutos"} por inatividade. Deseja continuar
+        conectado?
+      </p>
+      <div className="mt-6 flex justify-end">
+        <button
+          type="button"
+          onClick={onStay}
+          className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700"
+        >
+          Continuar conectado
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,6 +20,20 @@ export const publicApi = axios.create({
   headers: { "Content-Type": "application/json" },
 });
 
+/**
+ * Desliza a sessão no backend (idle timeout LGPD — Story 1.3): reemite um access token com a
+ * janela de inatividade renovada. Retorna o novo token, ou `null` se a sessão não pôde ser
+ * renovada (401 → o interceptor já cuida do logout). Não lança.
+ */
+export async function refreshSession(): Promise<string | null> {
+  try {
+    const { data } = await api.post<{ access_token: string }>("/auth/refresh");
+    return data.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function apiErrorMessage(err: unknown): string {
   if (err instanceof AxiosError) {
     const data = err.response?.data as ApiError | undefined;

--- a/apps/web/src/lib/idleTimer.test.ts
+++ b/apps/web/src/lib/idleTimer.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IdleTimer } from "./idleTimer";
+
+describe("IdleTimer (idle timeout LGPD — Story 1.3)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const make = (over = {}) => {
+    const onWarn = vi.fn();
+    const onTimeout = vi.fn();
+    const onActive = vi.fn();
+    const timer = new IdleTimer({
+      idleMs: 30_000,
+      warningMs: 5_000,
+      onWarn,
+      onTimeout,
+      onActive,
+      ...over,
+    });
+    return { timer, onWarn, onTimeout, onActive };
+  };
+
+  it("avisa em (idle - warning) e desloga em idle sem atividade", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(25_000); // janela de aviso
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5_000); // esgota
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("atividade reinicia a contagem e evita o timeout (fluxo ativo legítimo — AC2)", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(20_000);
+    timer.activity(); // usuário interagiu (ex.: digitando um formulário longo)
+    vi.advanceTimersByTime(20_000); // 40s desde o start, mas só 20s desde a atividade
+
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("atividade após o aviso o esconde (onActive) e cancela o timeout", () => {
+    const { timer, onWarn, onTimeout, onActive } = make();
+    timer.start();
+
+    vi.advanceTimersByTime(25_000);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+
+    timer.activity();
+    expect(onActive).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5_000); // teria estourado sem a atividade
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("stop() cancela timers pendentes", () => {
+    const { timer, onWarn, onTimeout } = make();
+    timer.start();
+    timer.stop();
+    vi.advanceTimersByTime(60_000);
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/idleTimer.ts
+++ b/apps/web/src/lib/idleTimer.ts
@@ -1,0 +1,110 @@
+/**
+ * Idle timeout LGPD (Story 1.3).
+ *
+ * Camada de UX no cliente: avisa o usuário ANTES do logout por inatividade e desliza a sessão
+ * no backend (`POST /auth/refresh`) enquanto há atividade real. A EXPIRAÇÃO em si é garantida
+ * pelo backend (o access token expira por inatividade e o interceptor 401 desloga) — este timer
+ * é a experiência amigável em cima disso. Se cliente e backend divergirem, o backend ainda
+ * protege via 401 (fail-closed).
+ *
+ * A classe é pura (timers injetáveis) para ser testável sem DOM.
+ */
+
+/**
+ * Minutos de inatividade até o logout. DEVE espelhar `session_idle_timeout_minutes` do backend
+ * (apps/api/app/config.py). O backend é a fonte de verdade da expiração; este número controla
+ * apenas o momento do AVISO/logout do cliente.
+ */
+export const IDLE_TIMEOUT_MINUTES = 30;
+
+/** Antecedência (min) com que o aviso aparece antes do logout. */
+export const IDLE_WARNING_MINUTES = 1;
+
+/**
+ * Intervalo mínimo (min) entre chamadas a `/auth/refresh`. Evita reemitir a cada mousemove —
+ * mantém a sessão viva durante uso ativo sem gerar carga desnecessária na API (IV3).
+ */
+export const IDLE_REFRESH_INTERVAL_MINUTES = 5;
+
+type TimerId = ReturnType<typeof setTimeout>;
+
+export interface IdleTimerOptions {
+  /** Duração total da janela de inatividade em ms. */
+  idleMs: number;
+  /** Quanto antes do timeout mostrar o aviso, em ms. */
+  warningMs: number;
+  /** Chamado ao entrar na janela de aviso (idleMs - warningMs sem atividade). */
+  onWarn: () => void;
+  /** Chamado quando a janela total esgota sem atividade. */
+  onTimeout: () => void;
+  /** Chamado quando há atividade APÓS um aviso ter sido exibido (para escondê-lo). */
+  onActive?: () => void;
+  /** Injeção para testes. */
+  setTimer?: (cb: () => void, ms: number) => TimerId;
+  clearTimer?: (id: TimerId) => void;
+}
+
+export class IdleTimer {
+  private readonly idleMs: number;
+  private readonly warningMs: number;
+  private readonly onWarn: () => void;
+  private readonly onTimeout: () => void;
+  private readonly onActive: () => void;
+  private readonly setTimer: (cb: () => void, ms: number) => TimerId;
+  private readonly clearTimer: (id: TimerId) => void;
+
+  private warnId: TimerId | null = null;
+  private timeoutId: TimerId | null = null;
+  private warned = false;
+
+  constructor(opts: IdleTimerOptions) {
+    this.idleMs = opts.idleMs;
+    this.warningMs = Math.min(opts.warningMs, opts.idleMs);
+    this.onWarn = opts.onWarn;
+    this.onTimeout = opts.onTimeout;
+    this.onActive = opts.onActive ?? (() => {});
+    this.setTimer = opts.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimer = opts.clearTimer ?? ((id) => clearTimeout(id));
+  }
+
+  /** Inicia a contagem. */
+  start(): void {
+    this.schedule();
+  }
+
+  /** Para a contagem e limpa os timers pendentes. */
+  stop(): void {
+    this.clear();
+    this.warned = false;
+  }
+
+  /**
+   * Registra atividade do usuário: reinicia a contagem. Se um aviso estava visível, dispara
+   * `onActive` para escondê-lo.
+   */
+  activity(): void {
+    if (this.warned) {
+      this.warned = false;
+      this.onActive();
+    }
+    this.schedule();
+  }
+
+  private schedule(): void {
+    this.clear();
+    this.warnId = this.setTimer(() => {
+      this.warned = true;
+      this.onWarn();
+    }, this.idleMs - this.warningMs);
+    this.timeoutId = this.setTimer(() => {
+      this.onTimeout();
+    }, this.idleMs);
+  }
+
+  private clear(): void {
+    if (this.warnId !== null) this.clearTimer(this.warnId);
+    if (this.timeoutId !== null) this.clearTimer(this.timeoutId);
+    this.warnId = null;
+    this.timeoutId = null;
+  }
+}

--- a/apps/web/src/store/auth.tsx
+++ b/apps/web/src/store/auth.tsx
@@ -9,6 +9,7 @@ interface AuthContextValue {
   isAuthenticated: boolean;
   login: (token: string, user: User, tenant: Tenant) => void;
   updateUser: (user: User) => void;
+  updateToken: (token: string) => void;
   logout: () => void;
 }
 
@@ -46,6 +47,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(u);
   }, []);
 
+  // Substitui só a credencial (usado ao deslizar a sessão via /auth/refresh — idle timeout LGPD).
+  const updateToken = useCallback((t: string) => {
+    localStorage.setItem(TOKEN_KEY, t);
+    setToken(t);
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
@@ -69,7 +76,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ token, user, tenant, isAuthenticated: Boolean(token), login, updateUser, logout }}
+      value={{
+        token,
+        user,
+        tenant,
+        isAuthenticated: Boolean(token),
+        login,
+        updateUser,
+        updateToken,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/apps/web/src/store/useIdleTimeout.ts
+++ b/apps/web/src/store/useIdleTimeout.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { refreshSession } from "../lib/api";
+import {
+  IDLE_REFRESH_INTERVAL_MINUTES,
+  IDLE_TIMEOUT_MINUTES,
+  IDLE_WARNING_MINUTES,
+  IdleTimer,
+} from "../lib/idleTimer";
+import { useAuth } from "./auth";
+
+const ACTIVITY_EVENTS = [
+  "mousedown",
+  "mousemove",
+  "keydown",
+  "touchstart",
+  "scroll",
+  "click",
+] as const;
+
+const MIN = 60_000;
+
+/**
+ * Idle timeout LGPD (Story 1.3). Enquanto o usuário está logado:
+ * - conta 30 min de inatividade (qualquer interação — não só requests — reinicia a contagem,
+ *   cobrindo formulários longos sem quebrar fluxos ativos legítimos — AC2);
+ * - desliza a sessão no backend (`/auth/refresh`, com throttle) enquanto há atividade;
+ * - avisa 1 min antes e, ao esgotar, faz logout limpo.
+ *
+ * O backend é a proteção real (token expira por inatividade → 401 → interceptor desloga); este
+ * hook é a experiência amigável em cima disso.
+ */
+export function useIdleTimeout(): { showWarning: boolean; stayConnected: () => void } {
+  const { isAuthenticated, updateToken, logout } = useAuth();
+  const [showWarning, setShowWarning] = useState(false);
+  const timerRef = useRef<IdleTimer | null>(null);
+  const lastRefreshRef = useRef(0);
+
+  // Reemite o token no backend (throttle), atualizando a credencial guardada.
+  const doRefresh = useCallback(
+    async (force: boolean) => {
+      const now = Date.now();
+      if (!force && now - lastRefreshRef.current < IDLE_REFRESH_INTERVAL_MINUTES * MIN) return;
+      lastRefreshRef.current = now;
+      const token = await refreshSession();
+      if (token) updateToken(token);
+    },
+    [updateToken],
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setShowWarning(false);
+      return;
+    }
+
+    const timer = new IdleTimer({
+      idleMs: IDLE_TIMEOUT_MINUTES * MIN,
+      warningMs: IDLE_WARNING_MINUTES * MIN,
+      onWarn: () => setShowWarning(true),
+      onTimeout: () => {
+        setShowWarning(false);
+        // Fail-closed: sessão ociosa é encerrada (o token do backend já expirou em paralelo).
+        logout();
+      },
+      onActive: () => setShowWarning(false),
+    });
+    timerRef.current = timer;
+    timer.start();
+
+    const onActivity = () => {
+      timer.activity();
+      void doRefresh(false);
+    };
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, onActivity, { passive: true });
+    }
+
+    return () => {
+      timer.stop();
+      timerRef.current = null;
+      for (const evt of ACTIVITY_EVENTS) window.removeEventListener(evt, onActivity);
+    };
+  }, [isAuthenticated, doRefresh, logout]);
+
+  // Botão "Continuar conectado": reinicia a contagem e força uma reemissão imediata.
+  const stayConnected = useCallback(() => {
+    setShowWarning(false);
+    timerRef.current?.activity();
+    void doRefresh(true);
+  }, [doRefresh]);
+
+  return { showWarning, stayConnected };
+}

--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -77,6 +77,16 @@ pro IP da VPS (`dig +short app.seudominio.com`) e se a porta 80 está mesmo aces
 - `https://app.seudominio.com` → tela de login.
 - `https://app.seudominio.com/api/health` (ou endpoint equivalente) → 200.
 - Login com `SUPER_ADMIN_EMAIL` / `SUPER_ADMIN_PASSWORD` do `.env.prod`.
+- **Segurança de credenciais (Story 1.4):**
+  - Guard de segredos fracos: o boot **recusa** subir em produção com `JWT_SECRET`
+    fraco/default (<32 chars), `ANTHROPIC_API_KEY` ausente ou `SUPER_ADMIN_PASSWORD`
+    default (`apps/api/app/config.py::_guard_production_secrets`; coberto por 6 testes em
+    `apps/api/tests/test_config.py`). Se algum estiver fraco, o container `api` **não sobe** —
+    confira os logs (`docker compose -f docker-compose.prod.yml logs api`).
+  - 1º login do Master força troca de senha: no primeiro acesso com a senha do `.env.prod`,
+    o app exibe a `FirstAccessPage` e só libera após a troca (`must_reset_password=True` no
+    Super Admin semeado; ver `apps/api/tests/test_seed.py`). Confirme que **não** consegue
+    navegar antes de trocar a senha.
 
 ## 5. Atualizações (deploy de uma nova versão)
 ```bash

--- a/docs/stories/1.2.story.md
+++ b/docs/stories/1.2.story.md
@@ -1,7 +1,7 @@
 # Story 1.2: Hardening de acesso à tabela global `users` + log de exclusão (LGPD)
 
 ## Status
-Ready
+InReview
 
 ## Executor Assignment
 ```yaml
@@ -36,8 +36,8 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Auditoria formal de acesso a `users` via `get_db` (AC: 1)**
-  - [ ] Confirmar (e documentar no Dev Agent Record) o levantamento já feito nesta story — todo arquivo em `apps/api/app/modules/**` e `apps/api/app/core/**` que importa `get_db` de `app.db.session`:
+- [x] **Task 1 — Auditoria formal de acesso a `users` via `get_db` (AC: 1)**
+  - [x] Confirmar (e documentar no Dev Agent Record) o levantamento já feito nesta story — todo arquivo em `apps/api/app/modules/**` e `apps/api/app/core/**` que importa `get_db` de `app.db.session`:
     - `apps/api/app/modules/auth/router.py` — LEGÍTIMO: é o próprio módulo de autenticação (register/login/forgot-password/reset-password/change-password), inerentemente global sobre `users` por design. Não é "módulo de negócio".
     - `apps/api/app/modules/platform/router.py` — LEGÍTIMO: é o módulo do Super Admin (Master); toda rota é protegida por `Depends(require_platform_admin)`, propositalmente cross-tenant sobre `users`/`tenants`.
     - `apps/api/app/modules/contracts/router.py:145,157` — usa `get_db` só nas rotas `public_view`/assinatura pública (sem login) para ler `published_contracts` (snapshot GLOBAL sem RLS) — **NÃO toca `users`**.
@@ -45,39 +45,39 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
     - `apps/api/app/modules/quotes/router.py:161,173` — idem, aceite público de proposta lê `published_proposals` — **NÃO toca `users`**.
     - `apps/api/app/modules/wallet/router.py:86,94,103` — protegidas por `Depends(require_platform_admin)` (`_admin`), consultam `platform_earnings` (agregado global) — **NÃO toca `users`** e já é guardado.
     - `apps/api/app/core/tenancy.py` — a própria dependência de resolução de tenant/usuário atual (`get_current_user`) precisa consultar `users` globalmente a partir do claim do JWT (é o mecanismo, não um módulo de negócio).
-  - [ ] Nenhum módulo de negócio "comum" (agenda, crm, receivables, payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings, cockpit) usa `get_db` hoje — todos usam `get_tenant_db` (RLS). Confirmar isso permanece true rodando um grep de auditoria (`grep -rln "get_db" apps/api/app/modules/`) e comparando com esta lista.
-  - [ ] Adicionar comentário/docstring explícito nos poucos usos legítimos acima (contracts/pages/quotes `public_view`, wallet admin routes) explicando POR QUE é seguro (não toca `users`, ou é protegido por `require_platform_admin`) — cumpre a exigência de "guarda explícita" da AC1.
-  - [ ] Criar um teste de regressão estático simples (novo arquivo `apps/api/tests/test_tenancy_guard.py`) que varre `apps/api/app/modules/**/router.py` e falha se algum arquivo fora da allowlist (auth, platform, e as rotas públicas específicas já mapeadas) importar `get_db` — protege contra regressão futura sem exigir ferramenta externa de lint.
+  - [x] Nenhum módulo de negócio "comum" (agenda, crm, receivables, payables, products, stock, funnels, marketing, juridico, attachments, notifications, settings, cockpit) usa `get_db` hoje — todos usam `get_tenant_db` (RLS). Confirmar isso permanece true rodando um grep de auditoria (`grep -rln "get_db" apps/api/app/modules/`) e comparando com esta lista.
+  - [x] Adicionar comentário/docstring explícito nos poucos usos legítimos acima (contracts/pages/quotes `public_view`, wallet admin routes) explicando POR QUE é seguro (não toca `users`, ou é protegido por `require_platform_admin`) — cumpre a exigência de "guarda explícita" da AC1.
+  - [x] Criar um teste de regressão estático simples (novo arquivo `apps/api/tests/test_tenancy_guard.py`) que varre `apps/api/app/modules/**/router.py` e falha se algum arquivo fora da allowlist (auth, platform, e as rotas públicas específicas já mapeadas) importar `get_db` — protege contra regressão futura sem exigir ferramenta externa de lint.
 
-- [ ] **Task 2 — Criar o modelo de log de plataforma (fora do tenant) (AC: 2, 3)**
-  - [ ] Adicionar `PlatformAuditEntry` em `apps/api/app/core/audit.py` (mesmo arquivo do `AuditEntry` já existente, mesma convenção de módulo) — **deliberadamente `Base` + `TimestampMixin`, SEM `TenantMixin`**, para que `_business_table_names()` (`apps/api/app/modules/platform/service.py`, descoberta dinâmica via `issubclass(mapper.class_, TenantMixin)`) NUNCA a inclua na purga por tenant.
-  - [ ] Campos sugeridos: `id`, `actor_user_id: str`, `actor_email: str` (snapshot — o ator é sempre o Master, que não é apagado), `target_tenant_id: str`, `target_tenant_slug: str` (snapshot — o tenant será apagado, não dá pra fazer FK/join depois), `action: str` (ex.: `"account_deleted"`), `created_at` (via `TimestampMixin`).
-  - [ ] Nova migration em `apps/api/migrations/versions/` — usar o próximo número livre após a última migration existente (`0029_user_invite_fields.py`; se a Story 1.1 já tiver criado `0030_*`, esta deve ser `0031_*` — **coordenar numeração sequencial com a Story 1.1 antes de gerar o arquivo**, alembic é sequencial por `down_revision`).
+- [x] **Task 2 — Criar o modelo de log de plataforma (fora do tenant) (AC: 2, 3)**
+  - [x] Adicionar `PlatformAuditEntry` em `apps/api/app/core/audit.py` (mesmo arquivo do `AuditEntry` já existente, mesma convenção de módulo) — **deliberadamente `Base` + `TimestampMixin`, SEM `TenantMixin`**, para que `_business_table_names()` (`apps/api/app/modules/platform/service.py`, descoberta dinâmica via `issubclass(mapper.class_, TenantMixin)`) NUNCA a inclua na purga por tenant.
+  - [x] Campos sugeridos: `id`, `actor_user_id: str`, `actor_email: str` (snapshot — o ator é sempre o Master, que não é apagado), `target_tenant_id: str`, `target_tenant_slug: str` (snapshot — o tenant será apagado, não dá pra fazer FK/join depois), `action: str` (ex.: `"account_deleted"`), `created_at` (via `TimestampMixin`).
+  - [x] Nova migration em `apps/api/migrations/versions/` — usar o próximo número livre após a última migration existente (`0029_user_invite_fields.py`; se a Story 1.1 já tiver criado `0030_*`, esta deve ser `0031_*` — **coordenar numeração sequencial com a Story 1.1 antes de gerar o arquivo**, alembic é sequencial por `down_revision`).
 
-- [ ] **Task 3 — Capturar o ator e o snapshot do tenant antes da purga (AC: 2)**
-  - [ ] `apps/api/app/modules/platform/service.py::delete_account` hoje tem assinatura `delete_account(db: Session, tenant_id: str) -> None` e não recebe quem está executando a ação. Alterar para `delete_account(db: Session, tenant_id: str, actor: User) -> None`.
-  - [ ] `apps/api/app/modules/platform/router.py` (rota `DELETE /accounts/{tenant_id}`, linhas ~151-160): hoje o admin autenticado vem como `_admin: CurrentUser = Depends(require_platform_admin)` e é ignorado (prefixo `_`); passar esse `_admin` (renomear para `admin`) para `service.delete_account(db, tenant_id, admin)`.
-  - [ ] Antes de qualquer `DELETE` dentro de `delete_account`, capturar `tenant.slug`/`tenant.legal_name` (o objeto `Tenant` já é buscado no início da função para o guard 404 — reaproveitar) para usar no log, já que depois do `DELETE FROM tenants` essa informação some.
+- [x] **Task 3 — Capturar o ator e o snapshot do tenant antes da purga (AC: 2)**
+  - [x] `apps/api/app/modules/platform/service.py::delete_account` hoje tem assinatura `delete_account(db: Session, tenant_id: str) -> None` e não recebe quem está executando a ação. Alterar para `delete_account(db: Session, tenant_id: str, actor: User) -> None`.
+  - [x] `apps/api/app/modules/platform/router.py` (rota `DELETE /accounts/{tenant_id}`, linhas ~151-160): hoje o admin autenticado vem como `_admin: CurrentUser = Depends(require_platform_admin)` e é ignorado (prefixo `_`); passar esse `_admin` (renomear para `admin`) para `service.delete_account(db, tenant_id, admin)`.
+  - [x] Antes de qualquer `DELETE` dentro de `delete_account`, capturar `tenant.slug`/`tenant.legal_name` (o objeto `Tenant` já é buscado no início da função para o guard 404 — reaproveitar) para usar no log, já que depois do `DELETE FROM tenants` essa informação some.
 
-- [ ] **Task 4 — Gravar o log de plataforma de forma que sobreviva à purga (AC: 2, 3)**
-  - [ ] A purga de negócio roda dentro de `with tenant_session(tenant_id) as tdb:` (que abre uma conexão dedicada com o GUC `app.current_tenant_id` setado para o tenant SENDO APAGADO — ver CLAUDE.md §3, nota sobre `tenant_session` e conexão dedicada). O log de plataforma NÃO deve ser gravado nessa sessão (seria uma escrita com RLS do tenant que está sumindo, e é logicamente "fora do tenant").
-  - [ ] **[AUTO-DECISION]** Gravar o `PlatformAuditEntry` na sessão GLOBAL `db` (a mesma recebida pelo endpoint via `Depends(get_db)`), **DEPOIS** que o bloco `with tenant_session(tenant_id) as tdb:` sair sem exceção (ou seja, depois que a purga já commitou com sucesso), e então dar `db.commit()` na sessão global antes de retornar. Reason: a AC2 pede rastro da exclusão que de fato aconteceu — logar uma tentativa que falhou no meio geraria um registro de "conta excluída" para algo que não ocorreu de fato, pior para fins de auditoria/LGPD do que o risco (raro) de falha entre os dois commits. Documentar essa limitação de atomicidade cross-sessão no Dev Agent Record (é uma escolha consciente, não um bug).
-  - [ ] Confirmar manualmente (ou via teste, ver Task 5) que a linha em `platform_audit_entries` (ou nome escolhido para a tabela) continua existindo depois que `tenants`/`users`/tabelas de negócio do tenant já foram apagadas — IV3.
+- [x] **Task 4 — Gravar o log de plataforma de forma que sobreviva à purga (AC: 2, 3)**
+  - [x] A purga de negócio roda dentro de `with tenant_session(tenant_id) as tdb:` (que abre uma conexão dedicada com o GUC `app.current_tenant_id` setado para o tenant SENDO APAGADO — ver CLAUDE.md §3, nota sobre `tenant_session` e conexão dedicada). O log de plataforma NÃO deve ser gravado nessa sessão (seria uma escrita com RLS do tenant que está sumindo, e é logicamente "fora do tenant").
+  - [x] **[AUTO-DECISION]** Gravar o `PlatformAuditEntry` na sessão GLOBAL `db` (a mesma recebida pelo endpoint via `Depends(get_db)`), **DEPOIS** que o bloco `with tenant_session(tenant_id) as tdb:` sair sem exceção (ou seja, depois que a purga já commitou com sucesso), e então dar `db.commit()` na sessão global antes de retornar. Reason: a AC2 pede rastro da exclusão que de fato aconteceu — logar uma tentativa que falhou no meio geraria um registro de "conta excluída" para algo que não ocorreu de fato, pior para fins de auditoria/LGPD do que o risco (raro) de falha entre os dois commits. Documentar essa limitação de atomicidade cross-sessão no Dev Agent Record (é uma escolha consciente, não um bug).
+  - [x] Confirmar manualmente (ou via teste, ver Task 5) que a linha em `platform_audit_entries` (ou nome escolhido para a tabela) continua existindo depois que `tenants`/`users`/tabelas de negócio do tenant já foram apagadas — IV3.
 
-- [ ] **Task 5 — Testes de regressão para `delete_account` (AC: 3; IV1, IV3)**
-  - [ ] **Risco identificado:** hoje **não existe nenhum teste automatizado** cobrindo `DELETE /admin/accounts/{tenant_id}` em `apps/api/tests/test_platform.py` (nem em nenhum outro arquivo de teste) — apesar de CLAUDE.md descrever esse fluxo como "já corrigido"/"validado e2e". A validação existente foi manual (Docker + Postgres real), não há regressão automatizada em CI. Esta story deve criar esse teste ANTES de alterar `delete_account`, para ter uma baseline confiável.
-  - [ ] Novo(s) teste(s) em `apps/api/tests/test_platform.py` (ou novo arquivo `test_platform_delete.py`) cobrindo:
+- [x] **Task 5 — Testes de regressão para `delete_account` (AC: 3; IV1, IV3)**
+  - [x] **Risco identificado:** hoje **não existe nenhum teste automatizado** cobrindo `DELETE /admin/accounts/{tenant_id}` em `apps/api/tests/test_platform.py` (nem em nenhum outro arquivo de teste) — apesar de CLAUDE.md descrever esse fluxo como "já corrigido"/"validado e2e". A validação existente foi manual (Docker + Postgres real), não há regressão automatizada em CI. Esta story deve criar esse teste ANTES de alterar `delete_account`, para ter uma baseline confiável.
+  - [x] Novo(s) teste(s) em `apps/api/tests/test_platform.py` (ou novo arquivo `test_platform_delete.py`) cobrindo:
     - Criar uma conta (tenant + owner) com dados em pelo menos 2 módulos de negócio diferentes (ex.: um `Client` do CRM e um `AgendaEvent`); excluir via `DELETE /admin/accounts/{tenant_id}`; confirmar que as tabelas de negócio desse tenant ficam vazias (purga funcionou).
     - Confirmar bloqueio (400) ao tentar excluir um tenant que contém um `is_platform_admin`.
     - Confirmar 404 ao excluir tenant inexistente.
     - Confirmar que a exclusão cria uma linha em `PlatformAuditEntry` com o `target_tenant_id`/`slug` corretos e o `actor_user_id` do Master que executou.
     - Confirmar que essa linha de log **continua consultável** depois do delete (a tabela não tem FK/cascata para `tenants`, é independente) — cobre IV3.
 
-- [ ] **Task 6 — Validação manual de isolamento cross-tenant (IV2)**
-  - [ ] Não há e2e automatizado no repositório (RLS só é exercitada com Postgres real — ver CLAUDE.md §6.1 "Teste de isolamento cross-tenant"). Validar manualmente via Docker (`docker compose -f infra/docker-compose.yml up -d --build`) que, após as mudanças desta story, um usuário de um tenant continua sem conseguir ver dados de outro tenant (cenário "João não vê dados da Maria", já citado como baseline no epic e em CLAUDE.md §3).
+- [ ] **Task 6 — Validação manual de isolamento cross-tenant (IV2)** — PENDENTE (manual, requer Postgres real)
+  - [ ] Não há e2e automatizado no repositório (RLS só é exercitada com Postgres real — ver CLAUDE.md §6.1 "Teste de isolamento cross-tenant"). Validar manualmente via Docker (`docker compose -f infra/docker-compose.yml up -d --build`) que, após as mudanças desta story, um usuário de um tenant continua sem conseguir ver dados de outro tenant (cenário "João não vê dados da Maria", já citado como baseline no epic e em CLAUDE.md §3). **NÃO executado neste worktree isolado** (sem stack Postgres/Docker compose ativa); as mudanças desta story NÃO alteram políticas RLS nem `tenant_session`, então o comportamento de isolamento existente é preservado por construção. Requer execução manual pelo quality gate (@architect) antes do merge.
 
-- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
-  - [ ] Rodar `bash scripts/check.sh` (lint + testes) — CLAUDE.md §5.
+- [x] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [x] Rodar lint + testes do backend (`ruff check .` + `pytest` em `apps/api`) — equivalente à parte backend de `scripts/check.sh`. Resultado: ruff OK, **257 passed**. Frontend (`@e1p/web`) não é tocado por esta story (backend-only), então typecheck/vitest do front não se aplicam.
 
 ## Dev Notes
 
@@ -125,20 +125,56 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 |------|---------|-------------|--------|
 | 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
 | 2026-07-10 | 0.1.1 | Validated GO (9/10) — Status: Draft → Ready | @po |
+| 2026-07-10 | 0.2 | Implementação Tasks 1-5,7 (Task 6 manual pendente) — Status: Ready → InReview | Dex (@dev) |
 
 ## Dev Agent Record
 
 ### Agent Model Used
-_(a preencher pelo @dev)_
+claude-opus-4-8 (Dex / @dev), modo YOLO autônomo.
 
 ### Debug Log References
-_(a preencher pelo @dev)_
+- Backend sem Python no host Windows; lint+testes rodados em container `python:3.13-slim` (mesma imagem do `apps/api/Dockerfile`), montando `apps/api`.
+- `ruff check .` → All checks passed.
+- `python -m pytest -q` → **257 passed, 0 failed** (~70s). Baseline anterior + 5 testes novos desta story (2 em `test_tenancy_guard.py`, 3 em `test_platform.py`).
 
 ### Completion Notes List
-_(a preencher pelo @dev)_
+
+**IDS (Search → Decide → Log):**
+- `PlatformAuditEntry`: ADAPT de `AuditEntry` (mesmo arquivo `core/audit.py`, mesma convenção), MENOS `TenantMixin` — decisão central da story.
+- `record_platform()`: CREATE, espelhando o helper `record()` já existente (consistência).
+- Log de guarda estático (`test_tenancy_guard.py`): CREATE — segue o espírito de `test_config.py` (invariante de segurança por asserção, sem mocks), sem precedente exato.
+- Testes de `delete_account`: CREATE em `test_platform.py` (overlap conhecido com Story 1.1 nesse arquivo — esperado, resolvido no merge).
+
+**Decisões / desvios em relação à story:**
+- **[AUTO-DECISION] Tipo do `actor`**: a story sugeriu `delete_account(..., actor: User)`, mas o router só dispõe do `CurrentUser` (de `require_platform_admin`), que NÃO tem `email`. Optei por `actor: CurrentUser` e resolvo `actor_email` via `db.get(User, actor.user_id)` dentro do service (o Master vive em outro tenant, sua linha sobrevive à purga). Evita um fetch-e-repassa artificial no router. Reason: fidelidade ao que o endpoint realmente tem + snapshot de e-mail correto.
+- **[AUTO-DECISION] Momento da gravação do log (Task 4)**: log gravado na sessão GLOBAL `db` APÓS a purga sair sem exceção, com `db.commit()` ao final. Limitação consciente de atomicidade cross-sessão (falha rara entre os dois commits deixaria conta apagada sem log) — preferível a logar exclusão que não ocorreu. Documentado em comentário no `service.py`.
+- **Migration `0031`**: `down_revision = "0029"` (a branch isolada não tem acesso ao `0030` da Story 1.1). O arquivo carrega NOTE explícita de que pode ser necessário REBASE da cadeia `down_revision` no merge — esperado, não é erro.
+- **Task 6 (IV2, e2e cross-tenant)**: NÃO executado — requer Postgres/Docker compose ativo, indisponível neste worktree. As mudanças não alteram RLS nem `tenant_session`, então o isolamento existente é preservado por construção. Deixado para o quality gate (@architect) validar antes do merge.
+- **Task 7**: rodei o equivalente backend de `scripts/check.sh` (ruff + pytest em `apps/api`); frontend não é tocado por esta story.
+
+**Verificação das ACs:**
+- AC1: guardas explícitas (docstrings) nos usos legítimos de `get_db` (contracts/pages/quotes `public_view`, wallet Master) + teste estático `test_tenancy_guard.py` que falha se módulo de negócio fora da allowlist usar `get_db`.
+- AC2: `PlatformAuditEntry` gravado fora do tenant, com ator + snapshot (slug/email); coberto por `test_delete_account_purges_and_writes_platform_log`.
+- AC3 / IV1: purga dinâmica preservada (assinatura e corpo do loop intactos); teste confirma tabelas de negócio vazias pós-delete.
+- IV3: teste confirma que o log continua consultável após a purga (tabela sem FK/cascata para `tenants`).
 
 ### File List
-_(a preencher pelo @dev)_
+
+**Alterados:**
+- `apps/api/app/core/audit.py` — novo modelo `PlatformAuditEntry` (sem `TenantMixin`) + helper `record_platform()`.
+- `apps/api/app/db/registry.py` — importa `PlatformAuditEntry` (metadata/create_all).
+- `apps/api/app/modules/platform/service.py` — `delete_account` nova assinatura (`actor: CurrentUser`), snapshot pré-purga, gravação do log de plataforma pós-purga.
+- `apps/api/app/modules/platform/router.py` — repassa `admin` autenticado ao service.
+- `apps/api/app/modules/contracts/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/pages/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/quotes/router.py` — docstring de guarda explícita em `public_view`.
+- `apps/api/app/modules/wallet/router.py` — comentário/docstring de guarda nas rotas de Master.
+- `apps/api/tests/test_platform.py` — 3 testes novos de `delete_account` (baseline de regressão) + imports.
+- `docs/stories/1.2.story.md` — Status, checkboxes, Dev Agent Record.
+
+**Novos:**
+- `apps/api/migrations/versions/0031_platform_audit_entries.py` — cria `platform_audit_entries` (global, sem RLS).
+- `apps/api/tests/test_tenancy_guard.py` — teste estático de guarda de `get_db`.
 
 ## QA Results
 _(a preencher pelo @qa)_

--- a/docs/stories/1.3.story.md
+++ b/docs/stories/1.3.story.md
@@ -1,7 +1,7 @@
 # Story 1.3: Idle timeout LGPD (30 min)
 
 ## Status
-Ready
+InReview
 
 ## Executor Assignment
 ```yaml
@@ -36,37 +36,37 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "vitest (apps
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Decisão de arquitetura para o mecanismo de idle timeout (AC: 1, 3)**
-  - [ ] **Esta story tem uma decisão de design em aberto que NÃO está resolvida nem no epic nem em CLAUDE.md** (ver Dev Notes → "Gap técnico identificado"). Antes de codar, o @dev deve escolher e documentar (no Dev Agent Record) uma das abordagens abaixo — ou outra equivalente — respeitando a AC3 (não afrouxar os 7 dias do JWT "para os demais casos"):
+- [x] **Task 1 — Decisão de arquitetura para o mecanismo de idle timeout (AC: 1, 3)**
+  - [x] **Esta story tem uma decisão de design em aberto que NÃO está resolvida nem no epic nem em CLAUDE.md** (ver Dev Notes → "Gap técnico identificado"). Antes de codar, o @dev deve escolher e documentar (no Dev Agent Record) uma das abordagens abaixo — ou outra equivalente — respeitando a AC3 (não afrouxar os 7 dias do JWT "para os demais casos"):
     - **Opção A — sliding refresh token curto** (mais alinhada à redação literal da AC1, "refresh token curto"): criar um `POST /auth/refresh` novo (não existe hoje) que emite um novo access token de vida curta a partir de um refresh token; o refresh token só é aceito se a última atividade foi há menos de `session_idle_timeout_minutes` (30); o frontend chama `/auth/refresh` periodicamente enquanto há atividade do usuário; se o refresh falhar (idle estourado), desloga.
     - **Opção B — tabela de sessão ativa server-side**: nova tabela (ex. `active_sessions`, chaveada por `user_id`/`jti` do JWT) atualizada a cada request autenticado com `last_activity_at`; uma dependency check (ex. em `get_current_user`) rejeita (401) requests cujo `last_activity_at` já passou de 30 min, mesmo com o JWT de 7 dias ainda tecnicamente válido.
-  - [ ] Qualquer que seja a opção, o JWT_SECRET/algoritmo/`jwt_expire_minutes=10080` (7 dias) usados hoje por `apps/api/app/core/security.py::create_access_token` **não devem ser reduzidos globalmente** — a AC3 pede que o idle timeout seja uma camada ADICIONAL, não uma troca do prazo de expiração do JWT em si (que continua valendo para os "demais casos" — ex. tokens de reset de senha usam mecanismo próprio via `hash_token`/sha256, não são afetados).
+  - [x] Qualquer que seja a opção, o JWT_SECRET/algoritmo/`jwt_expire_minutes=10080` (7 dias) usados hoje por `apps/api/app/core/security.py::create_access_token` **não devem ser reduzidos globalmente** — a AC3 pede que o idle timeout seja uma camada ADICIONAL, não uma troca do prazo de expiração do JWT em si (que continua valendo para os "demais casos" — ex. tokens de reset de senha usam mecanismo próprio via `hash_token`/sha256, não são afetados).
 
-- [ ] **Task 2 — Implementar o mecanismo de atividade/expiração no backend (AC: 1, 3)**
-  - [ ] Usar o config já existente `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`, hoje definido como `30  # LGPD` mas **NÃO referenciado em lugar nenhum do código** — é dead config, este é o ponto de entrada natural).
-  - [ ] Implementar a abordagem escolhida na Task 1 dentro de `apps/api/app/core/security.py` (primitivas) e `apps/api/app/core/tenancy.py::get_current_user`/nova dependency (ponto único onde toda rota autenticada já passa — ver Dev Notes para o fluxo exato hoje).
-  - [ ] Se a opção escolhida envolve nova tabela: nova migration em `apps/api/migrations/versions/` (coordenar numeração com Stories 1.1/1.2, que também adicionam migrations nesta mesma sequência de epic).
-  - [ ] Garantir que rotas PÚBLICAS (assinatura de contrato, aceite de proposta, página pública) continuam funcionando sem exigir sessão/atividade — elas já não usam `get_current_user`/`get_tenant_db` (usam `get_db` direto, ver Story 1.2 Task 1), então não devem ser afetadas por este mecanismo. Confirmar explicitamente com teste (IV2).
+- [x] **Task 2 — Implementar o mecanismo de atividade/expiração no backend (AC: 1, 3)**
+  - [x] Usar o config já existente `settings.session_idle_timeout_minutes` (`apps/api/app/config.py:24`, hoje definido como `30  # LGPD` mas **NÃO referenciado em lugar nenhum do código** — é dead config, este é o ponto de entrada natural).
+  - [x] Implementar a abordagem escolhida na Task 1 dentro de `apps/api/app/core/security.py` (primitivas) e `apps/api/app/core/tenancy.py::get_current_user`/nova dependency (ponto único onde toda rota autenticada já passa — ver Dev Notes para o fluxo exato hoje).
+  - [x] Se a opção escolhida envolve nova tabela: nova migration em `apps/api/migrations/versions/` (coordenar numeração com Stories 1.1/1.2, que também adicionam migrations nesta mesma sequência de epic).
+  - [x] Garantir que rotas PÚBLICAS (assinatura de contrato, aceite de proposta, página pública) continuam funcionando sem exigir sessão/atividade — elas já não usam `get_current_user`/`get_tenant_db` (usam `get_db` direto, ver Story 1.2 Task 1), então não devem ser afetadas por este mecanismo. Confirmar explicitamente com teste (IV2).
 
-- [ ] **Task 3 — Frontend: `ProtectedLayout` trata o timeout (AC: 2)**
-  - [ ] `apps/web/src/app/App.tsx`, função `ProtectedLayout` (linhas ~84-96): hoje só verifica `isAuthenticated`/`must_reset_password`. Adicionar o tracking de atividade (eventos de mouse/teclado/click/scroll) com um timer de 30 min (mesmo valor do backend — idealmente expor `session_idle_timeout_minutes` para o frontend via `/me` ou config pública, para não hardcodar o número duas vezes).
-  - [ ] Ao estourar o idle: mostrar um aviso (ex. toast/modal — usar padrão de UI já existente no design "Portal") e então chamar `logout()` (já existe em `apps/web/src/store/auth.tsx`, limpa `localStorage` e state) — o próprio `AuthProvider` já redireciona pro `/login` quando `isAuthenticated` vira `false` via `ProtectedLayout`/`LoginRoute`, então basta chamar `logout()` corretamente.
-  - [ ] Reaproveitar o padrão já existente de logout automático em 401: `apps/web/src/store/auth.tsx` linhas ~58-68 já intercepta respostas 401 da API e desloga — se a Opção A/B do backend passar a devolver 401 quando a sessão expira por inatividade, esse interceptor JÁ cobre parte do fluxo; a Task 3 deve then focar em: (a) o AVISO amigável antes/no momento do logout (a AC pede "aviso", o interceptor sozinho não avisa, só desloga), e (b) o timer local para não depender só de uma request falhar para perceber o timeout.
-  - [ ] Não quebrar fluxos ativos legítimos (AC2): qualquer interação do usuário (não só requests à API) deve resetar o timer — cobrir digitação em formulários longos (ex. editor de contrato, editor de funil) mesmo que o usuário não dispare uma request por alguns minutos.
+- [x] **Task 3 — Frontend: `ProtectedLayout` trata o timeout (AC: 2)**
+  - [x] `apps/web/src/app/App.tsx`, função `ProtectedLayout` (linhas ~84-96): hoje só verifica `isAuthenticated`/`must_reset_password`. Adicionar o tracking de atividade (eventos de mouse/teclado/click/scroll) com um timer de 30 min (mesmo valor do backend — idealmente expor `session_idle_timeout_minutes` para o frontend via `/me` ou config pública, para não hardcodar o número duas vezes).
+  - [x] Ao estourar o idle: mostrar um aviso (ex. toast/modal — usar padrão de UI já existente no design "Portal") e então chamar `logout()` (já existe em `apps/web/src/store/auth.tsx`, limpa `localStorage` e state) — o próprio `AuthProvider` já redireciona pro `/login` quando `isAuthenticated` vira `false` via `ProtectedLayout`/`LoginRoute`, então basta chamar `logout()` corretamente.
+  - [x] Reaproveitar o padrão já existente de logout automático em 401: `apps/web/src/store/auth.tsx` linhas ~58-68 já intercepta respostas 401 da API e desloga — se a Opção A/B do backend passar a devolver 401 quando a sessão expira por inatividade, esse interceptor JÁ cobre parte do fluxo; a Task 3 deve then focar em: (a) o AVISO amigável antes/no momento do logout (a AC pede "aviso", o interceptor sozinho não avisa, só desloga), e (b) o timer local para não depender só de uma request falhar para perceber o timeout.
+  - [x] Não quebrar fluxos ativos legítimos (AC2): qualquer interação do usuário (não só requests à API) deve resetar o timer — cobrir digitação em formulários longos (ex. editor de contrato, editor de funil) mesmo que o usuário não dispare uma request por alguns minutos.
 
-- [ ] **Task 4 — Testes de regressão de auth (AC: 1, 2, 3; IV1)**
-  - [ ] Rodar/estender `apps/api/tests/test_auth.py` para cobrir: login/logout continuam funcionando; rota protegida ainda aceita token dentro da janela de atividade; rota protegida rejeita quando a "última atividade" simulada excede 30 min (ajustar `settings.session_idle_timeout_minutes` no teste para um valor pequeno, evitar testes lentos).
-  - [ ] Confirmar que o teste de guarda de configuração (`apps/api/tests/test_config.py`) não precisa mudar (idle timeout é comportamento de runtime, não de boot) — se a abordagem escolhida adicionar novo campo de config, avaliar se merece guard semelhante.
+- [x] **Task 4 — Testes de regressão de auth (AC: 1, 2, 3; IV1)**
+  - [x] Rodar/estender `apps/api/tests/test_auth.py` para cobrir: login/logout continuam funcionando; rota protegida ainda aceita token dentro da janela de atividade; rota protegida rejeita quando a "última atividade" simulada excede 30 min (ajustar `settings.session_idle_timeout_minutes` no teste para um valor pequeno, evitar testes lentos).
+  - [x] Confirmar que o teste de guarda de configuração (`apps/api/tests/test_config.py`) não precisa mudar (idle timeout é comportamento de runtime, não de boot) — se a abordagem escolhida adicionar novo campo de config, avaliar se merece guard semelhante.
 
-- [ ] **Task 5 — Validar não-impacto em endpoints públicos (AC: 2; IV2)**
-  - [ ] Testar manualmente/via `apps/api/tests/test_contracts.py`, `test_quotes.py`(?), `test_pages.py` que os fluxos públicos (assinatura de contrato, aceite de proposta, visualização de página) continuam funcionando sem exigir login/atividade — eles não passam por `get_current_user`.
+- [x] **Task 5 — Validar não-impacto em endpoints públicos (AC: 2; IV2)**
+  - [x] Testar manualmente/via `apps/api/tests/test_contracts.py`, `test_quotes.py`(?), `test_pages.py` que os fluxos públicos (assinatura de contrato, aceite de proposta, visualização de página) continuam funcionando sem exigir login/atividade — eles não passam por `get_current_user`.
 
-- [ ] **Task 6 — Validar performance do fluxo de refresh (AC: todas; IV3)**
-  - [ ] Se a Opção A (refresh token) for escolhida: confirmar que o novo `/auth/refresh` é leve (uma consulta simples, sem N+1) e que o polling do frontend não gera carga desnecessária na API (ex.: só chamar refresh quando há atividade real, não em intervalo fixo agressivo).
-  - [ ] Se a Opção B (sessão server-side) for escolhida: confirmar que a escrita de `last_activity_at` a cada request não gera contenção/lock desnecessário (ex.: usar `UPDATE` simples por PK, sem lock de linha compartilhado entre requests concorrentes do mesmo usuário além do necessário).
+- [x] **Task 6 — Validar performance do fluxo de refresh (AC: todas; IV3)**
+  - [x] Se a Opção A (refresh token) for escolhida: confirmar que o novo `/auth/refresh` é leve (uma consulta simples, sem N+1) e que o polling do frontend não gera carga desnecessária na API (ex.: só chamar refresh quando há atividade real, não em intervalo fixo agressivo).
+  - [x] Se a Opção B (sessão server-side) for escolhida: confirmar que a escrita de `last_activity_at` a cada request não gera contenção/lock desnecessário (ex.: usar `UPDATE` simples por PK, sem lock de linha compartilhado entre requests concorrentes do mesmo usuário além do necessário).
 
-- [ ] **Task 7 — Checklist de qualidade (AC: todas)**
-  - [ ] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — CLAUDE.md §5.
+- [x] **Task 7 — Checklist de qualidade (AC: todas)**
+  - [x] Rodar `bash scripts/check.sh` (lint + testes backend + typecheck/testes frontend) — CLAUDE.md §5.
 
 ## Dev Notes
 
@@ -116,20 +116,59 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "vitest (apps
 |------|---------|-------------|--------|
 | 2026-07-10 | 0.1 | Story criada a partir do Epic 1 (Segurança & Compliance) | River (@sm) |
 | 2026-07-10 | 0.1.1 | Validated GO (8/10) — Status: Draft → Ready (fork de arquitetura Opção A/B delegado ao @dev/@architect na Task 1) | @po |
+| 2026-07-10 | 0.2 | Implementada (Opção A — sliding session stateless, sem tabela/migration). Backend: 262 pytest / ruff OK; Frontend: 4 vitest / tsc OK. Status: Ready → InReview | Dex (@dev) |
 
 ## Dev Agent Record
 
 ### Agent Model Used
-_(a preencher pelo @dev)_
+Dex (@dev) — Opus 4.8 (1M) — modo YOLO autônomo, worktree isolado `feature/1.3-idle-timeout-lgpd`.
 
 ### Debug Log References
-_(a preencher pelo @dev)_
+- Backend: `ruff check .` → All checks passed; `pytest -q` → **262 passed** (9 novos em `test_idle_timeout.py`, 0 regressões) — rodado em container `python:3.13-slim` (SQLite in-memory, sem Postgres, conforme conftest). Python não está instalado no host; suíte executada via Docker.
+- Frontend: `tsc --noEmit` → sem erros; `vitest run` → **4 passed** (`src/lib/idleTimer.test.ts`). `pnpm install` executado no worktree para habilitar typecheck/vitest.
+- Frontend eslint NÃO rodado: o repositório não tem `eslint.config.*` (flat config) presente — `scripts/check.sh` também não roda lint de frontend (só typecheck+vitest). Sem regressão introduzida.
 
 ### Completion Notes List
-_(a preencher pelo @dev — incluir obrigatoriamente a decisão de arquitetura tomada na Task 1 e o porquê)_
+
+**Decisão de arquitetura (Task 1) — OPÇÃO A (sliding session stateless), variante de token único. SEM tabela nova, SEM migration.**
+
+Mecanismo escolhido: o access token passa a carregar DUAS camadas de expiração, sem estado no servidor:
+- `exp` = janela de INATIVIDADE (`session_idle_timeout_minutes`, 30 min) — é o que o `jwt.decode` valida sozinho; passou disso sem atividade, o token morre e `get_current_user` retorna 401 (fail-closed, camada de segurança REAL, server-side).
+- `abs_exp` = teto ABSOLUTO da sessão (`jwt_expire_minutes`, 7 dias) — preserva a garantia atual do JWT como limite máximo.
+- Novo `POST /auth/refresh` desliza a janela de idle (reemite token com `exp` renovado) enquanto respeita `abs_exp`. O frontend o chama, com throttle, a cada atividade real do usuário. É stateless e NÃO toca o banco (leve — IV3).
+
+**Por que A e não B (tabela `active_sessions` server-side):**
+1. **Menor blast radius / zero coordenação de migration** — evita disputa de numeração Alembic com as Stories 1.1/1.2 em paralelo (o `0032` foi reservado mas NÃO foi necessário — não inventei tabela).
+2. **Preserva a arquitetura stateless atual** — `get_current_user` continua sem consulta ao banco; nenhuma escrita de `last_activity_at` por request (Opção B geraria contenção/escrita a cada request autenticado — pior para IV3/performance).
+3. **Atende a AC literal** ("refresh token curto") e a AC3 — `jwt_expire_minutes=10080` NÃO foi reduzido; ele agora é o teto `abs_exp`. Só o token de sessão de login é afetado (`create_access_token` só é chamado por login/register); tokens de reset de senha usam mecanismo próprio (`hash_token`/sha256) e ficam intactos.
+
+**Comportamento fail-closed:** token sem `abs_exp` legível (ex.: token legado emitido antes desta story) NÃO pode ser deslizado por `/auth/refresh` → força novo login. Aceitável: este epic é pré-go-live (sem usuários reais em produção ainda). Tokens legados seguem válidos até seu `exp` natural via `get_current_user`, sem idle enforcement, até relogin.
+
+**Frontend (AC2):** `ProtectedLayout` agora usa `useIdleTimeout`, que rastreia atividade de mouse/teclado/click/scroll/touch (qualquer interação — não só requests — reinicia a contagem, cobrindo formulários longos), desliza a sessão no backend com throttle (`/auth/refresh` no máx. a cada 5 min), avisa 1 min antes via `IdleWarningModal` (reusa o `Modal` do design Portal) e faz `logout()` limpo ao esgotar. O interceptor 401 já existente em `auth.tsx` é o backstop fail-closed.
+
+**IDS (reuso):** reusei `components/Modal.tsx` (aviso), o `logout()`/interceptor 401 de `store/auth.tsx`, o cliente `api` de `lib/api.ts`, e o config morto `session_idle_timeout_minutes` (agora vivo). Criei apenas o que não existia: `lib/idleTimer.ts` (timer puro testável), `store/useIdleTimeout.ts` (glue DOM), `components/IdleWarningModal.tsx`, e no backend `refresh_access_token` + endpoint `/auth/refresh`.
+
+**Desvios:** (1) nenhuma migration criada — a Opção A escolhida não precisa (o `0032` reservado no prompt fica livre). (2) Número de idle (30) mantido como constante no frontend (`IDLE_TIMEOUT_MINUTES`) espelhando o backend, em vez de expor via endpoint — o backend é a fonte de verdade da EXPIRAÇÃO (token `exp`); se divergir, o 401 ainda protege (fail-closed). Optei por menor superfície em vez de novo endpoint público de config.
 
 ### File List
-_(a preencher pelo @dev)_
+**Backend (alterados):**
+- `apps/api/app/core/security.py` — `create_access_token` agora emite `exp` (idle) + `abs_exp` (teto 7d); novo `refresh_access_token`.
+- `apps/api/app/modules/auth/router.py` — novo endpoint `POST /auth/refresh`.
+- `apps/api/app/modules/auth/schemas.py` — novo schema `RefreshedToken`.
+
+**Backend (novo):**
+- `apps/api/tests/test_idle_timeout.py` — 9 testes (unidade do token/refresh + integração /refresh + idle fail-closed + IV2 rota pública).
+
+**Frontend (alterados):**
+- `apps/web/src/app/App.tsx` — `ProtectedLayout` usa `useIdleTimeout` + renderiza `IdleWarningModal`.
+- `apps/web/src/store/auth.tsx` — novo `updateToken` no contexto de auth.
+- `apps/web/src/lib/api.ts` — novo helper `refreshSession()`.
+
+**Frontend (novo):**
+- `apps/web/src/lib/idleTimer.ts` — classe pura `IdleTimer` + constantes de config.
+- `apps/web/src/store/useIdleTimeout.ts` — hook que integra atividade DOM, refresh throttled, aviso e logout.
+- `apps/web/src/components/IdleWarningModal.tsx` — aviso reusando `Modal`.
+- `apps/web/src/lib/idleTimer.test.ts` — 4 testes (vitest) do timer.
 
 ## QA Results
 _(a preencher pelo @qa)_

--- a/docs/stories/1.4.story.md
+++ b/docs/stories/1.4.story.md
@@ -1,7 +1,7 @@
 # Story 1.4: Forçar troca de senha do Super Admin no 1º login + validar guard de segredos
 
 ## Status
-Ready
+InReview
 
 ## Executor Assignment
 ```yaml
@@ -36,30 +36,30 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Semear o Super Admin com `must_reset_password=True` (AC: 1)**
-  - [ ] `apps/api/app/seed.py::seed_super_admin` (linhas ~18-46): o `User(...)` criado para o admin (linhas ~32-41) hoje NÃO passa `must_reset_password` — o default do modelo é `False` (`apps/api/app/modules/auth/models.py:50`, `must_reset_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)`). Adicionar `must_reset_password=True` explicitamente na construção do `User` do admin.
-  - [ ] **Confirmado por inspeção de código: nenhuma outra mudança é necessária para o restante do fluxo.** O caminho já existe ponta-a-ponta e é genérico (não depende de `role`/`is_platform_admin`):
+- [x] **Task 1 — Semear o Super Admin com `must_reset_password=True` (AC: 1)**
+  - [x] `apps/api/app/seed.py::seed_super_admin` (linhas ~18-46): o `User(...)` criado para o admin (linhas ~32-41) hoje NÃO passa `must_reset_password` — o default do modelo é `False` (`apps/api/app/modules/auth/models.py:50`, `must_reset_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)`). Adicionar `must_reset_password=True` explicitamente na construção do `User` do admin.
+  - [x] **Confirmado por inspeção de código: nenhuma outra mudança é necessária para o restante do fluxo.** O caminho já existe ponta-a-ponta e é genérico (não depende de `role`/`is_platform_admin`):
     - `POST /auth/login` (`apps/api/app/modules/auth/router.py:61-67`) devolve `AuthToken.user` via `UserOut.model_validate(user)`, que já inclui `must_reset_password` (`apps/api/app/modules/auth/schemas.py:87`).
     - `apps/web/src/app/App.tsx::ProtectedLayout` (linha 88) já checa `user?.must_reset_password` e renderiza `FirstAccessPage` para QUALQUER usuário com a flag ativa — sem tratamento especial de admin, já cobre o Master automaticamente.
     - `POST /auth/change-password` (`apps/api/app/modules/auth/router.py:91-103`) usa `get_current_user` (não `require_platform_admin`, não tem restrição de módulo/role) + `set_own_password` (`apps/api/app/modules/auth/service.py:95-104`, genérico, limpa `must_reset_password=False` para qualquer `User`) — funciona para o Master sem alteração.
 
-- [ ] **Task 2 — Confirmar o guard de produção já existente (AC: 2)**
-  - [ ] `apps/api/app/config.py::_guard_production_secrets` (linhas ~50-64) **já implementa exatamente** o que a AC2 pede: bloqueia boot em produção se `jwt_secret` for o default OU tiver menos de 32 chars, se `anthropic_api_key` estiver vazio, ou se `super_admin_password` for o default (`_DEFAULT_ADMIN_PASSWORD = "trocar-no-primeiro-acesso"`).
-  - [ ] **Não há trabalho de implementação aqui** — apenas verificação/confirmação (ver Task 4, testes já existem e passam). Se algum dos 3 casos da AC2 não estiver coberto ao rodar os testes existentes, ajustar `_guard_production_secrets` para fechar a lacuna.
+- [x] **Task 2 — Confirmar o guard de produção já existente (AC: 2)**
+  - [x] `apps/api/app/config.py::_guard_production_secrets` (linhas ~50-64) **já implementa exatamente** o que a AC2 pede: bloqueia boot em produção se `jwt_secret` for o default OU tiver menos de 32 chars, se `anthropic_api_key` estiver vazio, ou se `super_admin_password` for o default (`_DEFAULT_ADMIN_PASSWORD = "trocar-no-primeiro-acesso"`).
+  - [x] **Não há trabalho de implementação aqui** — apenas verificação/confirmação (ver Task 4, testes já existem e passam). Confirmado: os 3 casos da AC2 já estão cobertos pelos 6 testes de `test_config.py` (todos verdes). Nenhuma alteração feita em `_guard_production_secrets`.
 
-- [ ] **Task 3 — Adicionar item ao checklist de release (AC: 3)**
-  - [ ] `docs/HOSTINGER-DEPLOY.md`, seção `## 4. Validar` (linhas ~76-79, já menciona "Login com `SUPER_ADMIN_EMAIL` / `SUPER_ADMIN_PASSWORD` do `.env.prod`"): adicionar um item explícito confirmando (a) que o boot falhou/falharia com segredos fracos (referenciar o guard `_guard_production_secrets` e seus 3 testes) e (b) que o primeiro login do Master força a troca de senha (Task 1).
-  - [ ] Repetir o mesmo item em `docs/AWS-DEPLOYMENT.md` se houver seção equivalente de validação pós-deploy (hoje o arquivo é mais uma referência de infraestrutura/custo do que um checklist passo-a-passo — avaliar se cabe um item novo ou uma nota apontando para `HOSTINGER-DEPLOY.md#4-validar`).
-  - [ ] **[AUTO-DECISION]** Não criar um novo documento dedicado `docs/RELEASE-CHECKLIST.md` nesta story — o Epic 3 (Deploy, Storage & Observabilidade, fora do escopo desta missão) é o dono natural de um checklist de release mais formal; aqui basta satisfazer a AC3 adicionando o item ao(s) documento(s) de deploy já existente(s). Reason: evitar inventar estrutura de documentação fora do escopo do Epic 1 e duplicar conteúdo que o Epic 3 provavelmente vai formalizar.
+- [x] **Task 3 — Adicionar item ao checklist de release (AC: 3)**
+  - [x] `docs/HOSTINGER-DEPLOY.md`, seção `## 4. Validar`: adicionado item explícito "Segurança de credenciais (Story 1.4)" confirmando (a) que o boot recusa segredos fracos (referenciando o guard `_guard_production_secrets` e os 6 testes de `test_config.py`) e (b) que o primeiro login do Master força a troca de senha (referenciando `must_reset_password=True` e `test_seed.py`).
+  - [x] `docs/AWS-DEPLOYMENT.md`: **não alterado** — [AUTO-DECISION] o arquivo é referência de infra/custo (não um checklist passo-a-passo de validação pós-deploy), então adicionar o item lá seria forçar estrutura inexistente. Reason: manter a AC3 no único documento que já tem uma seção "Validar" passo-a-passo, evitando duplicação/invenção de estrutura.
+  - [x] **[AUTO-DECISION]** Não criar um novo documento dedicado `docs/RELEASE-CHECKLIST.md` nesta story — o Epic 3 (Deploy, Storage & Observabilidade, fora do escopo desta missão) é o dono natural de um checklist de release mais formal; aqui basta satisfazer a AC3 adicionando o item ao documento de deploy já existente. Reason: evitar inventar estrutura de documentação fora do escopo do Epic 1 e duplicar conteúdo que o Epic 3 provavelmente vai formalizar.
 
-- [ ] **Task 4 — Testes (AC: 1, 2, 3; IV1, IV2, IV3)**
-  - [ ] **Gap identificado:** não existe hoje nenhum teste cobrindo `seed_super_admin` (`apps/api/tests` não tem nenhum arquivo `test_seed*.py` nem referência a `seed_super_admin`). Criar `apps/api/tests/test_seed.py` cobrindo: o admin semeado nasce com `must_reset_password=True`; rodar o seed duas vezes é idempotente (já é o comportamento hoje — `existing = db.scalar(...); if existing: return`).
-  - [ ] Confirmar que os testes já existentes em `apps/api/tests/test_config.py` (6 testes: `test_production_rejects_default_secret`, `test_production_rejects_short_secret`, `test_production_requires_anthropic_key`, `test_production_rejects_default_admin_password`, `test_production_ok_with_strong_secret`, `test_development_allows_defaults`) continuam passando — cobrem IV3 e a AC2 quase integralmente já.
-  - [ ] Rodar `apps/api/tests/test_platform.py`/`test_auth.py` para confirmar que login de usuário comum e fluxo de convite/1º acesso (funcionário/dono, que já usam `must_reset_password=True` desde a Story de convite existente) continuam passando — IV1.
-  - [ ] Validar manualmente (dev, sem produção) que o comportamento permissivo atual (defaults funcionam, boot não falha) continua intacto — IV2, já coberto por `test_development_allows_defaults`.
+- [x] **Task 4 — Testes (AC: 1, 2, 3; IV1, IV2, IV3)**
+  - [x] **Gap fechado:** criado `apps/api/tests/test_seed.py` (não existia antes). Cobre: o admin semeado nasce com `must_reset_password=True` (`test_seed_creates_admin_with_must_reset_password`); rodar o seed duas vezes é idempotente e não duplica o admin (`test_seed_is_idempotent`). O seed usa `SessionLocal` próprio (Postgres em prod) — nos testes ele é apontado (via `monkeypatch`) para um SQLite em memória (StaticPool).
+  - [x] Confirmado: os 6 testes de `apps/api/tests/test_config.py` continuam passando (cobrem IV3 e a AC2). Nenhuma alteração necessária neles.
+  - [x] Confirmado: `apps/api/tests/test_platform.py` (login de usuário comum, convite, 1º acesso de dono/funcionário) e `apps/api/tests/test_auth.py` continuam passando — IV1.
+  - [x] Confirmado: comportamento permissivo em dev intacto (defaults funcionam, boot não falha) — IV2, coberto por `test_development_allows_defaults`. Não é possível validar o e2e visual (login Master → FirstAccessPage) sem ambiente rodando; o caminho é role-agnostic e já coberto por `test_account_owner_first_access`/`test_first_access_password_change`.
 
-- [ ] **Task 5 — Checklist de qualidade (AC: todas)**
-  - [ ] Rodar `bash scripts/check.sh` (lint + testes) — CLAUDE.md §5.
+- [x] **Task 5 — Checklist de qualidade (AC: todas)**
+  - [x] `ruff check .` (apps/api) — **All checks passed**. `python -m pytest` — suite completa **verde** (rodado em container `python:3.13-slim`, já que não há Python/venv no host; SQLite em memória, sem necessidade de Postgres). Frontend não tocado nesta story.
 
 ## Dev Notes
 
@@ -105,16 +105,26 @@ quality_gate_tools: ["ruff (apps/api)", "pytest (apps/api/tests)", "manual secur
 ## Dev Agent Record
 
 ### Agent Model Used
-_(a preencher pelo @dev)_
+Dex (@dev) — Claude Opus 4.8 (1M). Modo YOLO (autônomo), worktree isolado `feature/1.4-admin-first-login-guard` (base `origin/docs/go-live-prd-epics-stories`).
 
 ### Debug Log References
-_(a preencher pelo @dev)_
+- Host sem Python/venv (só stub da Windows Store). Testes rodados em container `python:3.13-slim` com `requirements.txt` instalado e o worktree montado (SQLite em memória; sem Postgres — conftest já usa SQLite).
+- `ruff check .` (apps/api): **All checks passed**.
+- Suite completa `pytest`: **254 passed** (69s). Alvos da story: `test_seed.py` (2), `test_config.py` (6), `test_platform.py`, `test_auth.py` — todos verdes.
 
 ### Completion Notes List
-_(a preencher pelo @dev)_
+- **Task 1 (AC1):** adicionada 1 linha `must_reset_password=True` na construção do `User` do admin em `seed.py` (com comentário). O restante do fluxo (login → `must_reset_password` no `UserOut` → `FirstAccessPage` → `POST /auth/change-password` → `set_own_password`) já é role-agnostic e não precisou de mudança — confirmado por inspeção e pelos testes existentes de 1º acesso.
+- **Task 2 (AC2):** `_guard_production_secrets` já cobre os 3 casos (JWT fraco/default, ANTHROPIC ausente, SUPER_ADMIN_PASSWORD default). Nenhuma alteração — confirmado pelos 6 testes de `test_config.py`.
+- **Task 3 (AC3):** item de release adicionado em `docs/HOSTINGER-DEPLOY.md` §4. `docs/AWS-DEPLOYMENT.md` deixado intacto (não tem seção de validação passo-a-passo — [AUTO-DECISION] documentado na Task 3).
+- **Task 4:** criado `apps/api/tests/test_seed.py` (não existia). Técnica: `monkeypatch` do `app.seed.SessionLocal` para um SQLite em memória (StaticPool) — o seed abre sua própria sessão, então precisa ser plugado no engine de teste.
+- **IV1/IV2/IV3:** verificados via suite verde. E2E visual (Master → FirstAccessPage) não automatizável sem ambiente de pé (mesma limitação registrada nas Stories 1.1-1.3); caminho coberto por testes de 1º acesso de dono/funcionário.
+- **Sem migration** (confirmado: mudança é seed + testes; nenhuma alteração de schema). **Sem push** (delegado a @devops). Commit local feito.
 
 ### File List
-_(a preencher pelo @dev)_
+- ALTERADO: `apps/api/app/seed.py` (+`must_reset_password=True` no admin semeado)
+- NOVO: `apps/api/tests/test_seed.py`
+- ALTERADO: `docs/HOSTINGER-DEPLOY.md` (item de release §4 — guard + 1º login do Master)
+- ALTERADO: `docs/stories/1.4.story.md` (Status, tasks, Dev Agent Record)
 
 ## QA Results
 _(a preencher pelo @qa)_


### PR DESCRIPTION
## Resumo

Esta PR traz as **Stories 1.2, 1.3 e 1.4** do Epic 1, já **mergeadas com a Story 1.1** (que foi direto para `main`). Consolida toda a base de autenticação/hardening do go-live em uma única PR fresca para `main`.

## Stories incluídas

- **Story 1.2** — Hardening de users + RLS + log LGPD
- **Story 1.3** — Idle timeout (LGPD)
- **Story 1.4** — Senha Master (admin first-login guard)

## Fixes de consolidação

Ao mergear `main` (Story 1.1) nesta branch, dois ajustes foram necessários:

1. **Cadeia de migrations Alembic** — a migration `0031` agora encadeia corretamente **após `0030`** (`down_revision` corrigido). Antes a cadeia quebrava porque as stories foram desenvolvidas em paralelo.
2. **Fix de teste** — CNPJ dummy passou a ser inválido após a validação introduzida pela Story 1.1 entrar em `main`; o fixture de teste foi atualizado para um CNPJ válido.

## Testes

- **286 testes backend** — todos verdes
- **4 testes frontend** — todos verdes

Total: **290 testes, 100% passando.**

## Observações

- As PRs antigas #3 / #4 / #5 já foram mergeadas nesta branch e não servem mais de referência — esta é a PR consolidada.
- `main` não avançou desde o merge, portanto a PR deve estar limpa para merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)