### PR TITLE
feat: campo notes no endpoint público de captura de lead

### DIFF
--- a/apps/api/app/modules/integrations/schemas.py
+++ b/apps/api/app/modules/integrations/schemas.py
@@ -30,6 +30,8 @@ class LeadCapture(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     email: EmailStr | None = None
     phone: str | None = Field(default=None, max_length=32)
+    # Observação livre do formulário externo (ex.: "prefere data em dezembro").
+    notes: str | None = Field(default=None, max_length=2000)
     # Campos livres do formulário externo (ex.: "ocasião", "nº de convidados") sem equivalente
     # direto no CRM — viram um bloco de texto anexado a `notes`, sem inventar colunas novas.
     fields: dict[str, str] | None = None

--- a/apps/api/app/modules/integrations/service.py
+++ b/apps/api/app/modules/integrations/service.py
@@ -43,11 +43,13 @@ def _rate_limited(key_hash: str) -> bool:
     return False
 
 
-def _format_notes(fields: dict[str, str] | None) -> str:
-    if not fields:
-        return ""
-    lines = "\n".join(f"{k}: {v}" for k, v in fields.items() if v)
-    return f"Campos do formulário externo:\n{lines}" if lines else ""
+def _format_notes(notes: str | None, fields: dict[str, str] | None) -> str:
+    parts = [notes.strip()] if notes and notes.strip() else []
+    if fields:
+        lines = "\n".join(f"{k}: {v}" for k, v in fields.items() if v)
+        if lines:
+            parts.append(f"Campos do formulário externo:\n{lines}")
+    return "\n\n".join(parts)
 
 
 # ── CRUD autenticado ────────────────────────────────────
@@ -119,7 +121,7 @@ def capture_lead(db: Session, *, raw_key: str, data: LeadCapture, session_factor
                 name=data.name,
                 email=str(data.email) if data.email else None,
                 phone=data.phone,
-                notes=_format_notes(data.fields),
+                notes=_format_notes(data.notes, data.fields),
                 source="api",
             ),
         )

--- a/apps/api/tests/test_integrations.py
+++ b/apps/api/tests/test_integrations.py
@@ -45,6 +45,7 @@ def test_public_capture_creates_lead_with_source_api(client: TestClient, headers
         json={
             "name": "Lead Externo",
             "email": "lead@example.com",
+            "notes": "Prefere data em dezembro",
             "fields": {"ocasiao": "aniversário"},
         },
     )
@@ -52,6 +53,7 @@ def test_public_capture_creates_lead_with_source_api(client: TestClient, headers
     clients = client.get("/crm/clients", headers=headers).json()
     lead = next(c for c in clients if c["name"] == "Lead Externo")
     assert lead["source"] == "api"
+    assert "Prefere data em dezembro" in lead["notes"]
     assert "ocasiao: aniversário" in lead["notes"]
 
 

--- a/apps/web/src/features/config/IntegrationsSection.tsx
+++ b/apps/web/src/features/config/IntegrationsSection.tsx
@@ -14,7 +14,7 @@ function snippetFor(rawKey: string): string {
   return `fetch("${url}", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ name, email, phone }),
+  body: JSON.stringify({ name, email, phone, notes }),
 });`;
 }
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,7 +8,10 @@ services:
       POSTGRES_USER: e1puser
       POSTGRES_PASSWORD: e1ppass
     ports:
-      - "5432:5432"
+      # Porta do HOST remapeada pra 5433: 5432 colide com axisgov-postgres (outro projeto local).
+      # Comunicação api/worker -> postgres usa o nome interno do Docker ("postgres:5432"), não
+      # esta porta — só afeta acesso direto do host (psql/pgAdmin), que agora é em localhost:5433.
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # Demove o usuário da app a NÃO-superusuário p/ que a RLS valha (ver script).


### PR DESCRIPTION
## Summary
- `POST /api/public/leads/{key}` agora aceita um quarto parâmetro `notes` (observações livres), além de `name`/`email`/`phone`.
- `notes` vai direto para o `notes` do cliente no CRM, mesclado com o bloco já existente de `fields` (campos livres do formulário externo).
- Snippet de exemplo exibido em Configurações → Integrações atualizado.
- Bônus: `infra/docker-compose.yml` remapeia a porta host do Postgres de 5432→5433 para evitar colisão com outro projeto local (mudança já feita anteriormente, sem commit).

## Test plan
- [x] `pytest` (apps/api): 616 passed, 1 skipped
- [x] `pnpm --filter @e1p/web typecheck`: sem erros
- [x] Novo caso de teste em `test_integrations.py` cobrindo `notes` + `fields` combinados
- [ ] Deploy em produção — **fora do escopo deste PR** (deploy manual via SSH na VPS, conforme `docs/HOSTINGER-DEPLOY.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)