### PR TITLE
feat: reorganiza sidebar em seções por frequência de uso + remove barra horizontal

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -39,7 +39,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
         <X size={20} />
       </button>
 
-      <nav className="flex flex-1 flex-col gap-7 overflow-y-auto pr-1">
+      <nav className="flex flex-1 flex-col gap-7 overflow-x-hidden overflow-y-auto pr-1">
         {navSections.map((section, i) => (
           <div key={i}>
             {i > 0 && (
@@ -56,7 +56,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
                     end={item.to === "/" || item.exact === true}
                     className={({ isActive }) =>
                       clsx(
-                        "flex items-center gap-3 py-3 pl-4 text-[15px] font-medium transition",
+                        "flex min-w-0 items-center gap-3 py-3 pl-4 text-[15px] font-medium transition",
                         isActive
                           ? // pill branco que vaza para a direita (cancela o padding com -mr-4)
                             "-mr-4 rounded-l-full bg-white text-primary-700 shadow-sm"
@@ -65,8 +65,8 @@ function Sidebar({ onClose }: { onClose: () => void }) {
                       )
                     }
                   >
-                    <item.icon size={20} strokeWidth={2} />
-                    <span>{item.label}</span>
+                    <item.icon size={20} strokeWidth={2} className="shrink-0" />
+                    <span className="truncate">{item.label}</span>
                     {!item.ready && (
                       <span className="ml-auto mr-3 text-[10px] uppercase tracking-wide opacity-70">
                         em breve

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -40,23 +40,44 @@ export interface NavSection {
   items: NavItem[];
 }
 
-/** Dois grupos, no formato do design "Portal": principal + "Ferramentas de Produtividade". */
+/**
+ * Seções por ORDEM DE USO (mais usado no dia a dia primeiro), no formato do design "Portal".
+ * Cada grupo é separado por um divisor tracejado (ver AppShell.tsx) — evita a lista única
+ * misturando navegação diária com telas de configuração/relatório raramente abertas.
+ */
 export const navSections: NavSection[] = [
   {
+    // Núcleo: o que se abre todo dia.
     items: [
       { label: "Dashboard", to: "/", icon: LayoutDashboard, ready: true },
       { label: "Agenda", to: "/agenda", icon: CalendarDays, ready: true },
       { label: "CRM & Kanban", to: "/crm", icon: Users, ready: true },
+    ],
+  },
+  {
+    // Financeiro operacional: registrar/cobrar/pagar — uso diário. "Financeiro" (Carteira)
+    // primeiro porque é onde entra o lançamento de recebimento do dia a dia ("Registrar venda").
+    title: "Financeiro",
+    items: [
       { label: "Financeiro", to: "/financeiro", icon: Wallet, ready: true, exact: true },
-      { label: "Plano de contas", to: "/financeiro/plano-contas", icon: ListTree, ready: true },
-      { label: "DRE", to: "/financeiro/dre", icon: PieChart, ready: true },
-      { label: "Centros de custo", to: "/financeiro/centros-custo", icon: Layers, ready: true },
-      { label: "Investimentos", to: "/financeiro/investimentos", icon: TrendingUp, ready: true },
-      { label: "Projeção de caixa", to: "/financeiro/projecao-caixa", icon: LineChart, ready: true },
-      { label: "Diagnóstico", to: "/financeiro/diagnostico", icon: Activity, ready: true },
       { label: "Cobranças", to: "/cobrancas", icon: Receipt, ready: true },
       { label: "Contas a Pagar", to: "/pagar", icon: CreditCard, ready: true },
       { label: "Fila de pagamentos", to: "/financeiro/fila-pagamentos", icon: ListChecks, ready: true },
+    ],
+  },
+  {
+    // Relatórios (DRE/projeção/diagnóstico/investimentos) + cadastros de classificação (plano de
+    // contas/centro de custo) — tudo consultado/editado periodicamente, não todo dia. O nome cobre
+    // os dois perfis (análise E configuração) já que "Relatórios" sozinho não descrevia bem os
+    // cadastros.
+    title: "Análise & Configuração Financeira",
+    items: [
+      { label: "DRE", to: "/financeiro/dre", icon: PieChart, ready: true },
+      { label: "Projeção de caixa", to: "/financeiro/projecao-caixa", icon: LineChart, ready: true },
+      { label: "Diagnóstico", to: "/financeiro/diagnostico", icon: Activity, ready: true },
+      { label: "Investimentos", to: "/financeiro/investimentos", icon: TrendingUp, ready: true },
+      { label: "Plano de contas", to: "/financeiro/plano-contas", icon: ListTree, ready: true },
+      { label: "Centros de custo", to: "/financeiro/centros-custo", icon: Layers, ready: true },
     ],
   },
   {
@@ -70,7 +91,10 @@ export const navSections: NavSection[] = [
       { label: "Funil de Vendas", to: "/funis", icon: Workflow, ready: true },
       { label: "Sites", to: "/sites", icon: Globe, ready: true },
       { label: "Jurídico", to: "/juridico", icon: Scale, ready: true },
-      { label: "Configurações", to: "/config", icon: Settings, ready: true },
     ],
+  },
+  {
+    // Raramente aberto — fica isolado no fim, longe do que se usa todo dia.
+    items: [{ label: "Configurações", to: "/config", icon: Settings, ready: true }],
   },
 ];


### PR DESCRIPTION
## Summary
- Sidebar reorganizado em seções por frequência real de uso, validado lendo o que cada tela faz:
  - **Núcleo** (sem título): Dashboard, Agenda, CRM & Kanban.
  - **Financeiro**: Financeiro (Carteira/Registrar venda), Cobranças, Contas a Pagar, Fila de pagamentos.
  - **Análise & Configuração Financeira**: DRE, Projeção de caixa, Diagnóstico, Investimentos, Plano de contas, Centros de custo.
  - **Ferramentas de Produtividade**: inalterado.
  - **Configurações**: isolada no fim.
- Corrige a barra de rolagem horizontal na sidebar (`overflow-x-hidden` explícito + `truncate`/`min-w-0`/`shrink-0` nos itens).

## Test plan
- [x] `tsc --noEmit` sem erros
- [x] `vitest run`: 29 arquivos, 90 testes passed
- [x] Validado visualmente no dev server local (login real, screenshot antes/depois): seções corretas, sem barra horizontal
- [x] Confirmado que todas as rotas de topo do `App.tsx` aparecem no menu (nenhuma órfã)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>