### PR TITLE
fix: Google OAuth não descarta tokens quando userinfo falha

### DIFF
--- a/apps/api/app/modules/google_calendar/models.py
+++ b/apps/api/app/modules/google_calendar/models.py
@@ -17,7 +17,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
-DEFAULT_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+DEFAULT_SCOPE = (
+    "https://www.googleapis.com/auth/calendar.events"
+    " https://www.googleapis.com/auth/userinfo.email"
+)
 
 
 class GoogleCredential(Base, TenantMixin, TimestampMixin):

--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -126,10 +126,19 @@ def upsert_credential(db: Session, *, tenant_id: str, email: str, token_data: di
 
 
 def handle_callback(db: Session, *, tenant_id: str, code: str) -> None:
-    """Fluxo completo do callback: troca o code por tokens, descobre o e-mail e faz upsert."""
+    """Fluxo completo do callback: troca o code por tokens, descobre o e-mail e faz upsert.
+
+    Buscar o e-mail é só para exibição ("conectado como ...") — uma falha aí (rede, escopo
+    insuficiente) NUNCA deve descartar tokens já obtidos com sucesso (mesmo princípio de
+    robustez do módulo, ver docstring do topo do arquivo)."""
     token_data = exchange_code(code)
     access_token = token_data.get("access_token", "")
-    email = fetch_account_email(access_token) if access_token else ""
+    email = ""
+    if access_token:
+        try:
+            email = fetch_account_email(access_token)
+        except httpx.HTTPError:
+            logger.exception("[google:userinfo:failed] tenant=%s", tenant_id)
     upsert_credential(db, tenant_id=tenant_id, email=email, token_data=token_data)
 
 

--- a/apps/api/tests/test_google_calendar.py
+++ b/apps/api/tests/test_google_calendar.py
@@ -146,6 +146,40 @@ def test_callback_happy_connects_account(client: TestClient, headers, configured
     assert status == {"configured": True, "connected": True, "email": "owner@gmail.com"}
 
 
+def test_callback_userinfo_failure_still_connects(
+    client: TestClient, headers, configured, monkeypatch
+):
+    """Achado em produção (2026-07-12): o userinfo é só para exibição ("conectado como ...");
+    uma falha nele (rede, escopo insuficiente) NUNCA deve descartar tokens já obtidos com
+    sucesso — mesmo princípio de robustez do módulo (ver docstring de handle_callback)."""
+
+    def fake_post(url: str, **kw):
+        return FakeResp(
+            {"access_token": "ya29.fake-access", "refresh_token": "1//fake-refresh",
+             "expires_in": 3600, "scope": DEFAULT_SCOPE}
+        )
+
+    def fake_get_raises(url: str, **kw):
+        raise httpx.HTTPStatusError("401", request=None, response=None)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(httpx, "get", fake_get_raises)
+
+    url = client.get("/integrations/google/connect", headers=headers).json()["url"]
+    state = parse_qs(urlparse(url).query)["state"][0]
+    resp = client.get(
+        "/integrations/google/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 307
+    assert resp.headers["location"].endswith("/config?google=connected")
+
+    # Conectado mesmo sem e-mail (userinfo falhou) — tokens não foram descartados.
+    status = client.get("/integrations/google/status", headers=headers).json()
+    assert status == {"configured": True, "connected": True, "email": ""}
+
+
 def test_callback_reconnect_updates_same_credential(
     client: TestClient, headers, configured, monkeypatch
 ):

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -47,11 +47,34 @@
 - [ ] Validar IV3: o dump do Postgres encolhe depois do backfill
 
 ## 5. Google Calendar/Meet OAuth (Story 4.1)
-- [ ] Criar projeto no Google Cloud Console + ativar Calendar API
-- [ ] Gerar OAuth Client ID/Secret, configurar redirect URI
-- [ ] Preencher: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URI`
-- [ ] Testar fluxo OAuth ponta-a-ponta (autorizar, criar evento com Meet real)
-- [ ] Dívida conhecida sinalizada pela story: `refresh_token` guardado em texto plano (endurecer antes de produção séria); reschedule/cancel ainda não sincronizam de volta pro Google
+- [x] Criar projeto no Google Cloud Console + ativar Calendar API — projeto do fundador, Calendar
+  API habilitada, OAuth consent screen em modo "Testing" com `flaviokato76@gmail.com` como test
+  user (suficiente para uso próprio; sair de "Testing" exige verificação do Google só se/quando
+  precisar liberar para outras contas).
+- [x] Gerar OAuth Client ID/Secret, configurar redirect URI — client Web criado, redirect URI
+  `http://localhost:8000/integrations/google/callback` (dev). **Pendente:** cadastrar a URI de
+  produção (`https://<domínio-real>/integrations/google/callback`) quando o item 10 existir —
+  OAuth clients aceitam múltiplas redirect URIs simultâneas, então isso é aditivo, não substitui a
+  de dev.
+- [x] Preencher `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`/`GOOGLE_OAUTH_REDIRECT_URI` — feito no
+  `.env` local (raiz, gitignorado), repassado a `api`/`worker` via `env_file`.
+- [x] Testar fluxo OAuth ponta-a-ponta (autorizar, criar evento com Meet real) — validado em
+  2026-07-12: autorização real via navegador (conta do fundador), evento tipo "reuniao" criado via
+  `/agenda/events` gerou Meet real (`meeting_url`/`google_event_id` reais, confirmados
+  visualmente no Google Calendar do usuário). **Bug de produção corrigido no caminho** (achado
+  neste teste): `fetch_account_email` (só para exibir "conectado como...") lançava exceção não
+  capturada em `handle_callback` quando falhava (aqui: 401 por faltar o scope `userinfo.email` na
+  autorização original) — isso descartava os tokens de acesso/refresh JÁ obtidos com sucesso,
+  quebrando a conexão inteira por causa de um dado não-essencial. Corrigido: (1) adicionado o
+  scope `userinfo.email` a `DEFAULT_SCOPE` (o recurso "mostrar e-mail conectado" já existia no
+  código/schema mas nunca funcionava, para ninguém); (2) `fetch_account_email` agora é
+  best-effort em `handle_callback` (captura `httpx.HTTPError`, loga, segue com e-mail vazio) —
+  mesmo princípio de robustez que o resto do módulo já seguia. Teste de regressão adicionado
+  (`test_callback_userinfo_failure_still_connects`). Credencial de teste desconectada
+  (revogada) ao final da validação.
+- [ ] Dívida conhecida sinalizada pela story (ainda não endereçada): `refresh_token` guardado em
+  texto plano (endurecer antes de produção séria); reschedule/cancel ainda não sincronizam de
+  volta pro Google.
 
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [ ] Instalar/configurar `rclone` na VPS com remote S3-compatível (fora do repo, `rclone config`)


### PR DESCRIPTION
## Problema

Ao validar a integração Google Calendar/Meet OAuth (item 5 do go-live checklist) contra um projeto real do Google Cloud Console, o callback caía silenciosamente em erro mesmo com o token exchange funcionando. Dois bugs:

1. **`DEFAULT_SCOPE` faltava `userinfo.email`** — sem esse scope, o endpoint de userinfo do Google sempre rejeitava com 401.
2. **`handle_callback` deixava a exceção de `fetch_account_email` propagar** — isso descartava os tokens OAuth já obtidos com sucesso, quebrando a conexão inteira por causa de uma chamada acessória.

## Correção

- `models.py`: `DEFAULT_SCOPE` agora inclui `userinfo.email`.
- `service.py`: `handle_callback` trata falha de `fetch_account_email` como best-effort — captura `httpx.HTTPError`, loga e segue com e-mail vazio, preservando os tokens.
- `test_google_calendar.py`: novo teste de regressão `test_callback_userinfo_failure_still_connects`.
- `docs/GO-LIVE-CHECKLIST.md`: item 5 marcado como validado ponta a ponta (autorização real, evento com Meet real criado e confirmado no Google Calendar do usuário).

## Validação local

- `ruff check .` limpo.
- Suíte completa (`pytest -q -m "not rls_e2e"`) na imagem Docker oficial do backend: **567 passed**, incluindo os 11 testes de `test_google_calendar.py` (10 antigos + o novo).
- Nenhuma credencial real commitada — `.env` está gitignorado e fora do commit (confirmado via `git status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)