### PR TITLE
fix: allowlist commit de fixtures de teste no gitleaks (falso positivo)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -30,6 +30,16 @@ paths = [
     '''(^|/)yarn\.lock$''',
 ]
 
+# `commits` ignora achados introduzidos por um commit específico (só na varredura de
+# histórico completo do push para main — no PR o range já não inclui commits antigos).
+# b93bf6f: feat(auth) de recuperação de senha (29/06) — o `generic-api-key` pegou senhas
+# de FIXTURE em apps/api/tests/test_auth.py (ex.: "nova-senha-bem-forte",
+# "primeira-troca-123"), nunca um segredo real. Conferido o diff inteiro do commit antes
+# de allowlistar (só teste + código de feature, sem chave/token real). Ver PR #28.
+commits = [
+    "b93bf6fe4e85de7e658e0eca381157623f0bdfff",
+]
+
 # --- Precedente documentado (NÃO ativo hoje) --------------------------------------
 # O token do Apify que veio no zip da skill de carrossel foi REDIGIDO ANTES de ser
 # commitado (ver CLAUDE.md §"Gerador de Carrossel"), então não deve haver segredo vivo


### PR DESCRIPTION
## Summary
- O job `secret-scan` (gitleaks) falha em todo push pra `main` — não no PR, só na varredura de histórico completo do push (`.github/workflows/ci.yml`, job `secret-scan`).
- Achado: commit `b93bf6f` (feat de recuperação de senha, 29/06) tem senhas de **fixture de teste** em `apps/api/tests/test_auth.py` (`"nova-senha-bem-forte"`, `"primeira-troca-123"`) que o detector `generic-api-key` confunde com segredo real.
- Conferi o diff inteiro desse commit antes de allowlistar — só teste + código de feature, nenhuma chave/token real.
- Adiciona o commit a `[allowlist].commits` em `.gitleaks.toml`, com a justificativa documentada inline.

## Test plan
- [x] Rodei a MESMA imagem gitleaks pinada do CI localmente (`ghcr.io/gitleaks/gitleaks@sha256:c00b...`) contra o histórico completo: `no leaks found` depois da mudança.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>