### PR TITLE
feat: WhatsApp Cloud API por tenant + templates de mensagem

### DIFF
--- a/apps/api/app/core/whatsapp.py
+++ b/apps/api/app/core/whatsapp.py
@@ -37,3 +37,137 @@ def send_text(*, to: str, text: str) -> str:
     except Exception:
         logger.exception("[whatsapp:failed] para=%s", to)
         return "failed"
+
+
+class WhatsappApiError(Exception):
+    """Erro ao chamar a Graph API para gerenciamento de templates (create/sync/delete).
+
+    Diferente de send_text/send_template (fire-and-forget, nunca propagam exceção), estas são
+    ações administrativas explícitas e DEVEM propagar erro pro service tratar.
+    """
+
+
+def _raise_for_error(resp: httpx.Response) -> None:
+    if resp.status_code >= 400:
+        try:
+            detail = resp.json()
+        except Exception:
+            detail = resp.text
+        raise WhatsappApiError(f"Graph API retornou erro {resp.status_code}: {detail}")
+
+
+def create_template(
+    *,
+    waba_id: str,
+    token: str,
+    name: str,
+    language: str,
+    category: str,
+    body_text: str,
+    variable_examples: list[str],
+) -> dict:
+    """POST /{waba_id}/message_templates. Envia o template pra aprovação da Meta.
+
+    Retorna o JSON de resposta (contém pelo menos 'id' e 'status'; a Meta às vezes já devolve
+    'category' também). Levanta WhatsappApiError em qualquer falha (rede ou status >=400).
+    """
+    body_component: dict = {"type": "BODY", "text": body_text}
+    if variable_examples:
+        body_component["example"] = {"body_text": [variable_examples]}
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{waba_id}/message_templates",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "name": name,
+                "language": language,
+                "category": category,
+                "components": [body_component],
+            },
+            timeout=10,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao criar template: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.json()
+
+
+def fetch_template_status(*, token: str, meta_template_id: str) -> dict:
+    """GET /{meta_template_id}?fields=status,category,rejected_reason.
+
+    Retorna {"status": ..., "category": ..., "rejected_reason": ...|None}.
+    Levanta WhatsappApiError em qualquer falha.
+    """
+    try:
+        resp = httpx.get(
+            f"https://graph.facebook.com/v21.0/{meta_template_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"fields": "status,category,rejected_reason"},
+            timeout=10,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao consultar template: {exc}") from exc
+    _raise_for_error(resp)
+    data = resp.json()
+    return {
+        "status": data.get("status"),
+        "category": data.get("category"),
+        "rejected_reason": data.get("rejected_reason"),
+    }
+
+
+def delete_template(*, waba_id: str, token: str, name: str) -> None:
+    """DELETE /{waba_id}/message_templates?name={name}.
+
+    Levanta WhatsappApiError em qualquer falha.
+    """
+    try:
+        resp = httpx.delete(
+            f"https://graph.facebook.com/v21.0/{waba_id}/message_templates",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"name": name},
+            timeout=10,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao excluir template: {exc}") from exc
+    _raise_for_error(resp)
+
+
+def send_template(
+    *, to: str, token: str, phone_id: str, template_name: str, language: str, variables: list[str]
+) -> str:
+    """Retorna 'sent' | 'logged' | 'failed'.
+
+    MESMO contrato/invariante de send_text: NUNCA propaga exceção (fire-and-forget, graceful
+    degradation) — 'logged' quando token ou phone_id vier vazio; 'failed' se a chamada falhar;
+    'sent' em 200 OK.
+    """
+    if not token or not phone_id:
+        logger.info("[whatsapp:logged] template para=%s nome=%s", to, template_name)
+        return "logged"
+    components = (
+        [{"type": "body", "parameters": [{"type": "text", "text": v} for v in variables]}]
+        if variables
+        else []
+    )
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{phone_id}/messages",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "messaging_product": "whatsapp",
+                "to": to,
+                "type": "template",
+                "template": {
+                    "name": template_name,
+                    "language": {"code": language},
+                    "components": components,
+                },
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return "sent"
+    except Exception:
+        logger.exception("[whatsapp:failed] template para=%s nome=%s", to, template_name)
+        return "failed"

--- a/apps/api/app/core/whatsapp.py
+++ b/apps/api/app/core/whatsapp.py
@@ -15,15 +15,26 @@ from app.config import settings
 logger = logging.getLogger("e1p.whatsapp")
 
 
-def send_text(*, to: str, text: str) -> str:
-    """Retorna o status: 'sent' | 'logged' | 'failed'."""
-    if not settings.whatsapp_token or not settings.whatsapp_phone_id:
+def send_text(
+    *, to: str, text: str, token: str | None = None, phone_id: str | None = None
+) -> str:
+    """Retorna o status: 'sent' | 'logged' | 'failed'.
+
+    `token`/`phone_id` são as credenciais do TENANT (ver `TenantProfile`) — passe-as sempre que
+    o chamador já tiver o perfil do tenant em mãos. Quando omitidos (None, o default), cai na
+    env global `settings.whatsapp_token`/`whatsapp_phone_id` — mantido só por retrocompatibilidade
+    com testes/chamadas antigas; em produção essa env NUNCA está configurada (a integração é
+    100% por tenant), então omitir os parâmetros equivale, na prática, a 'logged' sempre.
+    """
+    tok = token if token is not None else settings.whatsapp_token
+    pid = phone_id if phone_id is not None else settings.whatsapp_phone_id
+    if not tok or not pid:
         logger.info("[whatsapp:logged] para=%s msg=%s", to, text)
         return "logged"
     try:
         resp = httpx.post(
-            f"https://graph.facebook.com/v21.0/{settings.whatsapp_phone_id}/messages",
-            headers={"Authorization": f"Bearer {settings.whatsapp_token}"},
+            f"https://graph.facebook.com/v21.0/{pid}/messages",
+            headers={"Authorization": f"Bearer {tok}"},
             json={
                 "messaging_product": "whatsapp",
                 "to": to,

--- a/apps/api/app/modules/__init__.py
+++ b/apps/api/app/modules/__init__.py
@@ -35,6 +35,7 @@ from app.modules.receivables.router import router as receivables_router
 from app.modules.settings.router import router as settings_router
 from app.modules.stock.router import router as stock_router
 from app.modules.wallet.router import router as wallet_router
+from app.modules.whatsapp_templates.router import router as whatsapp_templates_router
 
 ALL_ROUTERS: list[APIRouter] = [
     auth_router,
@@ -60,6 +61,7 @@ ALL_ROUTERS: list[APIRouter] = [
     funnels_router,
     stock_router,
     settings_router,
+    whatsapp_templates_router,
     pages_router,
     pages_public_router,
     attachments_router,

--- a/apps/api/app/modules/contracts/service.py
+++ b/apps/api/app/modules/contracts/service.py
@@ -23,6 +23,12 @@ from app.modules.contracts.models import (
 from app.modules.contracts.schemas import Clause, ContractCreate, ContractUpdate, TemplateCreate
 from app.modules.crm.models import Client
 from app.modules.notifications.models import Notification
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_CONTRACT_SEND,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
 
 # Templates oferecidos a todo tenant na primeira vez (cláusulas com variáveis [CHAVE]).
 DEFAULT_TEMPLATES: list[dict] = [
@@ -256,6 +262,14 @@ def update_contract(
     return c
 
 
+def _render_template_preview(body_text: str, variables: list[str]) -> str:
+    """Substitui {{1}}, {{2}}, ... no corpo do template pelos valores já resolvidos."""
+    rendered = body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    return rendered
+
+
 def send_contract(db: Session, *, contract_id: str, tenant_id: str, actor: str) -> Contract:
     c = get_contract(db, contract_id)
     if c.status not in (STATUS_DRAFT, STATUS_SENT):
@@ -267,8 +281,24 @@ def send_contract(db: Session, *, contract_id: str, tenant_id: str, actor: str) 
     link = (
         f"{settings.frontend_url.rstrip('/')}/contrato/{c.public_slug}" if c.public_slug else ""
     )
-    msg = f"Olá! Segue o contrato '{c.title}' para sua assinatura: {link}".strip()
-    status = whatsapp.send_text(to=recipient, text=msg)
+    profile = settings_service.get_profile(db, tenant_id)
+    template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_CONTRACT_SEND)
+    template = db.get(WhatsappTemplate, template_id) if template_id else None
+    if template is not None and template.status == STATUS_APPROVED:
+        client_name = client.name if client else "cliente"
+        variables = [client_name, c.title, link]
+        status = whatsapp.send_template(
+            to=client.phone if client and client.phone else "",
+            token=profile.whatsapp_token or "", phone_id=profile.whatsapp_phone_id or "",
+            template_name=template.name, language=template.language, variables=variables,
+        )
+        msg = _render_template_preview(template.body_text, variables)
+    else:
+        msg = f"Olá! Segue o contrato '{c.title}' para sua assinatura: {link}".strip()
+        status = whatsapp.send_text(
+            to=recipient, text=msg,
+            token=profile.whatsapp_token, phone_id=profile.whatsapp_phone_id,
+        )
     db.add(
         Notification(
             tenant_id=tenant_id, channel="whatsapp", recipient=recipient,

--- a/apps/api/app/modules/funnels/engine.py
+++ b/apps/api/app/modules/funnels/engine.py
@@ -99,7 +99,7 @@ def _params(data: dict) -> dict:
         return {"subject": cfg.get("subject", ""),
                 "message": cfg.get("body") or cfg.get("message", "")}
     if action == "send_message":
-        return {"message": cfg.get("body") or cfg.get("message", "")}
+        return {"template_id": cfg.get("template_id"), "variables": cfg.get("variables") or []}
     if action == "create_client":
         return {"name": cfg.get("name", "")}
     return {}

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -177,6 +177,31 @@ class FunnelError(Exception):
         self.status_code = status_code
 
 
+# ── WhatsApp: resolução de variáveis de template ({{cliente.*}} ou texto literal) ──
+_CLIENT_KEYWORDS = {
+    "cliente.nome": lambda c: c.name,
+    "cliente.telefone": lambda c: c.phone or "",
+    "cliente.email": lambda c: c.email or "",
+}
+
+
+def _resolve_template_variable(raw: str, client) -> str:
+    if raw.startswith("{{") and raw.endswith("}}"):
+        key = raw[2:-2].strip()
+        resolver = _CLIENT_KEYWORDS.get(key)
+        if resolver is not None:
+            return resolver(client) or ""
+    return raw  # texto fixo, literal
+
+
+def _render_template_preview(body_text: str, variables: list[str]) -> str:
+    """Substitui {{1}}, {{2}}, ... no corpo do template pelos valores já resolvidos."""
+    rendered = body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    return rendered
+
+
 # ── IA: compõe o conteúdo de um nó (e-mail / mensagem / texto) ──────────────
 _COMPOSE_SYSTEM = {
     "email": (
@@ -296,6 +321,8 @@ def run_node(
     from app.modules.quotes.schemas import QuoteCreate, QuoteItem
     from app.modules.receivables import service as receivables_service
     from app.modules.receivables.schemas import ChargeCreate
+    from app.modules.settings import service as settings_service
+    from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
 
     def _client() -> Client:
         c = db.get(Client, client_id) if client_id else None
@@ -352,25 +379,47 @@ def run_node(
         return {"message": f"Cobrança ({method}) criada para {c.name}", "kind": "charge",
                 "ref_id": ch.id}
 
-    if action in ("send_email", "send_message"):
+    if action == "send_email":
         c = _client()
         msg = (params.get("message") or "").strip()
         if not msg:
             raise FunnelError("Escreva a mensagem (ou gere com IA) antes de enviar", 422)
-        channel = "email" if action == "send_email" else "whatsapp"
-        recipient = (c.email if channel == "email" else c.phone) or c.name
-        if channel == "email":
-            subject = (params.get("subject") or "Mensagem").strip()
-            status = email.send_email(to=recipient, subject=subject, body=msg)
-        else:
-            status = whatsapp.send_text(to=recipient, text=msg)
+        recipient = c.email or c.name
+        subject = (params.get("subject") or "Mensagem").strip()
+        status = email.send_email(to=recipient, subject=subject, body=msg)
         db.add(Notification(
-            tenant_id=tenant_id, channel=channel, recipient=recipient,
+            tenant_id=tenant_id, channel="email", recipient=recipient,
             client_id=c.id, message=msg, status=status,
         ))
         audit.record(db, tenant_id=tenant_id, actor=actor, action="funnel.run.message", target=c.id)
         db.commit()
-        return {"message": f"Mensagem registrada para {c.name} ({channel})", "kind": "message",
+        return {"message": f"Mensagem registrada para {c.name} (email)", "kind": "message",
+                "ref_id": c.id}
+
+    if action == "send_message":
+        c = _client()
+        template_id = params.get("template_id")
+        if not template_id:
+            raise FunnelError("Selecione um template de WhatsApp aprovado", 422)
+        tpl = db.get(WhatsappTemplate, template_id)
+        if tpl is None or tpl.status != STATUS_APPROVED:
+            raise FunnelError("Template não encontrado ou ainda não aprovado pela Meta", 422)
+        recipient = c.phone or c.name
+        resolved_vars = [_resolve_template_variable(v, c) for v in (params.get("variables") or [])]
+        profile = settings_service.get_profile(db, tenant_id)
+        status = whatsapp.send_template(
+            to=c.phone or "", token=profile.whatsapp_token or "",
+            phone_id=profile.whatsapp_phone_id or "",
+            template_name=tpl.name, language=tpl.language, variables=resolved_vars,
+        )
+        rendered = _render_template_preview(tpl.body_text, resolved_vars)
+        db.add(Notification(
+            tenant_id=tenant_id, channel="whatsapp", recipient=recipient,
+            client_id=c.id, message=rendered, status=status,
+        ))
+        audit.record(db, tenant_id=tenant_id, actor=actor, action="funnel.run.message", target=c.id)
+        db.commit()
+        return {"message": f"Mensagem registrada para {c.name} (whatsapp)", "kind": "message",
                 "ref_id": c.id}
 
     raise FunnelError("Este componente ainda não executa uma ação automática", 400)

--- a/apps/api/app/modules/notifications/models.py
+++ b/apps/api/app/modules/notifications/models.py
@@ -10,7 +10,7 @@ Também é a FILA de envios assíncronos (Story 4.3): uma notificação criada c
 """
 from __future__ import annotations
 
-from sqlalchemy import Integer, String, Text
+from sqlalchemy import JSON, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
@@ -30,3 +30,9 @@ class Notification(Base, TenantMixin, TimestampMixin):
     # Fila assíncrona (Story 4.3): nº de tentativas de envio e último erro (se falhou).
     attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     last_error: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+    # Template WhatsApp resolvido no ENFILEIRAMENTO (dentro da request) — o worker entrega
+    # depois (process_pending) sem precisar recalcular propósito/vínculo. NULL nas 3 = mesmo
+    # comportamento antigo (texto livre em `message`, via send_text).
+    whatsapp_template_name: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    whatsapp_template_language: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    whatsapp_template_variables: Mapped[list | None] = mapped_column(JSON, nullable=True)

--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -20,6 +20,11 @@ from app.modules.crm.models import Client, PipelineStage
 from app.modules.crm.service import EVENT_CLIENT_MOVED
 from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_CLIENT_MOVED,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
 
 logger = logging.getLogger("e1p.notifications")
 
@@ -54,6 +59,19 @@ def _owner_recipient(db: Session, tenant_id: str) -> str:
     return owner.email if owner else ""
 
 
+def _render_template_preview(body_text: str, variables: list[str]) -> str:
+    """Substitui {{1}}, {{2}}, ... no corpo do template pelos valores já resolvidos.
+
+    Duplica `funnels.service._render_template_preview` (função privada de módulo, ~4 linhas) —
+    evitamos importar através de módulos por uma função tão pequena (preferência do projeto contra
+    abstração prematura).
+    """
+    rendered = body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    return rendered
+
+
 def enqueue(
     db: Session,
     *,
@@ -62,6 +80,9 @@ def enqueue(
     recipient: str,
     message: str,
     client_id: str | None = None,
+    whatsapp_template_name: str | None = None,
+    whatsapp_template_language: str | None = None,
+    whatsapp_template_variables: list | None = None,
 ) -> Notification:
     """Enfileira um envio (status="pending") — NÃO entrega agora nem commita.
 
@@ -72,6 +93,10 @@ def enqueue(
     Rede de segurança (Story 7.11): um `recipient` vazio/em-branco é entrada inválida e é
     REJEITADO explicitamente com `NotificationError` — nunca enfileirado como `pending`
     indistinguível de um envio válido (que depois falharia mudo no worker).
+
+    `whatsapp_template_*` (opcionais): template resolvido no ENFILEIRAMENTO (quando o propósito
+    tem um vínculo aprovado) — o worker (`process_pending`) usa esses campos pra decidir entre
+    `send_template` e `send_text`, sem precisar recalcular o vínculo depois.
     """
     if not recipient or not recipient.strip():
         raise NotificationError("destinatário (recipient) vazio ou inválido")
@@ -83,6 +108,9 @@ def enqueue(
         client_id=client_id,
         status="pending",
         attempts=0,
+        whatsapp_template_name=whatsapp_template_name,
+        whatsapp_template_language=whatsapp_template_language,
+        whatsapp_template_variables=whatsapp_template_variables,
     )
     db.add(notification)
     db.flush()
@@ -106,6 +134,9 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
             .limit(limit)
         ).all()
     )
+    # Carregado uma vez por sweep (não por notificação) — a função já é tenant-scoped (param
+    # `tenant_id`), então o token/phone_id do provedor é o mesmo para todo o lote.
+    profile = settings_service.get_profile(db, tenant_id)
     processed = 0
     for notification in pending:
         try:
@@ -115,9 +146,21 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
                     subject="Notificação e1p",
                     body=notification.message,
                 )
+            elif notification.whatsapp_template_name:
+                status = whatsapp.send_template(
+                    to=notification.recipient,
+                    token=profile.whatsapp_token or "",
+                    phone_id=profile.whatsapp_phone_id or "",
+                    template_name=notification.whatsapp_template_name,
+                    language=notification.whatsapp_template_language or "pt_BR",
+                    variables=notification.whatsapp_template_variables or [],
+                )
             else:
                 status = whatsapp.send_text(
-                    to=notification.recipient, text=notification.message
+                    to=notification.recipient,
+                    text=notification.message,
+                    token=profile.whatsapp_token,
+                    phone_id=profile.whatsapp_phone_id,
                 )
             notification.status = status
         except Exception as exc:  # noqa: BLE001 — isola a falha de UMA notificação (IV2)
@@ -151,6 +194,22 @@ def on_client_moved(*, tenant_id: str, client_id: str, to_stage: str, **_: objec
         col = stage.name if stage else "—"
         text = f'📌 O cliente {client.name} foi movido para a etapa "{col}".'
         recipient = _owner_recipient(db, tenant_id)
+
+        # Resolve o vínculo propósito→template (Configurações) AGORA, dentro da request — o
+        # worker (process_pending) só entrega depois, sem recalcular vínculo/propósito.
+        profile = settings_service.get_profile(db, tenant_id)
+        template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_CLIENT_MOVED)
+        template = db.get(WhatsappTemplate, template_id) if template_id else None
+
+        whatsapp_template_name = whatsapp_template_language = None
+        whatsapp_template_variables: list[str] | None = None
+        message = text
+        if template is not None and template.status == STATUS_APPROVED:
+            whatsapp_template_name = template.name
+            whatsapp_template_language = template.language
+            whatsapp_template_variables = [client.name, col]  # ordem = PURPOSE_VARIABLE_SPECS
+            message = _render_template_preview(template.body_text, whatsapp_template_variables)
+
         # Enfileira (status="pending") em vez de enviar síncrono aqui: o handler roda dentro da
         # MESMA request que moveu o card (crm.service.move_client → events.emit). A entrega real
         # (WhatsApp) fica para o worker (process_pending), sem bloquear a request (IV2).
@@ -160,8 +219,11 @@ def on_client_moved(*, tenant_id: str, client_id: str, to_stage: str, **_: objec
                 tenant_id=tenant_id,
                 channel="whatsapp",
                 recipient=recipient,
-                message=text,
+                message=message,
                 client_id=client_id,
+                whatsapp_template_name=whatsapp_template_name,
+                whatsapp_template_language=whatsapp_template_language,
+                whatsapp_template_variables=whatsapp_template_variables,
             )
             db.commit()
         except NotificationError:

--- a/apps/api/app/modules/platform/service.py
+++ b/apps/api/app/modules/platform/service.py
@@ -110,7 +110,7 @@ def create_account(db: Session, data: CreateAccountRequest) -> tuple[Tenant, Use
     db.refresh(owner)
     status = _send_invite(
         name=data.name, email=email, phone=data.phone, temp=temp,
-        delivery=data.delivery, company=tenant.legal_name,
+        delivery=data.delivery, company=tenant.legal_name, tenant_id=tenant.id,
     )
     return tenant, owner, temp, status
 
@@ -260,9 +260,17 @@ def _temp_password() -> str:
 
 
 def _send_invite(
-    *, name: str, email: str, phone: str, temp: str, delivery: str, company: str
+    *, name: str, email: str, phone: str, temp: str, delivery: str, company: str, tenant_id: str
 ) -> str:
-    """Entrega a senha temporária por e-mail ou WhatsApp. Devolve o status do envio."""
+    """Entrega a senha temporária por e-mail ou WhatsApp. Devolve o status do envio.
+
+    O convite é enviado em nome do TENANT sendo criado/atendido (`tenant_id`), nunca da
+    plataforma: por WhatsApp, usamos as credenciais e o vínculo de template daquele escritório
+    (Configurações). Como a `db` do Master aqui é a sessão GLOBAL sem tenant (ver `get_db`),
+    abrimos uma `tenant_session` dedicada só para essa leitura — mesmo padrão de `delete_account`
+    nesta mesma classe de serviço, já que ler `TenantProfile`/`WhatsappTemplate` (RLS) exige a GUC
+    de tenant setada na conexão.
+    """
     from app.core import whatsapp
     from app.core.email import send_email
 
@@ -273,7 +281,25 @@ def _send_invite(
         "Por segurança, você deverá definir uma nova senha no primeiro acesso."
     )
     if delivery == "whatsapp":
-        return whatsapp.send_text(to=phone, text=msg)
+        from app.modules.settings import service as settings_service
+        from app.modules.whatsapp_templates.models import (
+            PURPOSE_STAFF_INVITE,
+            STATUS_APPROVED,
+            WhatsappTemplate,
+        )
+
+        with tenant_session(tenant_id) as tdb:
+            profile = settings_service.get_profile(tdb, tenant_id)
+            template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_STAFF_INVITE)
+            template = tdb.get(WhatsappTemplate, template_id) if template_id else None
+            token, phone_id = profile.whatsapp_token, profile.whatsapp_phone_id
+        if template is not None and template.status == STATUS_APPROVED:
+            return whatsapp.send_template(
+                to=phone, token=token or "", phone_id=phone_id or "",
+                template_name=template.name, language=template.language,
+                variables=[name, company, email, temp],  # ordem = PURPOSE_VARIABLE_SPECS
+            )
+        return whatsapp.send_text(to=phone, text=msg, token=token, phone_id=phone_id)
     return send_email(to=email, subject="Seu acesso à plataforma", body=msg)
 
 
@@ -311,7 +337,7 @@ def create_staff(db: Session, tenant_id: str, data: CreateStaffRequest) -> tuple
 
     status = _send_invite(
         name=data.name, email=email, phone=data.phone, temp=temp,
-        delivery=data.delivery, company=tenant.legal_name,
+        delivery=data.delivery, company=tenant.legal_name, tenant_id=tenant_id,
     )
     return user, temp, status
 

--- a/apps/api/app/modules/quotes/service.py
+++ b/apps/api/app/modules/quotes/service.py
@@ -24,6 +24,14 @@ from app.modules.quotes.models import (
 from app.modules.quotes.schemas import QuoteCreate, QuoteItem, QuoteUpdate
 from app.modules.receivables import service as receivables_service
 from app.modules.receivables.schemas import ChargeCreate
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_QUOTE_SEND,
+    WhatsappTemplate,
+)
+from app.modules.whatsapp_templates.models import (
+    STATUS_APPROVED as TEMPLATE_STATUS_APPROVED,
+)
 
 # prazo padrão da cobrança gerada ao aprovar
 APPROVAL_DUE_DAYS = 7
@@ -178,6 +186,14 @@ def update_quote(
     return q
 
 
+def _render_template_preview(body_text: str, variables: list[str]) -> str:
+    """Substitui {{1}}, {{2}}, ... no corpo do template pelos valores já resolvidos."""
+    rendered = body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    return rendered
+
+
 def send_quote(db: Session, *, quote_id: str, tenant_id: str, actor: str) -> Quote:
     """Marca como enviado e registra uma mensagem ao cliente (WhatsApp stub)."""
     q = get_quote(db, quote_id)
@@ -192,8 +208,25 @@ def send_quote(db: Session, *, quote_id: str, tenant_id: str, actor: str) -> Quo
     )
     valor = f"R$ {q.total_cents / 100:.2f}".replace(".", ",")
     link = f"{settings.frontend_url.rstrip('/')}/orcamento/{q.public_slug}" if q.public_slug else ""
-    msg = f"Olá! Segue sua proposta de {q.title}: {valor}. Veja em: {link}".strip()
-    status = whatsapp.send_text(to=recipient, text=msg)
+    profile = settings_service.get_profile(db, tenant_id)
+    template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_QUOTE_SEND)
+    template = db.get(WhatsappTemplate, template_id) if template_id else None
+    if template is not None and template.status == TEMPLATE_STATUS_APPROVED:
+        client_name = q.client_name or (client.name if client else None) or "cliente"
+        variables = [client_name, q.title, valor, link]
+        phone_to = q.client_whatsapp or (client.phone if client and client.phone else None) or ""
+        status = whatsapp.send_template(
+            to=phone_to, token=profile.whatsapp_token or "",
+            phone_id=profile.whatsapp_phone_id or "",
+            template_name=template.name, language=template.language, variables=variables,
+        )
+        msg = _render_template_preview(template.body_text, variables)
+    else:
+        msg = f"Olá! Segue sua proposta de {q.title}: {valor}. Veja em: {link}".strip()
+        status = whatsapp.send_text(
+            to=recipient, text=msg,
+            token=profile.whatsapp_token, phone_id=profile.whatsapp_phone_id,
+        )
     db.add(
         Notification(
             tenant_id=tenant_id, channel="whatsapp", recipient=recipient,

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -531,16 +531,93 @@ def _compose_dunning(name: str, amount_cents: int, due: date, description: str) 
         )
 
 
+def _compose_dunning_phrase(name: str, amount_cents: int, due: date, description: str) -> str:
+    """Só a FRASE de cobrança (variável 2 do template `charge_reminder`) — não a mensagem inteira.
+
+    Usa a IA (Claude) se houver chave; senão, frase padrão. Mesma técnica de anonimização de PII
+    de `_compose_dunning` (placeholder [NOME], reinserido localmente): o nome/valor/vencimento já
+    são OUTRAS variáveis do template, então aqui só pedimos o motivo/tom da cobrança, sem repetir.
+    """
+    valor = _money(amount_cents)
+    venc = due.strftime("%d/%m/%Y")
+    desc = description or "sua cobrança"
+    if not settings.anthropic_api_key:
+        return "Notamos que sua cobrança está em aberto."
+    system = (
+        "Você é um assistente de cobrança amigável de um pequeno negócio brasileiro. "
+        "Escreva APENAS UMA frase curta (sem saudação, sem repetir valor/data/nome — isso já "
+        "aparece em outras partes da mensagem) explicando o motivo da cobrança em tom cordial e "
+        "respeitoso, em português do Brasil. Nunca ameace. Use o placeholder [NOME] se precisar "
+        "se referir ao cliente. Responda só com a frase."
+    )
+    user = f"Valor: {valor}\nVencimento: {venc}\nDescrição: {desc}\nNome do cliente: [NOME]"
+    try:
+        result = ai.complete(system=system, user_message=user, max_tokens=100)
+        return result.text.strip().replace("[NOME]", name)
+    except Exception:
+        return "Notamos que sua cobrança está em aberto."
+
+
+def _render_template_preview(body_text: str, variables: list[str]) -> str:
+    """Substitui {{1}}, {{2}}, ... no corpo do template pelos valores já resolvidos.
+
+    Duplica `funnels.service._render_template_preview` (função privada de módulo, ~4 linhas) —
+    evitamos importar através de módulos por uma função tão pequena (preferência do projeto contra
+    abstração prematura).
+    """
+    rendered = body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    return rendered
+
+
 def collect_with_ai(db: Session, *, charge_id: str, tenant_id: str, actor: str) -> dict:
-    """A IA escreve uma cobrança amigável e 'envia' no WhatsApp do cliente (rastro de IA)."""
+    """A IA escreve uma cobrança amigável e 'envia' no WhatsApp do cliente (rastro de IA).
+
+    Se o tenant já vinculou um template APROVADO ao propósito `charge_reminder` (Configurações),
+    envia via template (exigência da Meta para mensagens business-initiated): a IA só escreve a
+    frase-motivo (variável 2), o resto (nome/valor/vencimento) é preenchido pelo sistema. Sem
+    vínculo (ou template ainda não aprovado), cai no caminho antigo de texto livre — agora usando
+    as credenciais do TENANT em vez do env global morto.
+    """
+    from app.modules.settings import service as settings_service
+    from app.modules.whatsapp_templates.models import (
+        PURPOSE_CHARGE_REMINDER,
+        STATUS_APPROVED,
+        WhatsappTemplate,
+    )
+
     charge = get_charge(db, charge_id)
     if charge.status != STATUS_OPEN:
         raise ReceivableError("Só cobranças em aberto podem ser cobradas", 409)
     client = db.get(Client, charge.client_id) if charge.client_id else None
     name = client.name if client else "cliente"
     recipient = (client.phone if client and client.phone else None) or name
-    message = _compose_dunning(name, charge.amount_cents, charge.due_date, charge.description)
-    status = whatsapp.send_text(to=recipient, text=message)
+
+    profile = settings_service.get_profile(db, tenant_id)
+    template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_CHARGE_REMINDER)
+    template = db.get(WhatsappTemplate, template_id) if template_id else None
+
+    if template is not None and template.status == STATUS_APPROVED:
+        valor = _money(charge.amount_cents)
+        venc = charge.due_date.strftime("%d/%m/%Y")
+        phrase = _compose_dunning_phrase(
+            name, charge.amount_cents, charge.due_date, charge.description
+        )
+        variables = [name, phrase, valor, venc]
+        status = whatsapp.send_template(
+            to=client.phone if client and client.phone else "",
+            token=profile.whatsapp_token or "", phone_id=profile.whatsapp_phone_id or "",
+            template_name=template.name, language=template.language, variables=variables,
+        )
+        message = _render_template_preview(template.body_text, variables)
+    else:
+        message = _compose_dunning(name, charge.amount_cents, charge.due_date, charge.description)
+        status = whatsapp.send_text(
+            to=recipient, text=message,
+            token=profile.whatsapp_token, phone_id=profile.whatsapp_phone_id,
+        )
+
     db.add(
         Notification(
             tenant_id=tenant_id, channel="whatsapp", recipient=recipient,
@@ -556,7 +633,17 @@ def collect_with_ai(db: Session, *, charge_id: str, tenant_id: str, actor: str) 
 
 
 def send_message(db: Session, *, charge_id: str, tenant_id: str, actor: str, text: str) -> dict:
-    """Mensagem MANUAL (sem IA) ao cliente da cobrança."""
+    """Mensagem MANUAL (sem IA) ao cliente da cobrança.
+
+    Fica de FORA da conversão para template: é texto arbitrário digitado por um humano, e um
+    template não pode "envelopar" conteúdo livre (é exatamente o que a revisão da Meta existe para
+    impedir — usar um template como disfarce arriscaria o rating de qualidade/ban do número). Este
+    é o caso de "resposta dentro da janela de 24h": a própria Graph API da Meta aceita ou rejeita o
+    envio conforme o estado real da conversa — não precisamos (nem podemos) simular isso aqui.
+    Só passamos a usar as credenciais REAIS do tenant em vez do env global (sempre vazio agora).
+    """
+    from app.modules.settings import service as settings_service
+
     text = (text or "").strip()
     if not text:
         raise ReceivableError("Mensagem vazia", 400)
@@ -565,7 +652,10 @@ def send_message(db: Session, *, charge_id: str, tenant_id: str, actor: str, tex
     recipient = (client.phone if client and client.phone else None) or (
         client.name if client else "cliente"
     )
-    status = whatsapp.send_text(to=recipient, text=text)
+    profile = settings_service.get_profile(db, tenant_id)
+    status = whatsapp.send_text(
+        to=recipient, text=text, token=profile.whatsapp_token, phone_id=profile.whatsapp_phone_id,
+    )
     db.add(
         Notification(
             tenant_id=tenant_id, channel="whatsapp", recipient=recipient,

--- a/apps/api/app/modules/settings/models.py
+++ b/apps/api/app/modules/settings/models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from sqlalchemy import String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.token_crypto import EncryptedToken
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
 DEFAULT_PRIMARY = "#5D44F8"
@@ -49,3 +50,12 @@ class TenantProfile(Base, TenantMixin, TimestampMixin):
     # None = sem auto-enroll (comportamento padrão até o dono configurar). Sem FK dura pra
     # `funnels.id` (mesmo padrão do projeto): funil apagado só faz o auto-enroll no-opar.
     default_entry_funnel_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+
+    # WhatsApp Cloud API (Meta) — POR TENANT (cada escritório tem sua própria conta/número; NÃO
+    # existe mais uma env global compartilhada). None/vazio = integração desligada (graceful
+    # degradation: `core/whatsapp.send_template` cai no status "logged"). Token cifrado em
+    # repouso (mesmo padrão Fernet do Google OAuth, ver `core/token_crypto.py`); phone_id/waba_id
+    # não são segredos (IDs de conta), guardados em texto plano.
+    whatsapp_token: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
+    whatsapp_phone_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    whatsapp_waba_id: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/apps/api/app/modules/settings/models.py
+++ b/apps/api/app/modules/settings/models.py
@@ -5,7 +5,7 @@ TenantProfile: uma linha por tenant (RLS) com o perfil da empresa e o Brand Kit
 """
 from __future__ import annotations
 
-from sqlalchemy import String, Text
+from sqlalchemy import JSON, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.token_crypto import EncryptedToken
@@ -59,3 +59,6 @@ class TenantProfile(Base, TenantMixin, TimestampMixin):
     whatsapp_token: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
     whatsapp_phone_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     whatsapp_waba_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Vínculo propósito→template (dict[str, str], chaves em whatsapp_templates.PURPOSES).
+    # Propósito ausente/sem valor = fluxo correspondente ainda usa texto livre (send_text).
+    whatsapp_template_bindings: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)

--- a/apps/api/app/modules/settings/router.py
+++ b/apps/api/app/modules/settings/router.py
@@ -21,6 +21,9 @@ def _out(p: TenantProfile) -> ProfileOut:
         primary_color=p.primary_color, secondary_color=p.secondary_color,
         accent_color=p.accent_color, text_color=p.text_color, bg_color=p.bg_color, font=p.font,
         timezone=p.timezone, default_entry_funnel_id=p.default_entry_funnel_id,
+        whatsapp_configured=bool(p.whatsapp_token and p.whatsapp_phone_id and p.whatsapp_waba_id),
+        whatsapp_phone_id=p.whatsapp_phone_id or "",
+        whatsapp_waba_id=p.whatsapp_waba_id or "",
     )
 
 

--- a/apps/api/app/modules/settings/router.py
+++ b/apps/api/app/modules/settings/router.py
@@ -1,7 +1,7 @@
 """Rotas de Configurações + Brand Kit."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.tenancy import CurrentUser, get_tenant_db, require_module
@@ -24,6 +24,7 @@ def _out(p: TenantProfile) -> ProfileOut:
         whatsapp_configured=bool(p.whatsapp_token and p.whatsapp_phone_id and p.whatsapp_waba_id),
         whatsapp_phone_id=p.whatsapp_phone_id or "",
         whatsapp_waba_id=p.whatsapp_waba_id or "",
+        whatsapp_template_bindings=p.whatsapp_template_bindings or {},
     )
 
 
@@ -40,4 +41,10 @@ def update_profile(
     user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> ProfileOut:
-    return _out(service.update_profile(db, tenant_id=user.tenant_id, actor=user.user_id, data=data))
+    try:
+        profile = service.update_profile(
+            db, tenant_id=user.tenant_id, actor=user.user_id, data=data
+        )
+    except service.SettingsError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    return _out(profile)

--- a/apps/api/app/modules/settings/schemas.py
+++ b/apps/api/app/modules/settings/schemas.py
@@ -29,6 +29,11 @@ class ProfileOut(BaseModel):
     timezone: str
     # Funil de Vendas para auto-enroll de leads novos (source=landing/api). None = desligado.
     default_entry_funnel_id: str | None
+    # WhatsApp Cloud API (Meta) — por tenant. `whatsapp_token` NUNCA é exposto aqui (só o boolean
+    # de status); phone_id/waba_id não são segredos (IDs de conta), seguros para GET.
+    whatsapp_configured: bool
+    whatsapp_phone_id: str
+    whatsapp_waba_id: str
 
 
 class ProfileUpdate(BaseModel):
@@ -49,6 +54,12 @@ class ProfileUpdate(BaseModel):
     timezone: str | None = Field(default=None, max_length=64)
     # None = não altera; "" = desliga o auto-enroll (mesmo padrão de contract_id em Charge).
     default_entry_funnel_id: str | None = Field(default=None, max_length=36)
+    # WhatsApp Cloud API (Meta) — por tenant. None = não altera; "" = limpa/desconecta.
+    # Sem @field_validator: token/IDs são strings opacas vindas da Meta (não têm formato a validar
+    # como as cores hex/URLs/timezone acima).
+    whatsapp_token: str | None = Field(default=None)
+    whatsapp_phone_id: str | None = Field(default=None, max_length=64)
+    whatsapp_waba_id: str | None = Field(default=None, max_length=64)
 
     # Validações de formato — só se aplicam a valores NÃO vazios.
     # None (omitido) = não altera; "" = limpar o campo (ambos preservados, AC4).

--- a/apps/api/app/modules/settings/schemas.py
+++ b/apps/api/app/modules/settings/schemas.py
@@ -34,6 +34,9 @@ class ProfileOut(BaseModel):
     whatsapp_configured: bool
     whatsapp_phone_id: str
     whatsapp_waba_id: str
+    # Vínculo propósito→template (ver whatsapp_templates.models.PURPOSE_VARIABLE_SPECS).
+    # Propósito ausente/vazio = esse fluxo do sistema ainda usa texto livre.
+    whatsapp_template_bindings: dict[str, str]
 
 
 class ProfileUpdate(BaseModel):
@@ -60,6 +63,9 @@ class ProfileUpdate(BaseModel):
     whatsapp_token: str | None = Field(default=None)
     whatsapp_phone_id: str | None = Field(default=None, max_length=64)
     whatsapp_waba_id: str | None = Field(default=None, max_length=64)
+    # None = não altera; um dict substitui o mapa INTEIRO (a UI sempre manda o mapa completo
+    # após editar). Chave com valor "" desvincula aquele propósito específico.
+    whatsapp_template_bindings: dict[str, str] | None = Field(default=None)
 
     # Validações de formato — só se aplicam a valores NÃO vazios.
     # None (omitido) = não altera; "" = limpar o campo (ambos preservados, AC4).

--- a/apps/api/app/modules/settings/service.py
+++ b/apps/api/app/modules/settings/service.py
@@ -8,6 +8,46 @@ from app.core import audit
 from app.modules.auth.models import Tenant
 from app.modules.settings.models import TenantProfile
 from app.modules.settings.schemas import ProfileUpdate
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_VARIABLE_SPECS,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
+
+
+class SettingsError(Exception):
+    """Erro de domínio do módulo de Configurações (mesmo padrão de FunnelError)."""
+
+    def __init__(self, message: str, status_code: int = 422) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _validate_template_bindings(db: Session, bindings: dict[str, str]) -> None:
+    """Cada propósito só pode ser vinculado a um template do PRÓPRIO tenant (RLS via db.get),
+    já APROVADO pela Meta, e com exatamente a quantidade de variáveis que aquele propósito
+    preenche (ver PURPOSE_VARIABLE_SPECS) — evita vincular um template com menos/mais
+    variáveis do que o sistema vai passar em tempo de envio."""
+    for purpose, template_id in bindings.items():
+        if purpose not in PURPOSE_VARIABLE_SPECS:
+            raise SettingsError(f"Propósito de WhatsApp desconhecido: {purpose}")
+        if not template_id:
+            continue  # "" desvincula esse propósito — nada a validar
+        tpl = db.get(WhatsappTemplate, template_id)
+        if tpl is None:
+            raise SettingsError(f"Template não encontrado para o propósito '{purpose}'")
+        if tpl.status != STATUS_APPROVED:
+            raise SettingsError(
+                f"O template vinculado a '{purpose}' ainda não foi aprovado pela Meta"
+            )
+        expected = len(PURPOSE_VARIABLE_SPECS[purpose])
+        if tpl.variable_count != expected:
+            labels = ", ".join(PURPOSE_VARIABLE_SPECS[purpose])
+            raise SettingsError(
+                f"O template para '{purpose}' precisa ter exatamente {expected} "
+                f"variável(is) ({labels}), mas tem {tpl.variable_count}"
+            )
+
 
 _FIELDS = (
     "display_name", "document", "email", "phone", "address", "website", "about",
@@ -45,6 +85,9 @@ def update_profile(
     # contract_id/cost_center_id em receivables/service.py::update_charge.
     if data.default_entry_funnel_id is not None:
         profile.default_entry_funnel_id = data.default_entry_funnel_id or None
+    if data.whatsapp_template_bindings is not None:
+        _validate_template_bindings(db, data.whatsapp_template_bindings)
+        profile.whatsapp_template_bindings = data.whatsapp_template_bindings
     audit.record(db, tenant_id=tenant_id, actor=actor, action="settings.profile.update",
                  target=profile.id)
     db.commit()

--- a/apps/api/app/modules/settings/service.py
+++ b/apps/api/app/modules/settings/service.py
@@ -13,6 +13,7 @@ _FIELDS = (
     "display_name", "document", "email", "phone", "address", "website", "about",
     "logo_url", "primary_color", "secondary_color", "accent_color", "text_color",
     "bg_color", "font", "timezone",
+    "whatsapp_token", "whatsapp_phone_id", "whatsapp_waba_id",
 )
 
 

--- a/apps/api/app/modules/whatsapp_templates/models.py
+++ b/apps/api/app/modules/whatsapp_templates/models.py
@@ -23,6 +23,42 @@ STATUS_DISABLED = "DISABLED"
 # Categorias aceitas pela Meta (o que pedimos — a aprovada pode vir diferente).
 CATEGORIES = ("MARKETING", "UTILITY", "AUTHENTICATION")
 
+# ── Vínculo propósito→template (fluxos de sistema, NÃO o nó livre do funil) ──
+#
+# Diferente do nó de WhatsApp do Funil de Vendas (onde o usuário escolhe QUALQUER template
+# aprovado e monta as variáveis livremente), estes 5 pontos do produto disparam WhatsApp de
+# forma fixa/automática — o tenant só precisa vincular UM template aprovado por propósito
+# (uma vez, em Configurações), e o sistema preenche as variáveis sozinho a cada envio.
+#
+# `PURPOSE_VARIABLE_SPECS` documenta, pra cada propósito, o rótulo de cada variável NA ORDEM
+# em que o sistema vai preenchê-las ({{1}}, {{2}}, ...) — usado tanto para orientar o tenant ao
+# escrever o corpo do template quanto para VALIDAR o vínculo (o template escolhido precisa ter
+# exatamente `len(spec)` variáveis, ou o vínculo é rejeitado).
+PURPOSE_CHARGE_REMINDER = "charge_reminder"
+PURPOSE_CONTRACT_SEND = "contract_send"
+PURPOSE_QUOTE_SEND = "quote_send"
+PURPOSE_STAFF_INVITE = "staff_invite"
+PURPOSE_CLIENT_MOVED = "client_moved"
+
+PURPOSE_VARIABLE_SPECS: dict[str, list[str]] = {
+    PURPOSE_CHARGE_REMINDER: [
+        "Nome do cliente", "Frase de cobrança (a IA sugere uma; pode editar)",
+        "Valor", "Vencimento",
+    ],
+    PURPOSE_CONTRACT_SEND: ["Nome do cliente", "Título do contrato", "Link de assinatura"],
+    PURPOSE_QUOTE_SEND: ["Nome do cliente", "Título do orçamento", "Valor", "Link da proposta"],
+    PURPOSE_STAFF_INVITE: ["Nome", "Empresa", "E-mail de login", "Senha temporária"],
+    PURPOSE_CLIENT_MOVED: ["Nome do cliente", "Nome da nova etapa"],
+}
+
+PURPOSE_LABELS: dict[str, str] = {
+    PURPOSE_CHARGE_REMINDER: "Lembrete de cobrança (Cobrar com IA)",
+    PURPOSE_CONTRACT_SEND: "Envio de contrato",
+    PURPOSE_QUOTE_SEND: "Envio de orçamento/proposta",
+    PURPOSE_STAFF_INVITE: "Convite de funcionário (senha temporária)",
+    PURPOSE_CLIENT_MOVED: "Aviso interno: cliente mudou de etapa no CRM",
+}
+
 
 class WhatsappTemplate(Base, TenantMixin, TimestampMixin):
     __tablename__ = "whatsapp_templates"

--- a/apps/api/app/modules/whatsapp_templates/models.py
+++ b/apps/api/app/modules/whatsapp_templates/models.py
@@ -1,0 +1,48 @@
+"""Templates de mensagem do WhatsApp Cloud API (Meta) — um por tenant, RLS.
+
+A Meta exige que toda mensagem business-initiated (fora da janela de 24h de atendimento) use um
+template pré-aprovado (categoria Marketing/Utility/Authentication). Esta tabela espelha o que a
+Meta controla do lado dela: o tenant propõe (`category_requested`, `body_text`), a Meta aprova
+(`status`, `category_approved` — pode divergir do solicitado — e `meta_template_id`) ou rejeita
+(`rejected_reason`). Ver `app/core/whatsapp.py` para as chamadas à Graph API.
+"""
+from __future__ import annotations
+
+from sqlalchemy import JSON, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+# Status espelhando o retorno da Graph API (`GET /{waba_id}/message_templates`).
+STATUS_PENDING = "PENDING"
+STATUS_APPROVED = "APPROVED"
+STATUS_REJECTED = "REJECTED"
+STATUS_PAUSED = "PAUSED"
+STATUS_DISABLED = "DISABLED"
+
+# Categorias aceitas pela Meta (o que pedimos — a aprovada pode vir diferente).
+CATEGORIES = ("MARKETING", "UTILITY", "AUTHENTICATION")
+
+
+class WhatsappTemplate(Base, TenantMixin, TimestampMixin):
+    __tablename__ = "whatsapp_templates"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "name", "language", name="uq_whatsapp_templates_tenant_name_lang"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    name: Mapped[str] = mapped_column(String(512), nullable=False)
+    language: Mapped[str] = mapped_column(String(10), default="pt_BR", nullable=False)
+    category_requested: Mapped[str] = mapped_column(String(20), nullable=False)
+    # None até a Meta responder. Pode divergir de category_requested (a Meta recategoriza).
+    category_approved: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default=STATUS_PENDING, nullable=False)
+    rejected_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    meta_template_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Corpo com variáveis posicionais no formato Meta: {{1}}, {{2}}, ...
+    body_text: Mapped[str] = mapped_column(Text, nullable=False)
+    variable_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    # Exemplos obrigatórios por variável (a Meta rejeita submissão sem exemplo).
+    variable_examples: Mapped[list] = mapped_column(JSON, default=list, nullable=False)

--- a/apps/api/app/modules/whatsapp_templates/router.py
+++ b/apps/api/app/modules/whatsapp_templates/router.py
@@ -1,0 +1,80 @@
+"""Rotas de Templates de WhatsApp (Meta Cloud API)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.modules.whatsapp_templates import service
+from app.modules.whatsapp_templates.models import WhatsappTemplate
+from app.modules.whatsapp_templates.schemas import TemplateCreate, TemplateOut
+
+router = APIRouter(prefix="/whatsapp-templates", tags=["whatsapp-templates"])
+
+_guard = require_module("settings")
+
+
+def _out(t: WhatsappTemplate) -> TemplateOut:
+    return TemplateOut(
+        id=t.id, name=t.name, language=t.language, category_requested=t.category_requested,
+        category_approved=t.category_approved, status=t.status, rejected_reason=t.rejected_reason,
+        meta_template_id=t.meta_template_id, body_text=t.body_text,
+        variable_count=t.variable_count, variable_examples=t.variable_examples,
+        created_at=t.created_at, updated_at=t.updated_at,
+    )
+
+
+def _err(e: service.WhatsappTemplateError) -> HTTPException:
+    return HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("", response_model=list[TemplateOut])
+def list_templates(
+    status: str | None = None,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> list[TemplateOut]:
+    return [_out(t) for t in service.list_templates(db, user.tenant_id, status=status)]
+
+
+@router.post("", response_model=TemplateOut, status_code=201)
+def create_template(
+    data: TemplateCreate,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> TemplateOut:
+    try:
+        template = service.create_template(
+            db, tenant_id=user.tenant_id, actor=user.user_id, data=data
+        )
+    except service.WhatsappTemplateError as e:
+        raise _err(e) from e
+    return _out(template)
+
+
+@router.post("/{template_id}/sync", response_model=TemplateOut)
+def sync_template(
+    template_id: str,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> TemplateOut:
+    try:
+        template = service.sync_template(db, tenant_id=user.tenant_id, template_id=template_id)
+    except service.WhatsappTemplateError as e:
+        raise _err(e) from e
+    return _out(template)
+
+
+@router.delete("/{template_id}", status_code=204)
+def delete_template(
+    template_id: str,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> Response:
+    try:
+        service.delete_template(
+            db, tenant_id=user.tenant_id, actor=user.user_id, template_id=template_id
+        )
+    except service.WhatsappTemplateError as e:
+        raise _err(e) from e
+    return Response(status_code=204)

--- a/apps/api/app/modules/whatsapp_templates/schemas.py
+++ b/apps/api/app/modules/whatsapp_templates/schemas.py
@@ -1,0 +1,33 @@
+"""Schemas do módulo de Templates de WhatsApp (Meta Cloud API)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TemplateCreate(BaseModel):
+    # ex: "boas_vindas_lead" — a Meta só aceita minúsculas/números/underscore.
+    name: str = Field(pattern=r"^[a-z0-9_]+$")
+    language: str = "pt_BR"
+    category: Literal["MARKETING", "UTILITY", "AUTHENTICATION"]
+    # com {{1}}, {{2}}, ... (variáveis posicionais contíguas a partir de 1)
+    body_text: str
+    variable_examples: list[str] = []
+
+
+class TemplateOut(BaseModel):
+    id: str
+    name: str
+    language: str
+    category_requested: str
+    category_approved: str | None
+    status: str
+    rejected_reason: str | None
+    meta_template_id: str | None
+    body_text: str
+    variable_count: int
+    variable_examples: list[str]
+    created_at: datetime
+    updated_at: datetime

--- a/apps/api/app/modules/whatsapp_templates/service.py
+++ b/apps/api/app/modules/whatsapp_templates/service.py
@@ -1,0 +1,164 @@
+"""Templates de WhatsApp (Meta Cloud API) — CRUD local + sincronização com a Graph API.
+
+Todo envio business-initiated (fora da janela de 24h) exige um template pré-aprovado pela Meta
+(ver `app/modules/whatsapp_templates/models.py`). Este service propõe o template (`create_template`,
+que chama `core/whatsapp.create_template`), consulta o status de aprovação (`sync_template`) e
+remove tanto localmente quanto na Meta (`delete_template`, best-effort do lado da Meta).
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core import audit, whatsapp
+from app.modules.settings.service import get_profile
+from app.modules.whatsapp_templates.models import STATUS_PENDING, WhatsappTemplate
+from app.modules.whatsapp_templates.schemas import TemplateCreate
+
+logger = logging.getLogger("e1p.whatsapp_templates")
+
+_PLACEHOLDER_RE = re.compile(r"\{\{(\d+)\}\}")
+
+
+class WhatsappTemplateError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _validate_variables(body_text: str, variable_examples: list[str]) -> int:
+    """Extrai os placeholders {{n}} do corpo e garante que formam o conjunto contíguo {1..N},
+    sem lacunas nem duplicatas, e que há exatamente N exemplos (a Meta exige exemplo por
+    variável). Retorna N. Levanta WhatsappTemplateError (422) se algo não bater."""
+    numbers = [int(m.group(1)) for m in _PLACEHOLDER_RE.finditer(body_text)]
+    unique = set(numbers)
+    n = len(unique)
+    if n == 0:
+        if variable_examples:
+            raise WhatsappTemplateError(
+                "O corpo não usa variáveis ({{1}}, {{2}}, ...) mas foram informados exemplos", 422
+            )
+        return 0
+    if unique != set(range(1, n + 1)):
+        raise WhatsappTemplateError(
+            "As variáveis do corpo devem ser contíguas e começar em 1 ({{1}}, {{2}}, ...), "
+            "sem lacunas nem repetição de número diferente", 422
+        )
+    if len(variable_examples) != n:
+        found = len(variable_examples)
+        raise WhatsappTemplateError(
+            f"Informe exatamente {n} exemplo(s) de variável (encontrado(s) {found})", 422
+        )
+    return n
+
+
+def create_template(
+    db: Session, *, tenant_id: str, actor: str, data: TemplateCreate
+) -> WhatsappTemplate:
+    profile = get_profile(db, tenant_id)
+    if not profile.whatsapp_waba_id or not profile.whatsapp_token:
+        raise WhatsappTemplateError(
+            "Configure as credenciais do WhatsApp (Configurações → Integrações) antes de "
+            "criar um template",
+            422,
+        )
+    variable_count = _validate_variables(data.body_text, data.variable_examples)
+
+    try:
+        resp = whatsapp.create_template(
+            waba_id=profile.whatsapp_waba_id,
+            token=profile.whatsapp_token,
+            name=data.name,
+            language=data.language,
+            category=data.category,
+            body_text=data.body_text,
+            variable_examples=data.variable_examples,
+        )
+    except whatsapp.WhatsappApiError as e:
+        raise WhatsappTemplateError(str(e), 422) from e
+
+    template = WhatsappTemplate(
+        tenant_id=tenant_id,
+        name=data.name,
+        language=data.language,
+        category_requested=data.category,
+        category_approved=resp.get("category"),
+        status=resp.get("status") or STATUS_PENDING,
+        meta_template_id=resp.get("id"),
+        body_text=data.body_text,
+        variable_count=variable_count,
+        variable_examples=data.variable_examples,
+    )
+    db.add(template)
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_template.create", target=template.id
+    )
+    try:
+        db.commit()
+    except IntegrityError as e:
+        db.rollback()
+        raise WhatsappTemplateError("Já existe um template com esse nome e idioma", 409) from e
+    db.refresh(template)
+    return template
+
+
+def list_templates(
+    db: Session, tenant_id: str, *, status: str | None = None
+) -> list[WhatsappTemplate]:
+    # NÃO filtra por tenant_id manualmente — RLS já isola (Regra de Ouro nº 1).
+    stmt = select(WhatsappTemplate)
+    if status:
+        stmt = stmt.where(WhatsappTemplate.status == status)
+    stmt = stmt.order_by(WhatsappTemplate.created_at.desc())
+    return list(db.scalars(stmt).all())
+
+
+def _get(db: Session, template_id: str) -> WhatsappTemplate:
+    template = db.get(WhatsappTemplate, template_id)
+    if template is None:
+        raise WhatsappTemplateError("Template não encontrado", 404)
+    return template
+
+
+def sync_template(db: Session, *, tenant_id: str, template_id: str) -> WhatsappTemplate:
+    template = _get(db, template_id)
+    if template.meta_template_id is None:
+        raise WhatsappTemplateError("Template ainda não foi submetido à Meta", 422)
+    profile = get_profile(db, tenant_id)
+    try:
+        resp = whatsapp.fetch_template_status(
+            token=profile.whatsapp_token, meta_template_id=template.meta_template_id
+        )
+    except whatsapp.WhatsappApiError as e:
+        raise WhatsappTemplateError(str(e), 422) from e
+
+    if resp.get("status"):
+        template.status = resp["status"]
+    template.category_approved = resp.get("category")
+    template.rejected_reason = resp.get("rejected_reason")
+    db.commit()
+    db.refresh(template)
+    return template
+
+
+def delete_template(db: Session, *, tenant_id: str, actor: str, template_id: str) -> None:
+    template = _get(db, template_id)
+    profile = get_profile(db, tenant_id)
+    try:
+        whatsapp.delete_template(
+            waba_id=profile.whatsapp_waba_id, token=profile.whatsapp_token, name=template.name
+        )
+    except whatsapp.WhatsappApiError:
+        logger.warning(
+            "[whatsapp_template:delete] falha ao excluir na Meta (mantendo exclusão local) "
+            "template_id=%s name=%s", template_id, template.name,
+        )
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_template.delete", target=template.id
+    )
+    db.delete(template)
+    db.commit()

--- a/apps/api/migrations/versions/0052_whatsapp_integration.py
+++ b/apps/api/migrations/versions/0052_whatsapp_integration.py
@@ -1,0 +1,81 @@
+"""credenciais WhatsApp por tenant + gerenciamento de templates
+
+Revision ID: 0052
+Revises: 0051
+Create Date: 2026-07-18
+
+Duas mudanças, mesma story (integração real de WhatsApp por tenant — hoje era um único
+WHATSAPP_TOKEN/PHONE_ID global em env, errado pra um SaaS multi-tenant onde cada escritório
+precisa da própria conta no WhatsApp Cloud API da Meta):
+
+1. `tenant_profiles` ganha 3 colunas nullable (sem backfill — NULL = integração desligada, mesmo
+   comportamento de graceful degradation que já existia com a env global):
+   - `whatsapp_token` (texto cifrado em repouso via `EncryptedToken`/Fernet — mesmo padrão já
+     usado pelos tokens OAuth do Google em `google_credentials`, ver `core/token_crypto.py`).
+   - `whatsapp_phone_id` (Phone Number ID da Meta — não é segredo, é um ID de conta).
+   - `whatsapp_waba_id` (WhatsApp Business Account ID — necessário para criar/consultar
+     templates via Graph API, além de enviar mensagens).
+
+2. `whatsapp_templates` (RLS) — um template de mensagem por linha, espelhando o que a Meta
+   controla (nome, idioma, categoria solicitada x aprovada, status, motivo de rejeição, ID da
+   Meta). A Meta EXIGE que toda mensagem business-initiated (fora da janela de 24h de
+   atendimento) use um template pré-aprovado — não dá mais para disparar texto livre.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052"
+down_revision: str | None = "0051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("tenant_profiles", sa.Column("whatsapp_token", sa.Text(), nullable=True))
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_phone_id", sa.String(64), nullable=True)
+    )
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_waba_id", sa.String(64), nullable=True)
+    )
+
+    op.create_table(
+        "whatsapp_templates",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("name", sa.String(512), nullable=False),
+        sa.Column("language", sa.String(10), nullable=False, server_default="pt_BR"),
+        sa.Column("category_requested", sa.String(20), nullable=False),
+        sa.Column("category_approved", sa.String(20), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="PENDING"),
+        sa.Column("rejected_reason", sa.Text(), nullable=True),
+        sa.Column("meta_template_id", sa.String(64), nullable=True),
+        sa.Column("body_text", sa.Text(), nullable=False),
+        sa.Column("variable_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("variable_examples", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id", "name", "language", name="uq_whatsapp_templates_tenant_name_lang"
+        ),
+    )
+    op.create_index("ix_whatsapp_templates_tenant_id", "whatsapp_templates", ["tenant_id"])
+    op.execute("ALTER TABLE whatsapp_templates ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE whatsapp_templates FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON whatsapp_templates
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_whatsapp_templates_tenant_id", table_name="whatsapp_templates")
+    op.drop_table("whatsapp_templates")
+    op.drop_column("tenant_profiles", "whatsapp_waba_id")
+    op.drop_column("tenant_profiles", "whatsapp_phone_id")
+    op.drop_column("tenant_profiles", "whatsapp_token")

--- a/apps/api/migrations/versions/0053_whatsapp_template_bindings.py
+++ b/apps/api/migrations/versions/0053_whatsapp_template_bindings.py
@@ -1,0 +1,55 @@
+"""vínculo propósito→template do WhatsApp + colunas de template em notifications
+
+Revision ID: 0053
+Revises: 0052
+Create Date: 2026-07-18
+
+Fecha a lacuna deixada pela Story anterior (0052): os outros 5 pontos do produto que mandam
+WhatsApp business-initiated (lembrete de cobrança, envio de contrato, envio de orçamento,
+convite de staff, aviso interno de card movido) ainda usavam texto livre. A Meta exige template
+pré-aprovado pra todos — mas cada um desses fluxos tem um "propósito" fixo (não é livre escolha
+do usuário como no nó do funil), então o tenant só precisa VINCULAR um template já aprovado a
+cada propósito, uma vez, em vez de escolher a cada envio.
+
+1. `tenant_profiles.whatsapp_template_bindings` (JSON, dict propósito→template_id). Vazio/sem a
+   chave = propósito ainda não vinculado — o fluxo correspondente cai no comportamento antigo
+   (texto livre via `send_text`, agora ciente das credenciais do tenant), sem quebrar nada.
+2. `notifications` ganha 3 colunas nullable pra suportar o caminho ASSÍNCRONO (fila do worker,
+   usado hoje só por `on_client_moved`): o propósito é resolvido no ENFILEIRAMENTO (dentro da
+   request), mas o ENVIO real acontece depois no worker (`process_pending`) — por isso o nome/
+   idioma/variáveis do template precisam ficar guardados na própria notificação enfileirada.
+   `whatsapp_template_name`, `whatsapp_template_language`, `whatsapp_template_variables` (JSON).
+   NULL nas 3 = mesmo comportamento antigo (texto livre) nesse envio.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0053"
+down_revision: str | None = "0052"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenant_profiles",
+        sa.Column("whatsapp_template_bindings", sa.JSON(), nullable=False, server_default="{}"),
+    )
+    op.add_column(
+        "notifications", sa.Column("whatsapp_template_name", sa.String(512), nullable=True)
+    )
+    op.add_column(
+        "notifications", sa.Column("whatsapp_template_language", sa.String(10), nullable=True)
+    )
+    op.add_column(
+        "notifications", sa.Column("whatsapp_template_variables", sa.JSON(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notifications", "whatsapp_template_variables")
+    op.drop_column("notifications", "whatsapp_template_language")
+    op.drop_column("notifications", "whatsapp_template_name")
+    op.drop_column("tenant_profiles", "whatsapp_template_bindings")

--- a/apps/api/tests/test_contracts.py
+++ b/apps/api/tests/test_contracts.py
@@ -1,6 +1,16 @@
 """Testes do Construtor de Contratos + assinatura pública (KYC)."""
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp as core_whatsapp
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_CONTRACT_SEND,
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    WhatsappTemplate,
+)
 
 REGISTER = {
     "legal_name": "Contratos SA",
@@ -16,6 +26,26 @@ REGISTER = {
 def headers(client: TestClient) -> dict[str, str]:
     token = client.post("/auth/register", json=REGISTER).json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _template(db: Session, tenant_id: str, *, status: str = STATUS_APPROVED, **overrides):
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="contrato_assinatura", language="pt_BR",
+        category_requested="UTILITY", category_approved="UTILITY", status=status,
+        body_text="Olá {{1}}, segue o contrato {{2}} para sua assinatura: {{3}}",
+        variable_count=3, variable_examples=["Maria", "Prestação de serviços", "https://x"],
+    )
+    for k, v in overrides.items():
+        setattr(tpl, k, v)
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
 
 
 def _contract(**over):
@@ -95,6 +125,97 @@ def test_send_marks_sent(client: TestClient, headers):
     c = client.post("/contracts", json=_contract(client_id=cl["id"]), headers=headers).json()
     resp = client.post(f"/contracts/{c['id']}/send", headers=headers)
     assert resp.json()["status"] == "sent"
+
+
+def test_send_free_text_uses_tenant_credentials_when_no_template_bound(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_token = "tok-123"
+    profile.whatsapp_phone_id = "phone-456"
+    db.commit()
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_text",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    cl = client.post(
+        "/crm/clients", json={"name": "Cli", "phone": "5511999998888"}, headers=headers
+    ).json()
+    c = client.post("/contracts", json=_contract(client_id=cl["id"]), headers=headers).json()
+    resp = client.post(f"/contracts/{c['id']}/send", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
+    assert captured["token"] == "tok-123"
+    assert captured["phone_id"] == "phone-456"
+    assert f"Segue o contrato '{c['title']}'" in captured["text"]
+
+
+def test_send_uses_approved_bound_template(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    tpl = _template(db, tenant_id)
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_token = "tok-abc"
+    profile.whatsapp_phone_id = "phone-xyz"
+    profile.whatsapp_template_bindings = {PURPOSE_CONTRACT_SEND: tpl.id}
+    db.commit()
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    cl = client.post(
+        "/crm/clients", json={"name": "Maria Cliente", "phone": "5511988887777"}, headers=headers
+    ).json()
+    c = client.post("/contracts", json=_contract(client_id=cl["id"]), headers=headers).json()
+    resp = client.post(f"/contracts/{c['id']}/send", headers=headers)
+    assert resp.status_code == 200
+
+    assert captured["template_name"] == tpl.name
+    assert captured["language"] == tpl.language
+    assert captured["token"] == "tok-abc"
+    assert captured["phone_id"] == "phone-xyz"
+    assert captured["to"] == "5511988887777"
+    link = captured["variables"][2]
+    assert captured["variables"] == ["Maria Cliente", c["title"], link]
+
+    notifs = client.get("/notifications", headers=headers).json()
+    expected_msg = f"Olá Maria Cliente, segue o contrato {c['title']} para sua assinatura: {link}"
+    assert "{{" not in expected_msg
+    assert any(
+        n["message"] == expected_msg and n["channel"] == "whatsapp" for n in notifs
+    )
+
+
+def test_send_falls_back_to_free_text_when_bound_template_not_approved(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    tpl = _template(db, tenant_id, status=STATUS_PENDING)
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_template_bindings = {PURPOSE_CONTRACT_SEND: tpl.id}
+    db.commit()
+
+    called_template = {"value": False}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: called_template.__setitem__("value", True) or "sent",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_text",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    c = client.post("/contracts", json=_contract(), headers=headers).json()
+    resp = client.post(f"/contracts/{c['id']}/send", headers=headers)
+    assert resp.status_code == 200
+    assert called_template["value"] is False
+    assert f"Segue o contrato '{c['title']}'" in captured["text"]
 
 
 def test_cannot_edit_after_sent(client: TestClient, headers):

--- a/apps/api/tests/test_funnel_automation.py
+++ b/apps/api/tests/test_funnel_automation.py
@@ -2,6 +2,9 @@
 espera + agendador (tick), condicional (se-ou), estado por contato e isolamento."""
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
 
 REGISTER = {
     "legal_name": "Funil SA",
@@ -17,6 +20,23 @@ REGISTER = {
 def headers(client: TestClient) -> dict[str, str]:
     token = client.post("/auth/register", json=REGISTER).json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _approved_template(db: Session, tenant_id: str) -> WhatsappTemplate:
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="lembrete_jornada", language="pt_BR",
+        category_requested="UTILITY", category_approved="UTILITY", status=STATUS_APPROVED,
+        body_text="Olá {{1}}, tudo bem?", variable_count=1, variable_examples=["João"],
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
 
 
 def _node(nid, key, action="", config=None):
@@ -41,12 +61,16 @@ def _funnel(client, headers, nodes, edges):
     ).json()["id"]
 
 
-def test_enroll_runs_until_wait_then_tick_resumes(client: TestClient, headers):
+def test_enroll_runs_until_wait_then_tick_resumes(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    tpl = _approved_template(db, tenant_id)
     cid = _client_id(client, headers, "João Jornada")
     nodes = [
         _node("n1", "lead", "create_client"),  # contato já existe → pulado
         _node("n2", "esperar", config={"delay_seconds": 0}),
-        _node("n3", "whatsapp", "send_message", config={"body": "Olá, tudo bem? 🙂"}),
+        _node("n3", "whatsapp", "send_message",
+              config={"template_id": tpl.id, "variables": ["{{cliente.nome}}"]}),
     ]
     edges = [_edge("n1", "n2"), _edge("n2", "n3")]
     fid = _funnel(client, headers, nodes, edges)

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -1,6 +1,14 @@
 """Testes do Construtor de Funil de Vendas."""
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp as core_whatsapp
+from app.modules.whatsapp_templates.models import (
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    WhatsappTemplate,
+)
 
 REGISTER = {
     "legal_name": "Funil SA",
@@ -16,6 +24,28 @@ REGISTER = {
 def headers(client: TestClient) -> dict[str, str]:
     token = client.post("/auth/register", json=REGISTER).json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _template(
+    db: Session, tenant_id: str, *, status: str = STATUS_APPROVED, **overrides
+) -> WhatsappTemplate:
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="confirmacao_pedido", language="pt_BR",
+        category_requested="UTILITY", category_approved="UTILITY", status=status,
+        body_text="Olá {{1}}, seu pedido {{2}} foi confirmado!",
+        variable_count=2, variable_examples=["Maria", "#123"],
+    )
+    for k, v in overrides.items():
+        setattr(tpl, k, v)
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
 
 
 def test_components_catalog(client: TestClient, headers):
@@ -143,17 +173,84 @@ def test_run_create_charge(client: TestClient, headers):
     assert any(c["amount_cents"] == 9900 and c["method"] == "boleto" for c in charges)
 
 
-def test_run_send_message(client: TestClient, headers):
+def test_run_send_message(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+    tpl = _template(db, tenant_id)
+    cl = client.post(
+        "/crm/clients", json={"name": "Contato", "phone": "5511988887777"}, headers=headers
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"],
+              "params": {"template_id": tpl.id, "variables": ["Maria", "#123"]}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["template_name"] == tpl.name
+    assert captured["variables"] == ["Maria", "#123"]
+    notifs = client.get("/notifications", headers=headers).json()
+    # o texto registrado é o template RENDERIZADO (sem {{n}}), não o texto cru.
+    assert any(
+        n["message"] == "Olá Maria, seu pedido #123 foi confirmado!" and n["channel"] == "whatsapp"
+        for n in notifs
+    )
+
+
+def test_run_send_message_missing_template_is_422(client: TestClient, headers):
+    cl = client.post("/crm/clients", json={"name": "Contato"}, headers=headers).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"], "params": {}},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_run_send_message_template_not_approved_is_422(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    tpl = _template(db, tenant_id, status=STATUS_PENDING)
     cl = client.post("/crm/clients", json={"name": "Contato"}, headers=headers).json()
     resp = client.post(
         "/funnels/run-node",
         json={"action": "send_message", "client_id": cl["id"],
-              "params": {"message": "Olá! Tudo bem?"}},
+              "params": {"template_id": tpl.id, "variables": ["Maria", "#123"]}},
         headers=headers,
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 422
+
+
+def test_run_send_message_resolves_client_keyword_variables(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+    tpl = _template(db, tenant_id)
+    cl = client.post(
+        "/crm/clients", json={"name": "Maria Cliente", "phone": "5511988887777"}, headers=headers
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"],
+              "params": {"template_id": tpl.id, "variables": ["{{cliente.nome}}", "#999"]}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    # mistura de literal ("#999") + keyword ("{{cliente.nome}}") resolvida contra o cliente.
+    assert captured["variables"] == ["Maria Cliente", "#999"]
     notifs = client.get("/notifications", headers=headers).json()
-    assert any(n["message"] == "Olá! Tudo bem?" for n in notifs)
+    assert any(
+        n["message"] == "Olá Maria Cliente, seu pedido #999 foi confirmado!" for n in notifs
+    )
 
 
 def test_run_send_email(client: TestClient, headers):

--- a/apps/api/tests/test_notifications.py
+++ b/apps/api/tests/test_notifications.py
@@ -16,6 +16,7 @@ from app.modules.auth.models import Tenant, User
 from app.modules.notifications import service
 from app.modules.notifications.models import Notification
 from app.modules.notifications.service import NotificationError
+from app.modules.settings import service as settings_service
 from app.modules.settings.models import TenantProfile
 
 
@@ -117,6 +118,60 @@ def test_on_client_moved_enqueues_pending_for_existing_client(db, monkeypatch):
     assert notif.recipient == "dono@mov.com"
     assert "Maria Cliente" in notif.message  # usa o nome real, não o placeholder
     assert called["whatsapp"] == 0  # NÃO enviou síncrono — só enfileirou
+    # Sem vínculo propósito→template (Configurações): comportamento antigo, texto livre.
+    assert notif.whatsapp_template_name is None
+    assert notif.whatsapp_template_language is None
+    assert notif.whatsapp_template_variables is None
+
+
+def test_on_client_moved_uses_bound_template_when_approved(db, monkeypatch):
+    """Story de templates: propósito `client_moved` vinculado a um template APROVADO →
+    a Notification enfileirada carrega template_name/language/variables (nessa ordem: nome do
+    cliente, nome da etapa) e `message` guarda o PREVIEW renderizado, não o texto livre nem
+    `{{1}}`/`{{2}}` crus.
+    """
+    from app.modules.crm.models import Client
+    from app.modules.whatsapp_templates.models import PURPOSE_CLIENT_MOVED, WhatsappTemplate
+
+    tenant = _seed_owner_tenant(db, slug="mov3", document="00000000000353")
+    client = Client(tenant_id=tenant.id, name="Maria Cliente")
+    db.add(client)
+    template = WhatsappTemplate(
+        tenant_id=tenant.id,
+        name="aviso_mudanca_etapa",
+        language="pt_BR",
+        category_requested="UTILITY",
+        category_approved="UTILITY",
+        status="APPROVED",
+        body_text='O cliente {{1}} foi movido para a etapa "{{2}}".',
+        variable_count=2,
+        variable_examples=["Maria", "Proposta"],
+    )
+    db.add(template)
+    db.flush()
+
+    profile = settings_service.get_profile(db, tenant.id)
+    profile.whatsapp_template_bindings = {PURPOSE_CLIENT_MOVED: template.id}
+    db.commit()
+
+    @contextmanager
+    def _fake_tenant_session(_tenant_id):
+        yield db
+
+    monkeypatch.setattr(service, "tenant_session", _fake_tenant_session)
+    monkeypatch.setattr(whatsapp, "send_text", lambda *, to, text, **_k: "sent")
+
+    service.on_client_moved(tenant_id=tenant.id, client_id=client.id, to_stage="nao-existe")
+
+    notif = db.scalar(select(Notification))
+    assert notif is not None
+    assert notif.status == "pending"
+    assert notif.whatsapp_template_name == "aviso_mudanca_etapa"
+    assert notif.whatsapp_template_language == "pt_BR"
+    assert notif.whatsapp_template_variables == ["Maria Cliente", "—"]
+    assert notif.message == 'O cliente Maria Cliente foi movido para a etapa "—".'
+    assert "{{1}}" not in notif.message
+    assert "{{2}}" not in notif.message
 
 
 def test_on_client_moved_nonexistent_client_is_not_enqueued(db, monkeypatch):

--- a/apps/api/tests/test_notifications_queue.py
+++ b/apps/api/tests/test_notifications_queue.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from app.core import email, whatsapp
 from app.modules.notifications import service
 from app.modules.notifications.models import Notification
+from app.modules.settings.models import TenantProfile
 
 TENANT = "tenant-00000000-teste"
 
@@ -34,7 +35,9 @@ def test_enqueue_creates_pending(db):
 
 def test_process_pending_marks_sent(db, monkeypatch):
     _pending(db)
-    monkeypatch.setattr(whatsapp, "send_text", lambda *, to, text: "sent")
+    monkeypatch.setattr(
+        whatsapp, "send_text", lambda *, to, text, token=None, phone_id=None: "sent"
+    )
     processed = service.process_pending(db, tenant_id=TENANT)
     assert processed == 1
     n = db.scalar(select(Notification))
@@ -55,7 +58,7 @@ def test_failure_is_isolated_and_recorded(db, monkeypatch):
     _pending(db, message="boom")
     _pending(db, message="ok")
 
-    def _flaky(*, to, text):
+    def _flaky(*, to, text, token=None, phone_id=None):
         if "boom" in text:
             raise RuntimeError("provedor caiu")
         return "sent"
@@ -75,7 +78,9 @@ def test_failure_is_isolated_and_recorded(db, monkeypatch):
 def test_process_pending_respects_limit(db, monkeypatch):
     for i in range(3):
         _pending(db, message=f"msg-{i}")
-    monkeypatch.setattr(whatsapp, "send_text", lambda *, to, text: "sent")
+    monkeypatch.setattr(
+        whatsapp, "send_text", lambda *, to, text, token=None, phone_id=None: "sent"
+    )
     processed = service.process_pending(db, tenant_id=TENANT, limit=2)
     assert processed == 2
     remaining = db.scalars(
@@ -92,7 +97,7 @@ def test_email_channel_uses_email_sender(db, monkeypatch):
         calls["email"] += 1
         return "sent"
 
-    def _whatsapp(*, to, text):
+    def _whatsapp(*, to, text, token=None, phone_id=None):
         calls["whatsapp"] += 1
         return "sent"
 
@@ -101,4 +106,64 @@ def test_email_channel_uses_email_sender(db, monkeypatch):
     service.process_pending(db, tenant_id=TENANT)
     assert calls["email"] == 1
     assert calls["whatsapp"] == 0
+    assert db.scalar(select(Notification)).status == "sent"
+
+
+def test_process_pending_passes_tenant_credentials_to_send_text(db, monkeypatch):
+    """Caminho legado/sem template: token/phone_id do TENANT (não só posicional to/text)."""
+    db.add(
+        TenantProfile(
+            tenant_id=TENANT, whatsapp_token="tok-123", whatsapp_phone_id="phone-456"
+        )
+    )
+    db.commit()
+    _pending(db)
+
+    captured: dict = {}
+
+    def _send_text(*, to, text, token=None, phone_id=None):
+        captured.update(to=to, text=text, token=token, phone_id=phone_id)
+        return "sent"
+
+    monkeypatch.setattr(whatsapp, "send_text", _send_text)
+    processed = service.process_pending(db, tenant_id=TENANT)
+    assert processed == 1
+    assert captured["token"] == "tok-123"
+    assert captured["phone_id"] == "phone-456"
+
+
+def test_process_pending_uses_send_template_when_fields_set(db, monkeypatch):
+    """Notification com whatsapp_template_* preenchido → usa send_template, não send_text."""
+    service.enqueue(
+        db,
+        tenant_id=TENANT,
+        channel="whatsapp",
+        recipient="dono@example.com",
+        message="preview renderizado",
+        whatsapp_template_name="tmpl_client_moved",
+        whatsapp_template_language="pt_BR",
+        whatsapp_template_variables=["Maria Cliente", "Proposta Enviada"],
+    )
+    db.commit()
+
+    calls = {"template": 0, "text": 0}
+
+    def _send_template(*, to, token, phone_id, template_name, language, variables):
+        calls["template"] += 1
+        assert to == "dono@example.com"
+        assert template_name == "tmpl_client_moved"
+        assert language == "pt_BR"
+        assert variables == ["Maria Cliente", "Proposta Enviada"]
+        return "sent"
+
+    def _send_text(*_a, **_k):
+        calls["text"] += 1
+        return "sent"
+
+    monkeypatch.setattr(whatsapp, "send_template", _send_template)
+    monkeypatch.setattr(whatsapp, "send_text", _send_text)
+    processed = service.process_pending(db, tenant_id=TENANT)
+    assert processed == 1
+    assert calls["template"] == 1
+    assert calls["text"] == 0
     assert db.scalar(select(Notification)).status == "sent"

--- a/apps/api/tests/test_platform.py
+++ b/apps/api/tests/test_platform.py
@@ -6,12 +6,20 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core import whatsapp
 from app.core.audit import PlatformAuditEntry
 from app.core.security import hash_password
 from app.modules.agenda.models import AgendaEvent
 from app.modules.auth.models import Tenant, User
 from app.modules.crm.models import Client
 from app.modules.platform import service as platform_service
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_STAFF_INVITE,
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    WhatsappTemplate,
+)
 
 ADMIN_EMAIL = "master@e1p.com"
 ADMIN_PASS = "senha-do-master-123"
@@ -195,7 +203,7 @@ def test_create_edit_delete_staff(client: TestClient, admin_headers):
     assert node["staff_count"] == 0
 
 
-def test_staff_whatsapp_delivery(client: TestClient, admin_headers):
+def test_staff_whatsapp_delivery(client: TestClient, admin_headers, _tenant_session_to_test_db):
     tid = _tenant_id(client, admin_headers, slug="escw", email="escw@example.com")
     invite = client.post(
         f"/admin/accounts/{tid}/users",
@@ -203,6 +211,126 @@ def test_staff_whatsapp_delivery(client: TestClient, admin_headers):
         headers=admin_headers,
     ).json()
     assert invite["delivery"] == "whatsapp" and invite["delivery_status"] in ("sent", "logged")
+
+
+# ── WhatsApp por template (staff_invite) — Story convite via template ───────────────────────
+def test_staff_whatsapp_no_binding_uses_tenant_credentials(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db, monkeypatch
+):
+    """Sem template vinculado: mantém o texto livre, mas usando as credenciais do TENANT."""
+    tid = _tenant_id(client, admin_headers, slug="escwcred", email="escwcred@example.com")
+    db.add(TenantProfile(tenant_id=tid, whatsapp_token="tok-123", whatsapp_phone_id="phone-456"))
+    db.commit()
+
+    captured = {}
+
+    def _fake_send_text(*, to, text, token=None, phone_id=None):
+        captured.update(to=to, token=token, phone_id=phone_id)
+        return "sent"
+
+    monkeypatch.setattr(whatsapp, "send_text", _fake_send_text)
+
+    invite = client.post(
+        f"/admin/accounts/{tid}/users",
+        json=_staff_body(email="credzap@escwcred.com", delivery="whatsapp"),
+        headers=admin_headers,
+    ).json()
+    assert invite["delivery_status"] == "sent"
+    assert captured["token"] == "tok-123" and captured["phone_id"] == "phone-456"
+
+
+def test_staff_whatsapp_bound_approved_template_sends_variables_in_order(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db, monkeypatch
+):
+    """Template vinculado + aprovado: usa send_template com as variáveis na ordem do spec
+    (Nome, Empresa, E-mail de login, Senha temporária)."""
+    tid = _tenant_id(client, admin_headers, slug="esctpl", email="esctpl@example.com")
+    tpl = WhatsappTemplate(
+        tenant_id=tid,
+        name="convite_funcionario",
+        language="pt_BR",
+        category_requested="UTILITY",
+        status=STATUS_APPROVED,
+        body_text="Olá {{1}}, bem-vindo à {{2}}. Login: {{3}} Senha: {{4}}",
+        variable_count=4,
+        variable_examples=["Ana", "Empresa X", "ana@x.com", "abc123"],
+    )
+    db.add(tpl)
+    db.flush()
+    db.add(TenantProfile(
+        tenant_id=tid,
+        whatsapp_token="tok-1",
+        whatsapp_phone_id="phone-1",
+        whatsapp_template_bindings={PURPOSE_STAFF_INVITE: tpl.id},
+    ))
+    db.commit()
+
+    captured = {}
+
+    def _fake_send_template(*, to, token, phone_id, template_name, language, variables):
+        captured.update(
+            to=to, token=token, phone_id=phone_id, template_name=template_name,
+            language=language, variables=variables,
+        )
+        return "sent"
+
+    monkeypatch.setattr(whatsapp, "send_template", _fake_send_template)
+
+    body = _staff_body(email="tplzap@esctpl.com", delivery="whatsapp", name="Contadora Nova")
+    invite = client.post(f"/admin/accounts/{tid}/users", json=body, headers=admin_headers).json()
+
+    assert invite["delivery_status"] == "sent"
+    assert captured["template_name"] == "convite_funcionario"
+    assert captured["language"] == "pt_BR"
+    assert captured["token"] == "tok-1" and captured["phone_id"] == "phone-1"
+    assert captured["variables"] == [
+        "Contadora Nova", "Cliente Pagante", "tplzap@esctpl.com", invite["temp_password"],
+    ]
+
+
+def test_staff_whatsapp_bound_unapproved_template_falls_back_to_text(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db, monkeypatch
+):
+    """Template vinculado mas ainda não aprovado pela Meta: cai no texto livre (send_text)."""
+    tid = _tenant_id(client, admin_headers, slug="esctplpend", email="esctplpend@example.com")
+    tpl = WhatsappTemplate(
+        tenant_id=tid,
+        name="convite_pendente",
+        language="pt_BR",
+        category_requested="UTILITY",
+        status=STATUS_PENDING,
+        body_text="Olá {{1}}, bem-vindo à {{2}}. Login: {{3}} Senha: {{4}}",
+        variable_count=4,
+        variable_examples=[],
+    )
+    db.add(tpl)
+    db.flush()
+    db.add(TenantProfile(
+        tenant_id=tid,
+        whatsapp_token="tok-2",
+        whatsapp_phone_id="phone-2",
+        whatsapp_template_bindings={PURPOSE_STAFF_INVITE: tpl.id},
+    ))
+    db.commit()
+
+    calls = {"template": False, "text": False}
+
+    def _fake_send_template(**kwargs):
+        calls["template"] = True
+        return "sent"
+
+    def _fake_send_text(*, to, text, token=None, phone_id=None):
+        calls["text"] = True
+        return "sent"
+
+    monkeypatch.setattr(whatsapp, "send_template", _fake_send_template)
+    monkeypatch.setattr(whatsapp, "send_text", _fake_send_text)
+
+    body = _staff_body(email="pendzap@esctplpend.com", delivery="whatsapp")
+    invite = client.post(f"/admin/accounts/{tid}/users", json=body, headers=admin_headers).json()
+
+    assert invite["delivery_status"] == "sent"
+    assert calls["text"] is True and calls["template"] is False
 
 
 def test_first_access_password_change(client: TestClient, admin_headers):

--- a/apps/api/tests/test_quotes.py
+++ b/apps/api/tests/test_quotes.py
@@ -1,6 +1,16 @@
 """Testes da Central de Orçamentos — incluindo o efeito dominó (aprovar -> cobrança)."""
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp as core_whatsapp
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_QUOTE_SEND,
+    STATUS_APPROVED,
+    STATUS_PENDING,
+    WhatsappTemplate,
+)
 
 REGISTER = {
     "legal_name": "Orca Co",
@@ -16,6 +26,26 @@ REGISTER = {
 def headers(client: TestClient) -> dict[str, str]:
     token = client.post("/auth/register", json=REGISTER).json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _template(db: Session, tenant_id: str, *, status: str = STATUS_APPROVED, **overrides):
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="orcamento_proposta", language="pt_BR",
+        category_requested="UTILITY", category_approved="UTILITY", status=status,
+        body_text="Olá {{1}}, segue sua proposta {{2}}: {{3}}. Veja em {{4}}",
+        variable_count=4, variable_examples=["Maria", "Consultoria", "R$ 100", "https://x"],
+    )
+    for k, v in overrides.items():
+        setattr(tpl, k, v)
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
 
 
 def _quote(**over):
@@ -57,6 +87,98 @@ def test_send_marks_sent_and_notifies(client: TestClient, headers):
     assert resp.json()["status"] == "sent"
     notifs = client.get("/notifications", headers=headers).json()
     assert any(n["channel"] == "whatsapp" for n in notifs)
+
+
+def test_send_free_text_uses_tenant_credentials_when_no_template_bound(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_token = "tok-123"
+    profile.whatsapp_phone_id = "phone-456"
+    db.commit()
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_text",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    cl = client.post(
+        "/crm/clients", json={"name": "Cliente Orca", "phone": "5511977776666"}, headers=headers
+    ).json()
+    q = client.post("/quotes", json=_quote(client_id=cl["id"]), headers=headers).json()
+    resp = client.post(f"/quotes/{q['id']}/send", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
+    assert captured["token"] == "tok-123"
+    assert captured["phone_id"] == "phone-456"
+    assert f"Segue sua proposta de {q['title']}" in captured["text"]
+
+
+def test_send_uses_approved_bound_template(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    tpl = _template(db, tenant_id)
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_token = "tok-abc"
+    profile.whatsapp_phone_id = "phone-xyz"
+    profile.whatsapp_template_bindings = {PURPOSE_QUOTE_SEND: tpl.id}
+    db.commit()
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    cl = client.post(
+        "/crm/clients", json={"name": "Maria Cliente", "phone": "5511988887777"}, headers=headers
+    ).json()
+    q = client.post("/quotes", json=_quote(client_id=cl["id"]), headers=headers).json()
+    resp = client.post(f"/quotes/{q['id']}/send", headers=headers)
+    assert resp.status_code == 200
+
+    valor = f"R$ {q['total_cents'] / 100:.2f}".replace(".", ",")
+    assert captured["template_name"] == tpl.name
+    assert captured["language"] == tpl.language
+    assert captured["token"] == "tok-abc"
+    assert captured["phone_id"] == "phone-xyz"
+    assert captured["to"] == "5511988887777"
+    link = captured["variables"][3]
+    assert captured["variables"] == ["Maria Cliente", q["title"], valor, link]
+
+    notifs = client.get("/notifications", headers=headers).json()
+    expected_msg = f"Olá Maria Cliente, segue sua proposta {q['title']}: {valor}. Veja em {link}"
+    assert "{{" not in expected_msg
+    assert any(
+        n["message"] == expected_msg and n["channel"] == "whatsapp" for n in notifs
+    )
+
+
+def test_send_falls_back_to_free_text_when_bound_template_not_approved(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    tpl = _template(db, tenant_id, status=STATUS_PENDING)
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_template_bindings = {PURPOSE_QUOTE_SEND: tpl.id}
+    db.commit()
+
+    called_template = {"value": False}
+    monkeypatch.setattr(
+        core_whatsapp, "send_template",
+        lambda **kwargs: called_template.__setitem__("value", True) or "sent",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        core_whatsapp, "send_text",
+        lambda **kwargs: (captured.update(kwargs), "sent")[1],
+    )
+
+    q = client.post("/quotes", json=_quote(), headers=headers).json()
+    resp = client.post(f"/quotes/{q['id']}/send", headers=headers)
+    assert resp.status_code == 200
+    assert called_template["value"] is False
+    assert f"Segue sua proposta de {q['title']}" in captured["text"]
 
 
 def test_approve_generates_charge(client: TestClient, headers):

--- a/apps/api/tests/test_receivables.py
+++ b/apps/api/tests/test_receivables.py
@@ -524,6 +524,177 @@ def test_reclassify_open_charge(client: TestClient, headers):
     assert out["chart_account_id"] == acc["id"]
 
 
+# ── Fase 2: `collect_with_ai` convertido para template (propósito `charge_reminder`) ──────────
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _make_template(db, tenant_id: str, *, status: str = "APPROVED", variable_count: int = 4):
+    from app.modules.whatsapp_templates.models import WhatsappTemplate
+
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="cobranca_padrao", language="pt_BR",
+        category_requested="UTILITY", category_approved="UTILITY", status=status,
+        body_text="Olá {{1}}! {{2}} Valor: {{3}}, vencimento {{4}}.",
+        variable_count=variable_count,
+        variable_examples=["Cliente", "frase", "R$ 10,00", "01/01/2026"][:variable_count],
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    return tpl
+
+
+def _bind_charge_reminder(db, tenant_id: str, template_id: str) -> None:
+    from app.modules.settings import service as settings_service
+    from app.modules.whatsapp_templates.models import PURPOSE_CHARGE_REMINDER
+
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_template_bindings = {PURPOSE_CHARGE_REMINDER: template_id}
+    db.commit()
+
+
+def test_collect_with_ai_without_binding_uses_free_text_with_tenant_credentials(
+    client: TestClient, headers, db, tenant_id, monkeypatch
+):
+    """Sem vínculo configurado: comportamento antigo (mensagem completa de texto livre via
+    `send_text`), mas agora repassando as credenciais do tenant (mesmo vazias no teste)."""
+    from app.core import whatsapp
+
+    calls: list[dict] = []
+
+    def fake_send_text(*, to, text, token=None, phone_id=None):
+        calls.append({"to": to, "text": text, "token": token, "phone_id": phone_id})
+        return "logged"
+
+    monkeypatch.setattr(whatsapp, "send_text", fake_send_text)
+
+    c = client.post(
+        "/receivables/charges",
+        json=_charge(due_date="2020-01-01", amount_cents=15000),
+        headers=headers,
+    ).json()
+    r = client.post(f"/receivables/charges/{c['id']}/collect", headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["message"]) > 10
+    assert body["status"] == "logged"
+    assert len(calls) == 1
+    # credenciais do tenant repassadas explicitamente (None no teste, mas o parâmetro é usado)
+    assert calls[0]["token"] is None
+    assert calls[0]["phone_id"] is None
+
+
+def test_collect_with_ai_with_approved_binding_uses_template(
+    client: TestClient, headers, db, tenant_id, monkeypatch
+):
+    """Com um template APROVADO vinculado ao propósito, usa `send_template` (não `send_text`),
+    com as 4 variáveis na ordem [nome, frase, valor, vencimento] e a Notification guardando o
+    preview RENDERIZADO (placeholders substituídos)."""
+    from app.core import whatsapp
+
+    tpl = _make_template(db, tenant_id)
+    _bind_charge_reminder(db, tenant_id, tpl.id)
+
+    text_calls: list[dict] = []
+    template_calls: list[dict] = []
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda **kw: (text_calls.append(kw), "logged")[1],
+    )
+    monkeypatch.setattr(
+        whatsapp, "send_template",
+        lambda **kw: (template_calls.append(kw), "logged")[1],
+    )
+
+    cl = client.post(
+        "/crm/clients", json={"name": "Maria Cliente", "phone": "5511999990000"}, headers=headers
+    ).json()
+    c = client.post(
+        "/receivables/charges",
+        json=_charge(client_id=cl["id"], due_date="2020-01-01", amount_cents=15000),
+        headers=headers,
+    ).json()
+    r = client.post(f"/receivables/charges/{c['id']}/collect", headers=headers)
+    assert r.status_code == 200
+
+    assert not text_calls  # não usou o caminho de texto livre
+    assert len(template_calls) == 1
+    call = template_calls[0]
+    assert call["template_name"] == "cobranca_padrao"
+    variables = call["variables"]
+    assert len(variables) == 4
+    assert variables[0] == "Maria Cliente"
+    assert variables[2] == "R$ 150,00"
+    assert variables[3] == "01/01/2020"
+    # frase (variável 2) não deve conter placeholder [NOME] cru nem ficar vazia
+    assert variables[1]
+
+    notifs = client.get("/notifications", headers=headers).json()
+    whatsapp_notifs = [n for n in notifs if n["channel"] == "whatsapp"]
+    assert whatsapp_notifs
+    rendered = whatsapp_notifs[0]["message"]
+    assert "{{" not in rendered  # placeholders substituídos, não crus
+    assert "Maria Cliente" in rendered
+
+
+def test_collect_with_ai_with_pending_binding_falls_back_to_free_text(
+    client: TestClient, headers, db, tenant_id, monkeypatch
+):
+    """Template vinculado mas AINDA NÃO aprovado (ex.: PENDING) → trata como "sem vínculo":
+    cai no caminho antigo de texto livre, não quebra."""
+    from app.core import whatsapp
+
+    tpl = _make_template(db, tenant_id, status="PENDING")
+    _bind_charge_reminder(db, tenant_id, tpl.id)
+
+    template_calls: list[dict] = []
+    monkeypatch.setattr(
+        whatsapp, "send_template",
+        lambda **kw: (template_calls.append(kw), "logged")[1],
+    )
+
+    c = client.post(
+        "/receivables/charges",
+        json=_charge(due_date="2020-01-01", amount_cents=15000),
+        headers=headers,
+    ).json()
+    r = client.post(f"/receivables/charges/{c['id']}/collect", headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["message"]) > 10
+    assert not template_calls  # não usou o template ainda pendente
+
+
+def test_send_message_manual_uses_tenant_credentials(
+    client: TestClient, headers, monkeypatch
+):
+    """Mensagem manual continua texto livre (não vira template), mas agora repassa as
+    credenciais do tenant para `send_text`."""
+    from app.core import whatsapp
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda **kw: (calls.append(kw), "logged")[1],
+    )
+
+    c = client.post("/receivables/charges", json=_charge(), headers=headers).json()
+    r = client.post(
+        f"/receivables/charges/{c['id']}/message",
+        json={"text": "Oi, passando para lembrar 🙂"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["text"] == "Oi, passando para lembrar 🙂"
+    assert "token" in calls[0]
+    assert "phone_id" in calls[0]
+
+
 def test_unset_charge_chart_account(client: TestClient, headers):
     """"" desvincula (→ sem categoria), mesmo padrão de contract_id/cost_center_id."""
     acc = client.post(

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -1,6 +1,7 @@
 """Testes de Configurações + Brand Kit."""
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 REGISTER = {
     "legal_name": "Brand SA",
@@ -146,3 +147,87 @@ def test_set_and_clear_default_entry_funnel(client: TestClient, headers):
 
 def test_requires_auth(client: TestClient):
     assert client.get("/settings/profile").status_code == 401
+
+
+def test_whatsapp_starts_unconfigured(client: TestClient, headers):
+    resp = client.get("/settings/profile", headers=headers)
+    assert resp.status_code == 200
+    p = resp.json()
+    assert p["whatsapp_configured"] is False
+    assert p["whatsapp_phone_id"] == ""
+    assert p["whatsapp_waba_id"] == ""
+    assert "whatsapp_token" not in p
+
+
+def test_whatsapp_full_config_marks_configured(client: TestClient, headers):
+    resp = client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "EAAG-fake-meta-token",
+            "whatsapp_phone_id": "1234567890",
+            "whatsapp_waba_id": "0987654321",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    p = resp.json()
+    assert p["whatsapp_configured"] is True
+    assert p["whatsapp_phone_id"] == "1234567890"
+    assert p["whatsapp_waba_id"] == "0987654321"
+    assert "whatsapp_token" not in p
+    # persiste
+    again = client.get("/settings/profile", headers=headers).json()
+    assert again["whatsapp_configured"] is True
+    assert again["whatsapp_phone_id"] == "1234567890"
+    assert again["whatsapp_waba_id"] == "0987654321"
+
+
+def test_whatsapp_partial_config_not_configured(client: TestClient, headers):
+    resp = client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "EAAG-fake-meta-token",
+            "whatsapp_phone_id": "1234567890",
+            # whatsapp_waba_id omitido de propósito
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["whatsapp_configured"] is False
+
+
+def test_whatsapp_clear_token_unconfigures(client: TestClient, headers):
+    client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "EAAG-fake-meta-token",
+            "whatsapp_phone_id": "1234567890",
+            "whatsapp_waba_id": "0987654321",
+        },
+        headers=headers,
+    )
+    resp = client.patch(
+        "/settings/profile", json={"whatsapp_token": ""}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["whatsapp_configured"] is False
+    again = client.get("/settings/profile", headers=headers).json()
+    assert again["whatsapp_configured"] is False
+    # phone_id/waba_id não foram tocados (None = não altera), só o token foi limpo
+    assert again["whatsapp_phone_id"] == "1234567890"
+    assert again["whatsapp_waba_id"] == "0987654321"
+
+
+def test_whatsapp_token_encrypted_at_rest(client: TestClient, headers, db: Session):
+    from sqlalchemy import text
+
+    plaintext = "EAAG-fake-meta-token-for-encryption-check"
+    client.patch(
+        "/settings/profile", json={"whatsapp_token": plaintext}, headers=headers
+    )
+    # Bypassa o TypeDecorator (SQL cru) para inspecionar o valor REALMENTE gravado no banco.
+    stored_raw = db.execute(
+        text("SELECT whatsapp_token FROM tenant_profiles LIMIT 1")
+    ).scalar()
+    assert stored_raw != plaintext
+    assert stored_raw.startswith("enc:v1:")

--- a/apps/api/tests/test_whatsapp.py
+++ b/apps/api/tests/test_whatsapp.py
@@ -87,3 +87,217 @@ def test_failed_when_provider_returns_error_status(
     monkeypatch.setattr(httpx, "post", lambda *_a, **_k: _FakeResponse(401))
     # HTTPStatusError (via raise_for_status) também é capturado → "failed".
     assert whatsapp.send_text(to="5511988887777", text="Olá") == "failed"
+
+
+# ── Templates (gerência administrativa — PROPAGA exceção, ver WhatsappApiError) ─────────
+
+
+class _FakeJsonResponse:
+    """Resposta mínima com o contrato usado pelas funções de template (status_code + .json())."""
+
+    def __init__(self, status_code: int = 200, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_create_template_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeJsonResponse:
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        captured["json"] = kwargs.get("json")
+        return _FakeJsonResponse(200, {"id": "meta-123", "status": "PENDING"})
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    resp = whatsapp.create_template(
+        waba_id="waba1", token="tok", name="boas_vindas", language="pt_BR",
+        category="MARKETING", body_text="Olá {{1}}, bem-vindo!", variable_examples=["Maria"],
+    )
+    assert resp == {"id": "meta-123", "status": "PENDING"}
+    assert captured["url"] == "https://graph.facebook.com/v21.0/waba1/message_templates"
+    assert captured["headers"] == {"Authorization": "Bearer tok"}
+    assert captured["json"] == {
+        "name": "boas_vindas",
+        "language": "pt_BR",
+        "category": "MARKETING",
+        "components": [
+            {
+                "type": "BODY",
+                "text": "Olá {{1}}, bem-vindo!",
+                "example": {"body_text": [["Maria"]]},
+            }
+        ],
+    }
+
+
+def test_create_template_without_variables_omits_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeJsonResponse:
+        captured["json"] = kwargs.get("json")
+        return _FakeJsonResponse(200, {"id": "meta-1", "status": "PENDING"})
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    whatsapp.create_template(
+        waba_id="waba1", token="tok", name="sem_var", language="pt_BR",
+        category="UTILITY", body_text="Olá!", variable_examples=[],
+    )
+    assert "example" not in captured["json"]["components"][0]
+
+
+def test_create_template_raises_on_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.create_template(
+            waba_id="waba1", token="tok", name="x", language="pt_BR",
+            category="MARKETING", body_text="Olá", variable_examples=[],
+        )
+
+
+def test_create_template_raises_on_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        httpx, "post",
+        lambda *_a, **_k: _FakeJsonResponse(400, {"error": {"message": "nome inválido"}}),
+    )
+    with pytest.raises(whatsapp.WhatsappApiError, match="nome inválido"):
+        whatsapp.create_template(
+            waba_id="waba1", token="tok", name="x", language="pt_BR",
+            category="MARKETING", body_text="Olá", variable_examples=[],
+        )
+
+
+def test_fetch_template_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get(url: str, **kwargs: object) -> _FakeJsonResponse:
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        captured["headers"] = kwargs.get("headers")
+        return _FakeJsonResponse(
+            200, {"status": "APPROVED", "category": "MARKETING", "rejected_reason": None}
+        )
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    resp = whatsapp.fetch_template_status(token="tok", meta_template_id="meta-123")
+    assert resp == {"status": "APPROVED", "category": "MARKETING", "rejected_reason": None}
+    assert captured["url"] == "https://graph.facebook.com/v21.0/meta-123"
+    assert captured["params"] == {"fields": "status,category,rejected_reason"}
+
+
+def test_fetch_template_status_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "get", lambda *_a, **_k: _FakeJsonResponse(404, {}, "not found"))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.fetch_template_status(token="tok", meta_template_id="meta-404")
+
+
+def test_delete_template_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_delete(url: str, **kwargs: object) -> _FakeJsonResponse:
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        return _FakeJsonResponse(200, {"success": True})
+
+    monkeypatch.setattr(httpx, "delete", _fake_delete)
+    whatsapp.delete_template(waba_id="waba1", token="tok", name="boas_vindas")
+    assert captured["url"] == "https://graph.facebook.com/v21.0/waba1/message_templates"
+    assert captured["params"] == {"name": "boas_vindas"}
+
+
+def test_delete_template_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "delete", lambda *_a, **_k: _FakeJsonResponse(400, {}, "erro"))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.delete_template(waba_id="waba1", token="tok", name="x")
+
+
+def test_send_template_logged_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:  # pragma: no cover - não deve ser chamado
+        raise AssertionError("httpx.post não deveria ser chamado no caminho 'logged'")
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    assert whatsapp.send_template(
+        to="5511999999999", token="", phone_id="", template_name="boas_vindas",
+        language="pt_BR", variables=["Maria"],
+    ) == "logged"
+    # Sem phone_id, mesmo com token: também 'logged'.
+    assert whatsapp.send_template(
+        to="5511999999999", token="tok", phone_id="", template_name="boas_vindas",
+        language="pt_BR", variables=[],
+    ) == "logged"
+
+
+def test_send_template_sent_with_variables(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        captured["json"] = kwargs.get("json")
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    status = whatsapp.send_template(
+        to="5511988887777", token="tok", phone_id="123456789", template_name="boas_vindas",
+        language="pt_BR", variables=["Maria"],
+    )
+    assert status == "sent"
+    assert captured["url"] == "https://graph.facebook.com/v21.0/123456789/messages"
+    assert captured["headers"] == {"Authorization": "Bearer tok"}
+    assert captured["json"] == {
+        "messaging_product": "whatsapp",
+        "to": "5511988887777",
+        "type": "template",
+        "template": {
+            "name": "boas_vindas",
+            "language": {"code": "pt_BR"},
+            "components": [
+                {"type": "body", "parameters": [{"type": "text", "text": "Maria"}]}
+            ],
+        },
+    }
+
+
+def test_send_template_sent_without_variables_has_empty_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["json"] = kwargs.get("json")
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    whatsapp.send_template(
+        to="5511988887777", token="tok", phone_id="123456789", template_name="sem_var",
+        language="pt_BR", variables=[],
+    )
+    assert captured["json"]["template"]["components"] == []
+
+
+def test_send_template_failed_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+    status = whatsapp.send_template(
+        to="5511988887777", token="tok", phone_id="123456789", template_name="x",
+        language="pt_BR", variables=[],
+    )
+    assert status == "failed"
+
+
+def test_send_template_failed_on_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "post", lambda *_a, **_k: _FakeResponse(500))
+    status = whatsapp.send_template(
+        to="5511988887777", token="tok", phone_id="123456789", template_name="x",
+        language="pt_BR", variables=[],
+    )
+    assert status == "failed"

--- a/apps/api/tests/test_whatsapp_templates.py
+++ b/apps/api/tests/test_whatsapp_templates.py
@@ -1,0 +1,374 @@
+"""Testes do módulo de Templates de WhatsApp (Meta Cloud API).
+
+Cobre: exigência de credenciais configuradas antes de criar (422), criação com sucesso (as
+chamadas à Graph API são sempre mockadas — `core/whatsapp.create_template` etc.), validação de
+variáveis do corpo ({{1}}, {{2}}, ...) vs. exemplos informados, duplicidade nome+idioma (409),
+listagem, sincronização de status com a Meta e exclusão.
+
+RLS/isolamento cross-tenant é validado à parte no Postgres real
+(`test_whatsapp_templates_rls.py`, marcador `rls_e2e`) — mesmo padrão de
+`test_cost_centers.py`/`test_cost_centers_rls.py`. Aqui a suíte roda em SQLite, que não exerce
+RLS de verdade.
+
+Nota sobre o fixture `client`: o router deste módulo é deliberadamente NÃO registrado em
+`app/main.py`/`app/modules/__init__.py` ainda (outro agente, em paralelo, faz essa fiação depois
+que todos os módulos concorrentes terminarem — ver instruções da tarefa). Por isso este arquivo
+define seu PRÓPRIO fixture `client` (sombreando o de `conftest.py` só para este módulo de teste),
+montando uma app FastAPI mínima com `auth` (para register/me) + `whatsapp_templates`, com os
+mesmos overrides de sessão do fixture global.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp as core_whatsapp
+from app.core.tenancy import get_tenant_db
+from app.db.session import get_db, get_tenant_session_factory
+from app.modules.auth.router import router as auth_router
+from app.modules.settings.service import get_profile
+from app.modules.whatsapp_templates.models import WhatsappTemplate
+from app.modules.whatsapp_templates.router import router as whatsapp_templates_router
+
+REGISTER_A = {
+    "legal_name": "Templates SA",
+    "document": "61616161000107",
+    "slug": "templatesa",
+    "email": "templates@example.com",
+    "name": "Tia",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def client(db: Session) -> Iterator[TestClient]:
+    test_app = FastAPI()
+    test_app.include_router(auth_router)
+    test_app.include_router(whatsapp_templates_router)
+
+    def _override_get_db() -> Iterator[Session]:
+        yield db
+
+    def _override_factory():
+        @contextmanager
+        def _factory(_tenant_id: str) -> Iterator[Session]:
+            yield db
+
+        return _factory
+
+    test_app.dependency_overrides[get_db] = _override_get_db
+    test_app.dependency_overrides[get_tenant_db] = _override_get_db
+    test_app.dependency_overrides[get_tenant_session_factory] = _override_factory
+    with TestClient(test_app) as c:
+        yield c
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER_A).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+def _configure_credentials(db: Session, tenant_id: str) -> None:
+    """Simula o dono já tendo configurado as credenciais do WhatsApp em Configurações
+    (o schema/router de `/settings/profile` para esses campos é responsabilidade de outro
+    agente em paralelo — aqui escrevemos direto no `TenantProfile` para não depender disso)."""
+    profile = get_profile(db, tenant_id)
+    profile.whatsapp_token = "fake-token"
+    profile.whatsapp_phone_id = "123456789"
+    profile.whatsapp_waba_id = "waba-1"
+    db.commit()
+
+
+BODY = "Olá {{1}}, seu pedido {{2}} foi confirmado!"
+
+
+def _create_payload(**overrides) -> dict:
+    payload = {
+        "name": "confirmacao_pedido",
+        "language": "pt_BR",
+        "category": "UTILITY",
+        "body_text": BODY,
+        "variable_examples": ["Maria", "#123"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fake_create_ok(**_kwargs) -> dict:
+    return {"id": "meta-tpl-1", "status": "PENDING"}
+
+
+def test_create_without_credentials_is_422(client: TestClient, headers):
+    resp = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert resp.status_code == 422
+    assert "Configure as credenciais" in resp.json()["detail"]
+
+
+def test_create_with_credentials_returns_201(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    captured: dict[str, object] = {}
+
+    def _fake_create(**kwargs) -> dict:
+        captured.update(kwargs)
+        return {"id": "meta-tpl-1", "status": "PENDING", "category": "UTILITY"}
+
+    monkeypatch.setattr(core_whatsapp, "create_template", _fake_create)
+
+    resp = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "confirmacao_pedido"
+    assert body["meta_template_id"] == "meta-tpl-1"
+    assert body["status"] == "PENDING"
+    assert body["category_approved"] == "UTILITY"
+    assert body["category_requested"] == "UTILITY"
+    assert body["variable_count"] == 2
+    assert body["variable_examples"] == ["Maria", "#123"]
+    # Credenciais do tenant propagadas corretamente pro core/whatsapp.
+    assert captured["waba_id"] == "waba-1"
+    assert captured["token"] == "fake-token"
+    assert captured["name"] == "confirmacao_pedido"
+
+
+def test_create_defaults_status_pending_when_meta_omits_it(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: {"id": "meta-x"})
+    resp = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["status"] == "PENDING"
+    assert resp.json()["category_approved"] is None
+
+
+def test_create_variable_mismatch_is_422(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+
+    # corpo usa {{1}} e {{2}} mas só 1 exemplo informado
+    resp = client.post(
+        "/whatsapp-templates",
+        json=_create_payload(variable_examples=["Maria"]),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_create_variable_gap_is_422(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+
+    # {{1}} e {{3}} — não é contíguo (falta {{2}})
+    resp = client.post(
+        "/whatsapp-templates",
+        json=_create_payload(body_text="Olá {{1}}, código {{3}}", variable_examples=["a", "b"]),
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_create_meta_error_becomes_422(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+
+    def _raise(**_k):
+        raise core_whatsapp.WhatsappApiError("Graph API retornou erro 400: nome inválido")
+
+    monkeypatch.setattr(core_whatsapp, "create_template", _raise)
+    resp = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert resp.status_code == 422
+    assert "nome inválido" in resp.json()["detail"]
+
+
+def test_duplicate_name_and_language_is_409(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+
+    first = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert first.status_code == 201, first.text
+    dup = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert dup.status_code == 409
+
+
+def test_same_name_different_language_is_allowed(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+
+    first = client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+    assert first.status_code == 201
+    other_lang = client.post(
+        "/whatsapp-templates", json=_create_payload(language="en_US"), headers=headers
+    )
+    assert other_lang.status_code == 201
+
+
+def test_invalid_name_format_is_422(client: TestClient, headers, db: Session, tenant_id: str):
+    _configure_credentials(db, tenant_id)
+    resp = client.post(
+        "/whatsapp-templates", json=_create_payload(name="Boas Vindas!"), headers=headers
+    )
+    assert resp.status_code == 422
+
+
+def test_list_templates(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    client.post("/whatsapp-templates", json=_create_payload(), headers=headers)
+
+    listed = client.get("/whatsapp-templates", headers=headers).json()
+    assert len(listed) == 1
+    assert listed[0]["name"] == "confirmacao_pedido"
+
+    filtered = client.get(
+        "/whatsapp-templates", params={"status": "REJECTED"}, headers=headers
+    ).json()
+    assert filtered == []
+
+
+def test_sync_template_updates_status(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    created = client.post("/whatsapp-templates", json=_create_payload(), headers=headers).json()
+
+    monkeypatch.setattr(
+        core_whatsapp,
+        "fetch_template_status",
+        lambda **_k: {"status": "APPROVED", "category": "UTILITY", "rejected_reason": None},
+    )
+    resp = client.post(f"/whatsapp-templates/{created['id']}/sync", headers=headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "APPROVED"
+    assert resp.json()["category_approved"] == "UTILITY"
+
+
+def test_sync_template_rejected(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    created = client.post("/whatsapp-templates", json=_create_payload(), headers=headers).json()
+
+    monkeypatch.setattr(
+        core_whatsapp,
+        "fetch_template_status",
+        lambda **_k: {
+            "status": "REJECTED", "category": "UTILITY", "rejected_reason": "INVALID_FORMAT",
+        },
+    )
+    resp = client.post(f"/whatsapp-templates/{created['id']}/sync", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "REJECTED"
+    assert resp.json()["rejected_reason"] == "INVALID_FORMAT"
+
+
+def test_sync_template_not_submitted_yet_is_422(client: TestClient, headers, db: Session):
+    """Um template sem meta_template_id (não deveria acontecer via API normal, mas cobre a
+    guarda) não pode ser sincronizado."""
+    tpl = WhatsappTemplate(
+        tenant_id=client.get("/auth/me", headers=headers).json()["user"]["tenant_id"],
+        name="sem_meta", language="pt_BR", category_requested="UTILITY",
+        body_text="Olá", variable_count=0, variable_examples=[],
+    )
+    db.add(tpl)
+    db.commit()
+    db.refresh(tpl)
+    resp = client.post(f"/whatsapp-templates/{tpl.id}/sync", headers=headers)
+    assert resp.status_code == 422
+
+
+def test_sync_template_not_found_is_404(client: TestClient, headers):
+    resp = client.post("/whatsapp-templates/nao-existe/sync", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_sync_meta_error_becomes_422(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    created = client.post("/whatsapp-templates", json=_create_payload(), headers=headers).json()
+
+    def _raise(**_k):
+        raise core_whatsapp.WhatsappApiError("Graph API retornou erro 404: not found")
+
+    monkeypatch.setattr(core_whatsapp, "fetch_template_status", _raise)
+    resp = client.post(f"/whatsapp-templates/{created['id']}/sync", headers=headers)
+    assert resp.status_code == 422
+
+
+def test_delete_template(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    created = client.post("/whatsapp-templates", json=_create_payload(), headers=headers).json()
+
+    monkeypatch.setattr(core_whatsapp, "delete_template", lambda **_k: None)
+    resp = client.delete(f"/whatsapp-templates/{created['id']}", headers=headers)
+    assert resp.status_code == 204
+    assert client.get("/whatsapp-templates", headers=headers).json() == []
+
+
+def test_delete_template_survives_meta_side_failure(
+    client: TestClient, headers, db: Session, tenant_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    """Exclusão local NUNCA é bloqueada por falha do lado da Meta (best-effort)."""
+    _configure_credentials(db, tenant_id)
+    monkeypatch.setattr(core_whatsapp, "create_template", lambda **_k: _fake_create_ok())
+    created = client.post("/whatsapp-templates", json=_create_payload(), headers=headers).json()
+
+    def _raise(**_k):
+        raise core_whatsapp.WhatsappApiError("falhou do lado da Meta")
+
+    monkeypatch.setattr(core_whatsapp, "delete_template", _raise)
+    resp = client.delete(f"/whatsapp-templates/{created['id']}", headers=headers)
+    assert resp.status_code == 204
+    assert client.get("/whatsapp-templates", headers=headers).json() == []
+
+
+def test_delete_template_not_found_is_404(client: TestClient, headers):
+    resp = client.delete("/whatsapp-templates/nao-existe", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_requires_auth(client: TestClient):
+    assert client.get("/whatsapp-templates").status_code == 401
+    assert client.post("/whatsapp-templates", json=_create_payload()).status_code == 401
+
+
+# ── Isolamento por tenant ────────────────────────────────────────────────────
+# Nota: RLS é Postgres-only e NÃO é exercida pela suíte SQLite deste arquivo (mesmo racional de
+# test_cost_centers.py). `get_profile`/`list_templates`/`db.get` aqui não filtram manualmente
+# por tenant_id (Regra de Ouro nº 1 — a app confia na RLS); tentar simular "tenant A não vê
+# tenant B" registrando dois tenants no MESMO SQLite in-memory não provaria nada de real, porque
+# sem RLS as queries sem filtro (ex.: `get_profile`) veriam as linhas de ambos os tenants —
+# um falso-positivo (ou falso-negativo) que não reflete o comportamento em produção. O
+# isolamento cross-tenant de verdade (tenant A não vê/sincroniza/exclui template de tenant B) é
+# validado no Postgres real com RLS FORCE em `test_whatsapp_templates_rls.py` (marcador
+# `rls_e2e`, mesmo padrão de `test_cost_centers_rls.py`/`test_rls_isolation.py`).

--- a/apps/api/tests/test_whatsapp_templates_rls.py
+++ b/apps/api/tests/test_whatsapp_templates_rls.py
@@ -1,0 +1,170 @@
+"""Teste e2e de isolamento cross-tenant do template de WhatsApp no Postgres REAL (IV2).
+
+Valida, sob RLS real (papel NÃO-superusuário `e1p_app`, que NÃO faz bypass de RLS):
+- o template de A é invisível para B (`db.get` sob a ótica de B → None → 404 fail-closed em
+  sync/delete);
+- `list_templates` de B nunca inclui o template de A.
+
+Mesmo bootstrap/padrão de `test_cost_centers_rls.py`/`test_rls_isolation.py`. Módulo marcado
+`rls_e2e`: NÃO roda no `pytest -q`/`scripts/check.sh` (suíte SQLite), só no job dedicado do CI
+(`cross-tenant-rls`) ou manualmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+
+_API_DIR = Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original_url
+
+
+def _seed_template(app_url: str, tenant_id: str, *, name: str) -> str:
+    """Cria, sob a GUC do próprio tenant, um WhatsappTemplate. Retorna o id."""
+    from app.modules.whatsapp_templates.models import WhatsappTemplate
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()  # fixa a GUC (escopo de sessão) e ENCERRA a txn: sem isso a Session
+            # ligada a uma conexão já em transação usa join por SAVEPOINT e o session.commit()
+            # só libera o savepoint — a txn externa (com o seed) é revertida no close. Mesmo
+            # padrão da produção em app/db/session.py::tenant_session.
+            session = Session(bind=conn)
+            tpl = WhatsappTemplate(
+                tenant_id=tenant_id, name=name, language="pt_BR", category_requested="UTILITY",
+                status="APPROVED", meta_template_id=f"meta-{name}", body_text="Olá!",
+                variable_count=0, variable_examples=[],
+            )
+            session.add(tpl)
+            session.commit()
+            tpl_id = tpl.id
+            session.close()
+            return tpl_id
+    finally:
+        engine.dispose()
+
+
+def _visible_names(app_url: str, tenant_id: str) -> list[str]:
+    """Lista os templates visíveis sob a ótica de `tenant_id` (equivalente a
+    `service.list_templates`, sem filtro manual — a RLS é quem decide)."""
+    from app.modules.whatsapp_templates import service
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            names = [t.name for t in service.list_templates(session, tenant_id)]
+            session.close()
+            return names
+    finally:
+        engine.dispose()
+
+
+def _get_visible(app_url: str, tenant_id: str, template_id: str) -> bool:
+    """True se `template_id` é visível (existe) sob a ótica de `tenant_id`."""
+    from app.modules.whatsapp_templates.models import WhatsappTemplate
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            visible = session.get(WhatsappTemplate, template_id) is not None
+            session.close()
+            return visible
+    finally:
+        engine.dispose()
+
+
+def test_whatsapp_template_cross_tenant_a_nao_ve_b() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+        tpl_a = _seed_template(app_url, tenant_a, name="tpl_a")
+        tpl_b = _seed_template(app_url, tenant_b, name="tpl_b")
+
+        # Listagem: cada tenant só enxerga o próprio template.
+        assert _visible_names(app_url, tenant_a) == ["tpl_a"], (
+            "RLS falhou: listagem de A mostrou template de B"
+        )
+        assert _visible_names(app_url, tenant_b) == ["tpl_b"], (
+            "RLS falhou: listagem de B mostrou template de A"
+        )
+
+        # Get direto por id: o template de B é INVISÍVEL para A (base do 404 fail-closed em
+        # sync/delete) e vice-versa.
+        assert not _get_visible(app_url, tenant_a, tpl_b), (
+            "RLS falhou: A enxergou o template de B via get"
+        )
+        assert not _get_visible(app_url, tenant_b, tpl_a), (
+            "RLS falhou: B enxergou o template de A via get"
+        )
+        # E cada um continua enxergando o próprio.
+        assert _get_visible(app_url, tenant_a, tpl_a)
+        assert _get_visible(app_url, tenant_b, tpl_b)

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../lib/api";
 import { applyBrandTheme } from "../../lib/theme";
 import IntegrationsSection from "./IntegrationsSection";
+import WhatsappSection from "./WhatsappSection";
 
 const FONTS = ["Inter", "Poppins", "Raleway", "Georgia", "Arial"];
 const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
@@ -106,7 +107,12 @@ export default function ConfiguracoesPage() {
         })}
       </div>
 
-      {tab === "integracoes" && <IntegrationsSection />}
+      {tab === "integracoes" && (
+        <div className="space-y-6">
+          <WhatsappSection />
+          <IntegrationsSection />
+        </div>
+      )}
 
       {tab === "perfil" && (
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/apps/web/src/features/config/WhatsappSection.test.tsx
+++ b/apps/web/src/features/config/WhatsappSection.test.tsx
@@ -1,5 +1,6 @@
 import type { TenantProfile, WhatsappTemplate } from "@e1p/shared-types";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { WHATSAPP_PURPOSES } from "@e1p/shared-types";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
@@ -35,6 +36,7 @@ function profile(overrides: Partial<TenantProfile> = {}): TenantProfile {
     whatsapp_configured: false,
     whatsapp_phone_id: "",
     whatsapp_waba_id: "",
+    whatsapp_template_bindings: {},
     ...overrides,
   };
 }
@@ -240,6 +242,113 @@ describe("WhatsappSection — templates", () => {
 
     expect(
       await screen.findByText("Template com esse nome e idioma já existe"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("WhatsappSection — vínculos de template por propósito", () => {
+  const [firstPurpose] = WHATSAPP_PURPOSES;
+
+  function emptyBindings(): Record<string, string> {
+    return Object.fromEntries(WHATSAPP_PURPOSES.map((p) => [p.key, ""]));
+  }
+
+  it("renderiza os 5 propósitos fixos com rótulo e variáveis esperadas", async () => {
+    mockGet(profile({ whatsapp_configured: true }), []);
+    render(<WhatsappSection />);
+
+    for (const p of WHATSAPP_PURPOSES) {
+      expect(await screen.findByText(p.label)).toBeInTheDocument();
+      expect(screen.getByText(`Variáveis: ${p.variables.join(", ")}`)).toBeInTheDocument();
+    }
+  });
+
+  it("lista no select apenas templates cujo variable_count bate com o propósito", async () => {
+    const matching = template({
+      id: "t-match",
+      name: "tpl_match",
+      status: "APPROVED",
+      variable_count: firstPurpose.variables.length,
+    });
+    const mismatching = template({
+      id: "t-mismatch",
+      name: "tpl_mismatch",
+      status: "APPROVED",
+      variable_count: firstPurpose.variables.length + 1,
+    });
+    mockGet(profile({ whatsapp_configured: true }), [matching, mismatching]);
+    render(<WhatsappSection />);
+
+    const select = await screen.findByRole("combobox", { name: firstPurpose.label });
+    const options = within(select)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+
+    expect(options).toContain("tpl_match");
+    expect(options).not.toContain("tpl_mismatch");
+  });
+
+  it("carrega os vínculos existentes do perfil e pré-seleciona o template no select", async () => {
+    const bound = template({
+      id: "t-bound",
+      name: "tpl_bound",
+      status: "APPROVED",
+      variable_count: firstPurpose.variables.length,
+    });
+    mockGet(
+      profile({
+        whatsapp_configured: true,
+        whatsapp_template_bindings: { [firstPurpose.key]: "t-bound" },
+      }),
+      [bound],
+    );
+    render(<WhatsappSection />);
+
+    const select = await screen.findByRole("combobox", { name: firstPurpose.label });
+    await waitFor(() => expect(select).toHaveValue("t-bound"));
+  });
+
+  it("'Salvar vínculos' envia o mapa completo de 5 propósitos com a seleção atual", async () => {
+    const user = userEvent.setup();
+    const matching = template({
+      id: "t-1",
+      name: "tpl_match",
+      status: "APPROVED",
+      variable_count: firstPurpose.variables.length,
+    });
+    mockGet(profile({ whatsapp_configured: true }), [matching]);
+    vi.mocked(api.patch).mockResolvedValue({
+      data: profile({ whatsapp_template_bindings: { [firstPurpose.key]: "t-1" } }),
+    } as never);
+    render(<WhatsappSection />);
+
+    const select = await screen.findByRole("combobox", { name: firstPurpose.label });
+    await user.selectOptions(select, "t-1");
+
+    await user.click(screen.getByRole("button", { name: /Salvar vínculos/ }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_template_bindings: { ...emptyBindings(), [firstPurpose.key]: "t-1" },
+      }),
+    );
+  });
+
+  it("mostra o erro 422 retornado pela API ao salvar um vínculo incompatível", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: true }), []);
+    vi.mocked(api.patch).mockRejectedValue({
+      response: {
+        data: { detail: "Template deve ter exatamente 4 variáveis para este propósito" },
+      },
+    });
+    render(<WhatsappSection />);
+
+    await screen.findByRole("combobox", { name: firstPurpose.label });
+    await user.click(screen.getByRole("button", { name: /Salvar vínculos/ }));
+
+    expect(
+      await screen.findByText("Template deve ter exatamente 4 variáveis para este propósito"),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/config/WhatsappSection.test.tsx
+++ b/apps/web/src/features/config/WhatsappSection.test.tsx
@@ -1,0 +1,245 @@
+import type { TenantProfile, WhatsappTemplate } from "@e1p/shared-types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import WhatsappSection from "./WhatsappSection";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+function profile(overrides: Partial<TenantProfile> = {}): TenantProfile {
+  return {
+    display_name: "Empresa",
+    document: "",
+    email: "",
+    phone: "",
+    address: "",
+    website: "",
+    about: "",
+    logo_url: "",
+    primary_color: "#000",
+    secondary_color: "#000",
+    accent_color: "#000",
+    text_color: "#000",
+    bg_color: "#fff",
+    font: "Inter",
+    timezone: "America/Sao_Paulo",
+    default_entry_funnel_id: null,
+    whatsapp_configured: false,
+    whatsapp_phone_id: "",
+    whatsapp_waba_id: "",
+    ...overrides,
+  };
+}
+
+function template(overrides: Partial<WhatsappTemplate> = {}): WhatsappTemplate {
+  return {
+    id: "t-1",
+    name: "boas_vindas",
+    language: "pt_BR",
+    category_requested: "MARKETING",
+    category_approved: null,
+    status: "PENDING",
+    rejected_reason: null,
+    meta_template_id: null,
+    body_text: "Olá {{1}}",
+    variable_count: 1,
+    variable_examples: ["João"],
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function mockGet(p: TenantProfile, templates: WhatsappTemplate[] = []) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/settings/profile") return Promise.resolve({ data: p } as never);
+    if (url === "/whatsapp-templates") return Promise.resolve({ data: templates } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+  vi.mocked(api.post).mockReset();
+  vi.mocked(api.patch).mockReset();
+  vi.mocked(api.delete).mockReset();
+});
+
+describe("WhatsappSection — credenciais", () => {
+  it("mostra 'Não conectado' quando whatsapp_configured é false", async () => {
+    mockGet(profile({ whatsapp_configured: false }));
+    render(<WhatsappSection />);
+
+    expect(await screen.findByText("Não conectado")).toBeInTheDocument();
+    expect(screen.queryByText("Conectado")).not.toBeInTheDocument();
+  });
+
+  it("mostra 'Conectado' quando whatsapp_configured é true", async () => {
+    mockGet(
+      profile({
+        whatsapp_configured: true,
+        whatsapp_phone_id: "phone-123",
+        whatsapp_waba_id: "waba-456",
+      }),
+    );
+    render(<WhatsappSection />);
+
+    expect(await screen.findByText("Conectado")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("phone-123")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("waba-456")).toBeInTheDocument();
+  });
+
+  it("salva com payload mínimo (sem whatsapp_token) quando o token não foi tocado", async () => {
+    const user = userEvent.setup();
+    mockGet(
+      profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-123", whatsapp_waba_id: "waba-456" }),
+    );
+    vi.mocked(api.patch).mockResolvedValue({
+      data: profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-999", whatsapp_waba_id: "waba-456" }),
+    } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Conectado");
+    const phoneInput = screen.getByDisplayValue("phone-123");
+    await user.clear(phoneInput);
+    await user.type(phoneInput, "phone-999");
+
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "phone-999",
+        whatsapp_waba_id: "waba-456",
+      }),
+    );
+  });
+
+  it("inclui whatsapp_token no payload quando o campo é editado", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: false }));
+    vi.mocked(api.patch).mockResolvedValue({ data: profile({ whatsapp_configured: true }) } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Não conectado");
+    const tokenInput = screen.getByPlaceholderText("Cole o token de acesso");
+    await user.type(tokenInput, "meu-token-secreto");
+
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "",
+        whatsapp_waba_id: "",
+        whatsapp_token: "meu-token-secreto",
+      }),
+    );
+  });
+});
+
+describe("WhatsappSection — templates", () => {
+  it("mostra dica quando as credenciais não estão configuradas", async () => {
+    mockGet(profile({ whatsapp_configured: false }));
+    render(<WhatsappSection />);
+
+    expect(
+      await screen.findByText("Configure as credenciais do WhatsApp acima primeiro."),
+    ).toBeInTheDocument();
+  });
+
+  it("lista templates com badge de status e categoria solicitada vs aprovada", async () => {
+    mockGet(profile({ whatsapp_configured: true }), [
+      template({
+        name: "promo_verao",
+        status: "APPROVED",
+        category_requested: "MARKETING",
+        category_approved: "UTILITY",
+      }),
+    ]);
+    render(<WhatsappSection />);
+
+    expect(await screen.findByText(/promo_verao/)).toBeInTheDocument();
+    expect(screen.getByText("Aprovado")).toBeInTheDocument();
+    expect(screen.getByText("solicitado: Marketing → aprovado: Utilidade")).toBeInTheDocument();
+  });
+
+  it("mostra o motivo da rejeição quando presente", async () => {
+    mockGet(profile({ whatsapp_configured: true }), [
+      template({ status: "REJECTED", rejected_reason: "Conteúdo promocional não permitido" }),
+    ]);
+    render(<WhatsappSection />);
+
+    expect(await screen.findByText("Conteúdo promocional não permitido")).toBeInTheDocument();
+  });
+
+  it("sincroniza um template chamando o endpoint correto", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: true }), [template({ id: "t-1" })]);
+    vi.mocked(api.post).mockResolvedValue({ data: template({ id: "t-1", status: "APPROVED" }) } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText(/boas_vindas/);
+    await user.click(screen.getByTitle("Sincronizar"));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/whatsapp-templates/t-1/sync"));
+  });
+
+  it("exclui um template com confirmação e recarrega a lista", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: true }), [template({ id: "t-1" })]);
+    vi.mocked(api.delete).mockResolvedValue({ data: {} } as never);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<WhatsappSection />);
+
+    await screen.findByText(/boas_vindas/);
+    await user.click(screen.getByTitle("Excluir"));
+
+    await waitFor(() => expect(api.delete).toHaveBeenCalledWith("/whatsapp-templates/t-1"));
+  });
+
+  it("o formulário de criação rastreia {{n}} no corpo do texto com inputs de exemplo dinâmicos", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: true }), []);
+    render(<WhatsappSection />);
+
+    await user.click(await screen.findByRole("button", { name: /Novo template/ }));
+    const body = screen.getByPlaceholderText("Use {{1}}, {{2}} etc para variáveis");
+    // fireEvent.change (não user.type) porque `{{` é sintaxe especial de tecla no user-event.
+    fireEvent.change(body, { target: { value: "Olá {{1}}, seu pedido {{2}} está pronto" } });
+
+    expect(await screen.findByText("Exemplo da variável 1")).toBeInTheDocument();
+    expect(screen.getByText("Exemplo da variável 2")).toBeInTheDocument();
+    expect(screen.queryByText("Exemplo da variável 3")).not.toBeInTheDocument();
+  });
+
+  it("mostra erro de validação (422/409) retornado pela API ao criar template", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: true }), []);
+    vi.mocked(api.post).mockRejectedValue({
+      response: { data: { detail: "Template com esse nome e idioma já existe" } },
+    });
+    render(<WhatsappSection />);
+
+    await user.click(await screen.findByRole("button", { name: /Novo template/ }));
+    await user.type(screen.getByPlaceholderText("ex: boas_vindas_lead"), "duplicado");
+    await user.type(
+      screen.getByPlaceholderText("Use {{1}}, {{2}} etc para variáveis"),
+      "Corpo sem variáveis",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Criar template" }));
+
+    expect(
+      await screen.findByText("Template com esse nome e idioma já existe"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/config/WhatsappSection.tsx
+++ b/apps/web/src/features/config/WhatsappSection.tsx
@@ -1,0 +1,446 @@
+import type {
+  TenantProfile,
+  WhatsappTemplate,
+  WhatsappTemplateCategory,
+  WhatsappTemplateCreate,
+} from "@e1p/shared-types";
+import { Check, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+const CATEGORY_LABEL: Record<WhatsappTemplateCategory, string> = {
+  MARKETING: "Marketing",
+  UTILITY: "Utilidade",
+  AUTHENTICATION: "Autenticação",
+};
+
+const STATUS_LABEL: Record<WhatsappTemplate["status"], string> = {
+  PENDING: "Pendente",
+  APPROVED: "Aprovado",
+  REJECTED: "Rejeitado",
+  PAUSED: "Pausado",
+  DISABLED: "Desativado",
+};
+
+const STATUS_CLASS: Record<WhatsappTemplate["status"], string> = {
+  PENDING: "bg-amber-50 text-amber-700",
+  APPROVED: "bg-green-50 text-green-700",
+  REJECTED: "bg-red-50 text-danger",
+  PAUSED: "bg-neutral-100 text-neutral-500",
+  DISABLED: "bg-neutral-100 text-neutral-500",
+};
+
+/** Conta o maior índice `{{n}}` presente no corpo do template (0 se não houver nenhum). */
+function countVariables(bodyText: string): number {
+  const matches = [...bodyText.matchAll(/\{\{(\d+)\}\}/g)];
+  return matches.reduce((max, m) => Math.max(max, Number(m[1])), 0);
+}
+
+export default function WhatsappSection() {
+  return (
+    <div className="space-y-6">
+      <CredentialsCard />
+      <TemplatesCard />
+    </div>
+  );
+}
+
+/** Card "WhatsApp Business (Meta Cloud API)" — credenciais por tenant. */
+function CredentialsCard() {
+  const [profile, setProfile] = useState<TenantProfile | null>(null);
+  const [token, setToken] = useState("");
+  const [tokenTouched, setTokenTouched] = useState(false);
+  const [phoneId, setPhoneId] = useState("");
+  const [wabaId, setWabaId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await api.get<TenantProfile>("/settings/profile");
+    setProfile(data);
+    setPhoneId(data.whatsapp_phone_id ?? "");
+    setWabaId(data.whatsapp_waba_id ?? "");
+    setToken("");
+    setTokenTouched(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const patch: Pick<TenantProfile, "whatsapp_phone_id" | "whatsapp_waba_id"> & {
+        whatsapp_token?: string;
+      } = {
+        whatsapp_phone_id: phoneId.trim(),
+        whatsapp_waba_id: wabaId.trim(),
+      };
+      if (tokenTouched) patch.whatsapp_token = token;
+      const { data } = await api.patch<TenantProfile>("/settings/profile", patch);
+      setProfile(data);
+      setPhoneId(data.whatsapp_phone_id ?? "");
+      setWabaId(data.whatsapp_waba_id ?? "");
+      setToken("");
+      setTokenTouched(false);
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const configured = profile?.whatsapp_configured ?? false;
+
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm">
+      <div className="mb-1 flex items-center justify-between">
+        <h2 className="font-semibold text-neutral-800">WhatsApp Business (Meta Cloud API)</h2>
+        {profile &&
+          (configured ? (
+            <span className="flex items-center gap-1 rounded-pill bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
+              <Check size={12} /> Conectado
+            </span>
+          ) : (
+            <span className="rounded-pill bg-neutral-100 px-3 py-1 text-xs font-semibold text-neutral-500">
+              Não conectado
+            </span>
+          ))}
+      </div>
+      <p className="mb-4 text-xs text-neutral-400">
+        Essas credenciais vêm do painel Meta for Developers / WhatsApp Business Platform e são
+        específicas deste escritório — não são compartilhadas com outros tenants.
+      </p>
+
+      {!profile ? (
+        <p className="text-sm text-neutral-400">Carregando...</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">
+                Token de acesso
+              </span>
+              <input
+                type="password"
+                value={token}
+                onChange={(e) => {
+                  setToken(e.target.value);
+                  setTokenTouched(true);
+                }}
+                placeholder={configured ? "••••••••" : "Cole o token de acesso"}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">
+                Phone Number ID
+              </span>
+              <input
+                value={phoneId}
+                onChange={(e) => setPhoneId(e.target.value)}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">WABA ID</span>
+              <input
+                value={wabaId}
+                onChange={(e) => setWabaId(e.target.value)}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </label>
+          </div>
+
+          {error && (
+            <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
+          )}
+
+          <button
+            onClick={save}
+            disabled={saving}
+            className="mt-4 flex items-center gap-1.5 rounded-pill bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+          >
+            <Check size={14} /> {saving ? "Salvando..." : "Salvar"}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Card "Templates de Mensagem" — a Meta exige template pré-aprovado para toda mensagem
+ * business-initiated fora da janela de 24h de atendimento. */
+function TemplatesCard() {
+  const [configured, setConfigured] = useState(false);
+  const [templates, setTemplates] = useState<WhatsappTemplate[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const [{ data: profile }, { data: list }] = await Promise.all([
+      api.get<TenantProfile>("/settings/profile"),
+      api.get<WhatsappTemplate[]>("/whatsapp-templates"),
+    ]);
+    setConfigured(profile.whatsapp_configured);
+    setTemplates(Array.isArray(list) ? list : []);
+    setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function sync(id: string) {
+    setBusyId(id);
+    setError(null);
+    try {
+      const { data } = await api.post<WhatsappTemplate>(`/whatsapp-templates/${id}/sync`);
+      setTemplates((prev) => prev.map((t) => (t.id === id ? data : t)));
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function remove(id: string) {
+    if (!confirm("Excluir este template? Essa ação não pode ser desfeita.")) return;
+    setBusyId(id);
+    setError(null);
+    try {
+      await api.delete(`/whatsapp-templates/${id}`);
+      await load();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm">
+      <div className="mb-1 flex items-center justify-between">
+        <h2 className="font-semibold text-neutral-800">Templates de Mensagem</h2>
+        {configured && (
+          <button
+            onClick={() => setShowForm((v) => !v)}
+            className="flex items-center gap-1.5 rounded-pill bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+          >
+            <Plus size={14} /> Novo template
+          </button>
+        )}
+      </div>
+      <p className="mb-4 text-xs text-neutral-400">
+        A revisão da Meta pode levar de minutos a horas. Somente templates com status Aprovado
+        podem ser usados para enviar mensagens.
+      </p>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
+      )}
+
+      {!loaded ? (
+        <p className="text-sm text-neutral-400">Carregando...</p>
+      ) : !configured ? (
+        <p className="text-sm text-neutral-400">
+          Configure as credenciais do WhatsApp acima primeiro.
+        </p>
+      ) : (
+        <>
+          {showForm && (
+            <TemplateForm
+              onCancel={() => setShowForm(false)}
+              onCreated={async () => {
+                setShowForm(false);
+                await load();
+              }}
+            />
+          )}
+
+          {templates.length === 0 ? (
+            <p className="text-sm text-neutral-400">Nenhum template criado ainda.</p>
+          ) : (
+            <div className="space-y-2">
+              {templates.map((t) => (
+                <div key={t.id} className="rounded-xl border border-neutral-100 px-4 py-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-neutral-800">
+                        {t.name} <span className="font-normal text-neutral-400">({t.language})</span>
+                      </p>
+                      <p className="text-xs text-neutral-500">
+                        {t.category_approved && t.category_approved !== t.category_requested
+                          ? `solicitado: ${CATEGORY_LABEL[t.category_requested]} → aprovado: ${CATEGORY_LABEL[t.category_approved]}`
+                          : CATEGORY_LABEL[t.category_approved ?? t.category_requested]}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`rounded-pill px-3 py-1 text-xs font-semibold ${STATUS_CLASS[t.status]}`}
+                      >
+                        {STATUS_LABEL[t.status]}
+                      </span>
+                      <button
+                        onClick={() => sync(t.id)}
+                        disabled={busyId === t.id}
+                        title="Sincronizar"
+                        className="text-neutral-300 hover:text-primary-600 disabled:opacity-50"
+                      >
+                        <RefreshCw size={16} />
+                      </button>
+                      <button
+                        onClick={() => remove(t.id)}
+                        disabled={busyId === t.id}
+                        title="Excluir"
+                        className="text-neutral-300 hover:text-danger disabled:opacity-50"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </div>
+                  {t.rejected_reason && (
+                    <p className="mt-2 text-xs text-danger">{t.rejected_reason}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function TemplateForm({
+  onCancel,
+  onCreated,
+}: {
+  onCancel: () => void;
+  onCreated: () => void | Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [language, setLanguage] = useState("pt_BR");
+  const [category, setCategory] = useState<WhatsappTemplateCategory>("MARKETING");
+  const [bodyText, setBodyText] = useState("");
+  const [examples, setExamples] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const variableCount = useMemo(() => countVariables(bodyText), [bodyText]);
+
+  useEffect(() => {
+    setExamples((prev) => {
+      const next = prev.slice(0, variableCount);
+      while (next.length < variableCount) next.push("");
+      return next;
+    });
+  }, [variableCount]);
+
+  async function submit() {
+    setCreating(true);
+    setError(null);
+    try {
+      const payload: WhatsappTemplateCreate = {
+        name: name.trim(),
+        language: language.trim(),
+        category,
+        body_text: bodyText,
+        variable_examples: examples,
+      };
+      await api.post<WhatsappTemplate>("/whatsapp-templates", payload);
+      await onCreated();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="mb-4 rounded-xl border border-neutral-200 p-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Nome</span>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="ex: boas_vindas_lead"
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          />
+          <span className="mt-1 block text-xs text-neutral-400">
+            minúsculas, números e underscore apenas — ex: boas_vindas_lead
+          </span>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Idioma</span>
+          <input
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          />
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Categoria</span>
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value as WhatsappTemplateCategory)}
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          >
+            <option value="MARKETING">Marketing</option>
+            <option value="UTILITY">Utilidade</option>
+            <option value="AUTHENTICATION">Autenticação</option>
+          </select>
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Texto</span>
+          <textarea
+            value={bodyText}
+            onChange={(e) => setBodyText(e.target.value)}
+            rows={3}
+            placeholder="Use {{1}}, {{2}} etc para variáveis"
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          />
+        </label>
+        {examples.map((ex, i) => (
+          <label className="block" key={i}>
+            <span className="mb-1 block text-xs font-medium text-neutral-600">
+              Exemplo da variável {i + 1}
+            </span>
+            <input
+              value={ex}
+              onChange={(e) =>
+                setExamples((prev) => prev.map((v, idx) => (idx === i ? e.target.value : v)))
+              }
+              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            />
+          </label>
+        ))}
+      </div>
+
+      {error && (
+        <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
+      )}
+
+      <div className="mt-4 flex gap-2">
+        <button
+          onClick={submit}
+          disabled={creating || !name.trim() || !bodyText.trim()}
+          className="flex items-center gap-1.5 rounded-pill bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+        >
+          <Check size={14} /> {creating ? "Criando..." : "Criar template"}
+        </button>
+        <button
+          onClick={onCancel}
+          className="rounded-pill border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-600 hover:bg-neutral-50"
+        >
+          Cancelar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/config/WhatsappSection.tsx
+++ b/apps/web/src/features/config/WhatsappSection.tsx
@@ -4,6 +4,7 @@ import type {
   WhatsappTemplateCategory,
   WhatsappTemplateCreate,
 } from "@e1p/shared-types";
+import { WHATSAPP_PURPOSES } from "@e1p/shared-types";
 import { Check, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
@@ -41,6 +42,7 @@ export default function WhatsappSection() {
     <div className="space-y-6">
       <CredentialsCard />
       <TemplatesCard />
+      <BindingsCard />
     </div>
   );
 }
@@ -310,6 +312,131 @@ function TemplatesCard() {
               ))}
             </div>
           )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Card "Vínculos de Template por Propósito" — liga um template APROVADO a cada propósito
+ * fixo que o próprio produto define (lembrete de cobrança, envio de contrato/orçamento,
+ * convite de staff, aviso interno de card movido). Diferente do nó livre do Funil de Vendas:
+ * aqui a lista de propósitos é fixa (`WHATSAPP_PURPOSES`) e cada um exige um template com a
+ * contagem exata de variáveis — o backend valida isso no PATCH e retorna 422 se não bater. */
+function BindingsCard() {
+  const [templates, setTemplates] = useState<WhatsappTemplate[]>([]);
+  const [bindings, setBindings] = useState<Record<string, string>>({});
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const load = useCallback(async () => {
+    const [{ data: profile }, { data: list }] = await Promise.all([
+      api.get<TenantProfile>("/settings/profile"),
+      api.get<WhatsappTemplate[]>("/whatsapp-templates"),
+    ]);
+    setTemplates(Array.isArray(list) ? list : []);
+    const initial: Record<string, string> = {};
+    for (const p of WHATSAPP_PURPOSES) {
+      initial[p.key] = profile.whatsapp_template_bindings?.[p.key] ?? "";
+    }
+    setBindings(initial);
+    setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const approvedTemplates = useMemo(
+    () => templates.filter((t) => t.status === "APPROVED"),
+    [templates],
+  );
+
+  function setBinding(purposeKey: string, templateId: string) {
+    setBindings((prev) => ({ ...prev, [purposeKey]: templateId }));
+    setSuccess(false);
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await api.patch<TenantProfile>("/settings/profile", {
+        whatsapp_template_bindings: bindings,
+      });
+      setSuccess(true);
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm">
+      <h2 className="mb-1 font-semibold text-neutral-800">Vínculos de Template por Propósito</h2>
+      <p className="mb-4 text-xs text-neutral-400">
+        Escolha qual template aprovado o sistema deve usar automaticamente em cada fluxo. Deixe
+        "Nenhum (texto livre)" para continuar enviando texto livre nesse fluxo.
+      </p>
+
+      {!loaded ? (
+        <p className="text-sm text-neutral-400">Carregando...</p>
+      ) : (
+        <>
+          <div className="space-y-2">
+            {WHATSAPP_PURPOSES.map((p) => {
+              const matching = approvedTemplates.filter(
+                (t) => t.variable_count === p.variables.length,
+              );
+              return (
+                <div key={p.key} className="rounded-xl border border-neutral-100 px-4 py-3">
+                  <p className="text-sm font-semibold text-neutral-800">{p.label}</p>
+                  <p className="mb-2 text-xs text-neutral-400">
+                    Variáveis: {p.variables.join(", ")}
+                  </p>
+                  <select
+                    aria-label={p.label}
+                    value={bindings[p.key] ?? ""}
+                    onChange={(e) => setBinding(p.key, e.target.value)}
+                    className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+                  >
+                    <option value="">— Nenhum (texto livre) —</option>
+                    {matching.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.name}
+                      </option>
+                    ))}
+                  </select>
+                  {matching.length === 0 && (
+                    <p className="mt-1 text-xs text-neutral-400">
+                      Nenhum template aprovado com {p.variables.length} variáveis ainda.
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {error && (
+            <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
+          )}
+          {success && (
+            <div className="mt-3 rounded-lg bg-green-50 px-3 py-2 text-sm text-green-700">
+              Vínculos salvos
+            </div>
+          )}
+
+          <button
+            onClick={save}
+            disabled={saving}
+            className="mt-4 flex items-center gap-1.5 rounded-pill bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+          >
+            <Check size={14} /> {saving ? "Salvando..." : "Salvar vínculos"}
+          </button>
         </>
       )}
     </div>

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -1,4 +1,4 @@
-import type { Client, FunnelComponentCategory } from "@e1p/shared-types";
+import type { Client, FunnelComponentCategory, WhatsappTemplate } from "@e1p/shared-types";
 import html2canvas from "html2canvas";
 import {
   ArrowLeft, Download, GitBranch, type LucideIcon, Maximize2, MessageCircle, MousePointerClick,
@@ -31,6 +31,8 @@ type NodeConfig = {
   delay_value?: number; delay_unit?: "minutes" | "hours" | "days";
   field?: "always" | "has_tag" | "is_paid"; value?: string;
   amount_cents?: number; method?: "boleto" | "pix"; tag?: string;
+  // WhatsApp: template Meta aprovado + valores posicionais (literal ou {{cliente.*}}).
+  template_id?: string; variables?: string[];
 };
 type NodeData = {
   label: string; description: string; color: string; category: string; key: string;
@@ -106,7 +108,9 @@ function PageMockup({ model, color }: { model?: string; color: string }) {
 }
 
 function FunnelNode({ data, selected }: NodeProps<NodeData>) {
-  const configured = !!(data.config?.body || data.config?.model);
+  const configured = contentKind(data.key) === "whatsapp"
+    ? !!data.config?.template_id
+    : !!(data.config?.body || data.config?.model);
   const handleStyle = { background: "#fff", border: `2px solid ${data.color}`, width: 10, height: 10 };
 
   // PÁGINA → card quadrado com mockup colorido.
@@ -441,7 +445,9 @@ function Builder() {
                 {selectedNode.data.shape === "page"
                   ? "Editar página"
                   : KIND_VERB[contentKind(selectedNode.data.key)]}
-                {selectedNode.data.config?.body || selectedNode.data.config?.model ? " ✓" : ""}
+                {contentKind(selectedNode.data.key) === "whatsapp"
+                  ? (selectedNode.data.config?.template_id ? " ✓" : "")
+                  : (selectedNode.data.config?.body || selectedNode.data.config?.model ? " ✓" : "")}
               </button>
               {selectedNode.data.action && (
                 <button
@@ -568,8 +574,14 @@ function RunNodeModal({
       params.description = description;
       params.amount_cents = Math.round(parseFloat(amount.replace(",", ".") || "0") * 100);
     }
-    if (action === "send_email") params.subject = subject;
-    if (action === "send_email" || action === "send_message") params.message = message;
+    if (action === "send_email") {
+      params.subject = subject;
+      params.message = message;
+    }
+    if (action === "send_message") {
+      params.template_id = node.data.config?.template_id;
+      params.variables = node.data.config?.variables ?? [];
+    }
     try {
       const { data } = await api.post<{ message: string }>("/funnels/run-node", {
         action, client_id: needsClient ? clientId || null : null, params,
@@ -583,7 +595,7 @@ function RunNodeModal({
   }
 
   const money = action === "create_quote" || action === "create_charge";
-  const msg = action === "send_email" || action === "send_message";
+  const hasTemplate = !!node.data.config?.template_id;
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/30 p-4" onClick={onClose}>
@@ -623,17 +635,28 @@ function RunNodeModal({
           )}
           {money && <Field label="Valor (R$)" value={amount} onChange={setAmount} placeholder="0,00" />}
           {action === "send_email" && <Field label="Assunto" value={subject} onChange={setSubject} />}
-          {msg && (
+          {action === "send_email" && (
             <label className="block">
               <span className="mb-1 block text-xs font-medium text-neutral-600">Mensagem</span>
               <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={4} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
             </label>
           )}
+          {action === "send_message" && (
+            <p className={`rounded-lg p-2 text-xs ${hasTemplate ? "bg-neutral-50 text-neutral-500" : "bg-amber-50 text-amber-700"}`}>
+              {hasTemplate
+                ? "Usa o template de WhatsApp configurado no nó (botão “Escrever mensagem”)."
+                : "Configure um template de WhatsApp aprovado no nó (botão “Escrever mensagem”) antes de executar."}
+            </p>
+          )}
         </div>
 
         <div className="mt-5 flex gap-2">
           <button onClick={onClose} className="flex-1 rounded-pill bg-neutral-100 py-2.5 font-semibold text-neutral-600 hover:bg-neutral-200">Cancelar</button>
-          <button onClick={run} disabled={busy} className="flex flex-1 items-center justify-center gap-1.5 rounded-pill bg-accent-500 py-2.5 font-semibold text-white hover:bg-accent-600 disabled:opacity-60">
+          <button
+            onClick={run}
+            disabled={busy || (action === "send_message" && !hasTemplate)}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-pill bg-accent-500 py-2.5 font-semibold text-white hover:bg-accent-600 disabled:opacity-60"
+          >
             <Play size={14} /> {busy ? "Executando..." : "Executar agora"}
           </button>
         </div>
@@ -653,6 +676,8 @@ function Field({ label, value, onChange, placeholder }: {
   );
 }
 
+const TEMPLATE_KEYWORDS = ["cliente.nome", "cliente.telefone", "cliente.email"] as const;
+
 function NodeContentEditor({
   node,
   onClose,
@@ -665,11 +690,41 @@ function NodeContentEditor({
   const isPage = node.data.shape === "page";
   const kind = contentKind(node.data.key);
   const isEmail = kind === "email";
+  const isWhatsapp = kind === "whatsapp";
   const [subject, setSubject] = useState(node.data.config?.subject ?? "");
   const [body, setBody] = useState(node.data.config?.body ?? "");
   const [model, setModel] = useState(node.data.config?.model ?? (isPage ? "Vendas" : ""));
   const [brief, setBrief] = useState("");
   const [aiBusy, setAiBusy] = useState(false);
+
+  // WhatsApp: template Meta aprovado + valores posicionais (literal ou {{cliente.*}}).
+  const [templates, setTemplates] = useState<WhatsappTemplate[]>([]);
+  const [templateId, setTemplateId] = useState(node.data.config?.template_id ?? "");
+  const [variables, setVariables] = useState<string[]>(node.data.config?.variables ?? []);
+
+  useEffect(() => {
+    if (!isWhatsapp) return;
+    api
+      .get<WhatsappTemplate[]>("/whatsapp-templates", { params: { status: "APPROVED" } })
+      .then(({ data }) => setTemplates(data));
+  }, [isWhatsapp]);
+
+  const selectedTemplate = templates.find((t) => t.id === templateId);
+
+  useEffect(() => {
+    if (!selectedTemplate) return;
+    setVariables((prev) =>
+      Array.from({ length: selectedTemplate.variable_count }, (_, i) => prev[i] ?? ""),
+    );
+  }, [selectedTemplate]);
+
+  function setVariable(i: number, value: string) {
+    setVariables((prev) => {
+      const next = [...prev];
+      next[i] = value;
+      return next;
+    });
+  }
 
   const title = isPage ? "Editar página" : KIND_VERB[kind];
   const bodyLabel = isPage
@@ -708,30 +763,96 @@ function NodeContentEditor({
           </label>
         )}
 
-        <div className="mb-3 rounded-lg bg-primary-50 p-2">
-          <span className="mb-1 block text-xs font-medium text-primary-700">Gerar com IA</span>
-          <div className="flex gap-2">
-            <input value={brief} onChange={(e) => setBrief(e.target.value)} placeholder={`Sobre o que? (ex: ${node.data.label.toLowerCase()})`} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none" />
-            <button onClick={generate} disabled={aiBusy} className="flex shrink-0 items-center gap-1 rounded-lg bg-primary-500 px-3 text-xs font-semibold text-white disabled:opacity-60">
-              <Sparkles size={12} /> {aiBusy ? "..." : "Gerar"}
-            </button>
-          </div>
-        </div>
+        {isWhatsapp ? (
+          <>
+            <label className="mb-3 block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">Template aprovado (Meta)</span>
+              <select
+                value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              >
+                <option value="">Selecione um template</option>
+                {templates.map((t) => (
+                  <option key={t.id} value={t.id}>{t.name} ({t.language})</option>
+                ))}
+              </select>
+              {templates.length === 0 && (
+                <p className="mt-1.5 text-[11px] text-neutral-400">
+                  Nenhum template aprovado ainda — crie um em Configurações → Integrações → WhatsApp.
+                </p>
+              )}
+            </label>
 
-        {isEmail && (
-          <label className="mb-3 block">
-            <span className="mb-1 block text-xs font-medium text-neutral-600">Assunto</span>
-            <input value={subject} onChange={(e) => setSubject(e.target.value)} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
-          </label>
+            {selectedTemplate && (
+              <div className="mb-4 space-y-2">
+                <p className="text-xs font-medium text-neutral-600">Variáveis do template</p>
+                <p className="rounded-lg bg-neutral-50 p-2 text-xs text-neutral-500">{selectedTemplate.body_text}</p>
+                {Array.from({ length: selectedTemplate.variable_count }, (_, i) => (
+                  <div key={i} className="space-y-1">
+                    <span className="text-[11px] font-medium text-neutral-500">Variável {i + 1}</span>
+                    <div className="flex gap-1.5">
+                      <input
+                        value={variables[i] ?? ""}
+                        onChange={(e) => setVariable(i, e.target.value)}
+                        placeholder={selectedTemplate.variable_examples[i] ?? ""}
+                        className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-primary-400"
+                      />
+                      {TEMPLATE_KEYWORDS.map((kw) => (
+                        <button
+                          key={kw}
+                          type="button"
+                          onClick={() => setVariable(i, `{{${kw}}}`)}
+                          title={`Usar ${kw}`}
+                          className="shrink-0 rounded-lg bg-neutral-100 px-2 py-1 text-[10px] font-semibold text-neutral-600 hover:bg-neutral-200"
+                        >
+                          {kw.split(".")[1]}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="mb-3 rounded-lg bg-primary-50 p-2">
+              <span className="mb-1 block text-xs font-medium text-primary-700">Gerar com IA</span>
+              <div className="flex gap-2">
+                <input value={brief} onChange={(e) => setBrief(e.target.value)} placeholder={`Sobre o que? (ex: ${node.data.label.toLowerCase()})`} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none" />
+                <button onClick={generate} disabled={aiBusy} className="flex shrink-0 items-center gap-1 rounded-lg bg-primary-500 px-3 text-xs font-semibold text-white disabled:opacity-60">
+                  <Sparkles size={12} /> {aiBusy ? "..." : "Gerar"}
+                </button>
+              </div>
+            </div>
+
+            {isEmail && (
+              <label className="mb-3 block">
+                <span className="mb-1 block text-xs font-medium text-neutral-600">Assunto</span>
+                <input value={subject} onChange={(e) => setSubject(e.target.value)} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+              </label>
+            )}
+            <label className="mb-4 block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">{bodyLabel}</span>
+              <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={isEmail ? 8 : 5} placeholder={`Escreva ${bodyLabel.toLowerCase()}...`} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+            </label>
+          </>
         )}
-        <label className="mb-4 block">
-          <span className="mb-1 block text-xs font-medium text-neutral-600">{bodyLabel}</span>
-          <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={isEmail ? 8 : 5} placeholder={`Escreva ${bodyLabel.toLowerCase()}...`} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
-        </label>
 
         <div className="flex gap-2">
           <button onClick={onClose} className="flex-1 rounded-pill bg-neutral-100 py-2.5 font-semibold text-neutral-600 hover:bg-neutral-200">Cancelar</button>
-          <button onClick={() => onSave({ subject: isEmail ? subject : "", body, model: isPage ? model : undefined })} className="flex-1 rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500">
+          <button
+            onClick={() =>
+              onSave(
+                isWhatsapp
+                  ? { template_id: templateId, variables }
+                  : { subject: isEmail ? subject : "", body, model: isPage ? model : undefined },
+              )
+            }
+            disabled={isWhatsapp && !templateId}
+            className="flex-1 rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500 disabled:opacity-50"
+          >
             Salvar no nó
           </button>
         </div>

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -660,6 +660,46 @@ export interface TenantProfile {
   /** Funil de Vendas em que todo lead novo (source=landing/api) é inscrito automaticamente.
    * null = auto-enroll desligado (comportamento até o dono configurar). */
   default_entry_funnel_id: UUID | null;
+  /** WhatsApp Cloud API (Meta) — POR TENANT. true só quando token+phone_id+waba_id
+   * estiverem TODOS configurados (ver `whatsapp_configured` no backend). */
+  whatsapp_configured: boolean;
+  whatsapp_phone_id: string;
+  whatsapp_waba_id: string;
+  /** Só-escrita: nunca vem preenchido no GET (o token nunca é devolvido em claro).
+   * Setar antes do PATCH para configurar/trocar; "" limpa a credencial. */
+  whatsapp_token?: string;
+}
+
+// ── WhatsApp Cloud API (Meta): templates de mensagem por tenant ────
+// A Meta exige template pré-aprovado para toda mensagem business-initiated (fora da janela
+// de 24h de atendimento) — ver app/core/whatsapp.py e app/modules/whatsapp_templates.
+export type WhatsappTemplateStatus = "PENDING" | "APPROVED" | "REJECTED" | "PAUSED" | "DISABLED";
+export type WhatsappTemplateCategory = "MARKETING" | "UTILITY" | "AUTHENTICATION";
+
+export interface WhatsappTemplate {
+  id: UUID;
+  name: string;
+  language: string;
+  category_requested: WhatsappTemplateCategory;
+  /** Categoria que a Meta de fato aprovou — pode divergir da solicitada. null até responder. */
+  category_approved: WhatsappTemplateCategory | null;
+  status: WhatsappTemplateStatus;
+  rejected_reason: string | null;
+  meta_template_id: string | null;
+  /** Corpo com variáveis posicionais no formato Meta: {{1}}, {{2}}, ... */
+  body_text: string;
+  variable_count: number;
+  variable_examples: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WhatsappTemplateCreate {
+  name: string;
+  language: string;
+  category: WhatsappTemplateCategory;
+  body_text: string;
+  variable_examples: string[];
 }
 
 // ── Integrações (captura de lead de sites externos) ────

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -668,7 +668,37 @@ export interface TenantProfile {
   /** Só-escrita: nunca vem preenchido no GET (o token nunca é devolvido em claro).
    * Setar antes do PATCH para configurar/trocar; "" limpa a credencial. */
   whatsapp_token?: string;
+  /** Vínculo propósito→template_id para os fluxos FIXOS do sistema (lembrete de cobrança,
+   * envio de contrato/orçamento, convite de staff, aviso de card movido) — diferente do nó
+   * livre do Funil de Vendas, aqui o tenant vincula UM template aprovado por propósito.
+   * Chave ausente/"" = esse fluxo ainda usa texto livre. Ver WHATSAPP_PURPOSES. */
+  whatsapp_template_bindings: Record<string, string>;
 }
+
+/** Espelha `whatsapp_templates.models.PURPOSE_VARIABLE_SPECS` do backend — rótulo de cada
+ * variável, na ordem em que o sistema preenche {{1}}, {{2}}, ... para aquele propósito. */
+export const WHATSAPP_PURPOSES: { key: string; label: string; variables: string[] }[] = [
+  {
+    key: "charge_reminder", label: "Lembrete de cobrança (Cobrar com IA)",
+    variables: ["Nome do cliente", "Frase de cobrança (a IA sugere)", "Valor", "Vencimento"],
+  },
+  {
+    key: "contract_send", label: "Envio de contrato",
+    variables: ["Nome do cliente", "Título do contrato", "Link de assinatura"],
+  },
+  {
+    key: "quote_send", label: "Envio de orçamento/proposta",
+    variables: ["Nome do cliente", "Título do orçamento", "Valor", "Link da proposta"],
+  },
+  {
+    key: "staff_invite", label: "Convite de funcionário (senha temporária)",
+    variables: ["Nome", "Empresa", "E-mail de login", "Senha temporária"],
+  },
+  {
+    key: "client_moved", label: "Aviso interno: cliente mudou de etapa no CRM",
+    variables: ["Nome do cliente", "Nome da nova etapa"],
+  },
+];
 
 // ── WhatsApp Cloud API (Meta): templates de mensagem por tenant ────
 // A Meta exige template pré-aprovado para toda mensagem business-initiated (fora da janela


### PR DESCRIPTION
## Resumo

Substitui a integração de WhatsApp (antes uma única credencial global via env, incompatível com multi-tenant) por credenciais **por tenant** + **gerenciamento de templates**, exigido pela Meta para qualquer mensagem business-initiated (fora da janela de 24h de atendimento — o que cobre praticamente todo envio automático do produto).

## O que mudou

**Fase 1 — infraestrutura + nó do funil**
- Credenciais por tenant (`whatsapp_token` cifrado com Fernet, `whatsapp_phone_id`, `whatsapp_waba_id`) em Configurações → Integrações
- CRUD de templates (criar/sincronizar status com a Meta/excluir), com validação de variáveis `{{n}}` vs exemplos exigidos pela Meta
- Nó de WhatsApp do Funil de Vendas: troca texto livre por seletor de template aprovado + variáveis (texto fixo ou `{{cliente.nome/telefone/email}}`)

**Fase 2 — os 5 fluxos restantes que ainda usavam texto livre**
- Vínculo propósito→template (`tenant_profiles.whatsapp_template_bindings`): o tenant vincula UM template aprovado por propósito fixo, uma vez
- `charge_reminder` (Cobrar com IA) — a IA passa a escrever só a frase de cobrança, uma variável do template, preservando o diferencial de IA dentro da regra da Meta
- `contract_send`, `quote_send`, `staff_invite`, `client_moved` (aviso interno via fila assíncrona do worker)
- Mensagem manual de cobrança **permanece texto livre intencionalmente** — não dá pra embrulhar conteúdo arbitrário num template sem violar a política da Meta; a janela de 24h é enforced pela própria Graph API
- Sem vínculo configurado, cada fluxo cai no comportamento antigo (texto livre), agora com as credenciais reais do tenant em vez do env global morto — zero regressão

## Test plan
- [x] Backend: `pytest -q -m "not rls_e2e"` → 664 passed, 1 skipped
- [x] Backend lint: `ruff check app/` → limpo
- [x] Frontend: `pnpm --filter @e1p/web test` → 117 passed
- [x] Frontend typecheck: `tsc --noEmit` → limpo
- [x] Frontend lint: `eslint . --max-warnings 0` → limpo (1 warning pré-existente não relacionado em `ChartAccountSelect.tsx`, confirmado via `git diff main` = sem mudança nesse arquivo)
- [x] Migrations 0052/0053 validadas com upgrade→downgrade→upgrade real no Postgres do projeto
- [ ] Verificação end-to-end contra a Graph API real da Meta (exige WABA/token de sandbox configurado por vocês na tela nova — não verificável neste ambiente)

## Dívida técnica documentada
- Verificação real de envio via Meta (sandbox) fica para quando houver credenciais de teste
- Webhook de aprovação de template em tempo real (hoje é botão "Sincronizar" manual)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)