### PR TITLE
docs: valida webhook Asaas contra sandbox real

### DIFF
--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -16,16 +16,23 @@
   2026-07-12):** a API key da Asaas tem um `$` literal — precisa estar como `$$` no `.env` (ou
   usar `env_file`, não `environment: ${VAR}`), senão o Compose interpola e o valor vira string
   vazia. **Pendente:** replicar em `infra/.env.prod` de verdade quando a VPS existir (item 10).
-- [ ] Configurar `GATEWAY_WEBHOOK_SECRET` e registrar a URL do webhook no painel Asaas — falta
-  uma URL pública (só existe depois do item 10/deploy).
+- [x] Configurar `GATEWAY_WEBHOOK_SECRET` e registrar a URL do webhook no painel/API Asaas —
+  gerado um segredo real (48 hex chars) e configurado no `.env` local; registrado via
+  `POST /v3/webhooks` contra um túnel público temporário (`cloudflared`, autorizado
+  explicitamente pelo usuário, removido ao fim do teste). **Pendente:** repetir o registro contra
+  a URL pública real de produção quando o item 10 (deploy) existir — a URL de túnel foi só para
+  validação, não é permanente.
 - [x] Revalidar contra o sandbox real: campos/endpoints exatos do payload, formato do `bankSlipUrl`
   — validado em 2026-07-12: `POST /customers`, `POST /payments` e `GET /payments/{id}/pixQrCode`
   responderam `200` reais contra `api-sandbox.asaas.com` (boleto E Pix), com `gateway_charge_id`/
   `payment_code`/`boleto_url` reais retornados pelo fluxo completo (`receivables.create_charge`).
   Resolve a pendência de No Invention registrada no ADR 0002.
-- [ ] Testar boleto/Pix real de ponta a ponta + confirmação de pagamento via webhook — criação da
-  cobrança validada (linha acima); falta a ponta do webhook de confirmação (exige URL pública/
-  ngrok, não testado ainda).
+- [x] Testar boleto/Pix real de ponta a ponta + confirmação de pagamento via webhook — validado em
+  2026-07-12: criada cobrança Pix real (R$33,00) pelo fluxo do produto, confirmada via
+  `POST /v3/sandbox/payment/{id}/confirm` (endpoint sandbox-only), webhook real da Asaas capturado
+  (header `asaas-access-token` confirmado, payload `PAYMENT_RECEIVED`/`externalReference` conforme
+  doc pública), cobrança marcada `paid` e split de 30% aplicado corretamente na Carteira
+  (R$9,90 taxa → R$23,10 disponível). Ver ADR 0002 para os detalhes completos.
 
 ## 3. WhatsApp Cloud API (Story 2.3)
 - [ ] Criar app Meta for Developers + número WhatsApp Business

--- a/docs/decisions/0002-gateway-pagamento.md
+++ b/docs/decisions/0002-gateway-pagamento.md
@@ -85,9 +85,19 @@ Racional:
   LTDA") — `POST /customers`, `POST /payments` (boleto E Pix) e `GET /payments/{id}/pixQrCode`
   responderam `200` reais; header `access_token` (não `asaas-access-token`) confirmado como o
   mecanismo de auth correto para essas chamadas; `bankSlipUrl`/linha digitável/copia-e-cola
-  retornados no formato esperado pelo adapter. **Ainda não validado:** o lado de ENTRADA (webhook
-  que a Asaas chama de volta) — ver condições de go-live abaixo, item 2, que continua pendente
-  (exige URL pública, não testável em localhost sem tunnel).
+  retornados no formato esperado pelo adapter. **RESOLVIDO em 2026-07-12 também para o lado de
+  ENTRADA (webhook):** com autorização explícita do usuário, exposta a API local via túnel
+  temporário (`cloudflared`, `trycloudflare.com`, sem conta, encerrado ao fim do teste), registrado
+  um webhook real (`POST /v3/webhooks`) apontando pro túnel, e disparado `POST
+  /v3/sandbox/payment/{id}/confirm` (endpoint sandbox-only) sobre uma cobrança criada pelo fluxo
+  real do produto (`receivables.create_charge`). Capturada a requisição real da Asaas: header
+  **`asaas-access-token`** confirmado byte-a-byte (bate com o que o código já esperava — nenhuma
+  mudança de código necessária), payload `{event: "PAYMENT_RECEIVED", payment: {externalReference,
+  ...}}` confere com a doc pública. Processamento validado ponta a ponta: cobrança marcada `paid`,
+  split de 30% (serviço) aplicado corretamente na Carteira (R$33,00 → R$9,90 taxa → R$23,10
+  disponível). Webhook de teste e túnel removidos após a validação (não deixam rastro
+  permanente). `GATEWAY_WEBHOOK_SECRET` real gerado e configurado no `.env` local para uso
+  contínuo em dev.
 
 ## Segurança do webhook — condições de go-live (revisão do quality gate)
 
