### PR TITLE
fix: aceitar e-mail em branco no endpoint público de leads

### DIFF
--- a/apps/api/app/modules/integrations/schemas.py
+++ b/apps/api/app/modules/integrations/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 
 class IntegrationKeyCreate(BaseModel):
@@ -35,3 +35,12 @@ class LeadCapture(BaseModel):
     # Campos livres do formulário externo (ex.: "ocasião", "nº de convidados") sem equivalente
     # direto no CRM — viram um bloco de texto anexado a `notes`, sem inventar colunas novas.
     fields: dict[str, str] | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _blank_email_to_none(cls, v: object) -> object:
+        # Formulário HTML externo com campo opcional vazio manda `""`, não omite a chave nem
+        # manda `null` — sem isso o EmailStr rejeita string vazia com 422 e o lead se perde.
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v

--- a/apps/api/tests/test_integrations.py
+++ b/apps/api/tests/test_integrations.py
@@ -57,6 +57,22 @@ def test_public_capture_creates_lead_with_source_api(client: TestClient, headers
     assert "ocasiao: aniversário" in lead["notes"]
 
 
+def test_public_capture_accepts_blank_email_from_html_form(client: TestClient, headers):
+    """Formulário externo com campo de e-mail opcional deixado em branco manda `""`, não
+    omite a chave — sem normalizar isso vira 422 e o lead se perde (bug real de produção)."""
+    key = client.post(
+        "/integrations/leads/keys", json={"label": "Site Y"}, headers=headers
+    ).json()
+    resp = client.post(
+        f"/public/leads/{key['raw_key']}",
+        json={"name": "Lead Sem Email", "email": "", "phone": ""},
+    )
+    assert resp.status_code == 200
+    clients = client.get("/crm/clients", headers=headers).json()
+    lead = next(c for c in clients if c["name"] == "Lead Sem Email")
+    assert lead["email"] is None
+
+
 def test_public_capture_rejects_unknown_key(client: TestClient):
     resp = client.post("/public/leads/chave-invalida", json={"name": "X"})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Bug real de produção: `POST /api/public/leads/{key}` retornava **422** quando o formulário externo mandava `email: ""` (campo opcional deixado em branco) em vez de omitir a chave ou mandar `null`. O `EmailStr` do Pydantic rejeita string vazia.
- Efeito: o lead nunca era criado no CRM — e, por consequência, o auto-enroll no funil de entrada padrão (Story do PR #32) nunca disparava, porque não havia `client_id` nenhum pra inscrever.
- Confirmado nos logs de produção: dois `POST /public/leads/...` do usuário retornaram 422 (`00:25` e `00:30` de 2026-07-15).
- Fix: normaliza string vazia/só-espaço pra `None` antes da validação de e-mail (`field_validator mode="before"`).

## Test plan
- [x] Novo teste `test_public_capture_accepts_blank_email_from_html_form`
- [x] `pytest tests/test_integrations.py`: 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)