### PR TITLE
fix(infra): certresolver letsencrypt-dns pro wildcard de subdomínio [Story 4.4]

### DIFF
--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -61,14 +61,19 @@ services:
       # (app/main.py) NÃO esperam esse prefixo — por isso o stripprefix abaixo, que
       # substitui o `handle_path` do Caddyfile antigo (ver infra/Caddyfile).
       # Wildcard por tenant (Story 4.4): além do ${DOMAIN} único, aceita `<slug>.${ROOT_DOMAIN}`
-      # (HostRegexp). IMPORTANTE: a EMISSÃO do certificado wildcard depende de um certresolver
-      # DNS-01 no Traefik COMPARTILHADO (/opt/infra/proxy/, FORA deste repo) — este label só
-      # roteia; sem esse resolver externo o wildcard não recebe cert (ver docs/HOSTINGER-DEPLOY.md
-      # §8 e Dev Notes → Riscos da Story 4.4). Sintaxe HostRegexp do Traefik v2 (named group);
-      # no Traefik v3 use: HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`).
+      # (HostRegexp). Certresolver `letsencrypt-dns` é um resolver DISTINTO do `letsencrypt`
+      # (HTTP-01, usado pelos outros projetos na mesma VPS: nexus-publica, doro-site1,
+      # axisgov-stg) — precisa existir na config do Traefik COMPARTILHADO (/opt/infra/proxy/,
+      # FORA deste repo) com dnsChallenge/provider=cloudflare e o mesmo nome `letsencrypt-dns`,
+      # senão o router falha ao subir. tls.domains força o SAN wildcard explícito (sem isso o
+      # Traefik pediria um cert por-hostname individual, não um wildcard de verdade). Sintaxe
+      # HostRegexp do Traefik v2 (named group); no Traefik v3 use:
+      # HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`).
       - traefik.http.routers.e1p-api.rule=(Host(`${DOMAIN}`) || HostRegexp(`{subdomain:[a-z0-9-]+}.${ROOT_DOMAIN}`)) && PathPrefix(`/api`)
       - traefik.http.routers.e1p-api.entrypoints=websecure
-      - traefik.http.routers.e1p-api.tls.certresolver=letsencrypt
+      - traefik.http.routers.e1p-api.tls.certresolver=letsencrypt-dns
+      - traefik.http.routers.e1p-api.tls.domains[0].main=${ROOT_DOMAIN}
+      - traefik.http.routers.e1p-api.tls.domains[0].sans[0]=*.${ROOT_DOMAIN}
       # Precisa casar ANTES do catch-all do `web` (priority=1).
       - traefik.http.routers.e1p-api.priority=20
       - traefik.http.routers.e1p-api.middlewares=security-headers@file,e1p-api-stripprefix
@@ -104,10 +109,13 @@ services:
       - traefik.docker.network=edge
       # Wildcard por tenant (Story 4.4): catch-all aceita ${DOMAIN} e `<slug>.${ROOT_DOMAIN}`.
       # Mesma dependência externa do certresolver DNS-01 no Traefik compartilhado (ver router
-      # e1p-api acima). Prioridade 1 mantida: casa por último, depois do router /api.
+      # e1p-api acima, incluindo o nome `letsencrypt-dns` e o SAN wildcard explícito).
+      # Prioridade 1 mantida: casa por último, depois do router /api.
       - traefik.http.routers.e1p-web.rule=Host(`${DOMAIN}`) || HostRegexp(`{subdomain:[a-z0-9-]+}.${ROOT_DOMAIN}`)
       - traefik.http.routers.e1p-web.entrypoints=websecure
-      - traefik.http.routers.e1p-web.tls.certresolver=letsencrypt
+      - traefik.http.routers.e1p-web.tls.certresolver=letsencrypt-dns
+      - traefik.http.routers.e1p-web.tls.domains[0].main=${ROOT_DOMAIN}
+      - traefik.http.routers.e1p-web.tls.domains[0].sans[0]=*.${ROOT_DOMAIN}
       # Catch-all — casa por último, depois do router /api acima.
       - traefik.http.routers.e1p-web.priority=1
       - traefik.http.routers.e1p-web.middlewares=security-headers@file


### PR DESCRIPTION
## Summary
- Troca `tls.certresolver` de `letsencrypt` (HTTP-01) para `letsencrypt-dns` (DNS-01/Cloudflare) nos routers `e1p-api` e `e1p-web`.
- Adiciona `tls.domains[0].main`/`sans[0]` explícitos para forçar emissão do SAN wildcard `*.${ROOT_DOMAIN}` (sem isso o Traefik pediria cert por-hostname individual).

## Contexto
Pré-requisito externo já feito no Traefik compartilhado (fora deste repo, ver `docs/HOSTINGER-DEPLOY.md` §10.3):
- Resolver `letsencrypt-dns` criado (DNS-01, provider cloudflare), com storage separado — não interfere no resolver `letsencrypt` (HTTP-01) usado pelos demais serviços atrás do mesmo proxy compartilhado.
- Credencial de DNS (escopo mínimo, só leitura/edição de DNS na zona do domínio) configurada no proxy compartilhado.
- Registro DNS wildcard criado apontando pro host da aplicação.
- Backup da config anterior do proxy compartilhado feito antes de qualquer mudança; validado que os demais serviços atrás do mesmo proxy continuam respondendo normalmente após o restart.

Sem esse commit, o router referenciava `letsencrypt-dns` só localmente (mudança não commitada) — o proxy real em produção ainda usava `letsencrypt` (HTTP-01, não suporta wildcard), então a emissão do cert wildcard nunca disparava.

## Test plan
- [ ] Merge e deploy (`git pull` + `docker compose --env-file .env.prod -f docker-compose.traefik.yml up -d --build` na VPS) — só recria api/web do e1p, não mexe no proxy compartilhado de novo.
- [ ] Confirmar nos logs do proxy compartilhado que o certificado wildcard foi emitido com sucesso.
- [ ] Validar via `openssl s_client` que o SAN do certificado cobre `*.${ROOT_DOMAIN}`.
- [ ] Confirmar que o domínio único (não-wildcard) continua funcionando sem regressão (IV1 da Story 4.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)