### PR TITLE
feat: aplica o Brand Kit do tenant como tema do app (sidebar/botões)

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,7 +1,10 @@
+import type { TenantProfile } from "@e1p/shared-types";
 import clsx from "clsx";
 import { Bell, ChevronDown, LogOut, Plus, Search, ShieldCheck, X } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
+import { api } from "../lib/api";
+import { applyBrandTheme } from "../lib/theme";
 import { useAuth } from "../store/auth";
 import { usePageActions } from "../store/pageActions";
 import { navSections } from "./navigation";
@@ -12,6 +15,18 @@ import { navSections } from "./navigation";
  */
 export default function AppShell({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(true);
+
+  // Aplica o Brand Kit do tenant como tema do app (sidebar/botões) uma vez por sessão — as
+  // classes Tailwind já apontam pra CSS vars com fallback estático, então sem tema custom nada
+  // muda visualmente (ver packages/design-tokens/src/tailwind-preset.ts).
+  useEffect(() => {
+    api
+      .get<TenantProfile>("/settings/profile")
+      .then(({ data }) => applyBrandTheme(data))
+      .catch(() => {
+        /* tema é só um complemento visual — sem acesso/erro, fica no fallback estático padrão */
+      });
+  }, []);
 
   return (
     <div className="flex min-h-screen bg-neutral-50">

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -9,6 +9,7 @@ import {
   getGoogleConnectUrl,
   getGoogleStatus,
 } from "../../lib/api";
+import { applyBrandTheme } from "../../lib/theme";
 
 const FONTS = ["Inter", "Poppins", "Raleway", "Georgia", "Arial"];
 const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
@@ -38,6 +39,7 @@ export default function ConfiguracoesPage() {
     try {
       const { data } = await api.patch<TenantProfile>("/settings/profile", p);
       setP(data);
+      applyBrandTheme(data);
       setSavedAt(new Date().toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" }));
     } catch (err) {
       setError(apiErrorMessage(err));

--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,0 +1,79 @@
+import { cssVarName, generateScale, SHADE_KEYS } from "@e1p/design-tokens";
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyBrandTheme } from "./theme";
+
+describe("generateScale (design-tokens) — Story 5.11", () => {
+  it("o tom 500 é a própria cor de entrada (verbatim, minúsculo)", () => {
+    const scale = generateScale("#1A2B3C");
+    expect(scale[500]).toBe("#1a2b3c");
+  });
+
+  it("é uma rampa monotônica: cada tom mais claro tem luminosidade >= ao anterior", () => {
+    // Verificação indireta: dado o mesmo matiz, os hex mais "claros" (50) devem ter maior soma de
+    // canais RGB que os mais "escuros" (900) — sem depender de reimplementar HSL no teste.
+    const scale = generateScale("#5D44F8");
+    const sum = (hex: string) =>
+      parseInt(hex.slice(1, 3), 16) + parseInt(hex.slice(3, 5), 16) + parseInt(hex.slice(5, 7), 16);
+    const sums = SHADE_KEYS.map((s) => sum(scale[s]));
+    for (let i = 1; i < sums.length; i++) {
+      expect(sums[i]).toBeLessThanOrEqual(sums[i - 1]);
+    }
+  });
+
+  it("cor base clara (perto do âncora de 50) não gera rampa invertida", () => {
+    // Caso de borda: L já perto do teto (branco) — o "lado claro" quase não tem pra onde subir,
+    // mas a rampa não pode quebrar (900 continua o mais escuro).
+    const scale = generateScale("#F5F0FF"); // roxo bem claro
+    const sum = (hex: string) =>
+      parseInt(hex.slice(1, 3), 16) + parseInt(hex.slice(3, 5), 16) + parseInt(hex.slice(5, 7), 16);
+    expect(sum(scale[50])).toBeGreaterThanOrEqual(sum(scale[900]));
+  });
+
+  it("gera valores próximos da escala primary original a partir do mesmo hex base (#5D44F8)", () => {
+    const scale = generateScale("#5d44f8");
+    // Tolerância generosa (curva aproximada, não idêntica byte-a-byte) — só garante que o tom
+    // "500" bate exato e os extremos ficam na mesma família de cor (não divergem pra outro matiz).
+    expect(scale[500]).toBe("#5d44f8");
+    expect(scale[50].toLowerCase()).toMatch(/^#f[0-9a-f]e/); // clarinho, tom de lilás
+    expect(scale[900].toLowerCase()).toMatch(/^#1[0-9a-f]/); // bem escuro
+  });
+});
+
+describe("applyBrandTheme — Story 5.11", () => {
+  beforeEach(() => {
+    for (const token of ["primary", "accent"] as const) {
+      for (const shade of SHADE_KEYS) {
+        document.documentElement.style.removeProperty(cssVarName(token, shade));
+      }
+    }
+  });
+
+  it("seta as 10 CSS vars de primary e accent a partir do Brand Kit", () => {
+    applyBrandTheme({ primary_color: "#112233", accent_color: "#445566" });
+    expect(document.documentElement.style.getPropertyValue(cssVarName("primary", 500)).trim()).toBe(
+      "#112233",
+    );
+    expect(document.documentElement.style.getPropertyValue(cssVarName("accent", 500)).trim()).toBe(
+      "#445566",
+    );
+    // todos os 10 tons de cada token foram setados, não só o 500
+    for (const shade of SHADE_KEYS) {
+      expect(document.documentElement.style.getPropertyValue(cssVarName("primary", shade))).not.toBe("");
+      expect(document.documentElement.style.getPropertyValue(cssVarName("accent", shade))).not.toBe("");
+    }
+  });
+
+  it("ignora hex inválido/vazio sem lançar (fail-safe — mantém o fallback estático do preset)", () => {
+    expect(() => applyBrandTheme({ primary_color: "", accent_color: "não-é-hex" })).not.toThrow();
+    expect(document.documentElement.style.getPropertyValue(cssVarName("primary", 500))).toBe("");
+    expect(document.documentElement.style.getPropertyValue(cssVarName("accent", 500))).toBe("");
+  });
+
+  it("campos parciais só aplicam o que veio (primary sem accent, por exemplo)", () => {
+    applyBrandTheme({ primary_color: "#0a0a0a" });
+    expect(document.documentElement.style.getPropertyValue(cssVarName("primary", 500)).trim()).toBe(
+      "#0a0a0a",
+    );
+    expect(document.documentElement.style.getPropertyValue(cssVarName("accent", 500))).toBe("");
+  });
+});

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,33 @@
+import { cssVarName, generateScale, SHADE_KEYS } from "@e1p/design-tokens";
+
+/** Só os dois campos do Brand Kit (Configurações) que viram tema — cores semânticas
+ * (sucesso/erro/aviso) e neutros continuam fixos de propósito, nunca seguem a marca do tenant. */
+export interface BrandColors {
+  primary_color: string;
+  accent_color: string;
+}
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Aplica o Brand Kit do tenant como CSS custom properties no `<html>` — as classes Tailwind
+ * `bg-primary-*`/`text-accent-*` etc. já apontam para `var(--e1p-primary-*, <fallback>)` (ver
+ * `packages/design-tokens/src/tailwind-preset.ts`), então isto é o suficiente para o tema do
+ * app inteiro (sidebar, botões, links) refletir a cor da marca — sem recompilar nada.
+ *
+ * Hex inválido/vazio é ignorado silenciosamente por campo (fail-safe: mantém o fallback estático
+ * do preset em vez de quebrar o tema inteiro por um valor ruim).
+ */
+export function applyBrandTheme(brand: Partial<BrandColors>): void {
+  const root = document.documentElement;
+  for (const [token, hex] of [
+    ["primary", brand.primary_color],
+    ["accent", brand.accent_color],
+  ] as const) {
+    if (!hex || !HEX_RE.test(hex)) continue;
+    const scale = generateScale(hex);
+    for (const shade of SHADE_KEYS) {
+      root.style.setProperty(cssVarName(token, shade), scale[shade]);
+    }
+  }
+}

--- a/packages/design-tokens/src/colorScale.ts
+++ b/packages/design-tokens/src/colorScale.ts
@@ -1,0 +1,114 @@
+/**
+ * Gera uma escala de 10 tons (50→900) a partir de UMA cor base (hex) — usada para derivar o tema
+ * do app a partir do Brand Kit do tenant (uma única cor "primária"/"destaque" configurada em
+ * Configurações), preservando a mesma "forma" (curva de luminosidade/saturação) das escalas
+ * estáticas do design system (ver `colors.primary`/`colors.accent` em index.ts).
+ *
+ * O tom 500 é a própria cor de entrada (verbatim — é o que o tenant escolheu); os demais tons
+ * interpolam a partir do L/S reais da cor de entrada até âncoras fixas quase-branco (50) e
+ * quase-preto (900), usando os MESMOS pesos relativos da curva original — isso garante uma
+ * rampa sempre monotônica (nunca "invertida") não importa a luminosidade da cor escolhida.
+ */
+
+export type ShadeKey = 50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+
+export const SHADE_KEYS: readonly ShadeKey[] = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
+
+const LIGHT_ANCHOR_L = 96.5; // luminosidade do tom mais claro (50), fixa p/ qualquer matiz
+const DARK_ANCHOR_L = 20; // luminosidade do tom mais escuro (900), fixa
+const DARK_SAT_DROP = 0.35; // saturação cai até 35% no tom mais escuro (evita ficar "lamacento")
+
+// Peso de interpolação de cada tom entre a cor base (500) e as âncoras clara/escura — extraído
+// da curva de luminosidade da escala `colors.primary` original (ver index.ts), reaproveitado como
+// MOLDE para qualquer matiz de marca nova.
+const LIGHT_WEIGHT: Partial<Record<ShadeKey, number>> = {
+  400: 0.21,
+  300: 0.45,
+  200: 0.74,
+  100: 0.91,
+  50: 1,
+};
+const DARK_WEIGHT: Partial<Record<ShadeKey, number>> = { 600: 0.25, 700: 0.52, 800: 0.79, 900: 1 };
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function hexToHsl(hex: string): [number, number, number] {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16) / 255;
+  const g = parseInt(clean.slice(2, 4), 16) / 255;
+  const b = parseInt(clean.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) return [0, 0, l * 100];
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    default:
+      h = (r - g) / d + 4;
+  }
+  return [h * 60, s * 100, l * 100];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const hp = ((h % 360) + 360) % 360 / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  const m = lN - c / 2;
+  let [r1, g1, b1] = [0, 0, 0];
+  if (hp < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hp < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hp < 3) [r1, g1, b1] = [0, c, x];
+  else if (hp < 4) [r1, g1, b1] = [0, x, c];
+  else if (hp < 5) [r1, g1, b1] = [x, 0, c];
+  else [r1, g1, b1] = [c, 0, x];
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r1)}${toHex(g1)}${toHex(b1)}`;
+}
+
+/** Nome da CSS custom property de um tom — fonte única usada tanto pelo preset Tailwind (fallback
+ * estático) quanto pelo injetor de tema em runtime (apps/web/src/lib/theme.ts), para os dois
+ * lados nunca divergirem no nome da variável. */
+export function cssVarName(token: "primary" | "accent", shade: ShadeKey): string {
+  return `--e1p-${token}-${shade}`;
+}
+
+/** Gera as 10 tonalidades a partir de uma cor base hex (ex.: "#5D44F8"). */
+export function generateScale(baseHex: string): Record<ShadeKey, string> {
+  const [hue, sat, light] = hexToHsl(baseHex);
+  const lightSpan = Math.max(0, LIGHT_ANCHOR_L - light);
+  const darkSpan = Math.max(0, light - DARK_ANCHOR_L);
+  const scale = {} as Record<ShadeKey, string>;
+  for (const shade of SHADE_KEYS) {
+    if (shade === 500) {
+      scale[shade] = baseHex.toLowerCase();
+      continue;
+    }
+    const lightWeight = LIGHT_WEIGHT[shade];
+    if (lightWeight !== undefined) {
+      scale[shade] = hslToHex(hue, sat, clamp(light + lightWeight * lightSpan, 0, 100));
+    } else {
+      const darkWeight = DARK_WEIGHT[shade] as number;
+      scale[shade] = hslToHex(
+        hue,
+        clamp(sat * (1 - darkWeight * DARK_SAT_DROP), 0, 100),
+        clamp(light - darkWeight * darkSpan, 0, 100),
+      );
+    }
+  }
+  return scale;
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -84,3 +84,5 @@ export const typography = {
 
 export const tokens = { colors, radii, spacing, typography } as const;
 export default tokens;
+
+export { cssVarName, generateScale, SHADE_KEYS, type ShadeKey } from "./colorScale";

--- a/packages/design-tokens/src/tailwind-preset.ts
+++ b/packages/design-tokens/src/tailwind-preset.ts
@@ -2,14 +2,34 @@
  * Preset Tailwind do e1p. Importado por apps/web/tailwind.config.ts e (futuramente) pela mobile.
  * Mantém um único vocabulário visual em todos os apps.
  */
+import { cssVarName, type ShadeKey } from "./colorScale";
 import { colors, radii, typography } from "./index";
+
+/**
+ * `primary`/`accent` viram `var(--e1p-{token}-{tom}, <hex estático>)` — o fallback garante que,
+ * sem nenhum tema de tenant aplicado (JS ainda não rodou, ou Brand Kit nunca customizado), a
+ * aparência é IDÊNTICA à de hoje (mesmos hex fixos). Quando `apps/web/src/lib/theme.ts` seta as
+ * CSS vars a partir do Brand Kit do tenant, essas classes passam a refletir a cor da marca sem
+ * precisar recompilar o Tailwind — só `neutral`/`success`/`warning`/`danger`/`info` continuam
+ * 100% estáticos (cores semânticas fixas: erro/sucesso não devem seguir a marca do tenant).
+ */
+function withCssVarFallback(
+  token: "primary" | "accent",
+  scale: Record<ShadeKey, string>,
+): Record<ShadeKey, string> {
+  const out = {} as Record<ShadeKey, string>;
+  for (const shade of Object.keys(scale).map(Number) as ShadeKey[]) {
+    out[shade] = `var(${cssVarName(token, shade)}, ${scale[shade]})`;
+  }
+  return out;
+}
 
 const preset = {
   theme: {
     extend: {
       colors: {
-        primary: colors.primary,
-        accent: colors.accent,
+        primary: withCssVarFallback("primary", colors.primary),
+        accent: withCssVarFallback("accent", colors.accent),
         neutral: colors.neutral,
         success: colors.success,
         warning: colors.warning,


### PR DESCRIPTION
## Summary
- O Brand Kit (Configurações → cor primária/destaque) até agora só era usado em documentos gerados pro cliente (propostas/contratos/carrosséis) — o tema do próprio app (sidebar, botões) era estático, igual pra todo tenant.
- `packages/design-tokens/src/colorScale.ts`: gera as 10 tonalidades (50→900) a partir de UMA cor base, preservando a curva de luminosidade/saturação das escalas originais. O tom 500 é a cor exata escolhida pelo tenant.
- `tailwind-preset.ts`: `primary`/`accent` agora são `var(--e1p-primary-N, <hex estático>)` — sem tema custom, aparência idêntica a hoje. Cores semânticas (success/warning/danger/info) continuam fixas de propósito.
- `apps/web/src/lib/theme.ts`: injeta as CSS vars a partir do Brand Kit (fail-safe: hex inválido é ignorado por campo).
- `AppShell`: aplica o tema uma vez no boot da sessão. `ConfiguracoesPage`: aplica ao vivo após Salvar.

## Test plan
- [x] `tsc --noEmit` sem erros
- [x] `vitest run`: 30 arquivos, 97 testes passed (7 novos testes de `generateScale`/`applyBrandTheme`, incluindo caso de borda de cor clara sem inverter a rampa)
- [x] Validado visualmente no dev server local: troquei a cor primária pra um vermelho, salvei — sidebar/ícones mudaram na hora, sem reload. Recarreguei a página — cor persistida aplicada no boot também (inclusive os tons mais claros usados nos cards do Cockpit, não só o tom base).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>