### PR TITLE
fix(infra): corrige sintaxe do label tls.domains sans (SAN wildcard) [Story 4.4]

### DIFF
--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -73,7 +73,7 @@ services:
       - traefik.http.routers.e1p-api.entrypoints=websecure
       - traefik.http.routers.e1p-api.tls.certresolver=letsencrypt-dns
       - traefik.http.routers.e1p-api.tls.domains[0].main=${ROOT_DOMAIN}
-      - traefik.http.routers.e1p-api.tls.domains[0].sans[0]=*.${ROOT_DOMAIN}
+      - traefik.http.routers.e1p-api.tls.domains[0].sans=*.${ROOT_DOMAIN}
       # Precisa casar ANTES do catch-all do `web` (priority=1).
       - traefik.http.routers.e1p-api.priority=20
       - traefik.http.routers.e1p-api.middlewares=security-headers@file,e1p-api-stripprefix
@@ -115,7 +115,7 @@ services:
       - traefik.http.routers.e1p-web.entrypoints=websecure
       - traefik.http.routers.e1p-web.tls.certresolver=letsencrypt-dns
       - traefik.http.routers.e1p-web.tls.domains[0].main=${ROOT_DOMAIN}
-      - traefik.http.routers.e1p-web.tls.domains[0].sans[0]=*.${ROOT_DOMAIN}
+      - traefik.http.routers.e1p-web.tls.domains[0].sans=*.${ROOT_DOMAIN}
       # Catch-all — casa por último, depois do router /api acima.
       - traefik.http.routers.e1p-web.priority=1
       - traefik.http.routers.e1p-web.middlewares=security-headers@file


### PR DESCRIPTION
## Summary
- Corrige `tls.domains[0].sans[0]=` (sintaxe inválida de label do Traefik) para `tls.domains[0].sans=` — esse campo é uma string única separada por vírgula, não uma lista indexada.

## Contexto
Segue o PR #18 (merged). Depois do deploy daquele PR, validei via `GET /api/http/routers/e1p-api@docker` na API do Traefik e o campo `tls.domains` só trazia `main`, sem `sans` — o label com índice `[0]` foi ignorado silenciosamente pelo parser (sem erro nos logs). Sem o SAN wildcard explícito, o certificado nunca seria pedido como wildcard de verdade.

## Test plan
- [ ] Merge e deploy (`git pull` + `docker compose --env-file .env.prod -f docker-compose.traefik.yml up -d --build` na VPS).
- [ ] Confirmar via API do Traefik que `tls.domains[0].sans` aparece corretamente no router `e1p-api`/`e1p-web`.
- [ ] Confirmar emissão do certificado wildcard nos logs do proxy compartilhado.
- [ ] Validar via `openssl s_client` que o SAN do certificado cobre `*.${ROOT_DOMAIN}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)