### PR TITLE
fix(infra): corrige sintaxe HostRegexp pro Traefik v3 (wildcard não roteava) [Story 4.4]

### DIFF
--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -67,9 +67,11 @@ services:
       # FORA deste repo) com dnsChallenge/provider=cloudflare e o mesmo nome `letsencrypt-dns`,
       # senão o router falha ao subir. tls.domains força o SAN wildcard explícito (sem isso o
       # Traefik pediria um cert por-hostname individual, não um wildcard de verdade). Sintaxe
-      # HostRegexp do Traefik v2 (named group); no Traefik v3 use:
-      # HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`).
-      - traefik.http.routers.e1p-api.rule=(Host(`${DOMAIN}`) || HostRegexp(`{subdomain:[a-z0-9-]+}.${ROOT_DOMAIN}`)) && PathPrefix(`/api`)
+      # HostRegexp de named group (Traefik v2/mux) NÃO funciona no v3 — o parser aceita sem
+      # erro, mas o regex vira algo tipo "\{subdomain:[a-z0-9-]\}\." literal e nunca casa
+      # nenhum host real (confirmado em produção: 404 puro do Traefik pra qualquer
+      # subdomínio). Traefik v3 usa o regex do Go (RE2) direto, sem grupo nomeado.
+      - traefik.http.routers.e1p-api.rule=(Host(`${DOMAIN}`) || HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`)) && PathPrefix(`/api`)
       - traefik.http.routers.e1p-api.entrypoints=websecure
       - traefik.http.routers.e1p-api.tls.certresolver=letsencrypt-dns
       - traefik.http.routers.e1p-api.tls.domains[0].main=${ROOT_DOMAIN}
@@ -114,9 +116,10 @@ services:
       - traefik.docker.network=edge
       # Wildcard por tenant (Story 4.4): catch-all aceita ${DOMAIN} e `<slug>.${ROOT_DOMAIN}`.
       # Mesma dependência externa do certresolver DNS-01 no Traefik compartilhado (ver router
-      # e1p-api acima, incluindo o nome `letsencrypt-dns` e o SAN wildcard explícito).
+      # e1p-api acima, incluindo o nome `letsencrypt-dns`, o SAN wildcard explícito, e a
+      # sintaxe HostRegexp do Traefik v3 — regex RE2 puro, sem grupo nomeado de v2/mux).
       # Prioridade 1 mantida: casa por último, depois do router /api.
-      - traefik.http.routers.e1p-web.rule=Host(`${DOMAIN}`) || HostRegexp(`{subdomain:[a-z0-9-]+}.${ROOT_DOMAIN}`)
+      - traefik.http.routers.e1p-web.rule=Host(`${DOMAIN}`) || HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`)
       - traefik.http.routers.e1p-web.entrypoints=websecure
       - traefik.http.routers.e1p-web.tls.certresolver=letsencrypt-dns
       - traefik.http.routers.e1p-web.tls.domains[0].main=${ROOT_DOMAIN}


### PR DESCRIPTION
## Summary
- Corrige `HostRegexp(`{subdomain:[a-z0-9-]+}.${ROOT_DOMAIN}`)` (sintaxe de named group do Traefik v2/mux) para `HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`)` (regex RE2 puro, sintaxe correta do Traefik v3).

## Contexto (bug real em produção)
Depois dos PRs #18/#19 (certresolver DNS-01 + SAN wildcard), o certificado wildcard foi emitido corretamente, mas **nenhum subdomínio de tenant roteava** — qualquer `<slug>.${ROOT_DOMAIN}` retornava 404 puro do próprio Traefik (nenhum router bateu), mesmo o domínio único (`${DOMAIN}`) funcionando normalmente.

Causa: a sintaxe de "named group" (`{subdomain:...}`) é do Traefik v2 (baseado em gorilla/mux) — o v3 usa o regex do Go (RE2) diretamente, sem grupos nomeados. O parser do Traefik aceitava o label sem erro (por isso não apareceu nada nos logs), mas o padrão resultante era, na prática, um regex que só casaria com uma string literal como `{subdomain:xyz}.dominio` — nunca com um hostname real.

Validado localmente (semântica de regex, Node.js) antes de aplicar: o padrão novo casa subdomínio único (`slug.dominio`), não casa o domínio raiz sozinho nem múltiplos níveis (`a.b.dominio`).

## Test plan
- [ ] Merge e deploy (`git pull` + `docker compose --env-file .env.prod -f docker-compose.traefik.yml up -d --build`).
- [ ] `curl -s -o /dev/null -w '%{http_code}' https://<slug-real>.${ROOT_DOMAIN}/` → deve retornar 200 (hoje retorna 404).
- [ ] Confirmar que o domínio único continua funcionando sem regressão (IV1 da Story 4.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)