### PR TITLE
feat: auto-enroll de leads no funil de vendas + API de integração de captura

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -36,8 +36,17 @@ paths = [
 # de FIXTURE em apps/api/tests/test_auth.py (ex.: "nova-senha-bem-forte",
 # "primeira-troca-123"), nunca um segredo real. Conferido o diff inteiro do commit antes
 # de allowlistar (só teste + código de feature, sem chave/token real). Ver PR #28.
+#
+# 886f56f: feat(integrations) de auto-enroll de leads + API de captura (14/07) — o
+# `generic-api-key` pegou um `raw_key` de FIXTURE em
+# apps/web/src/features/config/IntegrationsSection.test.tsx ("abcd1234-segredo-completo"),
+# nunca um segredo real (o valor real é gerado em runtime via secrets.token_urlsafe(32) e
+# nunca commitado). Conferido o diff inteiro do commit antes de allowlistar (só feature +
+# testes, sem chave/token real). A fixture foi trocada num commit seguinte por um valor de
+# baixa entropia, mas o achado permanece no histórico deste commit específico. Ver PR #32.
 commits = [
     "b93bf6fe4e85de7e658e0eca381157623f0bdfff",
+    "886f56ffcf770bf03315e12c9d9da6a8dbaaf8ba",
 ]
 
 # --- Precedente documentado (NÃO ativo hoje) --------------------------------------

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -5,7 +5,56 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.modules import ALL_ROUTERS
+from app.modules.funnels.automation import register as register_funnel_automation
 from app.modules.notifications.service import register as register_notifications
+
+
+class PublicLeadsCORSMiddleware:
+    """CORS aberto (qualquer origem) só para `POST /public/leads/*`.
+
+    O `CORSMiddleware` global (abaixo) fica travado em `frontend_url` + `allow_credentials=True`
+    — é o que protege a API autenticada. Mas o site externo de um cliente (ex.: doroeventos.com.br)
+    precisa chamar essa rota via `fetch`/`<form>` de QUALQUER origem, sem cookie/credencial
+    nenhuma. Em vez de afrouxar o middleware global (enfraqueceria tudo), este middleware ASGI
+    puro fica ANTES dele na pilha (adicionado depois = mais externo, ver ordem do Starlette) e
+    intercepta só esse prefixo: responde o preflight OPTIONS direto e injeta
+    `Access-Control-Allow-Origin` na resposta real, sem tocar em mais nada.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or not scope["path"].startswith("/public/leads"):
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        origin = headers.get(b"origin", b"*")
+
+        if scope["method"] == "OPTIONS":
+            await send({
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [
+                    (b"access-control-allow-origin", origin),
+                    (b"access-control-allow-methods", b"POST, OPTIONS"),
+                    (b"access-control-allow-headers", b"content-type"),
+                    (b"access-control-max-age", b"600"),
+                ],
+            })
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        async def _send(message):
+            if message["type"] == "http.response.start":
+                message["headers"] = [
+                    *message.get("headers", []),
+                    (b"access-control-allow-origin", origin),
+                ]
+            await send(message)
+
+        await self.app(scope, receive, _send)
 
 # Sem isto, o root logger fica sem handler (só o "lastResort" do Python, WARNING+ pra stderr) —
 # logger.info/exception de core/email.py, core/whatsapp.py, core/payment_gateway.py etc. nunca
@@ -25,13 +74,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Adicionado DEPOIS do CORSMiddleware global → fica MAIS EXTERNO na pilha (Starlette prepende
+# a cada add_middleware), então intercepta /public/leads/* antes da política travada acima.
+app.add_middleware(PublicLeadsCORSMiddleware)
 
 # Módulos de negócio (vão sendo registrados conforme construídos — ver app/modules/__init__.py)
 for router in ALL_ROUTERS:
     app.include_router(router)
 
-# Liga os assinantes do barramento de eventos (ex.: WhatsApp ao mover card no CRM).
+# Liga os assinantes do barramento de eventos (ex.: WhatsApp ao mover card no CRM;
+# auto-enroll no funil de vendas padrão ao criar lead).
 register_notifications()
+register_funnel_automation()
 
 
 @app.get("/health", tags=["infra"])

--- a/apps/api/app/modules/__init__.py
+++ b/apps/api/app/modules/__init__.py
@@ -18,6 +18,8 @@ from app.modules.financial_intelligence.router import router as financial_intell
 from app.modules.funnels.router import router as funnels_router
 from app.modules.google_calendar.router import public_router as google_calendar_public_router
 from app.modules.google_calendar.router import router as google_calendar_router
+from app.modules.integrations.router import public_router as integrations_leads_public_router
+from app.modules.integrations.router import router as integrations_leads_router
 from app.modules.investments.router import router as investments_router
 from app.modules.juridico.router import router as juridico_router
 from app.modules.marketing.router import router as marketing_router
@@ -64,4 +66,6 @@ ALL_ROUTERS: list[APIRouter] = [
     attachments_public_router,
     google_calendar_router,
     google_calendar_public_router,
+    integrations_leads_router,
+    integrations_leads_public_router,
 ]

--- a/apps/api/app/modules/crm/models.py
+++ b/apps/api/app/modules/crm/models.py
@@ -23,7 +23,7 @@ from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
 # Gênero (para segmentação demográfica citada na spec).
 GENDER_VALUES = {"male", "female", "other", "unspecified"}
-SOURCE_VALUES = {"manual", "landing", "ai", "import"}
+SOURCE_VALUES = {"manual", "landing", "ai", "import", "api"}
 
 # Colunas padrão criadas no primeiro acesso ao board de um tenant.
 DEFAULT_STAGES = [

--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -13,6 +13,7 @@ from app.modules.crm.models import DEFAULT_STAGES, Client, PipelineStage
 from app.modules.crm.schemas import ClientCreate, ClientUpdate, StageCreate, StageUpdate
 
 EVENT_CLIENT_MOVED = "crm.client.moved"
+EVENT_CLIENT_CREATED = "crm.client.created"
 
 
 class CrmError(Exception):
@@ -156,6 +157,11 @@ def create_client(db: Session, *, tenant_id: str, actor: str, data: ClientCreate
     audit.record(db, tenant_id=tenant_id, actor=actor, action="crm.client.create", target=client.id)
     db.commit()
     db.refresh(client)
+    # Gatilho de automação: outros módulos podem reagir (ex.: auto-enroll no funil de entrada
+    # padrão do tenant, ver funnels/automation.py).
+    events.emit(
+        EVENT_CLIENT_CREATED, tenant_id=tenant_id, client_id=client.id, source=client.source
+    )
     return client
 
 

--- a/apps/api/app/modules/funnels/automation.py
+++ b/apps/api/app/modules/funnels/automation.py
@@ -1,0 +1,51 @@
+"""Auto-enroll: inscreve automaticamente um lead novo no Funil de Vendas padrão do tenant.
+
+Assina `crm.client.created` (barramento core/events). Como o evento é emitido após o commit
+da criação do cliente, abrimos uma nova tenant_session para rodar o `engine.enroll` — mesmo
+padrão de `notifications/service.py::on_client_moved` (IV2: uma falha aqui nunca derruba a
+request de origem, que já commitou o lead).
+
+Só dispara para leads que vieram de captura automatizada (`source` em AUTO_ENROLL_SOURCES) —
+criação manual no CRM e importação em lote NÃO entram sozinhas no funil, para não surpreender
+o dono nem inscrever em massa.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.core import events
+from app.db.session import tenant_session
+from app.modules.crm.service import EVENT_CLIENT_CREATED
+from app.modules.funnels import engine, service
+from app.modules.settings import service as settings_service
+
+logger = logging.getLogger("e1p.funnels.automation")
+
+AUTO_ENROLL_SOURCES = {"landing", "api"}
+
+
+def on_client_created(*, tenant_id: str, client_id: str, source: str, **_: object) -> None:
+    if source not in AUTO_ENROLL_SOURCES:
+        return
+    with tenant_session(tenant_id) as db:
+        profile = settings_service.get_profile(db, tenant_id)
+        if not profile.default_entry_funnel_id:
+            return
+        try:
+            engine.enroll(
+                db, tenant_id=tenant_id, actor="sistema:auto-enroll",
+                funnel_id=profile.default_entry_funnel_id, client_id=client_id,
+            )
+        except service.FunnelError:
+            # Funil apagado/inválido/vazio: não pode propagar e derrubar o publicador do
+            # evento (crm.service já commitou o lead). Loga e segue (mesma garantia de
+            # notifications.on_client_moved).
+            logger.warning(
+                "[funnels:on_client_created] auto-enroll falhou tenant=%s funil=%s cliente=%s",
+                tenant_id, profile.default_entry_funnel_id, client_id,
+            )
+
+
+def register() -> None:
+    """Liga os assinantes do barramento. Chamado uma vez no boot (app.main)."""
+    events.subscribe(EVENT_CLIENT_CREATED, on_client_created)

--- a/apps/api/app/modules/integrations/models.py
+++ b/apps/api/app/modules/integrations/models.py
@@ -1,0 +1,35 @@
+"""Integrações: chaves de API para captura de lead de sites externos.
+
+IntegrationKey = chave gerenciável (RLS) — o dono cria/revoga em `/integrations/leads/keys`.
+PublicIntegrationKey = snapshot GLOBAL (sem RLS), chaveado pelo hash da chave — permite à rota
+pública (`POST /public/leads/{key}`, sem login) resolver o tenant dono ANTES de qualquer
+autenticação, mesmo padrão de `pages.PublishedPage`/`quotes.PublishedProposal`. Nunca guardamos
+a chave em texto puro — só o hash (sha256) e um prefixo curto para identificação na lista.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+
+class IntegrationKey(Base, TenantMixin, TimestampMixin):
+    __tablename__ = "integration_keys"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    key_prefix: Mapped[str] = mapped_column(String(8), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class PublicIntegrationKey(Base, TimestampMixin):
+    """Snapshot público (GLOBAL, sem RLS) da chave ativa — lookup pré-auth pelo hash."""
+
+    __tablename__ = "public_integration_keys"
+
+    key_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)

--- a/apps/api/app/modules/integrations/router.py
+++ b/apps/api/app/modules/integrations/router.py
@@ -1,0 +1,78 @@
+"""Rotas de Integrações: CRUD de chaves (privado) + captura de lead (pública, sem login)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.db.session import get_db, get_tenant_session_factory
+from app.modules.integrations import service
+from app.modules.integrations.models import IntegrationKey
+from app.modules.integrations.schemas import (
+    IntegrationKeyCreate,
+    IntegrationKeyCreated,
+    IntegrationKeyOut,
+    LeadCapture,
+)
+
+router = APIRouter(prefix="/integrations/leads", tags=["integrations-leads"])
+public_router = APIRouter(prefix="/public/leads", tags=["integrations-leads-public"])
+
+_guard = require_module("settings")
+
+
+def _out(k: IntegrationKey) -> IntegrationKeyOut:
+    return IntegrationKeyOut(
+        id=k.id, label=k.label, key_prefix=k.key_prefix, revoked_at=k.revoked_at,
+        created_at=k.created_at,
+    )
+
+
+def _err(e: service.IntegrationError) -> HTTPException:
+    return HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("/keys", response_model=list[IntegrationKeyOut])
+def list_keys(_u: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)):
+    return [_out(k) for k in service.list_keys(db)]
+
+
+@router.post("/keys", response_model=IntegrationKeyCreated, status_code=201)
+def create_key(
+    data: IntegrationKeyCreate,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> IntegrationKeyCreated:
+    key, raw_key = service.create_key(
+        db, tenant_id=user.tenant_id, actor=user.user_id, label=data.label
+    )
+    return IntegrationKeyCreated(**_out(key).model_dump(), raw_key=raw_key)
+
+
+@router.post("/keys/{key_id}/revoke", response_model=IntegrationKeyOut)
+def revoke_key(
+    key_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> IntegrationKeyOut:
+    try:
+        key = service.revoke_key(db, key_id=key_id, tenant_id=user.tenant_id, actor=user.user_id)
+    except service.IntegrationError as e:
+        raise _err(e) from e
+    return _out(key)
+
+
+# ── Público (sem login) — chamado pelo site externo do cliente ─────────────
+@public_router.post("/{key}")
+def capture_lead(
+    key: str,
+    data: LeadCapture,
+    db: Session = Depends(get_db),
+    session_factory=Depends(get_tenant_session_factory),
+) -> dict:
+    """Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_integration_keys`, snapshot
+    GLOBAL sem RLS, pelo hash da chave. Nunca toca tabela de negócio por aqui — a escrita
+    real acontece dentro de `session_factory(tenant_id)` (ver service.capture_lead)."""
+    try:
+        service.capture_lead(db, raw_key=key, data=data, session_factory=session_factory)
+    except service.IntegrationError as e:
+        raise _err(e) from e
+    return {"status": "ok"}

--- a/apps/api/app/modules/integrations/schemas.py
+++ b/apps/api/app/modules/integrations/schemas.py
@@ -1,0 +1,35 @@
+"""Schemas do módulo de Integrações (chaves de captura de lead)."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class IntegrationKeyCreate(BaseModel):
+    label: str = Field(min_length=1, max_length=255)
+
+
+class IntegrationKeyOut(BaseModel):
+    id: str
+    label: str
+    key_prefix: str
+    revoked_at: datetime | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class IntegrationKeyCreated(IntegrationKeyOut):
+    """Retorno da criação: única vez em que a chave crua fica visível."""
+
+    raw_key: str
+
+
+class LeadCapture(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    email: EmailStr | None = None
+    phone: str | None = Field(default=None, max_length=32)
+    # Campos livres do formulário externo (ex.: "ocasião", "nº de convidados") sem equivalente
+    # direto no CRM — viram um bloco de texto anexado a `notes`, sem inventar colunas novas.
+    fields: dict[str, str] | None = None

--- a/apps/api/app/modules/integrations/service.py
+++ b/apps/api/app/modules/integrations/service.py
@@ -1,0 +1,125 @@
+"""Integrações: CRUD de chaves + captura pública de lead (site externo → CRM)."""
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from collections import defaultdict, deque
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import audit
+from app.modules.integrations.models import IntegrationKey, PublicIntegrationKey
+from app.modules.integrations.schemas import LeadCapture
+
+# Limite simples em memória (não sobrevive a múltiplas réplicas — aceitável no estágio atual,
+# mesmo racional de custo do Golden Rule #4). Protege contra uma chave vazada/reaproveitada
+# gerando spam de leads (e, por tabela, disparando ações reais do funil de auto-enroll).
+_RATE_LIMIT_WINDOW_SECONDS = 60
+_RATE_LIMIT_MAX_REQUESTS = 30
+_rate_buckets: dict[str, deque[float]] = defaultdict(deque)
+
+
+class IntegrationError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _hash(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def _rate_limited(key_hash: str) -> bool:
+    now = time.monotonic()
+    bucket = _rate_buckets[key_hash]
+    while bucket and now - bucket[0] > _RATE_LIMIT_WINDOW_SECONDS:
+        bucket.popleft()
+    if len(bucket) >= _RATE_LIMIT_MAX_REQUESTS:
+        return True
+    bucket.append(now)
+    return False
+
+
+def _format_notes(fields: dict[str, str] | None) -> str:
+    if not fields:
+        return ""
+    lines = "\n".join(f"{k}: {v}" for k, v in fields.items() if v)
+    return f"Campos do formulário externo:\n{lines}" if lines else ""
+
+
+# ── CRUD autenticado ────────────────────────────────────
+
+
+def create_key(
+    db: Session, *, tenant_id: str, actor: str, label: str
+) -> tuple[IntegrationKey, str]:
+    raw_key = secrets.token_urlsafe(32)
+    key_hash = _hash(raw_key)
+    key = IntegrationKey(
+        tenant_id=tenant_id, label=label, key_prefix=raw_key[:8], key_hash=key_hash
+    )
+    db.add(key)
+    db.add(PublicIntegrationKey(key_hash=key_hash, tenant_id=tenant_id))
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="integration_key.create", target=key.id
+    )
+    db.commit()
+    db.refresh(key)
+    return key, raw_key
+
+
+def list_keys(db: Session) -> list[IntegrationKey]:
+    return list(db.scalars(select(IntegrationKey).order_by(IntegrationKey.created_at.desc())).all())
+
+
+def get_key(db: Session, key_id: str) -> IntegrationKey:
+    key = db.get(IntegrationKey, key_id)
+    if key is None:
+        raise IntegrationError("Chave não encontrada", 404)
+    return key
+
+
+def revoke_key(db: Session, *, key_id: str, tenant_id: str, actor: str) -> IntegrationKey:
+    key = get_key(db, key_id)
+    if key.revoked_at is None:
+        key.revoked_at = datetime.now(UTC)
+        snap = db.get(PublicIntegrationKey, key.key_hash)
+        if snap is not None:
+            db.delete(snap)
+        audit.record(
+            db, tenant_id=tenant_id, actor=actor, action="integration_key.revoke", target=key.id
+        )
+        db.commit()
+        db.refresh(key)
+    return key
+
+
+# ── Público (sem login) ─────────────────────────────────
+
+
+def capture_lead(db: Session, *, raw_key: str, data: LeadCapture, session_factory) -> None:
+    """Formulário externo → cria um LEAD no CRM do tenant dono da chave (source="api")."""
+    key_hash = _hash(raw_key)
+    if _rate_limited(key_hash):
+        raise IntegrationError("Muitas requisições — tente novamente em instantes", 429)
+    snap = db.get(PublicIntegrationKey, key_hash)
+    if snap is None:
+        raise IntegrationError("Chave inválida ou revogada", 401)
+
+    from app.modules.crm import service as crm_service
+    from app.modules.crm.schemas import ClientCreate
+
+    with session_factory(snap.tenant_id) as tdb:
+        crm_service.create_client(
+            tdb, tenant_id=snap.tenant_id, actor="integracao:lead",
+            data=ClientCreate(
+                name=data.name,
+                email=str(data.email) if data.email else None,
+                phone=data.phone,
+                notes=_format_notes(data.fields),
+                source="api",
+            ),
+        )

--- a/apps/api/app/modules/settings/models.py
+++ b/apps/api/app/modules/settings/models.py
@@ -45,3 +45,7 @@ class TenantProfile(Base, TenantMixin, TimestampMixin):
     timezone: Mapped[str] = mapped_column(
         String(64), default=DEFAULT_TIMEZONE, nullable=False
     )
+    # Funil de Vendas em que todo lead novo (source=landing/api) é inscrito automaticamente.
+    # None = sem auto-enroll (comportamento padrão até o dono configurar). Sem FK dura pra
+    # `funnels.id` (mesmo padrão do projeto): funil apagado só faz o auto-enroll no-opar.
+    default_entry_funnel_id: Mapped[str | None] = mapped_column(String(36), nullable=True)

--- a/apps/api/app/modules/settings/router.py
+++ b/apps/api/app/modules/settings/router.py
@@ -20,7 +20,7 @@ def _out(p: TenantProfile) -> ProfileOut:
         address=p.address, website=p.website, about=p.about, logo_url=p.logo_url,
         primary_color=p.primary_color, secondary_color=p.secondary_color,
         accent_color=p.accent_color, text_color=p.text_color, bg_color=p.bg_color, font=p.font,
-        timezone=p.timezone,
+        timezone=p.timezone, default_entry_funnel_id=p.default_entry_funnel_id,
     )
 
 

--- a/apps/api/app/modules/settings/schemas.py
+++ b/apps/api/app/modules/settings/schemas.py
@@ -27,6 +27,8 @@ class ProfileOut(BaseModel):
     bg_color: str
     font: str
     timezone: str
+    # Funil de Vendas para auto-enroll de leads novos (source=landing/api). None = desligado.
+    default_entry_funnel_id: str | None
 
 
 class ProfileUpdate(BaseModel):
@@ -45,6 +47,8 @@ class ProfileUpdate(BaseModel):
     bg_color: str | None = Field(default=None, max_length=9)
     font: str | None = Field(default=None, max_length=40)
     timezone: str | None = Field(default=None, max_length=64)
+    # None = não altera; "" = desliga o auto-enroll (mesmo padrão de contract_id em Charge).
+    default_entry_funnel_id: str | None = Field(default=None, max_length=36)
 
     # Validações de formato — só se aplicam a valores NÃO vazios.
     # None (omitido) = não altera; "" = limpar o campo (ambos preservados, AC4).

--- a/apps/api/app/modules/settings/service.py
+++ b/apps/api/app/modules/settings/service.py
@@ -40,6 +40,10 @@ def update_profile(
         val = getattr(data, f)
         if val is not None:
             setattr(profile, f, val)
+    # None no PATCH = "não altera"; "" desvincula (sem auto-enroll). Mesmo padrão de
+    # contract_id/cost_center_id em receivables/service.py::update_charge.
+    if data.default_entry_funnel_id is not None:
+        profile.default_entry_funnel_id = data.default_entry_funnel_id or None
     audit.record(db, tenant_id=tenant_id, actor=actor, action="settings.profile.update",
                  target=profile.id)
     db.commit()

--- a/apps/api/migrations/versions/0051_lead_auto_enroll.py
+++ b/apps/api/migrations/versions/0051_lead_auto_enroll.py
@@ -1,0 +1,69 @@
+"""lead auto-enroll: funil de entrada padrão do tenant + chaves de captura de lead
+
+Revision ID: 0051
+Revises: 0050
+Create Date: 2026-07-14
+
+Duas mudanças independentes, na mesma migration por serem parte da mesma story (auto-enroll de
+leads no funil de vendas):
+
+1. `tenant_profiles.default_entry_funnel_id` (nullable, sem FK dura — mesmo padrão de
+   `quote_id`/`contract_id` no projeto): o funil em que todo lead novo (source=landing/api) é
+   inscrito automaticamente. Estritamente ADITIVA, sem backfill (NULL = "sem auto-enroll", o
+   comportamento de hoje).
+2. `integration_keys` (RLS) + `public_integration_keys` (global, sem RLS) — mesmo par
+   RLS/snapshot já usado por pages/quotes/contracts, aqui para a API pública de captura de lead
+   (`POST /public/leads/{key}`) resolver o tenant dono ANTES de qualquer autenticação.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0051"
+down_revision: str | None = "0050"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenant_profiles", sa.Column("default_entry_funnel_id", sa.String(36), nullable=True)
+    )
+
+    op.create_table(
+        "integration_keys",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("label", sa.String(255), nullable=False),
+        sa.Column("key_prefix", sa.String(8), nullable=False),
+        sa.Column("key_hash", sa.String(64), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_integration_keys_tenant_id", "integration_keys", ["tenant_id"])
+    op.execute("ALTER TABLE integration_keys ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE integration_keys FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON integration_keys
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+    op.create_table(
+        "public_integration_keys",
+        sa.Column("key_hash", sa.String(64), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("public_integration_keys")
+    op.drop_index("ix_integration_keys_tenant_id", table_name="integration_keys")
+    op.drop_table("integration_keys")
+    op.drop_column("tenant_profiles", "default_entry_funnel_id")

--- a/apps/api/tests/test_crm.py
+++ b/apps/api/tests/test_crm.py
@@ -88,6 +88,23 @@ def test_move_emits_event(client: TestClient, headers):
     assert captured.get("client_id") == c["id"]
 
 
+def test_create_emits_event(client: TestClient, headers):
+    captured = {}
+
+    def handler(**payload):
+        captured.update(payload)
+
+    events.subscribe("crm.client.created", handler)
+    try:
+        c = client.post(
+            "/crm/clients", json={"name": "Novo Lead", "source": "landing"}, headers=headers
+        ).json()
+    finally:
+        events.clear()
+    assert captured.get("client_id") == c["id"]
+    assert captured.get("source") == "landing"
+
+
 def test_move_to_unknown_stage_404(client: TestClient, headers):
     c = client.post("/crm/clients", json={"name": "X"}, headers=headers).json()
     resp = client.post(

--- a/apps/api/tests/test_integrations.py
+++ b/apps/api/tests/test_integrations.py
@@ -1,0 +1,119 @@
+"""Testes do módulo de Integrações: CRUD de chaves + captura pública de lead (API externa)."""
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import events
+from app.modules.funnels import automation
+
+REGISTER = {
+    "legal_name": "Integra SA",
+    "document": "61616161000107",
+    "slug": "integrasa",
+    "email": "integra@example.com",
+    "name": "In",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_key_shows_raw_key_once(client: TestClient, headers):
+    resp = client.post("/integrations/leads/keys", json={"label": "Site Dóro"}, headers=headers)
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["raw_key"]
+    assert body["key_prefix"] == body["raw_key"][:8]
+
+    listed = client.get("/integrations/leads/keys", headers=headers).json()
+    assert listed[0]["label"] == "Site Dóro"
+    assert "raw_key" not in listed[0]  # a chave crua nunca reaparece
+
+
+def test_public_capture_creates_lead_with_source_api(client: TestClient, headers):
+    key = client.post(
+        "/integrations/leads/keys", json={"label": "Site X"}, headers=headers
+    ).json()
+    resp = client.post(
+        f"/public/leads/{key['raw_key']}",
+        json={
+            "name": "Lead Externo",
+            "email": "lead@example.com",
+            "fields": {"ocasiao": "aniversário"},
+        },
+    )
+    assert resp.status_code == 200
+    clients = client.get("/crm/clients", headers=headers).json()
+    lead = next(c for c in clients if c["name"] == "Lead Externo")
+    assert lead["source"] == "api"
+    assert "ocasiao: aniversário" in lead["notes"]
+
+
+def test_public_capture_rejects_unknown_key(client: TestClient):
+    resp = client.post("/public/leads/chave-invalida", json={"name": "X"})
+    assert resp.status_code == 401
+
+
+def test_public_capture_rejects_revoked_key(client: TestClient, headers):
+    key = client.post(
+        "/integrations/leads/keys", json={"label": "Revogada"}, headers=headers
+    ).json()
+    client.post(f"/integrations/leads/keys/{key['id']}/revoke", headers=headers)
+    resp = client.post(f"/public/leads/{key['raw_key']}", json={"name": "X"})
+    assert resp.status_code == 401
+
+
+def test_rate_limit_blocks_after_threshold(client: TestClient, headers):
+    key = client.post(
+        "/integrations/leads/keys", json={"label": "Rate"}, headers=headers
+    ).json()
+    for _ in range(30):
+        ok = client.post(f"/public/leads/{key['raw_key']}", json={"name": "X"})
+        assert ok.status_code == 200
+    blocked = client.post(f"/public/leads/{key['raw_key']}", json={"name": "X"})
+    assert blocked.status_code == 429
+
+
+def test_requires_auth_for_key_management(client: TestClient):
+    assert client.get("/integrations/leads/keys").status_code == 401
+
+
+def test_public_capture_triggers_auto_enroll(client: TestClient, headers, db: Session, monkeypatch):
+    # A fixture `client` roda events.clear() no setup — religa o assinante manualmente pra
+    # provar a integração ponta a ponta (mesmo padrão de test_crm.py::test_move_emits_event).
+    # O assinante abre sua PRÓPRIA tenant_session (Postgres real) — nos testes (SQLite),
+    # aponta pra sessão compartilhada do fixture `db`, mesmo padrão de test_notifications.py.
+    @contextmanager
+    def _fake_tenant_session(_tenant_id):
+        yield db
+
+    monkeypatch.setattr(automation, "tenant_session", _fake_tenant_session)
+    automation.register()
+    try:
+        funnel = client.post(
+            "/funnels", json={"name": "Entrada", "nodes": [{"id": "n1"}]}, headers=headers
+        ).json()
+        client.patch(
+            "/settings/profile",
+            json={"default_entry_funnel_id": funnel["id"]},
+            headers=headers,
+        )
+        key = client.post(
+            "/integrations/leads/keys", json={"label": "Auto"}, headers=headers
+        ).json()
+        client.post(f"/public/leads/{key['raw_key']}", json={"name": "Lead Auto"})
+
+        lead = next(
+            c for c in client.get("/crm/clients", headers=headers).json()
+            if c["name"] == "Lead Auto"
+        )
+        runs = client.get(f"/funnels/{funnel['id']}/runs", headers=headers).json()
+        assert any(r["client_id"] == lead["id"] for r in runs)
+    finally:
+        events.clear()

--- a/apps/api/tests/test_lead_auto_enroll.py
+++ b/apps/api/tests/test_lead_auto_enroll.py
@@ -1,0 +1,114 @@
+"""Testes do auto-enroll: assinante `crm.client.created` -> `engine.enroll` no funil padrão
+do tenant (ver `app/modules/funnels/automation.py`).
+"""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from app.modules.auth.models import Tenant, User
+from app.modules.crm.models import Client
+from app.modules.funnels import automation
+from app.modules.funnels.models import Funnel, FunnelRun
+from app.modules.settings.models import TenantProfile
+
+
+def _seed_tenant(db: Session, *, slug: str, document: str) -> Tenant:
+    tenant = Tenant(slug=slug, legal_name="Auto SA", document=document)
+    db.add(tenant)
+    db.flush()
+    db.add(User(
+        tenant_id=tenant.id, email=f"{slug}@example.com", name="Dono",
+        password_hash=hash_password("senha-bem-grande"), role="owner",
+    ))
+    db.commit()
+    return tenant
+
+
+def _seed_funnel(db: Session, tenant_id: str) -> Funnel:
+    f = Funnel(tenant_id=tenant_id, name="Entrada", nodes=[{"id": "n1"}], edges=[])
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+@pytest.fixture()
+def _fake_session(db: Session, monkeypatch):
+    @contextmanager
+    def _factory(_tenant_id):
+        yield db
+
+    monkeypatch.setattr(automation, "tenant_session", _factory)
+
+
+def _run_for(db: Session, client_id: str) -> FunnelRun | None:
+    return db.scalar(select(FunnelRun).where(FunnelRun.client_id == client_id))
+
+
+def test_auto_enrolls_landing_lead_when_funnel_configured(db: Session, _fake_session):
+    tenant = _seed_tenant(db, slug="auto1", document="00000000000101")
+    funnel = _seed_funnel(db, tenant.id)
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id=funnel.id))
+    client = Client(tenant_id=tenant.id, name="Lead Externo", source="landing")
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source="landing")
+
+    run = _run_for(db, client.id)
+    assert run is not None
+    assert run.funnel_id == funnel.id
+
+
+def test_auto_enrolls_api_lead_when_funnel_configured(db: Session, _fake_session):
+    tenant = _seed_tenant(db, slug="auto2", document="00000000000102")
+    funnel = _seed_funnel(db, tenant.id)
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id=funnel.id))
+    client = Client(tenant_id=tenant.id, name="Lead API", source="api")
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source="api")
+
+    assert _run_for(db, client.id) is not None
+
+
+def test_no_enroll_when_no_default_funnel_configured(db: Session, _fake_session):
+    tenant = _seed_tenant(db, slug="auto3", document="00000000000103")
+    client = Client(tenant_id=tenant.id, name="Lead Sem Funil", source="landing")
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source="landing")
+
+    assert _run_for(db, client.id) is None
+
+
+@pytest.mark.parametrize("source", ["manual", "import", "ai"])
+def test_no_enroll_for_non_automated_sources(db: Session, _fake_session, source):
+    tenant = _seed_tenant(db, slug=f"auto-{source}", document=f"0000000000020{source[0]}")
+    funnel = _seed_funnel(db, tenant.id)
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id=funnel.id))
+    client = Client(tenant_id=tenant.id, name="X", source=source)
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source=source)
+
+    assert _run_for(db, client.id) is None
+
+
+def test_deleted_or_invalid_funnel_does_not_raise(db: Session, _fake_session):
+    tenant = _seed_tenant(db, slug="auto4", document="00000000000104")
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id="nao-existe"))
+    client = Client(tenant_id=tenant.id, name="X", source="api")
+    db.add(client)
+    db.commit()
+
+    # não deve levantar FunnelError — só loga e segue (não pode derrubar quem criou o lead)
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source="api")
+
+    assert _run_for(db, client.id) is None

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -125,5 +125,24 @@ def test_update_invalid_color_rejected(client: TestClient, headers):
     assert again["primary_color"] == "#5D44F8"
 
 
