### PR TITLE
hardening: cifra tokens OAuth do Google em repouso + sincroniza reschedule/cancel [Story 4.1]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,8 @@ GENERATED_DIR=./generated
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 # GOOGLE_OAUTH_REDIRECT_URI=https://api.<dominio>/integrations/google/callback
+# Chave de criptografia EM REPOUSO dos tokens OAuth do Google. Vazio em dev = derivada do
+# JWT_SECRET (criptografia sempre ativa). Em produção COM o Google configurado é obrigatória
+# (guard de boot). Gere com:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# GOOGLE_TOKEN_ENCRYPTION_KEY=

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -72,6 +72,13 @@ class Settings(BaseSettings):
     google_client_id: str = ""
     google_client_secret: str = ""
     google_oauth_redirect_uri: str = ""
+    # Chave de criptografia simétrica (Fernet) dos tokens OAuth do Google EM REPOUSO. Gere com:
+    #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    # Vazio em dev/test = derivado do JWT_SECRET (a criptografia fica SEMPRE ativa, nunca texto
+    # plano). Em produção COM o Google configurado é OBRIGATÓRIA (guard de boot abaixo): uma chave
+    # dedicada evita acoplar a rotação do JWT à leitura dos tokens já gravados. Ver
+    # app/core/token_crypto.py.
+    google_token_encryption_key: str = ""
 
     # App
     root_domain: str = "e1p.com"
@@ -113,6 +120,19 @@ class Settings(BaseSettings):
             if self.super_admin_password == _DEFAULT_ADMIN_PASSWORD:
                 raise ValueError(
                     "SUPER_ADMIN_PASSWORD default em produção: defina uma senha forte"
+                )
+            # Com o Google conectado em produção, tokens OAuth são gravados no banco: a chave
+            # dedicada de criptografia é obrigatória (não aceitar o fallback derivado do JWT, que
+            # acoplaria a rotação do JWT à leitura dos tokens). >=32 chars = entropia mínima.
+            if self.google_oauth_configured and (
+                not self.google_token_encryption_key
+                or len(self.google_token_encryption_key) < 32
+            ):
+                raise ValueError(
+                    "GOOGLE_TOKEN_ENCRYPTION_KEY ausente/fraca em produção com Google "
+                    "configurado: gere uma chave Fernet "
+                    "(python -c \"from cryptography.fernet import Fernet; "
+                    "print(Fernet.generate_key().decode())\")"
                 )
         return self
 