@@ -99,11 +109,14 @@ Como é **dinheiro entrando no sistema**, o gate exige que, ao configurar o prov
    **guard de boot** numa próxima story: se `is_production` e `payment_gateway_api_key` definido,
    então `gateway_webhook_secret` não pode ser vazio (fail-fast, mesmo espírito do
    `_guard_production_secrets`). — *item para o backlog, não bloqueia esta story.*
-2. **Confirmar o mecanismo de autenticação real do Asaas** (header `asaas-access-token` vs. HMAC de
-   assinatura do corpo). O código valida hoje um token de header por igualdade simples; se o Asaas
-   usar assinatura HMAC do payload, trocar a validação para verificação de assinatura
-   (constant-time). Verificação obrigatória contra a doc vigente antes do go-live.
-3. **Registrar o token do webhook no painel do Asaas** igual ao `GATEWAY_WEBHOOK_SECRET`.
+2. **[RESOLVIDO 2026-07-12]** Confirmar o mecanismo de autenticação real do Asaas: é o header
+   `asaas-access-token` por igualdade simples (NÃO é HMAC de assinatura do corpo) — confirmado
+   contra a doc pública E contra uma requisição real capturada do sandbox. Código já validava
+   assim; nenhuma mudança necessária.
+3. **[VALIDADO EM SANDBOX 2026-07-12, pendente para PRODUÇÃO]** Registrar o token do webhook no
+   painel/API do Asaas igual ao `GATEWAY_WEBHOOK_SECRET` — feito e validado contra uma URL de
+   túnel temporária (removida após o teste). Falta repetir contra a URL pública real de produção
+   quando o item 10 (deploy) existir.
 4. **Validar o isolamento cross-tenant no Postgres real** (RLS), não só no SQLite dos testes: um
    `externalReference` do tenant A não pode baixar cobrança sob o tenant B. O parsing já garante a
    separação; a RLS é a defesa final e precisa ser exercida no e2e (mesma lacuna de e2e já


### PR DESCRIPTION
## Resumo

Documentação apenas (2 arquivos, zero código de produção tocado). Registra a validação ponta a ponta do lado de **entrada** do gateway Asaas (webhook de callback), última pendência do item 2 do go-live checklist.

## O que foi validado (em sandbox real)

- API local exposta via túnel temporário (cloudflared/trycloudflare, sem conta, removido ao fim).
- `GATEWAY_WEBHOOK_SECRET` real gerado e webhook registrado via `POST /v3/webhooks` apontando pro túnel.
- Cobrança Pix real (R$33,00) criada pelo fluxo real do produto (`receivables.create_charge`).
- Pagamento simulado via `POST /v3/sandbox/payment/{id}/confirm` (endpoint sandbox-only).
- Requisição real da Asaas capturada: header `asaas-access-token` confirmado byte-a-byte (código já esperava exatamente isso — **zero mudança de código**); payload `PAYMENT_RECEIVED`/`externalReference` conforme docs públicas.
- Processamento ponta a ponta confirmado: cobrança marcada `paid` e split de 30% (categoria serviço) aplicado na Carteira (R$33,00 -> R$9,90 taxa -> R$23,10 disponível).
- Webhook de teste e túnel removidos ao final — nada permanente na conta Asaas.

## Impacto

Resolve pendências #2 e #3 do ADR 0002 (mecanismo de auth do webhook confirmado; registro validado em sandbox). Falta apenas repetir contra a URL de produção quando houver deploy.

## Segurança

Nenhuma credencial commitada. `.env` (raiz, com API key Asaas + webhook secret real) está gitignorado e fora do commit. Diff contém apenas nomes de variáveis/headers, nunca valores.

## Arquivos

- `docs/GO-LIVE-CHECKLIST.md`
- `docs/decisions/0002-gateway-pagamento.md`

Autorizado explicitamente pelo usuário nesta sessão.