### PR TITLE
fix(admin): exibe o domínio raiz real no painel do Master, não hardcoded [Story 4.4]

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,6 +11,12 @@ COPY packages ./packages
 COPY apps/web ./apps/web
 
 RUN pnpm install --frozen-lockfile || pnpm install
+# Domínio raiz usado pra exibir o endereço de subdomínio do tenant (Story 4.4) — Vite só
+# expõe env vars prefixadas com VITE_ e as embute no bundle em build-time (SPA estática,
+# sem servidor Node em runtime). Default "e1p.com" bate com o default do backend
+# (Settings.root_domain em app/config.py) para dev/build sem o arg explícito.
+ARG VITE_ROOT_DOMAIN=e1p.com
+ENV VITE_ROOT_DOMAIN=$VITE_ROOT_DOMAIN
 RUN pnpm --filter @e1p/web build
 
 FROM nginx:alpine

--- a/apps/web/src/features/admin/PlatformUsers.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.tsx
@@ -7,6 +7,11 @@ import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
 
+// Domínio raiz para exibir o endereço de subdomínio do tenant (Story 4.4) — embutido no
+// bundle em build-time via VITE_ROOT_DOMAIN (ver apps/web/Dockerfile), reflete o mesmo
+// ROOT_DOMAIN configurado no Traefik/backend. Fallback "e1p.com" só pra dev local sem o build arg.
+const ROOT_DOMAIN = import.meta.env.VITE_ROOT_DOMAIN ?? "e1p.com";
+
 // Módulos que um funcionário pode receber (vazio = acesso a tudo).
 const MODULES: { key: string; label: string }[] = [
   { key: "crm", label: "CRM" },
@@ -159,7 +164,7 @@ function OfficeCard({
         <div className="min-w-0 flex-1">
           <p className="truncate font-medium text-neutral-800">{node.tenant.legal_name}</p>
           <p className="truncate text-xs text-neutral-400">
-            {node.tenant.slug}.e1p.com · {node.admin?.name ?? "sem dono"}
+            {node.tenant.slug}.{ROOT_DOMAIN} · {node.admin?.name ?? "sem dono"}
           </p>
         </div>
         <Chip icon={<Users size={12} />} value={node.staff_count} compact />

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ROOT_DOMAIN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -100,6 +100,11 @@ services:
     build:
       context: ..
       dockerfile: apps/web/Dockerfile
+      args:
+        # Embutido no bundle estático em build-time (ver apps/web/Dockerfile) — usado só para
+        # exibir o endereço de subdomínio do tenant na tela do Master (Story 4.4). Sem efeito
+        # em roteamento/TLS (isso já usa ${ROOT_DOMAIN} de verdade nos labels abaixo).
+        VITE_ROOT_DOMAIN: ${ROOT_DOMAIN}
     restart: always
     depends_on:
       - api


### PR DESCRIPTION
## Summary
- `PlatformUsers.tsx` mostrava sempre `<slug>.e1p.com` na tela do Master, independente do domínio real configurado em produção.
- Passa a usar `VITE_ROOT_DOMAIN` (embutido no bundle em build-time via build arg), com fallback `e1p.com` pra dev local.

## Contexto
Era puramente cosmético — o roteamento e o certificado TLS (Story 4.4, já em produção) sempre usaram o `ROOT_DOMAIN` de verdade configurado no ambiente. Nenhum dado de tenant já cadastrado foi afetado; só o texto exibido na UI estava errado.

## Test plan
- [x] `pnpm --filter @e1p/web typecheck` — sem erros.
- [x] `pnpm --filter @e1p/web test` — 29 arquivos / 90 testes, todos verdes (incluindo `PlatformUsers.test.tsx`).
- [ ] Merge e deploy (rebuild do `web` com o novo build arg) — confirmar visualmente que o painel do Master passa a mostrar o domínio real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)