--- a/apps/api/app/core/token_crypto.py
+++ b/apps/api/app/core/token_crypto.py
@@ -1,0 +1,107 @@
+"""Criptografia simétrica em repouso para tokens OAuth (Fernet / AES-128-CBC + HMAC).
+
+Motivação (dívida técnica da Story 4.1, endereçada antes de produção): os tokens do Google
+(`access_token`/`refresh_token`) eram guardados em TEXTO PLANO no Postgres — protegidos só pela
+RLS. Um dump/backup vazado ou acesso ao banco expunha os tokens diretamente. Agora ciframos em
+repouso: o banco guarda ciphertext, o código Python sempre vê texto plano (transparente via o
+`TypeDecorator` `EncryptedToken`).
+
+Escolha da lib: `cryptography` (Fernet) — JÁ vem no projeto como dependência de
+`python-jose[cryptography]`, sem nova dependência (CLAUDE.md §3.4 "Custo importa"). Fernet é
+AES-128 em CBC com HMAC-SHA256 (autenticado) — adequado e simples para segredos curtos.
+
+Idempotência / best-effort (mesmo espírito fail-safe do resto do módulo Google):
+- `encrypt_token` marca o ciphertext com o prefixo `enc:v1:`; se já vier marcado, NÃO re-cifra.
+- `decrypt_token` só decifra o que tem o prefixo; texto plano legado (pré-criptografia) passa
+  direto, sem quebrar. Assim a migração de dados existentes é natural — ao regravar, cifra.
+
+Chave: `GOOGLE_TOKEN_ENCRYPTION_KEY` (env). Em dev/test, se ausente, deriva-se uma chave do
+`JWT_SECRET` (fallback) para que a criptografia esteja SEMPRE ativa (nunca texto plano, nem em
+teste). Em PRODUÇÃO com o Google configurado, a env dedicada é OBRIGATÓRIA (guard de boot em
+config.py) — chave dedicada evita acoplar a rotação do JWT à leitura dos tokens já gravados.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import Text
+from sqlalchemy.types import TypeDecorator
+
+from app.config import settings
+
+logger = logging.getLogger("e1p.token_crypto")
+
+# Marca do nosso ciphertext. Versionado p/ permitir troca futura de esquema sem ambiguidade.
+_PREFIX = "enc:v1:"
+
+
+def _derive_fernet_key(secret: str) -> bytes:
+    """Deriva uma chave Fernet válida (32 bytes base64 urlsafe) de uma passphrase arbitrária."""
+    digest = hashlib.sha256(secret.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def _fernet() -> Fernet:
+    """Constrói o cifrador a partir da config atual.
+
+    Não cacheamos (sha256 + Fernet() são baratos e as operações de token são raras): assim
+    respeitamos monkeypatch de settings nos testes, sem estado obsoleto entre casos.
+    """
+    key = settings.google_token_encryption_key
+    if key:
+        try:
+            # Aceita uma Fernet key crua (base64 urlsafe de 32 bytes)...
+            return Fernet(key.encode("ascii") if isinstance(key, str) else key)
+        except (ValueError, TypeError):
+            # ...ou uma passphrase qualquer (deriva a chave dela).
+            return Fernet(_derive_fernet_key(key))
+    # Fallback dev/test: deriva do JWT_SECRET. Produção exige a env dedicada (guard de boot).
+    return Fernet(_derive_fernet_key(settings.jwt_secret))
+
+
+def encrypt_token(plaintext: str | None) -> str | None:
+    """Cifra um token para persistência. Idempotente: vazio/None passa direto; já-cifrado não
+    é re-cifrado (evita camadas duplas)."""
+    if not plaintext:
+        return plaintext
+    if plaintext.startswith(_PREFIX):
+        return plaintext
+    token = _fernet().encrypt(plaintext.encode("utf-8")).decode("ascii")
+    return _PREFIX + token
+
+
+def decrypt_token(stored: str | None) -> str | None:
+    """Decifra um token lido do banco. Best-effort: vazio/None passa direto; texto plano legado
+    (sem o prefixo) passa direto; falha de decifração (chave trocada) loga e retorna vazio em vez
+    de quebrar a operação de negócio."""
+    if not stored:
+        return stored
+    if not stored.startswith(_PREFIX):
+        return stored  # legado em texto plano — não força migração destrutiva
+    raw = stored[len(_PREFIX):]
+    try:
+        return _fernet().decrypt(raw.encode("ascii")).decode("utf-8")
+    except (InvalidToken, ValueError):
+        logger.warning("[token_crypto] falha ao decifrar token (chave rotacionada/inválida?)")
+        return ""
+
+
+class EncryptedToken(TypeDecorator):
+    """Coluna `Text` que cifra em repouso de forma transparente.
+
+    O tipo SQL subjacente continua sendo `TEXT` (o ciphertext é só mais longo), então trocar uma
+    coluna `Text` por `EncryptedToken` NÃO exige migration de schema. O Python sempre lê/escreve
+    texto plano; o banco sempre guarda ciphertext (prefixo `enc:v1:`).
+    """
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: str | None, dialect) -> str | None:  # noqa: ANN001
+        return encrypt_token(value)
+
+    def process_result_value(self, value: str | None, dialect) -> str | None:  # noqa: ANN001
+        return decrypt_token(value)

--- a/apps/api/app/modules/agenda/models.py
+++ b/apps/api/app/modules/agenda/models.py
@@ -66,7 +66,8 @@ class AgendaEvent(Base, TenantMixin, TimestampMixin):
     meeting_url: Mapped[str | None] = mapped_column(String(512), nullable=True)  # link Meet/Zoom
     guests: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)  # e-mails
     # Id do evento espelhado no Google Calendar (quando o Meet foi gerado via OAuth Google).
-    # Permite sync futuro de reschedule/cancel (dívida — ver Story 4.1).
+    # Usado para sincronizar reschedule/cancel de volta pro Google (ver agenda/service.py +
+    # google_calendar/service.py::patch_meet_event/delete_meet_event).
     google_event_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     # Dinheiro SEMPRE em centavos inteiros (evita erro de float). Opcional (cobranças).

--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -205,6 +205,13 @@ def cancel_event(
     if event.status in TERMINAL_STATUSES:
         raise AgendaError("Evento já finalizado ou cancelado", 409)
     event.status = STATUS_CANCELLED
+    # Se este evento tem um espelho no Google (Meet real vinculado), remove-o lá para não deixar
+    # evento fantasma. Best-effort/não bloqueante: falha do Google não derruba o cancel local
+    # (mesmo padrão de create_event). Import lazy p/ não acoplar a Agenda-núcleo à extensão.
+    if event.google_event_id:
+        from app.modules.google_calendar import service as gcal
+
+        gcal.delete_meet_event(db, tenant_id=tenant_id, event=event)
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="agenda.event.cancel", target=event.id,
         is_ai=by_ai,
@@ -232,6 +239,13 @@ def reschedule_event(
         conflicts = find_conflicts(db, starts_at, ends_at, exclude_id=event.id)
     event.starts_at = starts_at
     event.ends_at = ends_at
+    # Se este evento tem um espelho no Google (Meet real vinculado), atualiza os horários lá para
+    # não ficar desatualizado. Best-effort/não bloqueante: falha do Google não derruba o
+    # reschedule local (mesmo padrão de create_event). Import lazy p/ não acoplar a Agenda-núcleo.
+    if event.google_event_id:
+        from app.modules.google_calendar import service as gcal
+
+        gcal.patch_meet_event(db, tenant_id=tenant_id, event=event)
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="agenda.event.reschedule", target=event.id,
         is_ai=by_ai,

--- a/apps/api/app/modules/google_calendar/models.py
+++ b/apps/api/app/modules/google_calendar/models.py
@@ -5,16 +5,18 @@ TenantMixin (RLS aplicada na migration). O app OAuth em si (client_id/secret) é
 em config; aqui guardamos só o token da conta que CADA owner conectou.
 
 IV3 / segurança: access_token e refresh_token NUNCA são expostos em schema de resposta nem em
-log. O refresh_token fica em texto plano (Text) protegido por RLS — dívida técnica documentada
-na Story 4.1 (não há utilitário de cripto reversível no projeto hoje).
+log. Além da RLS, os tokens são CIFRADOS EM REPOUSO (Fernet) via o tipo `EncryptedToken`: o
+banco guarda ciphertext, o código sempre vê texto plano (transparente). Endurecimento da dívida
+técnica sinalizada na Story 4.1 — ver app/core/token_crypto.py.
 """
 from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, Text
