### PR TITLE
feat: cadastro estruturado (plano de contas + centro de custo) em Cobranças, Contas a Pagar e Financeiro

### DIFF
--- a/apps/api/app/modules/financial_intelligence/dre.py
+++ b/apps/api/app/modules/financial_intelligence/dre.py
@@ -46,6 +46,8 @@ from app.modules.payables.models import STATUS_CANCELED as PAYABLE_CANCELED
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import STATUS_CANCELED as CHARGE_CANCELED
 from app.modules.receivables.models import Charge
+from app.modules.wallet.models import STATUS_REFUNDED as TX_REFUNDED
+from app.modules.wallet.models import Transaction
 
 # Bucket sintético (NÃO é um grupo do enum `grupo_dre`): lançamentos ainda não classificados
 # (chart_account_id IS NULL) ou apontando para uma conta inexistente. Somado à parte, FORA do
@@ -126,6 +128,35 @@ def _sum_by_account(
     return [(acc_id, sign * int(total or 0), int(count)) for acc_id, total, count in rows]
 
 
+def _sum_transactions_by_account(
+    db: Session, *, start: date, end: date, cost_center_id: str | None = None,
+) -> list[tuple[str | None, int, int]]:
+    """Soma `Transaction` (Carteira) por `chart_account_id` — Story 5.10. Mesma base da DRE, mas só
+    entram transações SEM `external_ref` e não estornadas.
+
+    `external_ref` preenchido significa que a transação nasceu de uma Charge já paga (`mark_paid`
+    grava `external_ref=charge.id`) — essa receita JÁ é contada via `_sum_by_account(Charge, ...)`;
+    somar a Transaction também dobraria o valor. Só entram aqui as transações "órfãs" (venda avulsa
+    em "Registrar venda" ou produto/checkout), que não existem em nenhuma outra tabela do DRE.
+    Sinal sempre +1 (Carteira só registra dinheiro entrando)."""
+    competence = func.coalesce(Transaction.competence_date, func.date(Transaction.created_at))
+    stmt = select(
+        Transaction.chart_account_id,
+        func.coalesce(func.sum(Transaction.gross_cents), 0),
+        func.count(Transaction.id),
+    ).where(
+        competence >= start,
+        competence <= end,
+        Transaction.status != TX_REFUNDED,
+        Transaction.external_ref.is_(None),
+    )
+    if cost_center_id is not None:
+        stmt = stmt.where(Transaction.cost_center_id == cost_center_id)
+    stmt = stmt.group_by(Transaction.chart_account_id)
+    rows = db.execute(stmt).all()
+    return [(acc_id, int(total or 0), int(count)) for acc_id, total, count in rows]
+
+
 def dre_report(
     db: Session, *, start: date, end: date, cost_center_id: str | None = None
 ) -> DreReport:
@@ -154,6 +185,8 @@ def dre_report(
     ) + _sum_by_account(
         db, Payable, start=start, end=end, canceled=PAYABLE_CANCELED, sign=-1,
         cost_center_id=cost_center_id,
+    ) + _sum_transactions_by_account(
+        db, start=start, end=end, cost_center_id=cost_center_id,
     )
 
     for acc_id, amount, count in aggregated:
@@ -262,6 +295,33 @@ def _sum_by_cost_center_and_account(
     ]
 
 
+def _sum_transactions_by_cost_center_and_account(
+    db: Session, *, start: date, end: date
+) -> list[tuple[str | None, str | None, int, int]]:
+    """Mesma regra de `_sum_transactions_by_account` (só transações órfãs, não estornadas), cruzada
+    também por centro de custo — usada pelo `by_cost_center_report` (Story 5.10)."""
+    competence = func.coalesce(Transaction.competence_date, func.date(Transaction.created_at))
+    rows = db.execute(
+        select(
+            Transaction.cost_center_id,
+            Transaction.chart_account_id,
+            func.coalesce(func.sum(Transaction.gross_cents), 0),
+            func.count(Transaction.id),
+        )
+        .where(
+            competence >= start,
+            competence <= end,
+            Transaction.status != TX_REFUNDED,
+            Transaction.external_ref.is_(None),
+        )
+        .group_by(Transaction.cost_center_id, Transaction.chart_account_id)
+    ).all()
+    return [
+        (cc_id, acc_id, int(total or 0), int(count))
+        for cc_id, acc_id, total, count in rows
+    ]
+
+
 def by_cost_center_report(db: Session, *, start: date, end: date) -> CostCenterReport:
     """Cruza o resultado do período por centro de custo (2ª dimensão) — Story 5.5, AC2/AC3.
 
@@ -279,7 +339,7 @@ def by_cost_center_report(db: Session, *, start: date, end: date) -> CostCenterR
         db, Charge, start=start, end=end, canceled=CHARGE_CANCELED, sign=1
     ) + _sum_by_cost_center_and_account(
         db, Payable, start=start, end=end, canceled=PAYABLE_CANCELED, sign=-1
-    )
+    ) + _sum_transactions_by_cost_center_and_account(db, start=start, end=end)
 
     # cost_center_id | None -> [receita, resultado, contagem]
     acc: dict[str | None, list[int]] = {}

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -165,9 +165,12 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     if data.competence_date is not None:
         p.competence_date = data.competence_date
     if data.chart_account_id is not None:
-        if not chart_service.exists(db, data.chart_account_id):
+        if data.chart_account_id == "":
+            p.chart_account_id = None
+        elif not chart_service.exists(db, data.chart_account_id):
             raise PayableError("Conta do plano de contas não encontrada", 404)
-        p.chart_account_id = data.chart_account_id
+        else:
+            p.chart_account_id = data.chart_account_id
     # Story 5.4: (re)vincular/desvincular do contrato. "" desvincula (bucket "Empresa"); um id
     # inexistente/de outro tenant → 404. Metadado analítico, não toca no caminho de dinheiro.
     if data.contract_id is not None:

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -314,9 +314,12 @@ def update_charge(db: Session, *, charge_id: str, tenant_id: str, actor: str, da
     if data.competence_date is not None:
         charge.competence_date = data.competence_date
     if data.chart_account_id is not None:
-        if not chart_service.exists(db, data.chart_account_id):
+        if data.chart_account_id == "":
+            charge.chart_account_id = None
+        elif not chart_service.exists(db, data.chart_account_id):
             raise ReceivableError("Conta do plano de contas não encontrada", 404)
-        charge.chart_account_id = data.chart_account_id
+        else:
+            charge.chart_account_id = data.chart_account_id
     # Story 5.4: (re)vincular/desvincular do contrato. "" desvincula (bucket "Empresa"); um id
     # inexistente/de outro tenant → 404. Metadado analítico, não toca no caminho de dinheiro.
     if data.contract_id is not None:

--- a/apps/api/app/modules/wallet/models.py
+++ b/apps/api/app/modules/wallet/models.py
@@ -7,7 +7,9 @@ DINHEIRO SEMPRE EM CENTAVOS INTEIROS (nunca float).
 """
 from __future__ import annotations
 
-from sqlalchemy import BigInteger, Integer, String, Text
+from datetime import date
+
+from sqlalchemy import BigInteger, Date, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
@@ -52,6 +54,16 @@ class Transaction(Base, TenantMixin, TimestampMixin):
     status: Mapped[str] = mapped_column(String(12), default=STATUS_AVAILABLE, nullable=False)
     client_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     external_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # Classificação DRE (Story 5.10, aditivas/nullable — migration 0050; mesmo padrão de
+    # payables/charges desde 5.1/5.2/5.5). competence_date: regime de COMPETÊNCIA (DRE); sem
+    # `due_date` p/ dar fallback (a transação já é caixa realizado), então o service preenche com a
+    # data de criação quando omitida — e a DRE ainda faz COALESCE(competence_date, created_at::date)
+    # como rede de segurança para qualquer linha legada. chart_account_id/cost_center_id: vínculo
+    # OPCIONAL (sem FK dura, mesmo padrão do projeto) — NULL = sem categoria / não atribuído.
+    competence_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    chart_account_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    cost_center_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
 
 SETTINGS_ID = "platform"  # singleton

--- a/apps/api/app/modules/wallet/router.py
+++ b/apps/api/app/modules/wallet/router.py
@@ -51,9 +51,12 @@ def create_transaction(
     user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> TransactionOut:
-    tx = service.create_transaction(
-        db, tenant_id=user.tenant_id, actor=user.user_id, by_ai=user.is_ai, data=data
-    )
+    try:
+        tx = service.create_transaction(
+            db, tenant_id=user.tenant_id, actor=user.user_id, by_ai=user.is_ai, data=data
+        )
+    except service.WalletError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return TransactionOut.model_validate(tx)
 
 

--- a/apps/api/app/modules/wallet/schemas.py
+++ b/apps/api/app/modules/wallet/schemas.py
@@ -1,7 +1,7 @@
 """Schemas da Carteira & Split."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -15,6 +15,13 @@ class TransactionCreate(BaseModel):
     description: str = ""
     client_id: str | None = None
     external_ref: str | None = None
+    # Classificação DRE (Story 5.10, opcionais). competence_date omitida → service usa a data de
+    # hoje como fallback (a transação já é caixa realizado, não tem due_date pra herdar).
+    # chart_account_id/cost_center_id validados contra os cadastros do tenant se informados (404
+    # se apontarem p/ registro inexistente/de outro tenant).
+    competence_date: date | None = None
+    chart_account_id: str | None = None
+    cost_center_id: str | None = None
 
     @field_validator("kind")
     @classmethod
@@ -43,6 +50,9 @@ class TransactionOut(BaseModel):
     status: str
     client_id: str | None
     external_ref: str | None
+    competence_date: date | None
+    chart_account_id: str | None
+    cost_center_id: str | None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/apps/api/app/modules/wallet/service.py
+++ b/apps/api/app/modules/wallet/service.py
@@ -1,10 +1,14 @@
 """Regras da Carteira & Split: cálculo do split, transações, saldos e ganhos da plataforma."""
 from __future__ import annotations
 
+from datetime import UTC, date, datetime
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import audit
+from app.modules.chart_of_accounts import service as chart_service
+from app.modules.cost_centers import service as cost_centers_service
 from app.modules.wallet.models import (
     DEFAULT_SPLIT_PCT,
     KIND_PRODUCT,
@@ -102,16 +106,27 @@ def build_transaction(
     description: str = "",
     client_id: str | None = None,
     external_ref: str | None = None,
+    competence_date: date | None = None,
+    chart_account_id: str | None = None,
+    cost_center_id: str | None = None,
 ) -> Transaction:
     """Cria a transação + ganho da plataforma na sessão SEM commitar.
 
     Permite que outros módulos (ex.: Contas a Receber, ao dar baixa) gravem a transação
-    atomicamente junto com sua própria mutação.
+    atomicamente junto com sua própria mutação. Chamadores que já reconhecem a receita em outro
+    lugar (ex.: Charge paga) não passam `chart_account_id`/`cost_center_id` — a classificação nessa
+    origem é do Charge, e a DRE já exclui transações com `external_ref` preenchido para não somar
+    em dobro (ver `financial_intelligence/dre.py`).
     """
     pct = split_pct_for(db, kind)
     fee, net = compute_split(gross_cents, pct)
     # Cartão entra como "a receber" (a liberar); Pix/boleto já caem como disponível.
     status = STATUS_PENDING if method == METHOD_CARD else STATUS_AVAILABLE
+
+    if chart_account_id and not chart_service.exists(db, chart_account_id):
+        raise WalletError("Conta do plano de contas não encontrada", 404)
+    if cost_center_id and not cost_centers_service.exists(db, cost_center_id):
+        raise WalletError("Centro de custo não encontrado", 404)
 
     tx = Transaction(
         tenant_id=tenant_id,
@@ -124,6 +139,9 @@ def build_transaction(
         status=status,
         client_id=client_id,
         external_ref=external_ref,
+        competence_date=competence_date or datetime.now(UTC).date(),
+        chart_account_id=chart_account_id,
+        cost_center_id=cost_center_id,
     )
     db.add(tx)
     # Registro GLOBAL do ganho da plataforma (sem RLS) — alimenta o painel do Master.
@@ -142,7 +160,8 @@ def create_transaction(
     tx = build_transaction(
         db, tenant_id=tenant_id, actor=actor, by_ai=by_ai, kind=data.kind, method=data.method,
         gross_cents=data.gross_cents, description=data.description, client_id=data.client_id,
-        external_ref=data.external_ref,
+        external_ref=data.external_ref, competence_date=data.competence_date,
+        chart_account_id=data.chart_account_id, cost_center_id=data.cost_center_id,
     )
     db.commit()
     db.refresh(tx)

--- a/apps/api/migrations/versions/0050_transaction_classification.py
+++ b/apps/api/migrations/versions/0050_transaction_classification.py
@@ -1,0 +1,53 @@
+"""transactions: classificação (plano de contas + centro de custo + competência) — St. 5.10
+
+Revision ID: 0050
+Revises: 0049
+Create Date: 2026-07-14
+
+Estende a classificação estrutural (plano de contas/centro de custo), já usada por
+payables/charges desde 5.1/5.2/5.5, para `transactions` (Carteira). Motivação: vendas lançadas
+direto em "Registrar venda" (ou por Produtos & Checkout) nunca passam por um Payable/Charge, então
+ficavam INVISÍVEIS pro DRE — a Carteira não tinha nenhum vínculo de classificação.
+
+Estritamente ADITIVA: só colunas NULLABLE, sem backfill (mesmo racional do cost_center_id em 0048 —
+`chart_account_id`/`cost_center_id` NULL tem significado próprio: "sem categoria"/"não atribuído").
+`competence_date` também nasce NULL nos legados; a query da DRE faz
+`COALESCE(competence_date, date(created_at))` em runtime, então não precisa de backfill (diferente
+do 0046, que tinha `due_date` como fallback fixo já existente para popular a coluna).
+
+Sem FK dura (mesmo padrão do projeto: nenhuma FK explícita entre tabelas de negócio). RLS +
+validação em app garantem a integridade lógica.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0050"
+down_revision: str | None = "0049"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("transactions", sa.Column("competence_date", sa.Date(), nullable=True))
+    op.add_column(
+        "transactions", sa.Column("chart_account_id", sa.String(length=36), nullable=True)
+    )
+    op.add_column(
+        "transactions", sa.Column("cost_center_id", sa.String(length=36), nullable=True)
+    )
+    op.create_index(
+        "ix_transactions_competence_date", "transactions", ["tenant_id", "competence_date"]
+    )
+    op.create_index(
+        "ix_transactions_cost_center_id", "transactions", ["tenant_id", "cost_center_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transactions_cost_center_id", table_name="transactions")
+    op.drop_index("ix_transactions_competence_date", table_name="transactions")
+    op.drop_column("transactions", "cost_center_id")
+    op.drop_column("transactions", "chart_account_id")
+    op.drop_column("transactions", "competence_date")

--- a/apps/api/tests/test_financial_intelligence_dre.py
+++ b/apps/api/tests/test_financial_intelligence_dre.py
@@ -12,6 +12,8 @@ não é exercida (ver conftest).
 """
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
@@ -20,6 +22,7 @@ from sqlalchemy.orm import Session
 from app.modules.chart_of_accounts.models import ChartAccount
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import Charge
+from app.modules.wallet.models import Transaction
 
 REGISTER = {
     "legal_name": "Consultoria DRE",
@@ -227,3 +230,48 @@ def test_report_is_read_only(client: TestClient, headers, db: Session):
     _dre(client, headers)
     after = _snapshot(db)
     assert after == before, "DRE escreveu/alterou dados — viola IV1 (read-only)"
+
+
+# ── Story 5.10: Carteira (Transaction) entra na DRE ─────────────────────────────────────────────
+
+
+def test_walkin_transaction_counts_as_receita(client: TestClient, headers):
+    """Venda avulsa ("Registrar venda", sem Charge por trás) classificada entra na DRE como
+    receita — antes da Story 5.10 a Carteira ficava totalmente fora do relatório."""
+    acc = _account(client, headers, "RECEITA", "Vendas avulsas")
+    r = client.post(
+        "/wallet/transactions",
+        json={
+            "kind": "service", "method": "pix", "gross_cents": 5000,
+            "chart_account_id": acc, "competence_date": "2026-07-10",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    body = _dre(client, headers)
+    receita = _group(body, "RECEITA")
+    assert receita["total_cents"] == 5000
+    assert receita["categorias"][0]["categoria"] == "Vendas avulsas"
+
+
+def test_paid_charge_transaction_is_not_double_counted(
+    client: TestClient, headers, db: Session
+):
+    """A Transaction gerada ao pagar uma Charge (`external_ref=charge.id`) NÃO soma de novo na
+    DRE — a Charge já é contada; somar as duas dobraria a receita do período."""
+    acc = _account(client, headers, "RECEITA", "Consultoria paga")
+    charge = _charge(client, headers, amount=20000, competence="2026-07-05", account_id=acc)
+    client.post(f"/receivables/charges/{charge['id']}/pay", headers=headers)
+
+    # Força a competência da Transaction resultante PRA DENTRO da janela testada — assim, se o
+    # filtro `external_ref IS NULL` da DRE quebrar, o teste pega o dobro (40000), não um falso
+    # negativo por a transação cair fora do período por coincidência de data.
+    tx = db.execute(
+        select(Transaction).where(Transaction.external_ref == charge["id"])
+    ).scalar_one()
+    tx.competence_date = date(2026, 7, 5)
+    db.commit()
+
+    body = _dre(client, headers)
+    receita = _group(body, "RECEITA")
+    assert receita["total_cents"] == 20000  # só a Charge — a Transaction fica de fora

--- a/apps/api/tests/test_payables.py
+++ b/apps/api/tests/test_payables.py
@@ -225,3 +225,20 @@ def test_reclassify_payable(client: TestClient, headers):
     out = resp.json()
     assert out["competence_date"] == "2099-07-31"
     assert out["chart_account_id"] == acc["id"]
+
+
+def test_unset_payable_chart_account(client: TestClient, headers):
+    """"" desvincula (→ sem categoria), mesmo padrão de contract_id/cost_center_id."""
+    acc = client.post(
+        "/chart-of-accounts",
+        json={"grupo_dre": "DESPESA_FIXA", "categoria": "Aluguel"},
+        headers=headers,
+    ).json()
+    b = client.post(
+        "/payables/bills", json=_bill(chart_account_id=acc["id"]), headers=headers
+    ).json()
+    resp = client.patch(
+        f"/payables/bills/{b['id']}", json={"chart_account_id": ""}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["chart_account_id"] is None

--- a/apps/api/tests/test_receivables.py
+++ b/apps/api/tests/test_receivables.py
@@ -522,3 +522,20 @@ def test_reclassify_open_charge(client: TestClient, headers):
     out = resp.json()
     assert out["competence_date"] == "2026-07-31"
     assert out["chart_account_id"] == acc["id"]
+
+
+def test_unset_charge_chart_account(client: TestClient, headers):
+    """"" desvincula (→ sem categoria), mesmo padrão de contract_id/cost_center_id."""
+    acc = client.post(
+        "/chart-of-accounts",
+        json={"grupo_dre": "RECEITA", "categoria": "Consultoria"},
+        headers=headers,
+    ).json()
+    c = client.post(
+        "/receivables/charges", json=_charge(chart_account_id=acc["id"]), headers=headers
+    ).json()
+    resp = client.patch(
+        f"/receivables/charges/{c['id']}", json={"chart_account_id": ""}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["chart_account_id"] is None

--- a/apps/api/tests/test_wallet.py
+++ b/apps/api/tests/test_wallet.py
@@ -138,6 +138,55 @@ def test_requires_auth(client: TestClient):
     assert client.get("/wallet/summary").status_code == 401
 
 
+# ── Story 5.10: classificação (plano de contas + centro de custo) ──────────────────────────────
+
+
+def test_transaction_accepts_valid_chart_account(client: TestClient, headers):
+    acc = client.post(
+        "/chart-of-accounts",
+        json={"grupo_dre": "RECEITA", "categoria": "Vendas avulsas"},
+        headers=headers,
+    ).json()
+    tx = client.post(
+        "/wallet/transactions",
+        json={
+            "kind": "service", "method": "pix", "gross_cents": 10000,
+            "chart_account_id": acc["id"],
+        },
+        headers=headers,
+    ).json()
+    assert tx["chart_account_id"] == acc["id"]
+    assert tx["competence_date"] is not None  # preenchida com a data de hoje por padrão
+
+
+def test_transaction_rejects_unknown_chart_account(client: TestClient, headers):
+    resp = client.post(
+        "/wallet/transactions",
+        json={"kind": "service", "method": "pix", "gross_cents": 100, "chart_account_id": "nao-existe"},
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_transaction_accepts_valid_cost_center(client: TestClient, headers):
+    cc = client.post("/cost-centers", json={"name": "Loja física"}, headers=headers).json()
+    tx = client.post(
+        "/wallet/transactions",
+        json={"kind": "service", "method": "pix", "gross_cents": 10000, "cost_center_id": cc["id"]},
+        headers=headers,
+    ).json()
+    assert tx["cost_center_id"] == cc["id"]
+
+
+def test_transaction_rejects_unknown_cost_center(client: TestClient, headers):
+    resp = client.post(
+        "/wallet/transactions",
+        json={"kind": "service", "method": "pix", "gross_cents": 100, "cost_center_id": "nao-existe"},
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.text
+
+
 # ── Master: ganhos da plataforma ───────────────────────
 
 

--- a/apps/api/tests/test_wallet.py
+++ b/apps/api/tests/test_wallet.py
@@ -162,7 +162,10 @@ def test_transaction_accepts_valid_chart_account(client: TestClient, headers):
 def test_transaction_rejects_unknown_chart_account(client: TestClient, headers):
     resp = client.post(
         "/wallet/transactions",
-        json={"kind": "service", "method": "pix", "gross_cents": 100, "chart_account_id": "nao-existe"},
+        json={
+            "kind": "service", "method": "pix", "gross_cents": 100,
+            "chart_account_id": "nao-existe",
+        },
         headers=headers,
     )
     assert resp.status_code == 404, resp.text
@@ -181,7 +184,10 @@ def test_transaction_accepts_valid_cost_center(client: TestClient, headers):
 def test_transaction_rejects_unknown_cost_center(client: TestClient, headers):
     resp = client.post(
         "/wallet/transactions",
-        json={"kind": "service", "method": "pix", "gross_cents": 100, "cost_center_id": "nao-existe"},
+        json={
+            "kind": "service", "method": "pix", "gross_cents": 100,
+            "cost_center_id": "nao-existe",
+        },
         headers=headers,
     )
     assert resp.status_code == 404, resp.text

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -1,11 +1,18 @@
 import type { Charge, ChargesSummary, Client, Contract } from "@e1p/shared-types";
 import { Copy, Paperclip } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage, publicApi } from "../../lib/api";
 import { pluralize } from "../../lib/pluralize";
 import { usePrimaryAction } from "../../store/pageActions";
+import ChartAccountSelect from "../financeiro/ChartAccountSelect";
+import type { CostCenter } from "../financeiro/costCenters";
+import CostCenterSelect from "../financeiro/CostCenterSelect";
+import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
+
+/** Grupos DRE cabíveis numa RECEITA (Cobranças nunca lança em Despesa/Tributo/Investimento). */
+const REVENUE_GROUPS = GRUPOS_DRE.filter((g) => g === "RECEITA");
 
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
@@ -37,6 +44,8 @@ export default function CobrancasPage() {
   };
   const [summary, setSummary] = useState<ChargesSummary>(empty);
   const [charges, setCharges] = useState<Charge[]>([]);
+  const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
+  const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
   const [open, setOpen] = useState(false);
   const [docs, setDocs] = useState<Charge | null>(null);
   const [edit, setEdit] = useState<Charge | null>(null);
@@ -54,11 +63,28 @@ export default function CobrancasPage() {
     ]);
     setSummary(s.data);
     setCharges(c.data);
+    // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
+    // (require_module), a lista de cobranças continua funcionando normalmente.
+    const [ca, cc] = await Promise.all([
+      api.get<ChartAccount[]>("/chart-of-accounts").catch(() => ({ data: [] as ChartAccount[] })),
+      api.get<CostCenter[]>("/cost-centers").catch(() => ({ data: [] as CostCenter[] })),
+    ]);
+    setChartAccounts(ca.data);
+    setCostCenters(cc.data);
   }, []);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  const accountLabel = useMemo(
+    () => Object.fromEntries(chartAccounts.map((a) => [a.id, a.categoria])),
+    [chartAccounts],
+  );
+  const costCenterLabel = useMemo(
+    () => Object.fromEntries(costCenters.map((c) => [c.id, c.name])),
+    [costCenters],
+  );
 
   usePrimaryAction("Nova cobrança", useCallback(() => setOpen(true), []));
 
@@ -115,6 +141,8 @@ export default function CobrancasPage() {
               <tr className="border-b border-neutral-100 text-left text-xs uppercase text-neutral-400">
                 <th className="px-4 py-3 font-medium">Cliente</th>
                 <th className="px-4 py-3 font-medium">Descrição</th>
+                <th className="px-4 py-3 font-medium">Categoria</th>
+                <th className="px-4 py-3 font-medium">Centro de custo</th>
                 <th className="px-4 py-3 font-medium">Vencimento</th>
                 <th className="px-4 py-3 font-medium">Valor</th>
                 <th className="px-4 py-3 font-medium">Status</th>
@@ -141,6 +169,12 @@ export default function CobrancasPage() {
                           <Copy size={11} />
                         </button>
                       </span>
+                    </td>
+                    <td className="px-4 py-3 text-neutral-500">
+                      {(c.chart_account_id && accountLabel[c.chart_account_id]) || "—"}
+                    </td>
+                    <td className="px-4 py-3 text-neutral-500">
+                      {(c.cost_center_id && costCenterLabel[c.cost_center_id]) || "—"}
                     </td>
                     <td className="px-4 py-3 tabular-nums text-neutral-600">
                       {new Date(c.due_date + "T00:00").toLocaleDateString("pt-BR")}
@@ -235,6 +269,8 @@ function EditChargeModal({
   onSaved: () => void;
 }) {
   const [description, setDescription] = useState(charge.description);
+  const [chartAccountId, setChartAccountId] = useState(charge.chart_account_id ?? "");
+  const [costCenterId, setCostCenterId] = useState(charge.cost_center_id ?? "");
   const [value, setValue] = useState((charge.amount_cents / 100).toFixed(2).replace(".", ","));
   const [dueDate, setDueDate] = useState(charge.due_date);
   const [error, setError] = useState<string | null>(null);
@@ -246,6 +282,8 @@ function EditChargeModal({
     try {
       await api.patch(`/receivables/charges/${charge.id}`, {
         description,
+        chart_account_id: chartAccountId,
+        cost_center_id: costCenterId,
         amount_cents: Math.round(parseFloat(value.replace(",", ".")) * 100),
         due_date: dueDate,
       });
@@ -261,6 +299,19 @@ function EditChargeModal({
     <Modal title="Editar cobrança" open onClose={onClose}>
       <div className="space-y-3">
         <Field label="Descrição" value={description} onChange={setDescription} />
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <ChartAccountSelect
+              value={chartAccountId}
+              onChange={setChartAccountId}
+              groups={REVENUE_GROUPS}
+              defaultNewGrupo="RECEITA"
+            />
+          </div>
+          <div className="flex-1">
+            <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
+          </div>
+        </div>
         <div className="flex gap-2">
           <Field label="Valor (R$)" value={value} onChange={setValue} />
           <Field label="Vencimento" type="date" value={dueDate} onChange={setDueDate} />
@@ -290,6 +341,8 @@ function NewChargeModal({
   const [dueDate, setDueDate] = useState("");
   const [description, setDescription] = useState("");
   const [clientId, setClientId] = useState("");
+  const [chartAccountId, setChartAccountId] = useState("");
+  const [costCenterId, setCostCenterId] = useState("");
   const [recurrence, setRecurrence] = useState("none");
   const [recurrenceCount, setRecurrenceCount] = useState("12");
   const [clients, setClients] = useState<Client[]>([]);
@@ -317,6 +370,8 @@ function NewChargeModal({
         due_date: dueDate,
         description,
         client_id: clientId || null,
+        chart_account_id: chartAccountId || null,
+        cost_center_id: costCenterId || null,
         contract_id: contractId || null,
         recurrence,
         recurrence_count: recurrence === "none" ? 1 : Math.max(1, Math.min(60, parseInt(recurrenceCount, 10) || 1)),
@@ -325,6 +380,8 @@ function NewChargeModal({
       setValue("");
       setDueDate("");
       setDescription("");
+      setChartAccountId("");
+      setCostCenterId("");
       setContractId("");
       onClose();
     } catch (err) {
@@ -375,6 +432,19 @@ function NewChargeModal({
           <Field label="Vencimento" type="date" value={dueDate} onChange={setDueDate} />
         </div>
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Mensalidade" />
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <ChartAccountSelect
+              value={chartAccountId}
+              onChange={setChartAccountId}
+              groups={REVENUE_GROUPS}
+              defaultNewGrupo="RECEITA"
+            />
+          </div>
+          <div className="flex-1">
+            <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
+          </div>
+        </div>
         <label className="block">
           <span className="mb-1 block text-xs font-medium text-neutral-600">
             Vincular a contrato (opcional)

--- a/apps/web/src/features/financeiro/ChartAccountSelect.tsx
+++ b/apps/web/src/features/financeiro/ChartAccountSelect.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+import { type ChartAccount, type GrupoDre, GRUPO_LABEL } from "./planoContas";
+
+/**
+ * Seletor "Categoria (plano de contas)" — cadastro estruturado por trás de um combo simples:
+ * escolhe entre categorias já cadastradas (agrupadas por grupo DRE) ou cria uma nova sem sair da
+ * tela. `groups` restringe a lista/criação aos grupos cabíveis no lançamento (Contas a Pagar
+ * exclui RECEITA; Cobranças mostra só RECEITA) — DRE/lucratividade agrupam por `chart_account_id`,
+ * nunca por texto livre, então este seletor substitui qualquer campo de categoria digitado à mão.
+ */
+export default function ChartAccountSelect({
+  value,
+  onChange,
+  groups,
+  defaultNewGrupo,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  groups: readonly GrupoDre[];
+  defaultNewGrupo: GrupoDre;
+}) {
+  const [accounts, setAccounts] = useState<ChartAccount[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newGrupo, setNewGrupo] = useState<GrupoDre>(defaultNewGrupo);
+  const [newCategoria, setNewCategoria] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await api
+      .get<ChartAccount[]>("/chart-of-accounts")
+      .catch(() => ({ data: [] as ChartAccount[] }));
+    setAccounts(data.filter((a) => groups.includes(a.grupo_dre)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groups]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function createNow() {
+    setError(null);
+    if (!newCategoria.trim()) return;
+    setSaving(true);
+    try {
+      const { data } = await api.post<ChartAccount>("/chart-of-accounts", {
+        grupo_dre: newGrupo,
+        categoria: newCategoria.trim(),
+      });
+      await load();
+      onChange(data.id);
+      setCreating(false);
+      setNewCategoria("");
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-neutral-600">
+        Categoria (plano de contas)
+      </span>
+      {!creating ? (
+        <select
+          value={value}
+          onChange={(e) => {
+            if (e.target.value === "__new__") {
+              setCreating(true);
+              return;
+            }
+            onChange(e.target.value);
+          }}
+          className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+        >
+          <option value="">Sem categoria</option>
+          {groups.map((g) => {
+            const items = accounts.filter((a) => a.grupo_dre === g);
+            return items.length > 0 ? (
+              <optgroup key={g} label={GRUPO_LABEL[g]}>
+                {items.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.categoria}
+                  </option>
+                ))}
+              </optgroup>
+            ) : null;
+          })}
+          <option value="__new__">+ Criar nova categoria...</option>
+        </select>
+      ) : (
+        <div className="space-y-2 rounded-lg border border-primary-200 bg-primary-50 p-2.5">
+          <div className="flex gap-2">
+            <select
+              value={newGrupo}
+              onChange={(e) => setNewGrupo(e.target.value as GrupoDre)}
+              className="rounded-lg border border-neutral-200 px-2 py-1.5 text-xs outline-none focus:border-primary-400"
+            >
+              {groups.map((g) => (
+                <option key={g} value={g}>
+                  {GRUPO_LABEL[g]}
+                </option>
+              ))}
+            </select>
+            <input
+              value={newCategoria}
+              onChange={(e) => setNewCategoria(e.target.value)}
+              placeholder="Nome da categoria"
+              className="flex-1 rounded-lg border border-neutral-200 px-2 py-1.5 text-xs outline-none focus:border-primary-400"
+            />
+          </div>
+          {error && <p className="text-xs text-danger">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={createNow}
+              disabled={saving || !newCategoria.trim()}
+              className="rounded-pill bg-accent-400 px-3 py-1 text-xs font-semibold text-white hover:bg-accent-500 disabled:opacity-60"
+            >
+              {saving ? "Criando..." : "Criar e usar"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setCreating(false)}
+              className="text-xs text-neutral-500 hover:underline"
+            >
+              Cancelar
+            </button>
+          </div>
+        </div>
+      )}
+    </label>
+  );
+}

--- a/apps/web/src/features/financeiro/CostCenterSelect.tsx
+++ b/apps/web/src/features/financeiro/CostCenterSelect.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+import type { CostCenter } from "./costCenters";
+
+/** Mesmo padrão do ChartAccountSelect, para a 2ª dimensão (centro de custo — Story 5.5). Não tem
+ * grupo fixo (kind é texto livre sugerido), então é usado igual em Contas a Pagar e Cobranças. */
+export default function CostCenterSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [centers, setCenters] = useState<CostCenter[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await api
+      .get<CostCenter[]>("/cost-centers")
+      .catch(() => ({ data: [] as CostCenter[] }));
+    setCenters(data);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function createNow() {
+    setError(null);
+    if (!newName.trim()) return;
+    setSaving(true);
+    try {
+      const { data } = await api.post<CostCenter>("/cost-centers", { name: newName.trim() });
+      await load();
+      onChange(data.id);
+      setCreating(false);
+      setNewName("");
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-neutral-600">
+        Centro de custo (opcional)
+      </span>
+      {!creating ? (
+        <select
+          value={value}
+          onChange={(e) => {
+            if (e.target.value === "__new__") {
+              setCreating(true);
+              return;
+            }
+            onChange(e.target.value);
+          }}
+          className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+        >
+          <option value="">Não atribuído</option>
+          {centers.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+          <option value="__new__">+ Criar novo centro de custo...</option>
+        </select>
+      ) : (
+        <div className="space-y-2 rounded-lg border border-primary-200 bg-primary-50 p-2.5">
+          <input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Ex.: Sócio João, Unidade Centro"
+            className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-xs outline-none focus:border-primary-400"
+          />
+          {error && <p className="text-xs text-danger">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={createNow}
+              disabled={saving || !newName.trim()}
+              className="rounded-pill bg-accent-400 px-3 py-1 text-xs font-semibold text-white hover:bg-accent-500 disabled:opacity-60"
+            >
+              {saving ? "Criando..." : "Criar e usar"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setCreating(false)}
+              className="text-xs text-neutral-500 hover:underline"
+            >
+              Cancelar
+            </button>
+          </div>
+        </div>
+      )}
+    </label>
+  );
+}

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -1,8 +1,15 @@
 import type { Transaction, WalletSummary } from "@e1p/shared-types";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
+import ChartAccountSelect from "./ChartAccountSelect";
+import type { CostCenter } from "./costCenters";
+import CostCenterSelect from "./CostCenterSelect";
+import { type ChartAccount, GRUPOS_DRE } from "./planoContas";
+
+/** Grupos DRE cabíveis numa venda da Carteira (é sempre receita, nunca despesa). */
+const REVENUE_GROUPS = GRUPOS_DRE.filter((g) => g === "RECEITA");
 
 export const brl = (cents: number) =>
   (cents / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -35,6 +42,8 @@ export default function FinanceiroPage() {
   };
   const [summary, setSummary] = useState<WalletSummary>(empty);
   const [txs, setTxs] = useState<Transaction[]>([]);
+  const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
+  const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
   const [open, setOpen] = useState(false);
 
   const load = useCallback(async () => {
@@ -44,11 +53,28 @@ export default function FinanceiroPage() {
     ]);
     setSummary(s.data);
     setTxs(t.data);
+    // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
+    // (require_module), a lista de transações continua funcionando normalmente.
+    const [ca, cc] = await Promise.all([
+      api.get<ChartAccount[]>("/chart-of-accounts").catch(() => ({ data: [] as ChartAccount[] })),
+      api.get<CostCenter[]>("/cost-centers").catch(() => ({ data: [] as CostCenter[] })),
+    ]);
+    setChartAccounts(ca.data);
+    setCostCenters(cc.data);
   }, []);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  const accountLabel = useMemo(
+    () => Object.fromEntries(chartAccounts.map((a) => [a.id, a.categoria])),
+    [chartAccounts],
+  );
+  const costCenterLabel = useMemo(
+    () => Object.fromEntries(costCenters.map((c) => [c.id, c.name])),
+    [costCenters],
+  );
 
   usePrimaryAction("Registrar venda", useCallback(() => setOpen(true), []));
 
@@ -95,6 +121,8 @@ export default function FinanceiroPage() {
             <thead>
               <tr className="border-b border-neutral-100 text-left text-xs uppercase text-neutral-400">
                 <th className="px-4 py-3 font-medium">Descrição</th>
+                <th className="px-4 py-3 font-medium">Categoria</th>
+                <th className="px-4 py-3 font-medium">Centro de custo</th>
                 <th className="px-4 py-3 font-medium">Bruto</th>
                 <th className="px-4 py-3 font-medium">Taxa</th>
                 <th className="px-4 py-3 font-medium">Líquido</th>
@@ -110,6 +138,12 @@ export default function FinanceiroPage() {
                     <span className="block text-xs text-neutral-400">
                       {t.kind} · {t.method}
                     </span>
+                  </td>
+                  <td className="px-4 py-3 text-neutral-500">
+                    {(t.chart_account_id && accountLabel[t.chart_account_id]) || "—"}
+                  </td>
+                  <td className="px-4 py-3 text-neutral-500">
+                    {(t.cost_center_id && costCenterLabel[t.cost_center_id]) || "—"}
                   </td>
                   <td className="px-4 py-3 tabular-nums text-neutral-600">{brl(t.gross_cents)}</td>
                   <td className="px-4 py-3 tabular-nums text-danger">
@@ -173,6 +207,8 @@ function NewSaleModal({
   const [method, setMethod] = useState("pix");
   const [value, setValue] = useState("");
   const [description, setDescription] = useState("");
+  const [chartAccountId, setChartAccountId] = useState("");
+  const [costCenterId, setCostCenterId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -181,10 +217,19 @@ function NewSaleModal({
     setSaving(true);
     try {
       const gross_cents = Math.round(parseFloat(value.replace(",", ".")) * 100);
-      await api.post("/wallet/transactions", { kind, method, gross_cents, description });
+      await api.post("/wallet/transactions", {
+        kind,
+        method,
+        gross_cents,
+        description,
+        chart_account_id: chartAccountId || null,
+        cost_center_id: costCenterId || null,
+      });
       onCreated();
       setValue("");
       setDescription("");
+      setChartAccountId("");
+      setCostCenterId("");
       onClose();
     } catch (err) {
       setError(apiErrorMessage(err));
@@ -226,6 +271,19 @@ function NewSaleModal({
         </label>
         <Field label="Valor (R$)" value={value} onChange={setValue} placeholder="150,00" />
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Consulta" />
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <ChartAccountSelect
+              value={chartAccountId}
+              onChange={setChartAccountId}
+              groups={REVENUE_GROUPS}
+              defaultNewGrupo="RECEITA"
+            />
+          </div>
+          <div className="flex-1">
+            <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
+          </div>
+        </div>
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -1,10 +1,17 @@
 import type { Contract, Payable, PayablesSummary } from "@e1p/shared-types";
 import { Copy, Paperclip } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
+import ChartAccountSelect from "../financeiro/ChartAccountSelect";
+import type { CostCenter } from "../financeiro/costCenters";
+import CostCenterSelect from "../financeiro/CostCenterSelect";
+import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
+
+/** Grupos DRE cabíveis numa DESPESA (Contas a Pagar nunca lança em Receita). */
+const EXPENSE_GROUPS = GRUPOS_DRE.filter((g) => g !== "RECEITA");
 
 /** Seletor "Vincular a contrato" (Story 5.4) — opcional; vazio = bucket "Empresa" (overhead). */
 function ContractSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
@@ -60,6 +67,8 @@ export default function PagarPage() {
   };
   const [summary, setSummary] = useState<PayablesSummary>(empty);
   const [bills, setBills] = useState<Payable[]>([]);
+  const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
+  const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
   const [open, setOpen] = useState(false);
   const [attach, setAttach] = useState<Payable | null>(null);
   const [edit, setEdit] = useState<Payable | null>(null);
@@ -71,11 +80,29 @@ export default function PagarPage() {
     ]);
     setSummary(s.data);
     setBills(b.data);
+    // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
+    // (require_module), a lista de contas a pagar continua funcionando normalmente.
+    const [ca, cc] = await Promise.all([
+      api.get<ChartAccount[]>("/chart-of-accounts").catch(() => ({ data: [] as ChartAccount[] })),
+      api.get<CostCenter[]>("/cost-centers").catch(() => ({ data: [] as CostCenter[] })),
+    ]);
+    setChartAccounts(ca.data);
+    setCostCenters(cc.data);
   }, []);
 
   useEffect(() => {
     load();
   }, [load]);
+
+  // Rótulo estruturado quando o lançamento tem vínculo; senão cai no texto legado (`category`).
+  const accountLabel = useMemo(
+    () => Object.fromEntries(chartAccounts.map((a) => [a.id, a.categoria])),
+    [chartAccounts],
+  );
+  const costCenterLabel = useMemo(
+    () => Object.fromEntries(costCenters.map((c) => [c.id, c.name])),
+    [costCenters],
+  );
 
   usePrimaryAction("Nova conta", useCallback(() => setOpen(true), []));
 
@@ -114,6 +141,7 @@ export default function PagarPage() {
               <tr className="border-b border-neutral-100 text-left text-xs uppercase text-neutral-400">
                 <th className="px-4 py-3 font-medium">Conta</th>
                 <th className="px-4 py-3 font-medium">Categoria</th>
+                <th className="px-4 py-3 font-medium">Centro de custo</th>
                 <th className="px-4 py-3 font-medium">Vencimento</th>
                 <th className="px-4 py-3 font-medium">Valor</th>
                 <th className="px-4 py-3 font-medium">Status</th>
@@ -131,7 +159,12 @@ export default function PagarPage() {
                         <span className="block text-xs text-neutral-400">{p.supplier}</span>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-neutral-500">{p.category}</td>
+                    <td className="px-4 py-3 text-neutral-500">
+                      {(p.chart_account_id && accountLabel[p.chart_account_id]) || p.category}
+                    </td>
+                    <td className="px-4 py-3 text-neutral-500">
+                      {(p.cost_center_id && costCenterLabel[p.cost_center_id]) || "—"}
+                    </td>
                     <td className="px-4 py-3 tabular-nums text-neutral-600">
                       {new Date(p.due_date + "T00:00").toLocaleDateString("pt-BR")}
                     </td>
@@ -209,7 +242,8 @@ function EditBillModal({
   onSaved: () => void;
 }) {
   const [description, setDescription] = useState(bill.description);
-  const [category, setCategory] = useState(bill.category);
+  const [chartAccountId, setChartAccountId] = useState(bill.chart_account_id ?? "");
+  const [costCenterId, setCostCenterId] = useState(bill.cost_center_id ?? "");
   const [supplier, setSupplier] = useState(bill.supplier);
   const [value, setValue] = useState((bill.amount_cents / 100).toFixed(2).replace(".", ","));
   const [dueDate, setDueDate] = useState(bill.due_date);
@@ -223,7 +257,8 @@ function EditBillModal({
     try {
       await api.patch(`/payables/bills/${bill.id}`, {
         description,
-        category,
+        chart_account_id: chartAccountId,
+        cost_center_id: costCenterId,
         supplier,
         amount_cents: Math.round(parseFloat(value.replace(",", ".")) * 100),
         due_date: dueDate,
@@ -241,9 +276,19 @@ function EditBillModal({
     <Modal title="Editar conta" open onClose={onClose}>
       <div className="space-y-3">
         <Field label="Descrição" value={description} onChange={setDescription} />
+        <Field label="Fornecedor" value={supplier} onChange={setSupplier} />
         <div className="flex gap-2">
-          <Field label="Categoria" value={category} onChange={setCategory} />
-          <Field label="Fornecedor" value={supplier} onChange={setSupplier} />
+          <div className="flex-1">
+            <ChartAccountSelect
+              value={chartAccountId}
+              onChange={setChartAccountId}
+              groups={EXPENSE_GROUPS}
+              defaultNewGrupo="DESPESA_FIXA"
+            />
+          </div>
+          <div className="flex-1">
+            <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
+          </div>
         </div>
         <div className="flex gap-2">
           <Field label="Valor (R$)" value={value} onChange={setValue} />
@@ -345,7 +390,8 @@ function NewBillModal({
   onCreated: () => void;
 }) {
   const [description, setDescription] = useState("");
-  const [category, setCategory] = useState("Geral");
+  const [chartAccountId, setChartAccountId] = useState("");
+  const [costCenterId, setCostCenterId] = useState("");
   const [supplier, setSupplier] = useState("");
   const [value, setValue] = useState("");
   const [dueDate, setDueDate] = useState("");
@@ -363,7 +409,8 @@ function NewBillModal({
       const amount_cents = Math.round(parseFloat(value.replace(",", ".")) * 100);
       await api.post("/payables/bills", {
         description,
-        category,
+        chart_account_id: chartAccountId || null,
+        cost_center_id: costCenterId || null,
         supplier,
         amount_cents,
         due_date: dueDate,
@@ -374,6 +421,8 @@ function NewBillModal({
       });
       onCreated();
       setDescription("");
+      setChartAccountId("");
+      setCostCenterId("");
       setSupplier("");
       setValue("");
       setDueDate("");
@@ -391,9 +440,19 @@ function NewBillModal({
     <Modal title="Nova conta a pagar" open={open} onClose={onClose}>
       <div className="space-y-3">
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Aluguel" />
+        <Field label="Fornecedor" value={supplier} onChange={setSupplier} placeholder="Imobiliária" />
         <div className="flex gap-2">
-          <Field label="Categoria" value={category} onChange={setCategory} placeholder="Estrutura" />
-          <Field label="Fornecedor" value={supplier} onChange={setSupplier} placeholder="Imobiliária" />
+          <div className="flex-1">
+            <ChartAccountSelect
+              value={chartAccountId}
+              onChange={setChartAccountId}
+              groups={EXPENSE_GROUPS}
+              defaultNewGrupo="DESPESA_FIXA"
+            />
+          </div>
+          <div className="flex-1">
+            <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
+          </div>
         </div>
         <div className="flex gap-2">
           <Field label="Valor (R$)" value={value} onChange={setValue} placeholder="2500,00" />

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -289,6 +289,10 @@ export interface Transaction {
   status: TransactionStatus;
   client_id: UUID | null;
   external_ref: string | null;
+  // Story 5.10: vínculo opcional ao plano de contas; null = sem categoria estruturada.
+  chart_account_id: UUID | null;
+  // Story 5.10: vínculo opcional ao centro de custo (2ª dimensão); null = "Não atribuído".
+  cost_center_id: UUID | null;
   created_at: string;
 }
 
@@ -327,8 +331,12 @@ export interface Charge {
   method: PaymentMethod;
   amount_cents: number;
   due_date: string;
+  // Story 5.1: vínculo opcional ao plano de contas; null = sem categoria estruturada.
+  chart_account_id: UUID | null;
   // Story 5.4: vínculo opcional ao contrato (eixo "projeto"); null = bucket "Empresa".
   contract_id: UUID | null;
+  // Story 5.5: vínculo opcional ao centro de custo (2ª dimensão); null = "Não atribuído".
+  cost_center_id: UUID | null;
   status: ChargeStatus;
   is_overdue: boolean;
   protested_at: string | null;
@@ -359,8 +367,12 @@ export interface Payable {
   supplier: string;
   amount_cents: number;
   due_date: string;
+  // Story 5.1: vínculo opcional ao plano de contas; null = sem categoria estruturada.
+  chart_account_id: UUID | null;
   // Story 5.4: vínculo opcional ao contrato (eixo "projeto"); null = bucket "Empresa".
   contract_id: UUID | null;
+  // Story 5.5: vínculo opcional ao centro de custo (2ª dimensão); null = "Não atribuído".
+  cost_center_id: UUID | null;
   status: PayableStatus;
   is_overdue: boolean;
   paid_at: string | null;


### PR DESCRIPTION
## Summary
- Contas a Pagar: substitui a categoria de texto livre por um seletor "buscar ou criar" ligado ao plano de contas + centro de custo (a divergência de digitação quebrava agregação no DRE, que já agrupa por `chart_account_id`, nunca por texto).
- Cobranças: mesmo padrão, restrito ao grupo RECEITA.
- Financeiro/Carteira: `Transaction` ganha `chart_account_id`/`cost_center_id`/`competence_date` (migration `0050`) e passa a entrar no DRE — vendas avulsas em "Registrar venda" eram invisíveis para qualquer relatório antes desta mudança. A DRE só soma transações **sem** `external_ref` (as vinculadas a uma Charge paga já são contadas via a própria Charge; incluir as duas dobraria a receita — coberto por teste).
- Correção de paridade: `chart_account_id` agora pode ser desvinculado via `""` no PATCH de Payable/Charge, igual já funcionava para `contract_id`/`cost_center_id`.

## Test plan
- [x] `pytest` completo da API: 599 passed, 1 skipped
- [x] `vitest` completo do web: 29 arquivos, 90 testes passed
- [x] `tsc --noEmit` sem erros
- [x] Teste dedicado provando que a Transaction de uma Charge paga não dobra a receita no DRE

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>