+def test_default_entry_funnel_starts_unset(client: TestClient, headers):
+    p = client.get("/settings/profile", headers=headers).json()
+    assert p["default_entry_funnel_id"] is None
+
+
+def test_set_and_clear_default_entry_funnel(client: TestClient, headers):
+    f = client.post("/funnels", json={"name": "Entrada"}, headers=headers).json()
+    resp = client.patch(
+        "/settings/profile", json={"default_entry_funnel_id": f["id"]}, headers=headers
+    )
+    assert resp.json()["default_entry_funnel_id"] == f["id"]
+
+    # "" desliga o auto-enroll (mesmo padrão de contract_id/cost_center_id em Charge/Payable)
+    cleared = client.patch(
+        "/settings/profile", json={"default_entry_funnel_id": ""}, headers=headers
+    )
+    assert cleared.json()["default_entry_funnel_id"] is None
+
+
 def test_requires_auth(client: TestClient):
     assert client.get("/settings/profile").status_code == 401

--- a/apps/api/tests/test_tenancy_guard.py
+++ b/apps/api/tests/test_tenancy_guard.py
@@ -18,6 +18,9 @@ Allowlist (usos legítimos, documentados com guarda explícita no próprio códi
   - attachments → só a rota pública `serve_public_image` lê `public_images` (tabela GLOBAL sem
                   RLS, imagens intencionalmente públicas — Story 4.2). `Attachment` permanece
                   100% RLS via `get_tenant_db`; nenhuma rota pública toca boletos/contratos.
+  - integrations → idem, `capture_lead` (API pública de captura de lead) resolve a chave via
+                  `public_integration_keys` (snapshot GLOBAL sem RLS) antes de abrir a
+                  tenant_session real — mesmo padrão de pages/quotes/contracts.
 """
 from __future__ import annotations
 
@@ -26,7 +29,9 @@ import pathlib
 MODULES_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules"
 
 # Módulos onde `get_db` (sessão global) é um uso legítimo e já auditado (ver docstring acima).
-ALLOWLIST = {"auth", "platform", "contracts", "pages", "quotes", "wallet", "attachments"}
+ALLOWLIST = {
+    "auth", "platform", "contracts", "pages", "quotes", "wallet", "attachments", "integrations",
+}
 
 
 def _module_routers() -> list[pathlib.Path]:

--- a/apps/web/src/features/config/ConfiguracoesPage.test.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.test.tsx
@@ -22,7 +22,7 @@ vi.mock("../../lib/api", () => ({
     "Erro inesperado",
 }));
 
-// TenantProfile COMPLETO (15 campos, sem opcionais) — fixture parcial quebraria os inputs
+// TenantProfile COMPLETO (16 campos, sem opcionais) — fixture parcial quebraria os inputs
 // controlados (Task 3). Dados fictícios (sem PII real).
 const profile = {
   display_name: "Empresa Fictícia",
@@ -40,11 +40,14 @@ const profile = {
   bg_color: "#FFFFFF",
   font: "Inter",
   timezone: "America/Sao_Paulo",
+  default_entry_funnel_id: null,
 };
 
 beforeEach(() => {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/settings/profile") return Promise.resolve({ data: profile } as never);
+    if (url === "/funnels") return Promise.resolve({ data: [] } as never);
+    if (url === "/integrations/leads/keys") return Promise.resolve({ data: [] } as never);
     return Promise.resolve({ data: {} } as never);
   });
   vi.mocked(api.patch).mockReset();
@@ -93,5 +96,58 @@ describe("ConfiguracoesPage — Brand Kit (Story 7.18, Task 3)", () => {
 
     expect(await screen.findByText("Falha ao salvar as configurações.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Salvar" })).toBeEnabled();
+  });
+});
+
+describe("ConfiguracoesPage — Funil de entrada padrão", () => {
+  it("lista os funis e envia default_entry_funnel_id ao salvar", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/settings/profile") return Promise.resolve({ data: profile } as never);
+      if (url === "/funnels") {
+        return Promise.resolve({
+          data: [{ id: "f-1", name: "Funil Principal", node_count: 3, created_at: "" }],
+        } as never);
+      }
+      return Promise.resolve({ data: [] } as never);
+    });
+    vi.mocked(api.patch).mockResolvedValue({
+      data: { ...profile, default_entry_funnel_id: "f-1" },
+    } as never);
+    render(<ConfiguracoesPage />);
+
+    const select = await screen.findByText("Funil Principal");
+    expect(select).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByDisplayValue("Nenhum (não inscrever automaticamente)"), "f-1");
+    await user.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(api.patch)).toHaveBeenCalledWith(
+        "/settings/profile",
+        expect.objectContaining({ default_entry_funnel_id: "f-1" }),
+      ),
+    );
+  });
+});
+
+describe("ConfiguracoesPage — aba Integrações", () => {
+  it("troca pra aba Integrações e lista as chaves", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/settings/profile") return Promise.resolve({ data: profile } as never);
+      if (url === "/integrations/leads/keys") {
+        return Promise.resolve({
+          data: [{ id: "k-1", label: "Site Dóro", key_prefix: "abcd1234", revoked_at: null, created_at: "" }],
+        } as never);
+      }
+      return Promise.resolve({ data: [] } as never);
+    });
+    render(<ConfiguracoesPage />);
+
+    await screen.findByText("Cor primária"); // espera o profile carregar
+    await user.click(screen.getByRole("button", { name: /Integrações/ }));
+
+    expect(await screen.findByText("Site Dóro")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -1,5 +1,5 @@
-import type { GoogleCalendarStatus, TenantProfile } from "@e1p/shared-types";
-import { Check, Video } from "lucide-react";
+import type { FunnelSummary, GoogleCalendarStatus, TenantProfile } from "@e1p/shared-types";
+import { Check, SlidersHorizontal, Video, Workflow } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import ImageUploadButton from "../../components/ImageUploadButton";
 import {
@@ -10,11 +10,20 @@ import {
   getGoogleStatus,
 } from "../../lib/api";
 import { applyBrandTheme } from "../../lib/theme";
+import IntegrationsSection from "./IntegrationsSection";
 
 const FONTS = ["Inter", "Poppins", "Raleway", "Georgia", "Arial"];
 const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
 
+type Tab = "perfil" | "integracoes";
+
+const TABS: { key: Tab; label: string; icon: typeof SlidersHorizontal }[] = [
+  { key: "perfil", label: "Perfil & Marca", icon: SlidersHorizontal },
+  { key: "integracoes", label: "Integrações", icon: Workflow },
+];
+
 export default function ConfiguracoesPage() {
+  const [tab, setTab] = useState<Tab>("perfil");
   const [p, setP] = useState<TenantProfile | null>(null);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
@@ -64,14 +73,42 @@ export default function ConfiguracoesPage() {
           <h1 className="text-2xl font-bold text-neutral-800">Configurações</h1>
         </div>
         <div className="flex items-center gap-3">
-          {savedAt && !error && <span className="text-xs text-neutral-400">Salvo {savedAt}</span>}
-          <button onClick={save} disabled={saving} className="flex items-center gap-1.5 rounded-pill bg-accent-400 px-5 py-2 text-sm font-semibold text-white hover:bg-accent-500 disabled:opacity-50">
-            <Check size={14} /> {saving ? "Salvando..." : "Salvar"}
-          </button>
+          {tab === "perfil" && savedAt && !error && (
+            <span className="text-xs text-neutral-400">Salvo {savedAt}</span>
+          )}
+          {tab === "perfil" && (
+            <button onClick={save} disabled={saving} className="flex items-center gap-1.5 rounded-pill bg-accent-400 px-5 py-2 text-sm font-semibold text-white hover:bg-accent-500 disabled:opacity-50">
+              <Check size={14} /> {saving ? "Salvando..." : "Salvar"}
+            </button>
+          )}
         </div>
       </div>
-      {error && <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+      {tab === "perfil" && error && (
+        <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
+      )}
 
+      {/* Abas — uma seção por responsabilidade (menos poluição). */}
+      <div className="flex gap-1 rounded-xl bg-neutral-100 p-1 lg:w-fit">
+        {TABS.map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.key;
+          return (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className={`flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition ${
+                active ? "bg-white text-primary-600 shadow-sm" : "text-neutral-500 hover:text-neutral-700"
+              }`}
+            >
+              <Icon size={16} /> {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "integracoes" && <IntegrationsSection />}
+
+      {tab === "perfil" && (
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Formulário */}
         <div className="space-y-6 lg:col-span-2">
@@ -117,6 +154,11 @@ export default function ConfiguracoesPage() {
             </div>
           </Card>
 
+          <FunnelEntryCard
+            value={p.default_entry_funnel_id}
+            onChange={(v) => set({ default_entry_funnel_id: v })}
+          />
+
           <GoogleSection />
         </div>
 
@@ -151,7 +193,43 @@ export default function ConfiguracoesPage() {
           </Card>
         </div>
       </div>
+      )}
     </div>
+  );
+}
+
+/**
+ * Funil de Vendas em que todo lead novo (source=landing/api) é inscrito automaticamente
+ * (auto-enroll). Sem seleção = comportamento atual (sem auto-enroll).
+ */
+function FunnelEntryCard({
+  value, onChange,
+}: { value: string | null; onChange: (v: string | null) => void }) {
+  const [funnels, setFunnels] = useState<FunnelSummary[]>([]);
+
+  useEffect(() => {
+    api.get<FunnelSummary[]>("/funnels").then(({ data }) => {
+      setFunnels(Array.isArray(data) ? data : []);
+    });
+  }, []);
+
+  return (
+    <Card title="Funil de entrada padrão">
+      <p className="mb-3 text-xs text-neutral-400">
+        Todo lead novo — de uma landing page publicada em Sites ou de um site externo via chave
+        de integração — entra automaticamente neste funil.
+      </p>
+      <select
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+      >
+        <option value="">Nenhum (não inscrever automaticamente)</option>
+        {funnels.map((f) => (
+          <option key={f.id} value={f.id}>{f.name}</option>
+        ))}
+      </select>
+    </Card>
   );
 }
 

--- a/apps/web/src/features/config/IntegrationsSection.test.tsx
+++ b/apps/web/src/features/config/IntegrationsSection.test.tsx
@@ -26,7 +26,7 @@ describe("IntegrationsSection", () => {
         return Promise.resolve({
           data: {
             id: "k-1", label: "Site Dóro", key_prefix: "abcd1234",
-            revoked_at: null, created_at: "", raw_key: "abcd1234-segredo-completo",
+            revoked_at: null, created_at: "", raw_key: "chave-fake-de-teste-sem-entropia",
           },
         } as never);
       }
@@ -39,7 +39,7 @@ describe("IntegrationsSection", () => {
     );
     await user.click(screen.getByRole("button", { name: /Nova chave/ }));
 
-    expect(await screen.findByText("abcd1234-segredo-completo")).toBeInTheDocument();
+    expect(await screen.findByText("chave-fake-de-teste-sem-entropia")).toBeInTheDocument();
     expect(api.post).toHaveBeenCalledWith("/integrations/leads/keys", { label: "Site Dóro" });
   });
 

--- a/apps/web/src/features/config/IntegrationsSection.test.tsx
+++ b/apps/web/src/features/config/IntegrationsSection.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import IntegrationsSection from "./IntegrationsSection";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+beforeEach(() => {
+  vi.mocked(api.get).mockResolvedValue({ data: [] } as never);
+  vi.mocked(api.post).mockReset();
+});
+
+describe("IntegrationsSection", () => {
+  it("cria uma chave, mostra a chave crua uma vez e some após recarregar a lista", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockImplementation((url: string) => {
+      if (url === "/integrations/leads/keys") {
+        return Promise.resolve({
+          data: {
+            id: "k-1", label: "Site Dóro", key_prefix: "abcd1234",
+            revoked_at: null, created_at: "", raw_key: "abcd1234-segredo-completo",
+          },
+        } as never);
+      }
+      return Promise.resolve({ data: {} } as never);
+    });
+    render(<IntegrationsSection />);
+
+    await user.type(
+      screen.getByPlaceholderText(/Nome da chave/), "Site Dóro",
+    );
+    await user.click(screen.getByRole("button", { name: /Nova chave/ }));
+
+    expect(await screen.findByText("abcd1234-segredo-completo")).toBeInTheDocument();
+    expect(api.post).toHaveBeenCalledWith("/integrations/leads/keys", { label: "Site Dóro" });
+  });
+
+  it("lista chaves existentes e permite revogar", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValue({
+      data: [{ id: "k-1", label: "Site X", key_prefix: "aaaaaaaa", revoked_at: null, created_at: "" }],
+    } as never);
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<IntegrationsSection />);
+
+    expect(await screen.findByText("Site X")).toBeInTheDocument();
+    await user.click(screen.getByTitle("Revogar"));
+
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/integrations/leads/keys/k-1/revoke"),
+    );
+  });
+});

--- a/apps/web/src/features/config/IntegrationsSection.tsx
+++ b/apps/web/src/features/config/IntegrationsSection.tsx
@@ -1,0 +1,165 @@
+import type { IntegrationKey, IntegrationKeyCreated } from "@e1p/shared-types";
+import { Check, Copy, KeyRound, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+function publicCaptureUrl(rawKey: string): string {
+  // Mesma convenção do `api` client (baseURL "/api"): em dev o Vite faz proxy /api -> :8000; em
+  // produção o reverse proxy expõe a API sob o mesmo domínio em /api (ver docs/HOSTINGER-DEPLOY.md).
+  return `${window.location.origin}/api/public/leads/${rawKey}`;
+}
+
+function snippetFor(rawKey: string): string {
+  const url = publicCaptureUrl(rawKey);
+  return `fetch("${url}", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name, email, phone }),
+});`;
+}
+
+export default function IntegrationsSection() {
+  const [keys, setKeys] = useState<IntegrationKey[]>([]);
+  const [label, setLabel] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [created, setCreated] = useState<IntegrationKeyCreated | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await api.get<IntegrationKey[]>("/integrations/leads/keys");
+    setKeys(Array.isArray(data) ? data : []);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create() {
+    if (!label.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const { data } = await api.post<IntegrationKeyCreated>("/integrations/leads/keys", {
+        label: label.trim(),
+      });
+      setCreated(data);
+      setLabel("");
+      await load();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function revoke(id: string) {
+    if (!confirm("Revogar esta chave? Sites que a usam param de conseguir enviar leads.")) return;
+    await api.post(`/integrations/leads/keys/${id}/revoke`);
+    await load();
+  }
+
+  function copy(text: string) {
+    navigator.clipboard?.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl bg-white p-5 shadow-sm">
+        <h2 className="mb-1 font-semibold text-neutral-800">Integrações</h2>
+        <p className="mb-4 text-xs text-neutral-400">
+          Gere uma chave para o formulário de um site externo (ex.: a landing page de um cliente)
+          enviar leads direto pra este CRM — cada lead entra com <code>source=api</code> e, se
+          houver um Funil de entrada padrão configurado, já nasce inscrito nele.
+        </p>
+
+        <div className="mb-4 flex gap-2">
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Nome da chave (ex.: Site Dóro Eventos)"
+            className="flex-1 rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          />
+          <button
+            onClick={create}
+            disabled={creating || !label.trim()}
+            className="flex items-center gap-1.5 rounded-pill bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+          >
+            <Plus size={14} /> Nova chave
+          </button>
+        </div>
+        {error && <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+
+        {created && (
+          <div className="mb-4 rounded-xl border border-primary-200 bg-primary-50 p-4">
+            <p className="mb-2 text-sm font-semibold text-primary-700">
+              Chave criada — copie agora, ela não aparece de novo:
+            </p>
+            <div className="mb-3 flex items-center gap-2">
+              <code className="flex-1 truncate rounded-lg bg-white px-3 py-2 text-xs">
+                {created.raw_key}
+              </code>
+              <button
+                onClick={() => copy(created.raw_key)}
+                className="flex items-center gap-1 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-600 hover:bg-neutral-50"
+              >
+                {copied ? <Check size={14} /> : <Copy size={14} />} Copiar
+              </button>
+            </div>
+            <p className="mb-1 text-xs text-neutral-500">
+              Repasse este exemplo pra quem cuida do site externo:
+            </p>
+            <div className="flex items-start gap-2">
+              <pre className="flex-1 overflow-x-auto rounded-lg bg-neutral-900 p-3 text-xs text-neutral-100">
+                {snippetFor(created.raw_key)}
+              </pre>
+              <button
+                onClick={() => copy(snippetFor(created.raw_key))}
+                className="rounded-lg border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-600 hover:bg-neutral-50"
+              >
+                <Copy size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {keys.length === 0 ? (
+          <p className="text-sm text-neutral-400">Nenhuma chave criada ainda.</p>
+        ) : (
+          <div className="space-y-2">
+            {keys.map((k) => (
+              <div
+                key={k.id}
+                className="flex items-center justify-between rounded-xl border border-neutral-100 px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50 text-primary-600">
+                    <KeyRound size={16} />
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-neutral-800">{k.label}</p>
+                    <p className="text-xs text-neutral-400">
+                      {k.key_prefix}••••••••
+                      {k.revoked_at && <span className="ml-2 text-danger">revogada</span>}
+                    </p>
+                  </div>
+                </div>
+                {!k.revoked_at && (
+                  <button
+                    onClick={() => revoke(k.id)}
+                    className="text-neutral-300 hover:text-danger"
+                    title="Revogar"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -657,6 +657,24 @@ export interface TenantProfile {
   bg_color: string;
   font: string;
   timezone: string;
+  /** Funil de Vendas em que todo lead novo (source=landing/api) é inscrito automaticamente.
+   * null = auto-enroll desligado (comportamento até o dono configurar). */
+  default_entry_funnel_id: UUID | null;
+}
+
+// ── Integrações (captura de lead de sites externos) ────
+export interface IntegrationKey {
+  id: UUID;
+  label: string;
+  /** 8 primeiros caracteres da chave, só para identificar na lista. */
+  key_prefix: string;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+/** Retorno da criação: única vez em que a chave crua fica visível. */
+export interface IntegrationKeyCreated extends IntegrationKey {
+  raw_key: string;
 }
 
 // ── Controle de Estoque ────────────────────────────────


### PR DESCRIPTION
## Resumo
- Todo lead novo com `source=landing` ou `source=api` entra automaticamente no **Funil de entrada padrão** do tenant (evento `crm.client.created` → assinante em `funnels/automation.py` → `engine.enroll`). Criação manual/importação em lote continuam sem auto-enroll.
- Novo módulo **Integrações** (`/config` → aba "Integrações"): chaves de API revogáveis, mostradas em texto puro só na criação, pra sites externos (ex.: landing page de um cliente) enviarem leads via `POST /public/leads/{key}` — sem login, com CORS aberto SÓ nesse caminho (rate limit de 30 req/min por chave) e `source=api` no CRM.
- `/config` → aba "Perfil & Marca" ganha o card **"Funil de entrada padrão"** (um único select por tenant, não por chave/página).
- Migration `0051`: `tenant_profiles.default_entry_funnel_id` + par `integration_keys` (RLS) / `public_integration_keys` (global, sem RLS — mesmo padrão de `pages`/`quotes`/`contracts`).

## Fora de escopo (próxima iniciativa)
Domínio próprio (hospedar o site do cliente dentro do construtor de Páginas) — precisa de verificação de domínio + roteamento por Host + TLS sob demanda, nenhum dos três existe hoje. Ver contexto completo na conversa/plano original.

## Nota sobre CodeRabbit
Não rodou aqui: o CLI via WSL reporta ~520 arquivos alterados (limite de 150 do plano free) por causa de um mismatch de CRLF/LF entre o git do Windows e o do WSL no mesmo working tree — não é um diff real (confirmado: `git diff main --stat` nativo no Windows mostra só ~25 arquivos). Não há CodeRabbit GitHub App instalado neste repo pra cobrir isso na PR. Gate de qualidade usado: lint (ruff) + typecheck (tsc) + testes (607 backend / 101 frontend), todos verdes.

## Test plan
- [x] `ruff check .` (backend) — limpo
- [x] `pytest -m "not rls_e2e"` — 607 passed, 1 skipped
- [x] `pnpm --filter @e1p/web typecheck` — limpo
- [x] `pnpm --filter @e1p/web test` — 101 passed
- [x] E2E manual contra Postgres real (RLS ativa): funil → funil padrão em Configurações → chave de integração → `POST /public/leads/{key}` sem auth → lead `source=api` no CRM → `FunnelRun` criada e `done` → preflight CORS liberado só em `/public/leads/*`, resto da API inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)