+from sqlalchemy import DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.token_crypto import EncryptedToken
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
 DEFAULT_SCOPE = (
@@ -28,7 +30,7 @@ class GoogleCredential(Base, TenantMixin, TimestampMixin):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     google_account_email: Mapped[str] = mapped_column(String(255), default="", nullable=False)
-    access_token: Mapped[str] = mapped_column(Text, default="", nullable=False)
-    refresh_token: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    access_token: Mapped[str] = mapped_column(EncryptedToken, default="", nullable=False)
+    refresh_token: Mapped[str] = mapped_column(EncryptedToken, default="", nullable=False)
     token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     scope: Mapped[str] = mapped_column(String(255), default=DEFAULT_SCOPE, nullable=False)

--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -33,6 +33,10 @@ _REVOKE_URL = "https://oauth2.googleapis.com/revoke"  # noqa: S105 (endpoint pú
 _CALENDAR_EVENTS_URL = (
     "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
 )
+# Evento específico (reschedule/cancel) — {event_id} é o google_event_id guardado no AgendaEvent.
+_CALENDAR_EVENT_URL = (
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events/{event_id}"
+)
 _HTTP_TIMEOUT = 10
 
 # Tipos de evento onde "reunião" faz sentido (geram Meet). Bloqueios/prazos/cobranças não.
@@ -237,6 +241,73 @@ def create_meet_event(
         # Falha de integração externa não derruba a Agenda (IV1). Não logamos o token.
         logger.exception("[google:create_meet:failed] tenant=%s", tenant_id)
         return None
+
+
+# ── Sincronização de reschedule/cancel de volta pro Google ───────────────────
+def patch_meet_event(db: Session, *, tenant_id: str, event) -> bool:
+    """Propaga um REMARCAR (novos horários) para o evento espelho no Google Calendar.
+
+    Best-effort e NÃO bloqueante (mesmo princípio de robustez de create_meet_event / IV1/IV2):
+    qualquer falha (token revogado, rede, quota, 404 porque o evento sumiu lá) é capturada e
+    logada — NUNCA propaga, para não derrubar o reschedule local da Agenda.
+
+    Retorna True se sincronizou; False se não havia o que/como sincronizar (sem google_event_id,
+    sem Google conectado, sem token) ou se a chamada falhou.
+    """
+    if not getattr(event, "google_event_id", None):
+        return False
+    cred = get_credential(db)
+    if cred is None:
+        return False
+    try:
+        access_token = _ensure_fresh_token(db, cred)
+        if not access_token:
+            return False
+        body = {
+            "start": {"dateTime": _iso(event.starts_at)},
+            "end": {"dateTime": _iso(event.ends_at)},
+        }
+        resp = httpx.patch(
+            _CALENDAR_EVENT_URL.format(event_id=event.google_event_id),
+            headers={"Authorization": f"Bearer {access_token}"},
+            json=body,
+            timeout=_HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return True
+    except Exception:
+        logger.exception("[google:patch_meet:failed] tenant=%s", tenant_id)
+        return False
+
+
+def delete_meet_event(db: Session, *, tenant_id: str, event) -> bool:
+    """Propaga um CANCELAR para o Google Calendar (remove o evento espelho).
+
+    Best-effort e NÃO bloqueante (ver patch_meet_event). Um 404/410 do Google significa que o
+    evento já não existe lá — o objetivo (não deixar evento fantasma) já está cumprido, então
+    conta como sucesso (idempotente).
+    """
+    if not getattr(event, "google_event_id", None):
+        return False
+    cred = get_credential(db)
+    if cred is None:
+        return False
+    try:
+        access_token = _ensure_fresh_token(db, cred)
+        if not access_token:
+            return False
+        resp = httpx.delete(
+            _CALENDAR_EVENT_URL.format(event_id=event.google_event_id),
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=_HTTP_TIMEOUT,
+        )
+        if resp.status_code in (404, 410):
+            return True  # já não existe no Google — nada a fazer
+        resp.raise_for_status()
+        return True
+    except Exception:
+        logger.exception("[google:delete_meet:failed] tenant=%s", tenant_id)
+        return False
 
 
 def _iso(dt: datetime) -> str:

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -37,6 +37,62 @@ def test_production_ok_with_strong_secret():
     assert s.is_production
 
 
+_GOOGLE = {
+    "google_client_id": "cid",
+    "google_client_secret": "csec",
+    "google_oauth_redirect_uri": "https://api.e1p.com/integrations/google/callback",
+}
+
+
+def test_production_requires_token_encryption_key_when_google_configured():
+    # Google ativo em produção → tokens gravados no banco → chave dedicada obrigatória.
+    with pytest.raises(ValidationError):
+        Settings(
+            environment="production",
+            jwt_secret=STRONG,
+            anthropic_api_key="sk-ant-x",
+            super_admin_password="uma-senha-de-admin-forte",
+            google_token_encryption_key="",
+            **_GOOGLE,
+        )
+
+
+def test_production_rejects_weak_token_encryption_key():
+    with pytest.raises(ValidationError):
+        Settings(
+            environment="production",
+            jwt_secret=STRONG,
+            anthropic_api_key="sk-ant-x",
+            super_admin_password="uma-senha-de-admin-forte",
+            google_token_encryption_key="curta",  # < 32 chars
+            **_GOOGLE,
+        )
+
+
+def test_production_ok_with_google_and_strong_encryption_key():
+    s = Settings(
+        environment="production",
+        jwt_secret=STRONG,
+        anthropic_api_key="sk-ant-x",
+        super_admin_password="uma-senha-de-admin-forte",
+        google_token_encryption_key="k" * 44,
+        **_GOOGLE,
+    )
+    assert s.is_production and s.google_oauth_configured
+
+
+def test_production_without_google_does_not_require_encryption_key():
+    # Google desligado → nenhum token gravado → a chave não é exigida (não bloqueia deploy).
+    s = Settings(
+        environment="production",
+        jwt_secret=STRONG,
+        anthropic_api_key="sk-ant-x",
+        super_admin_password="uma-senha-de-admin-forte",
+        google_token_encryption_key="",
+    )
+    assert s.is_production and not s.google_oauth_configured
+
+
 def test_development_allows_defaults():
     s = Settings(environment="development")
     assert not s.is_production

--- a/apps/api/tests/test_google_calendar_hardening.py
+++ b/apps/api/tests/test_google_calendar_hardening.py
@@ -1,0 +1,232 @@
+"""Endurecimento da integração Google (dívida da Story 4.1 endereçada antes de produção):
+
+1. Tokens OAuth (`access_token`/`refresh_token`) CIFRADOS EM REPOUSO — nunca texto plano no banco.
+2. reschedule/cancel de um AgendaEvent com `google_event_id` SINCRONIZAM de volta pro Google
+   (best-effort/não bloqueante — falha do Google não derruba a operação local).
+
+Todas as chamadas HTTP ao Google são MOCKADAS (não batemos na API real).
+"""
+from datetime import UTC, datetime, timedelta
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.token_crypto import _PREFIX, decrypt_token, encrypt_token
+from app.modules.agenda import service as agenda
+from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+from app.modules.google_calendar.models import GoogleCredential
+
+TENANT = "t" * 12
+
+
+# ── 1. Criptografia em repouso ───────────────────────────────────────────────
+def test_encrypt_decrypt_roundtrip_and_idempotent():
+    ct = encrypt_token("1//super-secret-refresh")
+    assert ct.startswith(_PREFIX)
+    assert "super-secret-refresh" not in ct  # o segredo não vaza no ciphertext
+    assert decrypt_token(ct) == "1//super-secret-refresh"
+    # Idempotente: não re-cifra um valor já cifrado (evita camadas duplas).
+    assert encrypt_token(ct) == ct
+    # Vazio/None passam direto (colunas com default "").
+    assert encrypt_token("") == ""
+    assert decrypt_token("") == ""
+    assert encrypt_token(None) is None
+
+
+def test_decrypt_of_legacy_plaintext_passes_through():
+    # Best-effort: token gravado ANTES da criptografia (sem o prefixo) é lido como está,
+    # sem quebrar. Ao ser regravado pelo código, passa a ser cifrado.
+    assert decrypt_token("legacy-plaintext-token") == "legacy-plaintext-token"
+
+
+def test_tokens_encrypted_at_rest_in_db(db: Session):
+    """A coluna crua NUNCA contém o texto plano; a leitura via ORM decifra transparente."""
+    cred = GoogleCredential(
+        tenant_id=TENANT,
+        google_account_email="owner@gmail.com",
+        access_token="ya29.super-secret-access",
+        refresh_token="1//super-secret-refresh",
+    )
+    db.add(cred)
+    db.commit()
+
+    # Leitura CRUA (sem o TypeDecorator): o banco guarda ciphertext, não o segredo.
+    raw = db.execute(
+        text("SELECT access_token, refresh_token FROM google_credentials WHERE id = :id"),
+        {"id": cred.id},
+    ).one()
+    assert raw[0].startswith(_PREFIX)
+    assert raw[1].startswith(_PREFIX)
+    assert "super-secret-access" not in raw[0]
+    assert "super-secret-refresh" not in raw[1]
+
+    # Leitura via ORM: decifra de volta ao texto plano (transparente para o código).
+    db.expire_all()
+    fresh = db.get(GoogleCredential, cred.id)
+    assert fresh.access_token == "ya29.super-secret-access"
+    assert fresh.refresh_token == "1//super-secret-refresh"
+
+
+def test_legacy_plaintext_row_still_readable_via_orm(db: Session):
+    """Credencial gravada antes da criptografia (texto plano cru no banco) segue legível."""
+    cred = GoogleCredential(tenant_id=TENANT, access_token="x", refresh_token="x")
+    db.add(cred)
+    db.commit()
+    # Sobrescreve com texto plano CRU (simula dado pré-criptografia).
+    db.execute(
+        text("UPDATE google_credentials SET refresh_token = 'legacy-refresh' WHERE id = :id"),
+        {"id": cred.id},
+    )
+    db.commit()
+    db.expire_all()
+    assert db.get(GoogleCredential, cred.id).refresh_token == "legacy-refresh"
+
+
+# ── 2. Sync de reschedule/cancel de volta pro Google ─────────────────────────
+def _connect_google(db: Session) -> None:
+    """Cria uma credencial Google conectada com token válido (não expira → sem refresh)."""
+    db.add(
+        GoogleCredential(
+            tenant_id=TENANT,
+            google_account_email="owner@gmail.com",
+            access_token="valid-access-token",
+            refresh_token="valid-refresh-token",
+            token_expiry=datetime.now(UTC) + timedelta(hours=1),
+        )
+    )
+    db.commit()
+
+
+def _make_event(db: Session, *, google_event_id: str | None) -> AgendaEvent:
+    ev = AgendaEvent(
+        tenant_id=TENANT,
+        title="Reunião com cliente",
+        kind="reuniao",
+        starts_at=datetime(2026, 7, 20, 14, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 7, 20, 15, 0, tzinfo=UTC),
+        google_event_id=google_event_id,
+    )
+    db.add(ev)
+    db.commit()
+    db.refresh(ev)
+    return ev
+
+
+class _FakeResp:
+    def __init__(self, status_code: int = 200):
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def test_reschedule_patches_google_when_event_linked(db: Session, monkeypatch):
+    _connect_google(db)
+    ev = _make_event(db, google_event_id="gcal-evt-123")
+    calls: list[dict] = []
+
+    def fake_patch(url: str, **kw):
+        calls.append({"url": url, "json": kw.get("json")})
+        return _FakeResp(200)
+
+    monkeypatch.setattr(httpx, "patch", fake_patch)
+
+    new_start = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
+    new_end = datetime(2026, 7, 21, 17, 0, tzinfo=UTC)
+    event, _ = agenda.reschedule_event(
+        db, event_id=ev.id, tenant_id=TENANT, actor="user-1",
+        starts_at=new_start, ends_at=new_end,
+    )
+
+    # O Google foi chamado no evento certo, com os novos horários.
+    assert len(calls) == 1
+    assert "gcal-evt-123" in calls[0]["url"]
+    assert calls[0]["json"]["start"]["dateTime"].startswith("2026-07-21T16:00")
+    # E a mudança local persistiu (SQLite descarta tzinfo no refresh — comparamos os campos).
+    assert (event.starts_at.day, event.starts_at.hour) == (21, 16)
+
+
+def test_cancel_deletes_google_when_event_linked(db: Session, monkeypatch):
+    _connect_google(db)
+    ev = _make_event(db, google_event_id="gcal-evt-456")
+    calls: list[str] = []
+
+    def fake_delete(url: str, **kw):
+        calls.append(url)
+        return _FakeResp(204)
+
+    monkeypatch.setattr(httpx, "delete", fake_delete)
+
+    event = agenda.cancel_event(db, event_id=ev.id, tenant_id=TENANT, actor="user-1")
+
+    assert len(calls) == 1
+    assert "gcal-evt-456" in calls[0]
+    assert event.status == STATUS_CANCELLED
+
+
+def test_reschedule_does_not_call_google_without_event_id(db: Session, monkeypatch):
+    _connect_google(db)
+    ev = _make_event(db, google_event_id=None)  # evento sem Meet vinculado
+    called = {"patch": False}
+
+    def fake_patch(url: str, **kw):
+        called["patch"] = True
+        return _FakeResp(200)
+
+    monkeypatch.setattr(httpx, "patch", fake_patch)
+    agenda.reschedule_event(
+        db, event_id=ev.id, tenant_id=TENANT, actor="user-1",
+        starts_at=datetime(2026, 7, 21, 16, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 7, 21, 17, 0, tzinfo=UTC),
+    )
+    assert called["patch"] is False
+
+
+def test_google_failure_does_not_break_local_reschedule(db: Session, monkeypatch):
+    """Robustez (IV1/IV2): token revogado / rede / 404 no Google NÃO derruba o reschedule local."""
+    _connect_google(db)
+    ev = _make_event(db, google_event_id="gcal-evt-789")
+
+    def fake_patch(url: str, **kw):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx, "patch", fake_patch)
+
+    new_start = datetime(2026, 7, 22, 9, 0, tzinfo=UTC)
+    new_end = datetime(2026, 7, 22, 10, 0, tzinfo=UTC)
+    event, _ = agenda.reschedule_event(
+        db, event_id=ev.id, tenant_id=TENANT, actor="user-1",
+        starts_at=new_start, ends_at=new_end,
+    )
+    # O reschedule local venceu mesmo com o Google falhando (SQLite descarta tzinfo no refresh).
+    assert (event.starts_at.day, event.starts_at.hour) == (22, 9)
+
+
+def test_google_failure_does_not_break_local_cancel(db: Session, monkeypatch):
+    _connect_google(db)
+    ev = _make_event(db, google_event_id="gcal-evt-000")
+
+    def fake_delete(url: str, **kw):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx, "delete", fake_delete)
+
+    event = agenda.cancel_event(db, event_id=ev.id, tenant_id=TENANT, actor="user-1")
+    assert event.status == STATUS_CANCELLED
+
+
+def test_cancel_treats_google_404_as_success(db: Session, monkeypatch):
+    """Evento já removido no Google (404/410) = objetivo cumprido, não é erro."""
+    _connect_google(db)
+    ev = _make_event(db, google_event_id="gcal-evt-410")
+
+    def fake_delete(url: str, **kw):
+        return _FakeResp(410)
+
+    monkeypatch.setattr(httpx, "delete", fake_delete)
+
+    from app.modules.google_calendar import service as gcal
+
+    db.refresh(ev)
+    assert gcal.delete_meet_event(db, tenant_id=TENANT, event=ev) is True

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -72,9 +72,31 @@
   mesmo princípio de robustez que o resto do módulo já seguia. Teste de regressão adicionado
   (`test_callback_userinfo_failure_still_connects`). Credencial de teste desconectada
   (revogada) ao final da validação.
-- [ ] Dívida conhecida sinalizada pela story (ainda não endereçada): `refresh_token` guardado em
-  texto plano (endurecer antes de produção séria); reschedule/cancel ainda não sincronizam de
-  volta pro Google.
+- [x] **Endurecimento: tokens OAuth cifrados em repouso** — `access_token`/`refresh_token` não
+  ficam mais em texto plano no Postgres. Criptografia simétrica Fernet (AES-128-CBC+HMAC, lib
+  `cryptography` que já vinha via `python-jose[cryptography]` — sem nova dependência) via o
+  `TypeDecorator` `EncryptedToken` (`app/core/token_crypto.py`): transparente ao código (Python vê
+  texto plano, banco guarda ciphertext com prefixo `enc:v1:`). Coluna segue `TEXT` → **sem
+  migration**. Chave `GOOGLE_TOKEN_ENCRYPTION_KEY` (nova env, em `.env.example` +
+  `infra/.env.prod.example`); vazio em dev = derivada do `JWT_SECRET` (criptografia SEMPRE ativa).
+  **Guard de boot** (`config._guard_production_secrets`): em `ENVIRONMENT=production` com o Google
+  configurado, a chave dedicada é obrigatória (>=32 chars) — recusa subir sem ela. Idempotente e
+  best-effort: token legado em texto plano segue legível; não re-cifra o que já está cifrado.
+  Validado 2026-07-12 por testes (`tests/test_google_calendar_hardening.py`): leitura CRUA da
+  coluna confirma que o segredo NUNCA aparece em texto plano (só ciphertext `enc:v1:`); round-trip
+  de decifração via ORM devolve o token original; linha legada em texto plano continua legível
+  (`tests/test_config.py`: guard exige/valida a chave em produção).
+- [x] **reschedule/cancel sincronizam de volta pro Google** — ao remarcar (`reschedule_event`) ou
+  cancelar (`cancel_event`) um `AgendaEvent` com `google_event_id` preenchido (evento com Meet
+  real vinculado), a mudança agora é propagada ao Google Calendar: `events.patch` (novos horários)
+  no reschedule e `events.delete` no cancel (`google_calendar/service.py::patch_meet_event` /
+  `delete_meet_event`, mesmo client/auth de `create_meet_event`). **Best-effort, não bloqueante**
+  (IV1/IV2, mesmo princípio do `fetch_account_email`): falha do Google (token revogado, rede, 404
+  porque o evento já sumiu lá) é capturada, logada e NÃO derruba o reschedule/cancel local; 404/410
+  no delete conta como sucesso (idempotente). Rastro da IA preservado (o `audit.record` existente
+  segue). Validado 2026-07-12 por testes (`tests/test_google_calendar_hardening.py`): patch/delete
+  são chamados no evento certo com os novos horários quando há `google_event_id`; NÃO são chamados
+  quando não há; e um erro HTTP mockado do Google não impede o reschedule/cancel local de persistir.
 
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [x] Instalar/configurar `rclone` com remote S3-compatível — validado em 2026-07-12 **localmente**

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -35,6 +35,16 @@ FRONTEND_URL=https://app.seudominio.com
 # Pré-requisito: DNS de ${ROOT_DOMAIN} gerido pela Cloudflare (ver docs/HOSTINGER-DEPLOY.md §8).
 CLOUDFLARE_API_TOKEN=
 
+# Google (Meet/Calendar OAuth) — app OAuth GLOBAL da plataforma. Vazio = integração indisponível
+# (a Agenda segue com o campo manual de reunião). Se preencher o trio abaixo (ativar o Google),
+# GOOGLE_TOKEN_ENCRYPTION_KEY passa a ser OBRIGATÓRIA — o guard de boot recusa subir sem ela
+# (os tokens OAuth são gravados no banco e precisam ser cifrados em repouso). Gere a chave com:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_OAUTH_REDIRECT_URI=https://api.seudominio.com/integrations/google/callback
+GOOGLE_TOKEN_ENCRYPTION_KEY=
+
 # Integrações (vazio = stub/log; preencher quando conectar de verdade)
 WHATSAPP_TOKEN=
 WHATSAPP_PHONE_ID=


### PR DESCRIPTION
## Problema

A Story 4.1 (integração Google Meet/Calendar via OAuth) entrou com uma dívida técnica conhecida, listada no item 5 do `docs/GO-LIVE-CHECKLIST.md`, que precisava ser fechada antes de produção:

1. **Tokens OAuth do Google guardados em texto plano** — `access_token` e `refresh_token` ficavam legíveis no banco. Um dump ou acesso indevido ao Postgres exporia credenciais capazes de agir na conta Google do usuário.
2. **Reschedule e cancel não sincronizavam de volta pro Google** — remarcar ou cancelar um evento na Agenda local não refletia no Google Calendar, deixando os dois lados dessincronizados.

## Correção

### 1. Criptografia em repouso dos tokens OAuth
- Novo `app/core/token_crypto.py`: `TypeDecorator` `EncryptedToken` (Fernet / AES-128 + HMAC), via `cryptography` que já vinha em `python-jose[cryptography]` — **sem nova dependência**. Transparente: o Python vê texto plano, o Postgres guarda ciphertext (prefixo `enc:v1:`).
- `google_credentials.access_token` / `refresh_token` passam a usar `EncryptedToken`. A coluna segue `TEXT` → **sem migration**. Idempotente e best-effort: dados legados em texto plano seguem legíveis e não são re-cifrados.
- Nova env `GOOGLE_TOKEN_ENCRYPTION_KEY` (`.env.example` + `infra/.env.prod.example`). Vazia em dev = derivada do `JWT_SECRET`. Guard de boot exige a chave dedicada (>= 32 chars) em produção quando o Google está configurado.

### 2. Sync de reschedule/cancel de volta pro Google
- `google_calendar/service.py`: `patch_meet_event` (`events.patch`) e `delete_meet_event` (`events.delete`).
- `agenda/service.py` propaga em `reschedule_event` / `cancel_event` quando o evento tem `google_event_id`. Best-effort e não bloqueante (IV1/IV2): falha do Google não derruba a operação local; 404/410 no delete = sucesso idempotente.

## Validação local

- `ruff check .` limpo.
- Suíte da API (`pytest -q -m "not rls_e2e"`): **580 passed, 1 skipped** (9 testes `rls_e2e` deselecionados por exigirem Docker) — 589 no total, incluindo os novos `tests/test_google_calendar_hardening.py` (criptografia em repouso, round-trip, legado, sync patch/delete, robustez a erro HTTP) e os guards de boot em `tests/test_config.py`.
- Sem migration necessária. Nenhuma credencial real commitada.

## Arquivos

- `apps/api/app/core/token_crypto.py` (novo)
- `apps/api/app/config.py`, `app/modules/agenda/{models,service}.py`, `app/modules/google_calendar/{models,service}.py`
- `apps/api/tests/test_google_calendar_hardening.py` (novo), `tests/test_config.py`
- `.env.example`

Fecha o item 5 do `docs/GO-LIVE-CHECKLIST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
