### PR TITLE
feat: Inbox de WhatsApp (conversa bidirecional com clientes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ test-results/
 .aiox/
 .claude/agent-memory/
 .claude/worktrees/
+
+# Superpowers subagent-driven-development scratch (progress ledger, review packages)
+.superpowers/

--- a/apps/api/app/core/whatsapp.py
+++ b/apps/api/app/core/whatsapp.py
@@ -6,6 +6,8 @@ entrega de verdade pela Graph API.
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 
 import httpx
@@ -181,4 +183,87 @@ def send_template(
         return "sent"
     except Exception:
         logger.exception("[whatsapp:failed] template para=%s nome=%s", to, template_name)
+        return "failed"
+
+
+def verify_webhook_signature(
+    *, app_secret: str, body: bytes, signature_header: str | None
+) -> bool:
+    """Valida `X-Hub-Signature-256` (HMAC-SHA256 do corpo CRU do webhook). Comparação de tempo
+    constante — nunca comparar segredos com `==`."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(app_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    provided = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, provided)
+
+
+def upload_media(
+    *, phone_id: str, token: str, file_bytes: bytes, filename: str, mime_type: str
+) -> str:
+    """POST /{phone_id}/media (multipart). Retorna o `media_id` temporário da Meta.
+    Levanta WhatsappApiError em qualquer falha."""
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{phone_id}/media",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"messaging_product": "whatsapp"},
+            files={"file": (filename, file_bytes, mime_type)},
+            timeout=30,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao subir mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.json()["id"]
+
+
+def fetch_media_url(*, token: str, media_id: str) -> str:
+    """GET /{media_id}. Retorna a URL temporária de download. Levanta WhatsappApiError."""
+    try:
+        resp = httpx.get(
+            f"https://graph.facebook.com/v21.0/{media_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao resolver mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.json()["url"]
+
+
+def download_media(*, token: str, url: str) -> bytes:
+    """Baixa os bytes da URL temporária (a Meta exige o Bearer token também neste GET).
+    Levanta WhatsappApiError."""
+    try:
+        resp = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=30)
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao baixar mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.content
+
+
+def send_media(
+    *, to: str, token: str, phone_id: str, kind: str, media_id: str, caption: str = ""
+) -> str:
+    """Retorna 'sent' | 'logged' | 'failed'. Mesmo contrato de send_text/send_template: NUNCA
+    propaga exceção."""
+    if not token or not phone_id:
+        logger.info("[whatsapp:logged] mídia para=%s kind=%s", to, kind)
+        return "logged"
+    media_obj: dict[str, str] = {"id": media_id}
+    if caption:
+        media_obj["caption"] = caption
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{phone_id}/messages",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "messaging_product": "whatsapp", "to": to, "type": kind, kind: media_obj,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return "sent"
+    except Exception:
+        logger.exception("[whatsapp:failed] mídia para=%s kind=%s", to, kind)
         return "failed"

--- a/apps/api/app/modules/__init__.py
+++ b/apps/api/app/modules/__init__.py
@@ -35,6 +35,8 @@ from app.modules.receivables.router import router as receivables_router
 from app.modules.settings.router import router as settings_router
 from app.modules.stock.router import router as stock_router
 from app.modules.wallet.router import router as wallet_router
+from app.modules.whatsapp_inbox.router import public_router as whatsapp_inbox_public_router
+from app.modules.whatsapp_inbox.router import router as whatsapp_inbox_router
 from app.modules.whatsapp_templates.router import router as whatsapp_templates_router
 
 ALL_ROUTERS: list[APIRouter] = [
@@ -62,6 +64,8 @@ ALL_ROUTERS: list[APIRouter] = [
     stock_router,
     settings_router,
     whatsapp_templates_router,
+    whatsapp_inbox_router,
+    whatsapp_inbox_public_router,
     pages_router,
     pages_public_router,
     attachments_router,

--- a/apps/api/app/modules/attachments/models.py
+++ b/apps/api/app/modules/attachments/models.py
@@ -12,8 +12,12 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
-# tipos de arquivo aceitos
-ALLOWED_TYPES = {"application/pdf", "image/jpeg", "image/png"}
+# tipos de arquivo aceitos (inclui mídia recebida/enviada via WhatsApp — áudio/vídeo/documento
+# genérico — ver whatsapp_inbox)
+ALLOWED_TYPES = {
+    "application/pdf", "image/jpeg", "image/png",
+    "audio/ogg", "audio/mpeg", "video/mp4", "application/octet-stream",
+}
 MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 
 # Imagens INTENCIONALMENTE públicas (logo/fotos): só formatos renderizáveis em <img>/CSS.

--- a/apps/api/app/modules/crm/models.py
+++ b/apps/api/app/modules/crm/models.py
@@ -23,7 +23,7 @@ from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
 # Gênero (para segmentação demográfica citada na spec).
 GENDER_VALUES = {"male", "female", "other", "unspecified"}
-SOURCE_VALUES = {"manual", "landing", "ai", "import", "api"}
+SOURCE_VALUES = {"manual", "landing", "ai", "import", "api", "whatsapp"}
 
 # Colunas padrão criadas no primeiro acesso ao board de um tenant.
 DEFAULT_STAGES = [

--- a/apps/api/app/modules/settings/models.py
+++ b/apps/api/app/modules/settings/models.py
@@ -59,6 +59,13 @@ class TenantProfile(Base, TenantMixin, TimestampMixin):
     whatsapp_token: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
     whatsapp_phone_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     whatsapp_waba_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Segredo do App da Meta (cifrado, mesmo padrão do token) — valida a assinatura
+    # X-Hub-Signature-256 do webhook de mensagens recebidas (ver whatsapp_inbox).
+    whatsapp_app_secret: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
+    # Token de verificação do webhook (texto simples, NÃO é segredo — só combina com o que a
+    # Meta ecoa no handshake GET). Gerado automaticamente na 1ª vez que as 4 credenciais ficam
+    # completas (ver settings/service.py::update_profile).
+    whatsapp_verify_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # Vínculo propósito→template (dict[str, str], chaves em whatsapp_templates.PURPOSES).
     # Propósito ausente/sem valor = fluxo correspondente ainda usa texto livre (send_text).
     whatsapp_template_bindings: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)

--- a/apps/api/app/modules/settings/router.py
+++ b/apps/api/app/modules/settings/router.py
@@ -24,6 +24,7 @@ def _out(p: TenantProfile) -> ProfileOut:
         whatsapp_configured=bool(p.whatsapp_token and p.whatsapp_phone_id and p.whatsapp_waba_id),
         whatsapp_phone_id=p.whatsapp_phone_id or "",
         whatsapp_waba_id=p.whatsapp_waba_id or "",
+        whatsapp_verify_token=p.whatsapp_verify_token or "",
         whatsapp_template_bindings=p.whatsapp_template_bindings or {},
     )
 

--- a/apps/api/app/modules/settings/schemas.py
+++ b/apps/api/app/modules/settings/schemas.py
@@ -34,6 +34,7 @@ class ProfileOut(BaseModel):
     whatsapp_configured: bool
     whatsapp_phone_id: str
     whatsapp_waba_id: str
+    whatsapp_verify_token: str
     # Vínculo propósito→template (ver whatsapp_templates.models.PURPOSE_VARIABLE_SPECS).
     # Propósito ausente/vazio = esse fluxo do sistema ainda usa texto livre.
     whatsapp_template_bindings: dict[str, str]
@@ -63,6 +64,7 @@ class ProfileUpdate(BaseModel):
     whatsapp_token: str | None = Field(default=None)
     whatsapp_phone_id: str | None = Field(default=None, max_length=64)
     whatsapp_waba_id: str | None = Field(default=None, max_length=64)
+    whatsapp_app_secret: str | None = Field(default=None)
     # None = não altera; um dict substitui o mapa INTEIRO (a UI sempre manda o mapa completo
     # após editar). Chave com valor "" desvincula aquele propósito específico.
     whatsapp_template_bindings: dict[str, str] | None = Field(default=None)

--- a/apps/api/app/modules/settings/service.py
+++ b/apps/api/app/modules/settings/service.py
@@ -1,6 +1,8 @@
 """Configurações: perfil da empresa + Brand Kit (um por tenant, criado sob demanda)."""
 from __future__ import annotations
 
+import secrets
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -8,6 +10,7 @@ from app.core import audit
 from app.modules.auth.models import Tenant
 from app.modules.settings.models import TenantProfile
 from app.modules.settings.schemas import ProfileUpdate
+from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
 from app.modules.whatsapp_templates.models import (
     PURPOSE_VARIABLE_SPECS,
     STATUS_APPROVED,
@@ -53,7 +56,7 @@ _FIELDS = (
     "display_name", "document", "email", "phone", "address", "website", "about",
     "logo_url", "primary_color", "secondary_color", "accent_color", "text_color",
     "bg_color", "font", "timezone",
-    "whatsapp_token", "whatsapp_phone_id", "whatsapp_waba_id",
+    "whatsapp_token", "whatsapp_phone_id", "whatsapp_waba_id", "whatsapp_app_secret",
 )
 
 
@@ -73,6 +76,43 @@ def get_profile(db: Session, tenant_id: str) -> TenantProfile:
     return profile
 
 
+def _sync_whatsapp_webhook_snapshot(db: Session, profile: TenantProfile) -> None:
+    """Mantém `public_whatsapp_accounts` em sincronia com as credenciais do tenant — dual-write
+    no mesmo espírito de `integration_keys`/`public_integration_keys`. Remove qualquer snapshot
+    antigo do tenant (cobre o caso de `phone_id` ter mudado) e recria só se as 4 credenciais
+    (token/phone_id/waba_id/app_secret) estiverem TODAS presentes. Gera `verify_token`
+    automaticamente na primeira vez que isso acontece."""
+    existing = db.scalars(
+        select(PublicWhatsappAccount).where(
+            PublicWhatsappAccount.tenant_id == profile.tenant_id
+        )
+    ).all()
+    for row in existing:
+        db.delete(row)
+
+    fully_configured = bool(
+        profile.whatsapp_token
+        and profile.whatsapp_phone_id
+        and profile.whatsapp_waba_id
+        and profile.whatsapp_app_secret
+    )
+    if not fully_configured:
+        profile.whatsapp_verify_token = None
+        return
+
+    if not profile.whatsapp_verify_token:
+        profile.whatsapp_verify_token = secrets.token_urlsafe(24)
+
+    db.add(
+        PublicWhatsappAccount(
+            phone_number_id=profile.whatsapp_phone_id,
+            tenant_id=profile.tenant_id,
+            app_secret=profile.whatsapp_app_secret,
+            verify_token=profile.whatsapp_verify_token,
+        )
+    )
+
+
 def update_profile(
     db: Session, *, tenant_id: str, actor: str, data: ProfileUpdate
 ) -> TenantProfile:
@@ -88,6 +128,7 @@ def update_profile(
     if data.whatsapp_template_bindings is not None:
         _validate_template_bindings(db, data.whatsapp_template_bindings)
         profile.whatsapp_template_bindings = data.whatsapp_template_bindings
+    _sync_whatsapp_webhook_snapshot(db, profile)
     audit.record(db, tenant_id=tenant_id, actor=actor, action="settings.profile.update",
                  target=profile.id)
     db.commit()

--- a/apps/api/app/modules/whatsapp_inbox/models.py
+++ b/apps/api/app/modules/whatsapp_inbox/models.py
@@ -52,6 +52,9 @@ class WhatsappMessage(Base, TenantMixin, TimestampMixin):
     )
     # ID da própria Meta — evita duplicar se o webhook reentregar a mesma mensagem.
     wa_message_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # ID de mídia da Meta (distinto de wa_message_id, que é o ID da MENSAGEM) — só setado
+    # quando kind != "text" e ainda não baixamos os bytes.
+    meta_media_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     # Só relevante pra `direction=out` ("sent"|"logged"|"failed", mesmo vocabulário de sempre).
     status: Mapped[str] = mapped_column(String(16), default="sent", nullable=False)
 

--- a/apps/api/app/modules/whatsapp_inbox/models.py
+++ b/apps/api/app/modules/whatsapp_inbox/models.py
@@ -1,0 +1,90 @@
+"""Conversa de WhatsApp (inbox): mensagens trocadas com o cliente (RLS) + resolução
+pré-autenticação do webhook (tabela global, sem RLS).
+
+Não confundir com `whatsapp_templates` (templates aprovados pela Meta) — aqui é a conversa de
+verdade, ida-e-volta, entre o tenant e o cliente. Ver docs/superpowers/specs/
+2026-07-19-whatsapp-inbox-design.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+DIRECTION_IN = "in"
+DIRECTION_OUT = "out"
+DIRECTIONS = (DIRECTION_IN, DIRECTION_OUT)
+
+KIND_TEXT = "text"
+KIND_IMAGE = "image"
+KIND_AUDIO = "audio"
+KIND_DOCUMENT = "document"
+KIND_VIDEO = "video"
+KINDS = (KIND_TEXT, KIND_IMAGE, KIND_AUDIO, KIND_DOCUMENT, KIND_VIDEO)
+
+MEDIA_STATUS_NONE = "none"
+MEDIA_STATUS_PENDING = "pending"
+MEDIA_STATUS_DOWNLOADED = "downloaded"
+MEDIA_STATUS_FAILED = "failed"
+
+
+class WhatsappMessage(Base, TenantMixin, TimestampMixin):
+    __tablename__ = "whatsapp_messages"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "wa_message_id", name="uq_whatsapp_messages_tenant_wa_id"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    client_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    direction: Mapped[str] = mapped_column(String(4), nullable=False)
+    kind: Mapped[str] = mapped_column(String(16), default=KIND_TEXT, nullable=False)
+    text_body: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    # Link pro módulo de Anexos já existente (reaproveita storage S3/Postgres).
+    media_attachment_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    # Só relevante pra mídia `in` (baixada de forma assíncrona pelo worker).
+    media_status: Mapped[str] = mapped_column(
+        String(16), default=MEDIA_STATUS_NONE, nullable=False
+    )
+    # ID da própria Meta — evita duplicar se o webhook reentregar a mesma mensagem.
+    wa_message_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Só relevante pra `direction=out` ("sent"|"logged"|"failed", mesmo vocabulário de sempre).
+    status: Mapped[str] = mapped_column(String(16), default="sent", nullable=False)
+
+
+class WhatsappConversationState(Base, TenantMixin, TimestampMixin):
+    """Uma linha por cliente com atividade — só guarda `last_read_at` (compartilhado entre toda
+    a equipe do tenant: "lida por qualquer um" marca lida pra todos, sem granularidade por
+    atendente, mesma decisão de 'inbox compartilhada' do brainstorming)."""
+
+    __tablename__ = "whatsapp_conversation_states"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "client_id", name="uq_whatsapp_conv_state_tenant_client"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    client_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    last_read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class PublicWhatsappAccount(Base, TimestampMixin):
+    """Snapshot GLOBAL (sem RLS, SEM TenantMixin) — resolve `tenant_id` a partir do
+    `phone_number_id` ANTES de qualquer autenticação. O webhook da Meta não manda tenant nenhum,
+    só o `phone_number_id` que recebeu a mensagem; esta tabela é o único jeito de saber de quem é
+    o evento e qual `app_secret` usar pra validar a assinatura. Mesmo padrão de
+    `PublicIntegrationKey`/`published_pages`. Mantida em sincronia (dual-write) por
+    `settings/service.py::update_profile` toda vez que o tenant salva/altera as credenciais.
+    """
+
+    __tablename__ = "public_whatsapp_accounts"
+
+    phone_number_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    app_secret: Mapped[str] = mapped_column(String(255), nullable=False)
+    verify_token: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/apps/api/app/modules/whatsapp_inbox/models.py
+++ b/apps/api/app/modules/whatsapp_inbox/models.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from sqlalchemy import DateTime, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.token_crypto import EncryptedToken
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
 
 DIRECTION_IN = "in"
@@ -89,5 +90,9 @@ class PublicWhatsappAccount(Base, TimestampMixin):
 
     phone_number_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
-    app_secret: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Cifrado em repouso (mesmo padrão de `TenantProfile.whatsapp_app_secret`, ver
+    # `core/token_crypto.py`) — vazamento de dump/backup não deve expor o segredo do App da Meta,
+    # que forjaria a assinatura do webhook. Transparente: leitura/escrita seguem em texto plano
+    # no nível Python (migration 0056 ajusta o tipo SQL subjacente p/ TEXT).
+    app_secret: Mapped[str] = mapped_column(EncryptedToken, nullable=False)
     verify_token: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -69,7 +69,7 @@ async def receive_webhook(
     body = await request.body()
     try:
         payload = json.loads(body) if body else {}
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise HTTPException(status_code=400, detail="JSON inválido") from exc
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="JSON inválido")

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -46,7 +46,10 @@ async def receive_webhook(
     validar a assinatura (a assinatura usa o `app_secret` DAQUELE tenant, então precisamos saber
     quem é primeiro). Se a assinatura não bater, rejeita sem processar nada."""
     body = await request.body()
-    payload = json.loads(body) if body else {}
+    try:
+        payload = json.loads(body) if body else {}
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="JSON inválido") from exc
     phone_number_id = None
     for entry in payload.get("entry", []):
         for change in entry.get("changes", []):

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -1,0 +1,110 @@
+# apps/api/app/modules/whatsapp_inbox/router.py
+"""Webhook público de WhatsApp (recebimento de mensagens) + rotas autenticadas da inbox."""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.db.session import get_db, get_tenant_session_factory
+from app.modules.whatsapp_inbox import service
+
+public_router = APIRouter(prefix="/public/whatsapp", tags=["whatsapp-inbox-public"])
+router = APIRouter(prefix="/whatsapp-conversations", tags=["whatsapp-inbox"])
+
+_guard = require_module("crm")
+
+
+@public_router.get("/webhook")
+def verify_webhook(
+    hub_mode: str = Query(alias="hub.mode"),
+    hub_verify_token: str = Query(alias="hub.verify_token"),
+    hub_challenge: str = Query(alias="hub.challenge"),
+    db: Session = Depends(get_db),
+) -> PlainTextResponse:
+    """Handshake de verificação chamado 1x pela Meta quando o tenant configura o webhook no
+    painel dele. Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_whatsapp_accounts`,
+    tabela GLOBAL sem RLS, pelo verify_token — não toca tabela de negócio."""
+    if hub_mode != "subscribe" or service.resolve_by_verify_token(
+        db, verify_token=hub_verify_token
+    ) is None:
+        raise HTTPException(status_code=403, detail="Token de verificação inválido")
+    return PlainTextResponse(content=hub_challenge)
+
+
+@public_router.post("/webhook")
+async def receive_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    session_factory=Depends(get_tenant_session_factory),
+) -> dict:
+    """Recebe o evento da Meta. Descobre o tenant pelo `phone_number_id` do payload ANTES de
+    validar a assinatura (a assinatura usa o `app_secret` DAQUELE tenant, então precisamos saber
+    quem é primeiro). Se a assinatura não bater, rejeita sem processar nada."""
+    body = await request.body()
+    payload = json.loads(body) if body else {}
+    phone_number_id = None
+    for entry in payload.get("entry", []):
+        for change in entry.get("changes", []):
+            phone_number_id = change.get("value", {}).get("metadata", {}).get("phone_number_id")
+            if phone_number_id:
+                break
+        if phone_number_id:
+            break
+
+    if not phone_number_id:
+        raise HTTPException(status_code=404, detail="phone_number_id não encontrado no payload")
+
+    account = service.resolve_account(db, phone_number_id=phone_number_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Número não configurado nesta plataforma")
+
+    signature = request.headers.get("x-hub-signature-256")
+    if not whatsapp.verify_webhook_signature(
+        app_secret=account.app_secret, body=body, signature_header=signature
+    ):
+        raise HTTPException(status_code=403, detail="Assinatura inválida")
+
+    with session_factory(account.tenant_id) as tdb:
+        service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
+
+    return {"status": "ok"}
+
+
+# ── Rotas autenticadas (tela de Conversas) ──────────────────────────────────
+
+
+def _err(e: service.WhatsappInboxError) -> HTTPException:
+    return HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("")
+def list_conversations(
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> list[dict]:
+    return service.list_conversations(db, user.tenant_id)
+
+
+@router.get("/{client_id}/timeline")
+def get_timeline(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> list[dict]:
+    return service.get_timeline(db, client_id=client_id)
+
+
+@router.get("/{client_id}/window")
+def get_window(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> dict:
+    return {"within_session_window": service.is_within_session_window(db, client_id=client_id)}
+
+
+@router.post("/{client_id}/read", status_code=204)
+def mark_read(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+):
+    service.mark_read(db, tenant_id=user.tenant_id, client_id=client_id)

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import PlainTextResponse
 from sqlalchemy.orm import Session
 
@@ -12,6 +12,7 @@ from app.core import whatsapp
 from app.core.tenancy import CurrentUser, get_tenant_db, require_module
 from app.db.session import get_db, get_tenant_session_factory
 from app.modules.whatsapp_inbox import service
+from app.modules.whatsapp_inbox.schemas import SendTemplateRequest, SendTextRequest
 
 public_router = APIRouter(prefix="/public/whatsapp", tags=["whatsapp-inbox-public"])
 router = APIRouter(prefix="/whatsapp-conversations", tags=["whatsapp-inbox"])
@@ -135,3 +136,56 @@ def mark_read(
     client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
 ):
     service.mark_read(db, tenant_id=user.tenant_id, client_id=client_id)
+
+
+def _msg_out(msg) -> dict:
+    return {
+        "id": msg.id, "direction": msg.direction, "kind": msg.kind,
+        "text_body": msg.text_body, "status": msg.status, "created_at": msg.created_at,
+    }
+
+
+@router.post("/{client_id}/messages/text")
+def send_text_reply(
+    client_id: str, data: SendTextRequest,
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    try:
+        msg = service.send_reply_text(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id, text=data.text,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)
+
+
+@router.post("/{client_id}/messages/media")
+async def send_media_reply(
+    client_id: str, caption: str = Form(""), file: UploadFile = File(...),
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    data = await file.read()
+    try:
+        msg = service.send_reply_media(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id,
+            file_bytes=data, filename=file.filename or "arquivo",
+            mime_type=file.content_type or "application/octet-stream", caption=caption,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)
+
+
+@router.post("/{client_id}/messages/template")
+def send_template_reply(
+    client_id: str, data: SendTemplateRequest,
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    try:
+        msg = service.send_reply_template(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id,
+            template_id=data.template_id, variables=data.variables,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -50,9 +50,21 @@ async def receive_webhook(
         payload = json.loads(body) if body else {}
     except json.JSONDecodeError as exc:
         raise HTTPException(status_code=400, detail="JSON inválido") from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="JSON inválido")
+    entries = payload.get("entry", [])
+    if not isinstance(entries, list):
+        raise HTTPException(status_code=400, detail="JSON inválido")
     phone_number_id = None
-    for entry in payload.get("entry", []):
-        for change in entry.get("changes", []):
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise HTTPException(status_code=400, detail="JSON inválido")
+        changes = entry.get("changes", [])
+        if not isinstance(changes, list):
+            raise HTTPException(status_code=400, detail="JSON inválido")
+        for change in changes:
+            if not isinstance(change, dict):
+                raise HTTPException(status_code=400, detail="JSON inválido")
             phone_number_id = change.get("value", {}).get("metadata", {}).get("phone_number_id")
             if phone_number_id:
                 break

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -94,7 +94,10 @@ async def receive_webhook(
         raise HTTPException(status_code=403, detail="Assinatura inválida")
 
     with session_factory(account.tenant_id) as tdb:
-        service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
+        try:
+            service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
+        except service.WhatsappInboxError as e:
+            raise _err(e) from e
 
     return {"status": "ok"}
 

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -36,6 +36,27 @@ def verify_webhook(
     return PlainTextResponse(content=hub_challenge)
 
 
+def _extract_phone_number_id(payload: dict) -> str | None:
+    """Extrai o `phone_number_id` do payload da Meta. Levanta `HTTPException(400)` para
+    QUALQUER formato inesperado dentro de um JSON sintaticamente válido (o payload vem de uma
+    fonte não confiável — este endpoint é público): não tenta adivinhar `isinstance` a cada
+    nível aninhado (histórico: rounds 1-2 de review já encontraram gaps assim duas vezes,
+    sempre um nível mais fundo); captura toda a classe de erro de indexação inesperada de uma
+    vez só (`AttributeError` de `.get()` em algo que não é dict, `TypeError` de iterar algo
+    não-iterável, `KeyError` defensivo)."""
+    try:
+        for entry in payload.get("entry", []):
+            for change in entry.get("changes", []):
+                value = change.get("value", {})
+                metadata = value.get("metadata", {})
+                phone_number_id = metadata.get("phone_number_id")
+                if phone_number_id:
+                    return phone_number_id
+    except (AttributeError, TypeError, KeyError) as exc:
+        raise HTTPException(status_code=400, detail="Payload inválido") from exc
+    return None
+
+
 @public_router.post("/webhook")
 async def receive_webhook(
     request: Request,
@@ -52,25 +73,13 @@ async def receive_webhook(
         raise HTTPException(status_code=400, detail="JSON inválido") from exc
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="JSON inválido")
-    entries = payload.get("entry", [])
-    if not isinstance(entries, list):
-        raise HTTPException(status_code=400, detail="JSON inválido")
-    phone_number_id = None
-    for entry in entries:
-        if not isinstance(entry, dict):
-            raise HTTPException(status_code=400, detail="JSON inválido")
-        changes = entry.get("changes", [])
-        if not isinstance(changes, list):
-            raise HTTPException(status_code=400, detail="JSON inválido")
-        for change in changes:
-            if not isinstance(change, dict):
-                raise HTTPException(status_code=400, detail="JSON inválido")
-            phone_number_id = change.get("value", {}).get("metadata", {}).get("phone_number_id")
-            if phone_number_id:
-                break
-        if phone_number_id:
-            break
 
+    phone_number_id = _extract_phone_number_id(payload)
+    if phone_number_id is not None and not isinstance(phone_number_id, str):
+        # Presente mas com tipo errado (dict/list) — passaria direto pro `if not phone_number_id`
+        # abaixo (valores truthy) e quebraria `resolve_account`'s `db.get()` com
+        # `sqlalchemy.exc.InvalidRequestError`. Barra aqui, antes de chegar no service.
+        raise HTTPException(status_code=400, detail="Payload inválido")
     if not phone_number_id:
         raise HTTPException(status_code=404, detail="phone_number_id não encontrado no payload")
 

--- a/apps/api/app/modules/whatsapp_inbox/schemas.py
+++ b/apps/api/app/modules/whatsapp_inbox/schemas.py
@@ -1,0 +1,35 @@
+# apps/api/app/modules/whatsapp_inbox/schemas.py
+"""Schemas do inbox de WhatsApp: lista de conversas, linha do tempo, resposta."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ConversationSummary(BaseModel):
+    client_id: str
+    client_name: str
+    client_phone: str | None
+    last_message_at: datetime | None
+    last_message_preview: str
+    unread: bool
+
+
+class TimelineEntry(BaseModel):
+    source: str  # "conversation" | "automated"
+    direction: str  # "in" | "out"
+    kind: str
+    text_body: str
+    media_attachment_id: str | None
+    purpose_label: str | None
+    created_at: datetime
+
+
+class SendTextRequest(BaseModel):
+    text: str
+
+
+class SendTemplateRequest(BaseModel):
+    template_id: str
+    variables: list[str] = []

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -245,13 +245,32 @@ def process_pending_media(db: Session, *, tenant_id: str) -> int:
     mensagens deste tenant — mesma convenção do resto do módulo. Uma falha isolada (rede,
     credencial ausente/inválida, media_id inválido) NÃO trava as demais mensagens pendentes: a
     mensagem falha é marcada `MEDIA_STATUS_FAILED` e o loop segue (IV2, mesmo princípio de
-    `ingest_webhook_payload`/`notifications.service.process_pending`)."""
+    `ingest_webhook_payload`/`notifications.service.process_pending`).
+
+    CRÍTICO — commit POR MENSAGEM (não um único commit no fim do laço): `create_attachment` já
+    faz seu PRÓPRIO `db.commit()`/`db.refresh()` internamente, então a Session já sofre um commit
+    real a cada iteração bem-sucedida — não existe "commit único no fim" de fato, só a ILUSÃO de
+    um. Se o `create_attachment` de UMA mensagem falhar no meio (erro transitório de rede/storage,
+    plausível para bytes de mídia reais de vários MB), o SQLAlchemy 2.0 deixa a Session "poisoned"
+    (exige `db.rollback()` explícito antes de qualquer novo uso); sem esse rollback aqui, a
+    PRÓXIMA mensagem do mesmo lote (ou o commit final) levantaria `PendingRollbackError` e
+    contaminaria em cascata mensagens seguintes que seriam bem-sucedidas. Por isso, mesmo padrão de
+    `ingest_webhook_payload`: cada mensagem commita a si mesma (sucesso OU falha) e o `except`
+    chama `db.rollback()` ANTES de marcar `MEDIA_STATUS_FAILED`, para garantir que a Session volte
+    a um estado limpo antes de seguir para a próxima."""
     profile = settings_service.get_profile(db, tenant_id)
     pending = db.scalars(
-        select(WhatsappMessage).where(WhatsappMessage.media_status == MEDIA_STATUS_PENDING)
+        select(WhatsappMessage)
+        .where(WhatsappMessage.media_status == MEDIA_STATUS_PENDING)
+        .limit(50)
     ).all()
     processed = 0
     for msg in pending:
+        # `msg_id`/`msg_kind` capturados ANTES do try: se `create_attachment` falhar no meio do
+        # seu próprio commit, a Session fica "poisoned" e QUALQUER acesso a atributo de `msg`
+        # depois disso (inclusive para logar) levantaria PendingRollbackError de novo — capturar
+        # antes garante que já temos os valores em mãos, sem tocar a Session no `except`.
+        msg_id = msg.id
         try:
             url = whatsapp.fetch_media_url(
                 token=profile.whatsapp_token or "", media_id=msg.meta_media_id or ""
@@ -263,16 +282,21 @@ def process_pending_media(db: Session, *, tenant_id: str) -> int:
             }.get(msg.kind, "application/octet-stream")
             attachment = attachments_service.create_attachment(
                 db, tenant_id=tenant_id, actor="system:worker", owner_type="whatsapp_message",
-                owner_id=msg.id, label="outro", filename=f"{msg.kind}-{msg.id}",
+                owner_id=msg_id, label="outro", filename=f"{msg.kind}-{msg_id}",
                 content_type=mime_type, data=data,
             )
             msg.media_attachment_id = attachment.id
             msg.media_status = MEDIA_STATUS_DOWNLOADED
+            db.commit()  # commita SÓ esta mensagem — transação isolada da próxima do lote.
         except Exception:  # noqa: BLE001 — isola a falha por mensagem (IV2)
-            logger.exception("[whatsapp_inbox] falha ao baixar mídia msg=%s", msg.id)
+            db.rollback()  # limpa a Session (possivelmente "poisoned" pelo create_attachment
+            # que falhou no meio) ANTES de qualquer outro uso — senão o log abaixo, a marcação de
+            # status ou o próximo db.add/commit (desta mensagem ou da seguinte) levantaria
+            # PendingRollbackError.
+            logger.exception("[whatsapp_inbox] falha ao baixar mídia msg=%s", msg_id)
             msg.media_status = MEDIA_STATUS_FAILED
+            db.commit()  # commita só a marcação de falha desta mensagem.
         processed += 1
-    db.commit()
     return processed
 
 

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -26,6 +26,7 @@ from app.modules.whatsapp_inbox.models import (
     KIND_TEXT,
     MEDIA_STATUS_NONE,
     MEDIA_STATUS_PENDING,
+    PublicWhatsappAccount,
     WhatsappConversationState,
     WhatsappMessage,
 )
@@ -54,6 +55,24 @@ class WhatsappInboxError(Exception):
     def __init__(self, message: str, status_code: int = 422) -> None:
         super().__init__(message)
         self.status_code = status_code
+
+
+# ── Resolução de tenant (pré-autenticação do webhook) ───────────────────────
+
+
+def resolve_account(db: Session, *, phone_number_id: str) -> PublicWhatsappAccount | None:
+    """Resolve tenant/app_secret pelo `phone_number_id` — chamado numa sessão SEM tenant
+    (`get_db`), ANTES de qualquer autenticação, mesmo padrão de `PublicIntegrationKey`."""
+    return db.get(PublicWhatsappAccount, phone_number_id)
+
+
+def resolve_by_verify_token(db: Session, *, verify_token: str) -> PublicWhatsappAccount | None:
+    """Usado só no handshake GET — confere se o token bate com ALGUM tenant cadastrado."""
+    return db.scalar(
+        select(PublicWhatsappAccount).where(
+            PublicWhatsappAccount.verify_token == verify_token
+        )
+    )
 
 
 # ── Ingestão (webhook) ──────────────────────────────────────────────────────

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -64,11 +64,18 @@ class WhatsappInboxError(Exception):
 
 
 def _is_safe_identifier(value: str) -> bool:
-    """Recusa caracteres de controle (NUL em especial) que o driver do Postgres rejeita na
-    hora de fazer bind do parâmetro (psycopg.DataError) — inofensivo no SQLite dos testes,
-    mas quebra em produção. Ambos os identificadores vêm de entrada não confiável (payload
-    público do webhook / query param do handshake), então validamos antes de qualquer lookup."""
-    return "\x00" not in value
+    """Recusa NUL e qualquer string que não codifique em UTF-8 (ex.: surrogate solto) — ambos
+    quebram o driver do Postgres na hora de fazer bind do parâmetro (psycopg.DataError /
+    UnicodeEncodeError). Inofensivo pra maioria dos back-ends de teste, mas explode em
+    produção. Ambos os identificadores vêm de entrada não confiável (payload público do
+    webhook / query param do handshake), então validamos antes de qualquer lookup."""
+    if "\x00" in value:
+        return False
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
 
 
 def resolve_account(db: Session, *, phone_number_id: str) -> PublicWhatsappAccount | None:

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -1,0 +1,371 @@
+# apps/api/app/modules/whatsapp_inbox/service.py
+"""Inbox de WhatsApp: ingestão do webhook, lead automático, linha do tempo unificada, janela
+de 24h e envio de resposta (texto/mídia/template).
+
+Ver docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md para o desenho completo.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import audit, whatsapp
+from app.modules.attachments import service as attachments_service
+from app.modules.attachments.service import AttachmentError
+from app.modules.crm import service as crm_service
+from app.modules.crm.models import Client
+from app.modules.crm.schemas import ClientCreate
+from app.modules.notifications.models import Notification
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    KIND_TEXT,
+    MEDIA_STATUS_NONE,
+    MEDIA_STATUS_PENDING,
+    PublicWhatsappAccount,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+
+logger = logging.getLogger("e1p.whatsapp_inbox")
+
+SESSION_WINDOW = timedelta(hours=24)
+
+# Rótulo genérico para avisos automáticos na timeline (ver `get_timeline`): `Notification` hoje
+# não guarda o propósito explicitamente, então todo aviso automático cai neste rótulo único.
+# Refinamento (guardar o propósito na própria Notification) fica para depois — não bloqueia
+# esta feature.
+AUTOMATED_PURPOSE_LABEL = "Aviso automático"
+
+# Mapeia o mime_type recebido em `send_reply_media` para o `type` que a Graph API espera.
+_MEDIA_KIND_BY_MIME = {
+    "image/jpeg": "image",
+    "image/png": "image",
+    "application/pdf": "document",
+    "audio/mpeg": "audio",
+    "audio/ogg": "audio",
+    "video/mp4": "video",
+}
+
+
+class WhatsappInboxError(Exception):
+    def __init__(self, message: str, status_code: int = 422) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+# ── Ingestão (webhook) ──────────────────────────────────────────────────────
+
+
+def _extract_messages(payload: dict) -> list[tuple[str | None, dict, str]]:
+    """Devolve [(phone_number_id, mensagem, nome_do_contato)] achatando o formato aninhado do
+    payload da Meta. `phone_number_id` vem por `value.metadata` — é dali que resolvemos o
+    `tenant_id` (a Meta não manda tenant nenhum, só o número que recebeu o evento)."""
+    out: list[tuple[str | None, dict, str]] = []
+    for entry in payload.get("entry", []):
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            phone_number_id = value.get("metadata", {}).get("phone_number_id")
+            contacts = value.get("contacts", [])
+            name = contacts[0]["profile"]["name"] if contacts else "Cliente"
+            for msg in value.get("messages", []):
+                out.append((phone_number_id, msg, name))
+    return out
+
+
+def _resolve_tenant_id(db: Session, *, phone_number_id: str | None) -> str | None:
+    """Resolve o `tenant_id` a partir do `phone_number_id` via `PublicWhatsappAccount` (tabela
+    global, sem RLS — o único jeito de saber de quem é o evento antes de qualquer autenticação).
+    Devolve None se o número não estiver cadastrado (evento descartado silenciosamente)."""
+    if not phone_number_id:
+        return None
+    account = db.scalar(
+        select(PublicWhatsappAccount).where(
+            PublicWhatsappAccount.phone_number_id == phone_number_id
+        )
+    )
+    return account.tenant_id if account else None
+
+
+def _get_or_create_client(db: Session, *, tenant_id: str, phone: str, name: str) -> Client:
+    client = db.scalar(select(Client).where(Client.phone == phone))
+    if client is not None:
+        return client
+    return crm_service.create_client(
+        db, tenant_id=tenant_id, actor="whatsapp:inbox",
+        data=ClientCreate(name=name or phone, phone=phone, source="whatsapp"),
+    )
+
+
+def ingest_webhook_payload(db: Session, *, payload: dict) -> None:
+    """Processa UM payload de webhook. Idempotente: mensagens com `wa_message_id` já visto são
+    ignoradas (a Meta reentrega o mesmo evento às vezes). `tenant_id` é resolvido por mensagem
+    a partir do `phone_number_id` (ver `_resolve_tenant_id`) — eventos de números não
+    cadastrados são descartados."""
+    for phone_number_id, msg, contact_name in _extract_messages(payload):
+        wa_message_id = msg.get("id")
+        if wa_message_id and db.scalar(
+            select(WhatsappMessage).where(WhatsappMessage.wa_message_id == wa_message_id)
+        ):
+            continue  # duplicata — ignora
+
+        tenant_id = _resolve_tenant_id(db, phone_number_id=phone_number_id)
+        if tenant_id is None:
+            logger.warning(
+                "[whatsapp_inbox] phone_number_id desconhecido, descartando mensagem: %s",
+                phone_number_id,
+            )
+            continue
+
+        from_number = msg.get("from", "")
+        kind = msg.get("type", "text")
+        text_body = ""
+        media_status = MEDIA_STATUS_NONE
+
+        if kind == "text":
+            text_body = msg.get("text", {}).get("body", "")
+        elif kind in ("image", "audio", "document", "video"):
+            media_obj = msg.get(kind, {})
+            text_body = media_obj.get("caption", "")
+            media_status = MEDIA_STATUS_PENDING
+        else:
+            kind = "text"
+            text_body = "[tipo de mensagem não suportado]"
+
+        client = _get_or_create_client(
+            db, tenant_id=tenant_id, phone=from_number, name=contact_name
+        )
+        db.add(WhatsappMessage(
+            tenant_id=tenant_id, client_id=client.id, direction=DIRECTION_IN, kind=kind,
+            text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
+            status="sent",
+        ))
+    db.commit()
+
+
+# ── Timeline unificada + janela de 24h ──────────────────────────────────────
+
+
+def list_conversations(db: Session, tenant_id: str) -> list[dict]:
+    """Uma linha por cliente com pelo menos 1 WhatsappMessage, ordenada pela mais recente.
+
+    `tenant_id` não filtra a query explicitamente: a sessão já chega escopada por RLS (mesma
+    convenção de `crm_service.build_board`), é mantido no parâmetro por simetria com o resto do
+    módulo (e uso futuro, ex.: auditoria)."""
+    last_msgs: dict[str, WhatsappMessage] = {}
+    for msg in db.scalars(
+        select(WhatsappMessage).order_by(WhatsappMessage.created_at)
+    ).all():
+        last_msgs[msg.client_id] = msg  # a última iteração (ordem crescente) vence
+
+    states = {
+        s.client_id: s
+        for s in db.scalars(select(WhatsappConversationState)).all()
+    }
+
+    out = []
+    for client_id, last_msg in last_msgs.items():
+        client = db.get(Client, client_id)
+        if client is None:
+            continue
+        state = states.get(client_id)
+        unread = (
+            last_msg.direction == DIRECTION_IN
+            and (
+                state is None
+                or state.last_read_at is None
+                or last_msg.created_at > state.last_read_at
+            )
+        )
+        out.append({
+            "client_id": client_id,
+            "client_name": client.name,
+            "client_phone": client.phone,
+            "last_message_at": last_msg.created_at,
+            "last_message_preview": last_msg.text_body or f"[{last_msg.kind}]",
+            "unread": unread,
+        })
+    out.sort(key=lambda c: c["last_message_at"], reverse=True)
+    return out
+
+
+def get_timeline(db: Session, *, client_id: str) -> list[dict]:
+    """Mescla WhatsappMessage (conversa) + Notification(channel=whatsapp) do mesmo cliente
+    (avisos automáticos já existentes: cobrança, contrato, etc.) — leitura combinada, SEM
+    migrar nenhum dado antigo (ver design doc §2)."""
+    entries: list[dict] = []
+    for msg in db.scalars(
+        select(WhatsappMessage)
+        .where(WhatsappMessage.client_id == client_id)
+        .order_by(WhatsappMessage.created_at)
+    ).all():
+        entries.append({
+            "source": "conversation",
+            "direction": msg.direction,
+            "kind": msg.kind,
+            "text_body": msg.text_body,
+            "media_attachment_id": msg.media_attachment_id,
+            "purpose_label": None,
+            "created_at": msg.created_at,
+        })
+    for notif in db.scalars(
+        select(Notification)
+        .where(Notification.client_id == client_id, Notification.channel == "whatsapp")
+        .order_by(Notification.created_at)
+    ).all():
+        entries.append({
+            "source": "automated",
+            "direction": "out",
+            "kind": "text",
+            "text_body": notif.message,
+            "media_attachment_id": None,
+            "purpose_label": AUTOMATED_PURPOSE_LABEL,
+            "created_at": notif.created_at,
+        })
+    entries.sort(key=lambda e: e["created_at"])
+    return entries
+
+
+def is_within_session_window(db: Session, *, client_id: str) -> bool:
+    last_inbound = db.scalar(
+        select(WhatsappMessage)
+        .where(WhatsappMessage.client_id == client_id, WhatsappMessage.direction == DIRECTION_IN)
+        .order_by(WhatsappMessage.created_at.desc())
+        .limit(1)
+    )
+    if last_inbound is None:
+        return False
+    created_at = last_inbound.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)  # SQLite guarda naive; normaliza p/ comparar
+    return datetime.now(UTC) - created_at < SESSION_WINDOW
+
+
+def mark_read(db: Session, *, tenant_id: str, client_id: str) -> None:
+    state = db.scalar(
+        select(WhatsappConversationState).where(
+            WhatsappConversationState.client_id == client_id
+        )
+    )
+    if state is None:
+        state = WhatsappConversationState(tenant_id=tenant_id, client_id=client_id)
+        db.add(state)
+    state.last_read_at = datetime.now(UTC)
+    db.commit()
+
+
+# ── Envio de resposta ────────────────────────────────────────────────────────
+
+
+def send_reply_text(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, text: str
+) -> WhatsappMessage:
+    if not is_within_session_window(db, client_id=client_id):
+        raise WhatsappInboxError(
+            "Fora da janela de 24h — use um template aprovado para responder", 422
+        )
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    profile = settings_service.get_profile(db, tenant_id)
+    status = whatsapp.send_text(
+        to=client.phone or "", text=text, token=profile.whatsapp_token,
+        phone_id=profile.whatsapp_phone_id,
+    )
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=KIND_TEXT,
+        text_body=text, status=status,
+    )
+    db.add(msg)
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_inbox.reply.text", target=client_id
+    )
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+def send_reply_media(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, file_bytes: bytes,
+    filename: str, mime_type: str, caption: str = "",
+) -> WhatsappMessage:
+    if not is_within_session_window(db, client_id=client_id):
+        raise WhatsappInboxError(
+            "Fora da janela de 24h — use um template aprovado para responder", 422
+        )
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    kind = _MEDIA_KIND_BY_MIME.get(mime_type, "document")
+    profile = settings_service.get_profile(db, tenant_id)
+    try:
+        media_id = whatsapp.upload_media(
+            phone_id=profile.whatsapp_phone_id or "", token=profile.whatsapp_token or "",
+            file_bytes=file_bytes, filename=filename, mime_type=mime_type,
+        )
+    except whatsapp.WhatsappApiError as exc:
+        raise WhatsappInboxError(f"Falha ao subir mídia: {exc}", 502) from exc
+    status = whatsapp.send_media(
+        to=client.phone or "", token=profile.whatsapp_token or "",
+        phone_id=profile.whatsapp_phone_id or "", kind=kind, media_id=media_id, caption=caption,
+    )
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=kind,
+        text_body=caption, status=status,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    try:
+        attachment = attachments_service.create_attachment(
+            db, tenant_id=tenant_id, actor=actor, owner_type="whatsapp_message",
+            owner_id=msg.id, label="outro", filename=filename, content_type=mime_type,
+            data=file_bytes,
+        )
+    except AttachmentError as exc:
+        raise WhatsappInboxError(str(exc), exc.status_code) from exc
+    msg.media_attachment_id = attachment.id
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_inbox.reply.media", target=client_id
+    )
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+def send_reply_template(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, template_id: str,
+    variables: list[str],
+) -> WhatsappMessage:
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    template = db.get(WhatsappTemplate, template_id)
+    if template is None or template.status != STATUS_APPROVED:
+        raise WhatsappInboxError("Template não encontrado ou ainda não aprovado pela Meta", 422)
+    profile = settings_service.get_profile(db, tenant_id)
+    status = whatsapp.send_template(
+        to=client.phone or "", token=profile.whatsapp_token or "",
+        phone_id=profile.whatsapp_phone_id or "", template_name=template.name,
+        language=template.language, variables=variables,
+    )
+    rendered = template.body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=KIND_TEXT,
+        text_body=rendered, status=status,
+    )
+    db.add(msg)
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_inbox.reply.template",
+        target=client_id,
+    )
+    db.commit()
+    db.refresh(msg)
+    return msg

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -97,6 +97,8 @@ def _extract_messages(payload: dict) -> list[tuple[dict, str]]:
                 contacts = value.get("contacts", [])
                 name = contacts[0]["profile"]["name"] if contacts else "Cliente"
                 for msg in value.get("messages", []):
+                    if not isinstance(msg, dict):
+                        raise WhatsappInboxError("Payload inválido", 400)
                     out.append((msg, name))
     except (AttributeError, TypeError, KeyError) as exc:
         raise WhatsappInboxError("Payload inválido", 400) from exc

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -81,15 +81,25 @@ def resolve_by_verify_token(db: Session, *, verify_token: str) -> PublicWhatsapp
 def _extract_messages(payload: dict) -> list[tuple[dict, str]]:
     """Devolve [(mensagem, nome_do_contato)] achatando o formato aninhado do payload da Meta.
     O `tenant_id` já vem resolvido e validado pelo chamador (ver `ingest_webhook_payload`) — não
-    precisamos extrair `phone_number_id` aqui."""
+    precisamos extrair `phone_number_id` aqui.
+
+    Este método é chamado DEPOIS que a assinatura do webhook já foi verificada (ver router), mas
+    o CONTEÚDO do payload continua não confiável — a Meta não garante o shape interno. Em vez de
+    `isinstance` a cada nível aninhado (mesmo histórico de gaps do router — ver
+    `router._extract_phone_number_id`), captura a classe inteira de erro de shape inesperado de
+    uma vez: `AttributeError` (`.get()` em algo que não é dict), `TypeError` (iterar algo
+    não-iterável), `KeyError` (defensivo, ex.: `contacts[0]["profile"]` sem essas chaves)."""
     out: list[tuple[dict, str]] = []
-    for entry in payload.get("entry", []):
-        for change in entry.get("changes", []):
-            value = change.get("value", {})
-            contacts = value.get("contacts", [])
-            name = contacts[0]["profile"]["name"] if contacts else "Cliente"
-            for msg in value.get("messages", []):
-                out.append((msg, name))
+    try:
+        for entry in payload.get("entry", []):
+            for change in entry.get("changes", []):
+                value = change.get("value", {})
+                contacts = value.get("contacts", [])
+                name = contacts[0]["profile"]["name"] if contacts else "Cliente"
+                for msg in value.get("messages", []):
+                    out.append((msg, name))
+    except (AttributeError, TypeError, KeyError) as exc:
+        raise WhatsappInboxError("Payload inválido", 400) from exc
     return out
 
 

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -6,6 +6,7 @@ Ver docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md para o desenho co
 """
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
@@ -31,6 +32,8 @@ from app.modules.whatsapp_inbox.models import (
     WhatsappMessage,
 )
 from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+
+logger = logging.getLogger("e1p.whatsapp_inbox")
 
 SESSION_WINDOW = timedelta(hours=24)
 
@@ -122,40 +125,67 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
     assinatura do webhook — reaproveitamos aqui o mesmo `tenant_id` já validado, sem resolvê-lo
     de novo. Idempotente: mensagens com `wa_message_id` já visto são ignoradas (a Meta reentrega
     o mesmo evento às vezes)."""
+    # Cada mensagem do lote é processada de forma ISOLADA: uma mensagem malformada (campo `text`/
+    # mídia com tipo errado, `contacts[0].profile.name` não-string que quebra o `ClientCreate`, ou
+    # qualquer outra falha de UMA mensagem) NUNCA derruba a request inteira nem bloqueia as demais
+    # mensagens válidas do MESMO lote. Mesmo princípio de isolamento de
+    # `notifications/service.py::process_pending` (uma falha por item, logada, sem travar o resto).
+    # A validação estrutural do payload como um todo continua em `_extract_messages` (antes deste
+    # loop) — falha lá é uma classe diferente (não dá nem pra identificar as mensagens) e ainda
+    # levanta `WhatsappInboxError` para a request toda, corretamente.
     for msg, contact_name in _extract_messages(payload):
-        wa_message_id = msg.get("id")
-        if wa_message_id and db.scalar(
-            select(WhatsappMessage).where(WhatsappMessage.wa_message_id == wa_message_id)
-        ):
-            continue  # duplicata — ignora
+        try:
+            wa_message_id = msg.get("id")
+            if wa_message_id and db.scalar(
+                select(WhatsappMessage).where(WhatsappMessage.wa_message_id == wa_message_id)
+            ):
+                continue  # duplicata — ignora
 
-        from_number = msg.get("from", "")
-        kind = msg.get("type", "text")
-        text_body = ""
-        media_status = MEDIA_STATUS_NONE
+            from_number = msg.get("from", "")
+            kind = msg.get("type", "text")
+            text_body = ""
+            media_status = MEDIA_STATUS_NONE
 
-        if kind == "text":
-            text_body = msg.get("text", {}).get("body", "")
-        elif kind in ("image", "audio", "document", "video"):
-            media_obj = msg.get(kind, {})
-            text_body = media_obj.get("caption", "")
-            media_status = MEDIA_STATUS_PENDING
-        else:
-            kind = "text"
-            text_body = "[tipo de mensagem não suportado]"
+            if kind == "text":
+                text_field = msg.get("text", {})
+                if not isinstance(text_field, dict):
+                    raise WhatsappInboxError("Payload inválido: campo 'text' malformado", 400)
+                text_body = text_field.get("body", "")
+            elif kind in ("image", "audio", "document", "video"):
+                media_obj = msg.get(kind, {})
+                if not isinstance(media_obj, dict):
+                    raise WhatsappInboxError(f"Payload inválido: campo '{kind}' malformado", 400)
+                text_body = media_obj.get("caption", "")
+                media_status = MEDIA_STATUS_PENDING
+            else:
+                kind = "text"
+                text_body = "[tipo de mensagem não suportado]"
 
-        client = _get_or_create_client(
-            db, tenant_id=tenant_id, phone=from_number, name=contact_name
-        )
-        db.add(WhatsappMessage(
-            tenant_id=tenant_id, client_id=client.id, direction=DIRECTION_IN, kind=kind,
-            text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
-            status="sent",
-        ))
-        audit.record(
-            db, tenant_id=tenant_id, actor="whatsapp:inbox",
-            action="whatsapp_inbox.message.received", target=client.id,
-        )
+            client = _get_or_create_client(
+                db, tenant_id=tenant_id, phone=from_number, name=contact_name
+            )
+            db.add(WhatsappMessage(
+                tenant_id=tenant_id, client_id=client.id, direction=DIRECTION_IN, kind=kind,
+                text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
+                status="sent",
+            ))
+            audit.record(
+                db, tenant_id=tenant_id, actor="whatsapp:inbox",
+                action="whatsapp_inbox.message.received", target=client.id,
+            )
+        except (AttributeError, TypeError, KeyError, WhatsappInboxError) as exc:
+            logger.warning(
+                "[whatsapp_inbox] mensagem malformada ignorada, wa_message_id=%s: %s",
+                msg.get("id") if isinstance(msg, dict) else None, exc,
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 — isola a falha de UMA mensagem (inclui
+            # pydantic.ValidationError de ClientCreate e qualquer outra falha inesperada); não trava
+            # o restante do lote (mesmo princípio de process_pending)
+            logger.warning(
+                "[whatsapp_inbox] falha inesperada processando mensagem, ignorada: %s", exc
+            )
+            continue
     db.commit()
 
 

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.core import audit, whatsapp
 from app.modules.attachments import service as attachments_service
+from app.modules.attachments.models import ALLOWED_TYPES, MAX_BYTES
 from app.modules.attachments.service import AttachmentError
 from app.modules.crm import service as crm_service
 from app.modules.crm.models import Client
@@ -26,7 +27,6 @@ from app.modules.whatsapp_inbox.models import (
     KIND_TEXT,
     MEDIA_STATUS_NONE,
     MEDIA_STATUS_PENDING,
-    PublicWhatsappAccount,
     WhatsappConversationState,
     WhatsappMessage,
 )
@@ -62,34 +62,19 @@ class WhatsappInboxError(Exception):
 # ── Ingestão (webhook) ──────────────────────────────────────────────────────
 
 
-def _extract_messages(payload: dict) -> list[tuple[str | None, dict, str]]:
-    """Devolve [(phone_number_id, mensagem, nome_do_contato)] achatando o formato aninhado do
-    payload da Meta. `phone_number_id` vem por `value.metadata` — é dali que resolvemos o
-    `tenant_id` (a Meta não manda tenant nenhum, só o número que recebeu o evento)."""
-    out: list[tuple[str | None, dict, str]] = []
+def _extract_messages(payload: dict) -> list[tuple[dict, str]]:
+    """Devolve [(mensagem, nome_do_contato)] achatando o formato aninhado do payload da Meta.
+    O `tenant_id` já vem resolvido e validado pelo chamador (ver `ingest_webhook_payload`) — não
+    precisamos extrair `phone_number_id` aqui."""
+    out: list[tuple[dict, str]] = []
     for entry in payload.get("entry", []):
         for change in entry.get("changes", []):
             value = change.get("value", {})
-            phone_number_id = value.get("metadata", {}).get("phone_number_id")
             contacts = value.get("contacts", [])
             name = contacts[0]["profile"]["name"] if contacts else "Cliente"
             for msg in value.get("messages", []):
-                out.append((phone_number_id, msg, name))
+                out.append((msg, name))
     return out
-
-
-def _resolve_tenant_id(db: Session, *, phone_number_id: str | None) -> str | None:
-    """Resolve o `tenant_id` a partir do `phone_number_id` via `PublicWhatsappAccount` (tabela
-    global, sem RLS — o único jeito de saber de quem é o evento antes de qualquer autenticação).
-    Devolve None se o número não estiver cadastrado (evento descartado silenciosamente)."""
-    if not phone_number_id:
-        return None
-    account = db.scalar(
-        select(PublicWhatsappAccount).where(
-            PublicWhatsappAccount.phone_number_id == phone_number_id
-        )
-    )
-    return account.tenant_id if account else None
 
 
 def _get_or_create_client(db: Session, *, tenant_id: str, phone: str, name: str) -> Client:
@@ -102,25 +87,19 @@ def _get_or_create_client(db: Session, *, tenant_id: str, phone: str, name: str)
     )
 
 
-def ingest_webhook_payload(db: Session, *, payload: dict) -> None:
-    """Processa UM payload de webhook. Idempotente: mensagens com `wa_message_id` já visto são
-    ignoradas (a Meta reentrega o mesmo evento às vezes). `tenant_id` é resolvido por mensagem
-    a partir do `phone_number_id` (ver `_resolve_tenant_id`) — eventos de números não
-    cadastrados são descartados."""
-    for phone_number_id, msg, contact_name in _extract_messages(payload):
+def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> None:
+    """Processa UM payload de webhook para um tenant já resolvido/validado pelo chamador. O
+    router do webhook resolve o `tenant_id` via `PublicWhatsappAccount` (pelo `phone_number_id`)
+    ANTES de chamar esta função, pois precisa do `app_secret` daquele tenant para validar a
+    assinatura do webhook — reaproveitamos aqui o mesmo `tenant_id` já validado, sem resolvê-lo
+    de novo. Idempotente: mensagens com `wa_message_id` já visto são ignoradas (a Meta reentrega
+    o mesmo evento às vezes)."""
+    for msg, contact_name in _extract_messages(payload):
         wa_message_id = msg.get("id")
         if wa_message_id and db.scalar(
             select(WhatsappMessage).where(WhatsappMessage.wa_message_id == wa_message_id)
         ):
             continue  # duplicata — ignora
-
-        tenant_id = _resolve_tenant_id(db, phone_number_id=phone_number_id)
-        if tenant_id is None:
-            logger.warning(
-                "[whatsapp_inbox] phone_number_id desconhecido, descartando mensagem: %s",
-                phone_number_id,
-            )
-            continue
 
         from_number = msg.get("from", "")
         kind = msg.get("type", "text")
@@ -301,6 +280,10 @@ def send_reply_media(
     client = db.get(Client, client_id)
     if client is None:
         raise WhatsappInboxError("Cliente não encontrado", 404)
+    if mime_type not in ALLOWED_TYPES:
+        raise WhatsappInboxError("Tipo de arquivo não permitido para envio", 415)
+    if len(file_bytes) > MAX_BYTES:
+        raise WhatsappInboxError("Arquivo acima de 10 MB", 413)
     kind = _MEDIA_KIND_BY_MIME.get(mime_type, "document")
     profile = settings_service.get_profile(db, tenant_id)
     try:

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -124,6 +124,10 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
             text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
             status="sent",
         ))
+        audit.record(
+            db, tenant_id=tenant_id, actor="whatsapp:inbox",
+            action="whatsapp_inbox.message.received", target=client.id,
+        )
     db.commit()
 
 
@@ -235,6 +239,10 @@ def mark_read(db: Session, *, tenant_id: str, client_id: str) -> None:
         state = WhatsappConversationState(tenant_id=tenant_id, client_id=client_id)
         db.add(state)
     state.last_read_at = datetime.now(UTC)
+    audit.record(
+        db, tenant_id=tenant_id, actor="whatsapp:inbox",
+        action="whatsapp_inbox.conversation.mark_read", target=client_id,
+    )
     db.commit()
 
 
@@ -282,6 +290,8 @@ def send_reply_media(
         raise WhatsappInboxError("Cliente não encontrado", 404)
     if mime_type not in ALLOWED_TYPES:
         raise WhatsappInboxError("Tipo de arquivo não permitido para envio", 415)
+    if not file_bytes:
+        raise WhatsappInboxError("Arquivo vazio", 422)
     if len(file_bytes) > MAX_BYTES:
         raise WhatsappInboxError("Arquivo acima de 10 MB", 413)
     kind = _MEDIA_KIND_BY_MIME.get(mime_type, "document")

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -144,14 +144,29 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
     assinatura do webhook — reaproveitamos aqui o mesmo `tenant_id` já validado, sem resolvê-lo
     de novo. Idempotente: mensagens com `wa_message_id` já visto são ignoradas (a Meta reentrega
     o mesmo evento às vezes)."""
-    # Cada mensagem do lote é processada de forma ISOLADA: uma mensagem malformada (campo `text`/
-    # mídia com tipo errado, `contacts[0].profile.name` não-string que quebra o `ClientCreate`, ou
-    # qualquer outra falha de UMA mensagem) NUNCA derruba a request inteira nem bloqueia as demais
-    # mensagens válidas do MESMO lote. Mesmo princípio de isolamento de
-    # `notifications/service.py::process_pending` (uma falha por item, logada, sem travar o resto).
-    # A validação estrutural do payload como um todo continua em `_extract_messages` (antes deste
-    # loop) — falha lá é uma classe diferente (não dá nem pra identificar as mensagens) e ainda
-    # levanta `WhatsappInboxError` para a request toda, corretamente.
+    # Cada mensagem do lote é processada de forma ISOLADA e commitada individualmente: uma mensagem
+    # malformada (campo `text`/mídia com tipo errado, `contacts[0].profile.name` não-string que
+    # quebra o `ClientCreate`, ou qualquer outra falha de UMA mensagem) NUNCA derruba a request
+    # inteira nem bloqueia as demais mensagens válidas do MESMO lote. Mesmo princípio de isolamento
+    # de `notifications/service.py::process_pending` (uma falha por item, logada, sem travar o
+    # resto). A validação estrutural do payload como um todo continua em `_extract_messages` (antes
+    # deste loop) — falha lá é uma classe diferente (não dá nem pra identificar as mensagens) e
+    # ainda levanta `WhatsappInboxError` para a request toda, corretamente.
+    #
+    # CRÍTICO — commit POR MENSAGEM (não um único commit no fim do laço): o `db.add(...)` apenas
+    # STAGE o insert; a falha real de PERSISTÊNCIA (ex.: `text_body`/caption com surrogate solto ou
+    # NUL que o driver não consegue codificar — mesma classe de crash que rounds 6-8 blindaram em
+    # `phone_number_id`/`verify_token`) só dispara no flush/commit. Se houvesse um único
+    # `db.commit()` DEPOIS do laço, esse erro cairia FORA de todo try/except por mensagem e viraria
+    # um 500 não tratado, quebrando a garantia de isolamento. E um `db.flush()` por mensagem com
+    # commit único no fim também não serve: o `db.rollback()` de recuperação de uma mensagem
+    # posterior desfaria TUDO desde o último commit — inclusive mensagens anteriores já flushadas e
+    # válidas. Por isso cada mensagem é sua PRÓPRIA transação atômica: commita a si mesma no fim do
+    # try; qualquer falha faz rollback só da sua própria transação e segue para a próxima. O
+    # `db.rollback()` aqui NÃO limpa a GUC `app.current_tenant_id`: ela foi setada em
+    # `tenant_session` com `set_config(..., is_local=false)` + `conn.commit()` no nível da CONEXÃO
+    # (escopo de sessão), então o rollback ORM não a reverte e as mensagens seguintes continuam
+    # corretamente escopadas por tenant.
     for msg, contact_name in _extract_messages(payload):
         try:
             wa_message_id = msg.get("id")
@@ -192,20 +207,27 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
                 db, tenant_id=tenant_id, actor="whatsapp:inbox",
                 action="whatsapp_inbox.message.received", target=client.id,
             )
+            db.commit()  # commita SÓ esta mensagem — transação atômica própria, isolada de
+            # qualquer mensagem seguinte do mesmo lote que venha a falhar (ver nota no topo da
+            # função sobre por que um único commit no fim do laço, ou flush+rollback parcial,
+            # arriscaria desfazer mensagens anteriores já processadas com sucesso).
         except (AttributeError, TypeError, KeyError, WhatsappInboxError) as exc:
+            db.rollback()  # desfaz só a transação desta mensagem (não a GUC de tenant — ver nota)
             logger.warning(
                 "[whatsapp_inbox] mensagem malformada ignorada, wa_message_id=%s: %s",
                 msg.get("id") if isinstance(msg, dict) else None, exc,
             )
             continue
         except Exception as exc:  # noqa: BLE001 — isola a falha de UMA mensagem (inclui
-            # pydantic.ValidationError de ClientCreate e qualquer outra falha inesperada); não trava
-            # o restante do lote (mesmo princípio de process_pending)
+            # pydantic.ValidationError de ClientCreate E falha de persistência do driver no commit,
+            # ex.: text_body/caption com surrogate solto ou NUL); não trava o restante do lote
+            # (mesmo princípio de process_pending)
+            db.rollback()  # desfaz só a transação desta mensagem (não a GUC de tenant — ver nota)
             logger.warning(
                 "[whatsapp_inbox] falha inesperada processando mensagem, ignorada: %s", exc
             )
             continue
-    db.commit()
+    # NENHUM db.commit() aqui: cada mensagem já commitou (ou fez rollback) a si mesma acima.
 
 
 # ── Timeline unificada + janela de 24h ──────────────────────────────────────

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -25,6 +25,8 @@ from app.modules.whatsapp_inbox.models import (
     DIRECTION_IN,
     DIRECTION_OUT,
     KIND_TEXT,
+    MEDIA_STATUS_DOWNLOADED,
+    MEDIA_STATUS_FAILED,
     MEDIA_STATUS_NONE,
     MEDIA_STATUS_PENDING,
     PublicWhatsappAccount,
@@ -179,6 +181,7 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
             kind = msg.get("type", "text")
             text_body = ""
             media_status = MEDIA_STATUS_NONE
+            meta_media_id = None
 
             if kind == "text":
                 text_field = msg.get("text", {})
@@ -191,6 +194,7 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
                     raise WhatsappInboxError(f"Payload inválido: campo '{kind}' malformado", 400)
                 text_body = media_obj.get("caption", "")
                 media_status = MEDIA_STATUS_PENDING
+                meta_media_id = media_obj.get("id")
             else:
                 kind = "text"
                 text_body = "[tipo de mensagem não suportado]"
@@ -201,6 +205,7 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
             db.add(WhatsappMessage(
                 tenant_id=tenant_id, client_id=client.id, direction=DIRECTION_IN, kind=kind,
                 text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
+                meta_media_id=meta_media_id if kind != "text" else None,
                 status="sent",
             ))
             audit.record(
@@ -228,6 +233,47 @@ def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> Non
             )
             continue
     # NENHUM db.commit() aqui: cada mensagem já commitou (ou fez rollback) a si mesma acima.
+
+
+# ── Worker: download assíncrono de mídia recebida ───────────────────────────
+
+
+def process_pending_media(db: Session, *, tenant_id: str) -> int:
+    """Baixa mídia pendente de mensagens recebidas (chamado pelo worker, `run_sweep`).
+
+    A sessão já chega escopada por RLS (`tenant_session`), então o `select` abaixo só enxerga
+    mensagens deste tenant — mesma convenção do resto do módulo. Uma falha isolada (rede,
+    credencial ausente/inválida, media_id inválido) NÃO trava as demais mensagens pendentes: a
+    mensagem falha é marcada `MEDIA_STATUS_FAILED` e o loop segue (IV2, mesmo princípio de
+    `ingest_webhook_payload`/`notifications.service.process_pending`)."""
+    profile = settings_service.get_profile(db, tenant_id)
+    pending = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.media_status == MEDIA_STATUS_PENDING)
+    ).all()
+    processed = 0
+    for msg in pending:
+        try:
+            url = whatsapp.fetch_media_url(
+                token=profile.whatsapp_token or "", media_id=msg.meta_media_id or ""
+            )
+            data = whatsapp.download_media(token=profile.whatsapp_token or "", url=url)
+            mime_type = {
+                "image": "image/jpeg", "audio": "audio/ogg",
+                "document": "application/octet-stream", "video": "video/mp4",
+            }.get(msg.kind, "application/octet-stream")
+            attachment = attachments_service.create_attachment(
+                db, tenant_id=tenant_id, actor="system:worker", owner_type="whatsapp_message",
+                owner_id=msg.id, label="outro", filename=f"{msg.kind}-{msg.id}",
+                content_type=mime_type, data=data,
+            )
+            msg.media_attachment_id = attachment.id
+            msg.media_status = MEDIA_STATUS_DOWNLOADED
+        except Exception:  # noqa: BLE001 — isola a falha por mensagem (IV2)
+            logger.exception("[whatsapp_inbox] falha ao baixar mídia msg=%s", msg.id)
+            msg.media_status = MEDIA_STATUS_FAILED
+        processed += 1
+    db.commit()
+    return processed
 
 
 # ── Timeline unificada + janela de 24h ──────────────────────────────────────

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -10,6 +10,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core import audit, whatsapp
@@ -399,6 +400,23 @@ def is_within_session_window(db: Session, *, client_id: str) -> bool:
 
 
 def mark_read(db: Session, *, tenant_id: str, client_id: str) -> None:
+    """Marca a conversa como lida (`last_read_at = agora`).
+
+    CHECK-THEN-ACT contra `uq_whatsapp_conv_state_tenant_client` (achado em smoke test manual:
+    clicar numa conversa dispara `/read` de mais de um lugar quase ao mesmo tempo — ex. a lista
+    de conversas E a thread aberta — e ambas as requests chegam aqui antes de qualquer uma
+    commitar). O SELECT abaixo pode devolver `None` para as duas; as duas tentam INSERIR a
+    mesma linha (tenant_id, client_id) e a que commita por último esbarra num
+    `IntegrityError` (UniqueViolation) não tratado, virando 500.
+
+    Mesma classe de corrida já resolvida em `crm_service._ordered_stages` (não a de
+    `create_stage`): a linha já existir NÃO é um conflito de negócio a rejeitar — só significa
+    que outra request venceu a corrida e já criou o estado; a ação correta é recuperar (rollback
+    + reconsultar) e atualizar essa linha, nunca deixar o IntegrityError escapar. Mesmo
+    `db.rollback()`-antes-de-reusar já documentado em `ingest_webhook_payload`/
+    `process_pending_media` acima: o commit que falhou deixa a Session "poisoned" e qualquer
+    uso posterior (inclusive o SELECT de recuperação) precisa do rollback explícito primeiro.
+    """
     state = db.scalar(
         select(WhatsappConversationState).where(
             WhatsappConversationState.client_id == client_id
@@ -412,7 +430,29 @@ def mark_read(db: Session, *, tenant_id: str, client_id: str) -> None:
         db, tenant_id=tenant_id, actor="whatsapp:inbox",
         action="whatsapp_inbox.conversation.mark_read", target=client_id,
     )
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()  # desfaz nosso INSERT perdedor (e o audit.record da mesma transação) —
+        # a linha vencedora da corrida já está commitada por quem chegou primeiro; sem este
+        # rollback a Session fica poisoned e o SELECT de recuperação abaixo levantaria
+        # PendingRollbackError em vez de simplesmente reconsultar.
+        state = db.scalar(
+            select(WhatsappConversationState).where(
+                WhatsappConversationState.client_id == client_id
+            )
+        )
+        if state is None:
+            # Não deveria acontecer (o IntegrityError só dispara se a linha já existe pra
+            # alguém ter vencido a corrida), mas não escondemos um bug diferente atrás de um
+            # AttributeError em `state.last_read_at` — propaga o erro original.
+            raise
+        state.last_read_at = datetime.now(UTC)
+        audit.record(
+            db, tenant_id=tenant_id, actor="whatsapp:inbox",
+            action="whatsapp_inbox.conversation.mark_read", target=client_id,
+        )
+        db.commit()
 
 
 # ── Envio de resposta ────────────────────────────────────────────────────────

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -63,14 +63,26 @@ class WhatsappInboxError(Exception):
 # ── Resolução de tenant (pré-autenticação do webhook) ───────────────────────
 
 
+def _is_safe_identifier(value: str) -> bool:
+    """Recusa caracteres de controle (NUL em especial) que o driver do Postgres rejeita na
+    hora de fazer bind do parâmetro (psycopg.DataError) — inofensivo no SQLite dos testes,
+    mas quebra em produção. Ambos os identificadores vêm de entrada não confiável (payload
+    público do webhook / query param do handshake), então validamos antes de qualquer lookup."""
+    return "\x00" not in value
+
+
 def resolve_account(db: Session, *, phone_number_id: str) -> PublicWhatsappAccount | None:
     """Resolve tenant/app_secret pelo `phone_number_id` — chamado numa sessão SEM tenant
     (`get_db`), ANTES de qualquer autenticação, mesmo padrão de `PublicIntegrationKey`."""
+    if not _is_safe_identifier(phone_number_id):
+        return None
     return db.get(PublicWhatsappAccount, phone_number_id)
 
 
 def resolve_by_verify_token(db: Session, *, verify_token: str) -> PublicWhatsappAccount | None:
     """Usado só no handshake GET — confere se o token bate com ALGUM tenant cadastrado."""
+    if not _is_safe_identifier(verify_token):
+        return None
     return db.scalar(
         select(PublicWhatsappAccount).where(
             PublicWhatsappAccount.verify_token == verify_token

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -6,7 +6,6 @@ Ver docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md para o desenho co
 """
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
@@ -31,8 +30,6 @@ from app.modules.whatsapp_inbox.models import (
     WhatsappMessage,
 )
 from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
-
-logger = logging.getLogger("e1p.whatsapp_inbox")
 
 SESSION_WINDOW = timedelta(hours=24)
 
@@ -312,8 +309,7 @@ def send_reply_media(
         text_body=caption, status=status,
     )
     db.add(msg)
-    db.commit()
-    db.refresh(msg)
+    db.flush()  # materializa msg.id na mesma transação, sem commitar — nada é durável ainda
     try:
         attachment = attachments_service.create_attachment(
             db, tenant_id=tenant_id, actor=actor, owner_type="whatsapp_message",
@@ -322,6 +318,8 @@ def send_reply_media(
         )
     except AttachmentError as exc:
         raise WhatsappInboxError(str(exc), exc.status_code) from exc
+    except Exception as exc:  # noqa: BLE001 — falha de storage (S3/rede) vira erro de domínio
+        raise WhatsappInboxError(f"Falha ao salvar anexo: {exc}", 502) from exc
     msg.media_attachment_id = attachment.id
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="whatsapp_inbox.reply.media", target=client_id

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -33,6 +33,7 @@ from app.db.session import SessionLocal, tenant_session
 from app.modules.auth.models import Tenant
 from app.modules.funnels import engine as funnels_engine
 from app.modules.notifications import service as notifications_service
+from app.modules.whatsapp_inbox import service as whatsapp_inbox_service
 from app.seed import PLATFORM_SLUG
 
 logging.basicConfig(level=logging.INFO)
@@ -65,6 +66,7 @@ def run_sweep(
         "tenants_checked": 0,
         "funnel_resumed": 0,
         "notifications_processed": 0,
+        "whatsapp_media_processed": 0,
         "errors": [],
     }
 
@@ -96,11 +98,25 @@ def run_sweep(
                 {"tenant_id": tenant_id, "stage": "notifications", "error": str(exc)}
             )
 
+        # Etapa 3 — mídia pendente do inbox de WhatsApp (sessão SEPARADA das outras duas).
+        try:
+            with tenant_session_factory(tenant_id) as db:
+                media_processed = whatsapp_inbox_service.process_pending_media(
+                    db, tenant_id=tenant_id
+                )
+            result["whatsapp_media_processed"] += media_processed
+        except Exception as exc:  # noqa: BLE001 — idem: isola a falha por tenant (IV2)
+            logger.exception("[worker] mídia do whatsapp falhou tenant=%s", tenant_id)
+            result["errors"].append(
+                {"tenant_id": tenant_id, "stage": "whatsapp_media", "error": str(exc)}
+            )
+
     logger.info(
-        "[worker] sweep: tenants=%s funil_resumido=%s notificacoes=%s erros=%s",
+        "[worker] sweep: tenants=%s funil_resumido=%s notificacoes=%s midia_whatsapp=%s erros=%s",
         result["tenants_checked"],
         result["funnel_resumed"],
         result["notifications_processed"],
+        result["whatsapp_media_processed"],
         len(result["errors"]),
     )
     return result

--- a/apps/api/migrations/versions/0054_whatsapp_inbox.py
+++ b/apps/api/migrations/versions/0054_whatsapp_inbox.py
@@ -46,7 +46,6 @@ def upgrade() -> None:
         sa.Column("media_attachment_id", sa.String(36), nullable=True),
         sa.Column("media_status", sa.String(16), nullable=False, server_default="none"),
         sa.Column("wa_message_id", sa.String(128), nullable=True),
-        sa.Column("meta_media_id", sa.String(128), nullable=True),
         sa.Column("status", sa.String(16), nullable=False, server_default="sent"),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
@@ -114,7 +113,6 @@ def downgrade() -> None:
     op.drop_index(
         "ix_whatsapp_conversation_states_client_id",
         table_name="whatsapp_conversation_states",
-        if_exists=True,
     )
     op.drop_index(
         "ix_whatsapp_conversation_states_tenant_id", table_name="whatsapp_conversation_states"

--- a/apps/api/migrations/versions/0054_whatsapp_inbox.py
+++ b/apps/api/migrations/versions/0054_whatsapp_inbox.py
@@ -46,6 +46,7 @@ def upgrade() -> None:
         sa.Column("media_attachment_id", sa.String(36), nullable=True),
         sa.Column("media_status", sa.String(16), nullable=False, server_default="none"),
         sa.Column("wa_message_id", sa.String(128), nullable=True),
+        sa.Column("meta_media_id", sa.String(128), nullable=True),
         sa.Column("status", sa.String(16), nullable=False, server_default="sent"),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),

--- a/apps/api/migrations/versions/0054_whatsapp_inbox.py
+++ b/apps/api/migrations/versions/0054_whatsapp_inbox.py
@@ -82,6 +82,11 @@ def upgrade() -> None:
         "whatsapp_conversation_states",
         ["tenant_id"],
     )
+    op.create_index(
+        "ix_whatsapp_conversation_states_client_id",
+        "whatsapp_conversation_states",
+        ["client_id"],
+    )
     op.execute("ALTER TABLE whatsapp_conversation_states ENABLE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE whatsapp_conversation_states FORCE ROW LEVEL SECURITY")
     op.execute(
@@ -105,6 +110,11 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("public_whatsapp_accounts")
+    op.drop_index(
+        "ix_whatsapp_conversation_states_client_id",
+        table_name="whatsapp_conversation_states",
+        if_exists=True,
+    )
     op.drop_index(
         "ix_whatsapp_conversation_states_tenant_id", table_name="whatsapp_conversation_states"
     )

--- a/apps/api/migrations/versions/0054_whatsapp_inbox.py
+++ b/apps/api/migrations/versions/0054_whatsapp_inbox.py
@@ -1,0 +1,116 @@
+"""inbox de whatsapp: mensagens, estado de leitura, resolução pré-auth do webhook
+
+Revision ID: 0054
+Revises: 0053
+Create Date: 2026-07-19
+
+Três peças novas pra suportar a conversa de ida-e-volta com clientes pelo WhatsApp (design em
+docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md):
+
+1. `tenant_profiles` ganha `whatsapp_app_secret` (cifrado, valida a assinatura do webhook) e
+   `whatsapp_verify_token` (texto simples, handshake de verificação da Meta).
+2. `whatsapp_messages` (RLS) — cada mensagem trocada (`in`/`out`), com mídia opcional.
+3. `whatsapp_conversation_states` (RLS) — 1 linha por cliente com atividade, só pra "lida/não
+   lida" (compartilhada, sem granularidade por atendente).
+4. `public_whatsapp_accounts` (GLOBAL, sem RLS) — resolve `phone_number_id -> tenant_id` +
+   `app_secret`/`verify_token` ANTES de qualquer autenticação, mesmo padrão de
+   `public_integration_keys`.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0054"
+down_revision: str | None = "0053"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_app_secret", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_verify_token", sa.String(64), nullable=True)
+    )
+
+    op.create_table(
+        "whatsapp_messages",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("client_id", sa.String(36), nullable=False),
+        sa.Column("direction", sa.String(4), nullable=False),
+        sa.Column("kind", sa.String(16), nullable=False, server_default="text"),
+        sa.Column("text_body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("media_attachment_id", sa.String(36), nullable=True),
+        sa.Column("media_status", sa.String(16), nullable=False, server_default="none"),
+        sa.Column("wa_message_id", sa.String(128), nullable=True),
+        sa.Column("status", sa.String(16), nullable=False, server_default="sent"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id", "wa_message_id", name="uq_whatsapp_messages_tenant_wa_id"
+        ),
+    )
+    op.create_index("ix_whatsapp_messages_tenant_id", "whatsapp_messages", ["tenant_id"])
+    op.create_index("ix_whatsapp_messages_client_id", "whatsapp_messages", ["client_id"])
+    op.execute("ALTER TABLE whatsapp_messages ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE whatsapp_messages FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON whatsapp_messages
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+    op.create_table(
+        "whatsapp_conversation_states",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("client_id", sa.String(36), nullable=False),
+        sa.Column("last_read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id", "client_id", name="uq_whatsapp_conv_state_tenant_client"
+        ),
+    )
+    op.create_index(
+        "ix_whatsapp_conversation_states_tenant_id",
+        "whatsapp_conversation_states",
+        ["tenant_id"],
+    )
+    op.execute("ALTER TABLE whatsapp_conversation_states ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE whatsapp_conversation_states FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON whatsapp_conversation_states
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+    op.create_table(
+        "public_whatsapp_accounts",
+        sa.Column("phone_number_id", sa.String(64), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("app_secret", sa.String(255), nullable=False),
+        sa.Column("verify_token", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("public_whatsapp_accounts")
+    op.drop_index(
+        "ix_whatsapp_conversation_states_tenant_id", table_name="whatsapp_conversation_states"
+    )
+    op.drop_table("whatsapp_conversation_states")
+    op.drop_index("ix_whatsapp_messages_client_id", table_name="whatsapp_messages")
+    op.drop_index("ix_whatsapp_messages_tenant_id", table_name="whatsapp_messages")
+    op.drop_table("whatsapp_messages")
+    op.drop_column("tenant_profiles", "whatsapp_verify_token")
+    op.drop_column("tenant_profiles", "whatsapp_app_secret")

--- a/apps/api/migrations/versions/0055_whatsapp_meta_media_id.py
+++ b/apps/api/migrations/versions/0055_whatsapp_meta_media_id.py
@@ -1,0 +1,38 @@
+"""whatsapp_messages ganha meta_media_id (separado de 0054)
+
+Revision ID: 0055
+Revises: 0054
+Create Date: 2026-07-19
+
+Achado da revisão final de branch: `meta_media_id` foi adicionado a `whatsapp_messages` editando
+o arquivo `0054_whatsapp_inbox.py` DEPOIS que essa migration já havia rodado (e sido "stampada"
+em `alembic_version`) em pelo menos um ambiente de dev compartilhado. Editar uma migration já
+aplicada é silenciosamente ignorado por `alembic upgrade head` (o hash da revisão não muda) — o
+banco fica divergente do modelo até alguém rodar a DDL manualmente. O smoke test manual (Task 11)
+já reproduziu esse exato sintoma: todo webhook inbound quebrava com `UndefinedColumn:
+meta_media_id`. Esta migration própria garante que qualquer ambiente que já tenha `0054`
+stampada (na versão original, sem `meta_media_id`) recebe a coluna faltante ao rodar
+`alembic upgrade head` normalmente, sem intervenção manual.
+
+O modelo (`app/modules/whatsapp_inbox/models.py::WhatsappMessage.meta_media_id`) não mudou —
+só a migration que a cria.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0055"
+down_revision: str | None = "0054"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "whatsapp_messages", sa.Column("meta_media_id", sa.String(128), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("whatsapp_messages", "meta_media_id")

--- a/apps/api/migrations/versions/0056_whatsapp_account_secret_encryption.py
+++ b/apps/api/migrations/versions/0056_whatsapp_account_secret_encryption.py
@@ -1,0 +1,54 @@
+"""public_whatsapp_accounts.app_secret cifrado em repouso (EncryptedToken)
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-07-19
+
+Achado da revisão final de branch: `PublicWhatsappAccount.app_secret` guardava o segredo do App
+da Meta em TEXTO PLANO (`String(255)`), ao contrário de `TenantProfile.whatsapp_app_secret`
+(mesmo segredo, mesma origem, já cifrado via `EncryptedToken`/Fernet — ver
+`app/core/token_crypto.py`). Um vazamento de dump/backup do banco expunha o segredo em claro,
+permitindo forjar a assinatura `X-Hub-Signature-256` do webhook e injetar mensagens/leads falsos
+em qualquer tenant (`public_whatsapp_accounts` é uma tabela GLOBAL, sem RLS, por design — resolve
+`phone_number_id -> tenant_id` ANTES de qualquer autenticação).
+
+`EncryptedToken` (`app/core/token_crypto.py`) cifra/decifra de forma transparente no nível
+Python — nenhum código que lê/escreve `account.app_secret` precisa mudar (confirmado:
+`settings/service.py::_sync_whatsapp_webhook_snapshot` e
+`whatsapp_inbox/router.py::receive_webhook` só manipulam a string em claro via o atributo do
+ORM). Mas o tipo SQL subjacente do `TypeDecorator` é `TEXT`, não `VARCHAR(255)` — mesmo padrão
+que `TenantProfile.whatsapp_app_secret` já usa (criada como `sa.Text()` direto na migration 0054,
+por já nascer com o tipo certo). Como `public_whatsapp_accounts.app_secret` nasceu como
+`String(255)` (migration 0054, tabela ainda sem `EncryptedToken` na época), aqui fazemos o
+ALTER explícito de VARCHAR(255) -> TEXT para acomodar o ciphertext (mais longo que o segredo
+original) e alinhar o tipo real da coluna ao `TypeDecorator`.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0056"
+down_revision: str | None = "0055"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "public_whatsapp_accounts",
+        "app_secret",
+        existing_type=sa.String(255),
+        type_=sa.Text(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "public_whatsapp_accounts",
+        "app_secret",
+        existing_type=sa.Text(),
+        type_=sa.String(255),
+        existing_nullable=False,
+    )

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -231,3 +231,69 @@ def test_whatsapp_token_encrypted_at_rest(client: TestClient, headers, db: Sessi
     ).scalar()
     assert stored_raw != plaintext
     assert stored_raw.startswith("enc:v1:")
+
+
+def test_whatsapp_verify_token_generated_when_fully_configured(
+    client: TestClient, headers, db: Session
+) -> None:
+    """Ao completar as 4 credenciais (token/phone_id/waba_id/app_secret), o backend gera
+    sozinho o verify_token e cria o snapshot público."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    resp = client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok-abc", "whatsapp_phone_id": "phone-123",
+            "whatsapp_waba_id": "waba-456", "whatsapp_app_secret": "secret-xyz",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["whatsapp_verify_token"]  # gerado, não vazio
+    assert "whatsapp_app_secret" not in body  # nunca exposto em claro
+
+    snap = db.get(PublicWhatsappAccount, "phone-123")
+    assert snap is not None
+    assert snap.app_secret == "secret-xyz"
+    assert snap.verify_token == body["whatsapp_verify_token"]
+
+
+def test_whatsapp_public_snapshot_removed_when_incomplete(
+    client: TestClient, headers, db: Session
+) -> None:
+    """Se as credenciais ficam incompletas de novo (ex.: limpar o app_secret), o snapshot
+    público é removido — o webhook não deve mais resolver esse phone_number_id."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok", "whatsapp_phone_id": "phone-999",
+            "whatsapp_waba_id": "waba", "whatsapp_app_secret": "secret",
+        },
+        headers=headers,
+    )
+    assert db.get(PublicWhatsappAccount, "phone-999") is not None
+
+    client.patch("/settings/profile", json={"whatsapp_app_secret": ""}, headers=headers)
+    assert db.get(PublicWhatsappAccount, "phone-999") is None
+
+
+def test_whatsapp_public_snapshot_moves_when_phone_id_changes(
+    client: TestClient, headers, db: Session
+) -> None:
+    """Trocar o phone_id remove o snapshot antigo e cria um novo na chave certa."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok", "whatsapp_phone_id": "phone-old",
+            "whatsapp_waba_id": "waba", "whatsapp_app_secret": "secret",
+        },
+        headers=headers,
+    )
+    client.patch("/settings/profile", json={"whatsapp_phone_id": "phone-new"}, headers=headers)
+    assert db.get(PublicWhatsappAccount, "phone-old") is None
+    assert db.get(PublicWhatsappAccount, "phone-new") is not None

--- a/apps/api/tests/test_tenancy_guard.py
+++ b/apps/api/tests/test_tenancy_guard.py
@@ -21,6 +21,10 @@ Allowlist (usos legítimos, documentados com guarda explícita no próprio códi
   - integrations → idem, `capture_lead` (API pública de captura de lead) resolve a chave via
                   `public_integration_keys` (snapshot GLOBAL sem RLS) antes de abrir a
                   tenant_session real — mesmo padrão de pages/quotes/contracts.
+  - whatsapp_inbox → idem, `verify_webhook`/`receive_webhook` (webhook público da Meta) resolvem
+                  o tenant via `public_whatsapp_accounts` (snapshot GLOBAL sem RLS) pelo
+                  `phone_number_id`/`verify_token` antes de abrir a tenant_session real — mesmo
+                  padrão de pages/quotes/contracts/integrations.
 """
 from __future__ import annotations
 
@@ -31,6 +35,7 @@ MODULES_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules"
 # Módulos onde `get_db` (sessão global) é um uso legítimo e já auditado (ver docstring acima).
 ALLOWLIST = {
     "auth", "platform", "contracts", "pages", "quotes", "wallet", "attachments", "integrations",
+    "whatsapp_inbox",
 }
 
 

--- a/apps/api/tests/test_whatsapp.py
+++ b/apps/api/tests/test_whatsapp.py
@@ -419,3 +419,66 @@ def test_send_media_sent(monkeypatch: pytest.MonkeyPatch) -> None:
         "messaging_product": "whatsapp", "to": "5511988887777", "type": "document",
         "document": {"id": "media-123", "caption": "Cardápio"},
     }
+
+
+def test_send_media_failed_when_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+    # Falha do provedor não propaga (IV3): retorna "failed".
+    assert whatsapp.send_media(
+        to="5511988887777", token="tok", phone_id="123", kind="image", media_id="m1"
+    ) == "failed"
+
+
+def test_send_media_failed_when_provider_returns_error_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(httpx, "post", lambda *_a, **_k: _FakeResponse(500))
+    # HTTPStatusError (via raise_for_status) também é capturado → "failed".
+    assert whatsapp.send_media(
+        to="5511988887777", token="tok", phone_id="123", kind="image", media_id="m1"
+    ) == "failed"
+
+
+def test_upload_media_raises_on_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.upload_media(
+            phone_id="123", token="tok", file_bytes=b"x", filename="a.pdf",
+            mime_type="application/pdf",
+        )
+
+
+def test_fetch_media_url_raises_on_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "get", _raise)
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.fetch_media_url(token="tok", media_id="media-123")
+
+
+def test_fetch_media_url_raises_on_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "get", lambda *_a, **_k: _FakeResponse(404))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.fetch_media_url(token="tok", media_id="media-123")
+
+
+def test_download_media_raises_on_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "get", _raise)
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.download_media(token="tok", url="https://example.com/f")
+
+
+def test_download_media_raises_on_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "get", lambda *_a, **_k: _FakeResponse(500))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.download_media(token="tok", url="https://example.com/f")

--- a/apps/api/tests/test_whatsapp.py
+++ b/apps/api/tests/test_whatsapp.py
@@ -7,6 +7,9 @@ Cobre os 3 status possíveis de `send_text`:
 
 A chamada real (`httpx.post`) é sempre mockada — este ambiente não tem credenciais reais.
 """
+import hashlib
+import hmac
+
 import httpx
 import pytest
 
@@ -15,16 +18,26 @@ from app.core import whatsapp
 
 
 class _FakeResponse:
-    """Resposta mínima com o contrato usado por send_text (raise_for_status)."""
+    """Resposta mínima com o contrato usado por send_text/send_template (raise_for_status) +
+    .json()/.content pros novos testes de mídia."""
 
     def __init__(self, status_code: int = 200) -> None:
         self.status_code = status_code
+        self._json: dict = {}
+        self._content: bytes = b""
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise httpx.HTTPStatusError(
                 "erro", request=httpx.Request("POST", "https://x"), response=self
             )
+
+    def json(self) -> dict:
+        return self._json
+
+    @property
+    def content(self) -> bytes:
+        return self._content
 
 
 @pytest.fixture()
@@ -301,3 +314,108 @@ def test_send_template_failed_on_error_status(monkeypatch: pytest.MonkeyPatch) -
         language="pt_BR", variables=[],
     )
     assert status == "failed"
+
+
+# ── Webhook, media upload/download/send ───────────────────────────────────────────────────
+
+
+def test_verify_webhook_signature_valid():
+    body = b'{"hello":"world"}'
+    secret = "shh-its-a-secret"
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    assert whatsapp.verify_webhook_signature(
+        app_secret=secret, body=body, signature_header=sig
+    ) is True
+
+
+def test_verify_webhook_signature_invalid():
+    assert whatsapp.verify_webhook_signature(
+        app_secret="shh-its-a-secret", body=b'{"hello":"world"}',
+        signature_header="sha256=deadbeef",
+    ) is False
+
+
+def test_verify_webhook_signature_missing_header():
+    assert whatsapp.verify_webhook_signature(
+        app_secret="shh-its-a-secret", body=b"{}", signature_header=None
+    ) is False
+
+
+def test_upload_media_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["url"] = url
+        captured["files"] = kwargs.get("files")
+        resp = _FakeResponse(200)
+        resp._json = {"id": "media-123"}
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    media_id = whatsapp.upload_media(
+        phone_id="123456789", token="fake-token", file_bytes=b"fake-bytes",
+        filename="cardapio.pdf", mime_type="application/pdf",
+    )
+    assert media_id == "media-123"
+    assert captured["url"] == "https://graph.facebook.com/v21.0/123456789/media"
+
+
+def test_upload_media_raises_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "post", lambda *_a, **_k: _FakeResponse(500))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.upload_media(
+            phone_id="123", token="tok", file_bytes=b"x", filename="a.pdf",
+            mime_type="application/pdf",
+        )
+
+
+def test_fetch_media_url_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(url: str, **_k: object) -> _FakeResponse:
+        resp = _FakeResponse(200)
+        resp._json = {"url": "https://lookaside.fbsbx.com/whatsapp_business/temp/abc"}
+        return resp
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    url = whatsapp.fetch_media_url(token="tok", media_id="media-123")
+    assert url == "https://lookaside.fbsbx.com/whatsapp_business/temp/abc"
+
+
+def test_download_media_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(url: str, **_k: object) -> _FakeResponse:
+        resp = _FakeResponse(200)
+        resp._content = b"file-bytes-here"
+        return resp
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    data = whatsapp.download_media(token="tok", url="https://example.com/f")
+    assert data == b"file-bytes-here"
+
+
+def test_send_media_logged_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("httpx.post não deveria ser chamado no caminho 'logged'")
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    status = whatsapp.send_media(
+        to="5511999999999", token="", phone_id="", kind="image", media_id="m1"
+    )
+    assert status == "logged"
+
+
+def test_send_media_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["json"] = kwargs.get("json")
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    status = whatsapp.send_media(
+        to="5511988887777", token="tok", phone_id="123", kind="document",
+        media_id="media-123", caption="Cardápio",
+    )
+    assert status == "sent"
+    assert captured["json"] == {
+        "messaging_product": "whatsapp", "to": "5511988887777", "type": "document",
+        "document": {"id": "media-123", "caption": "Cardápio"},
+    }

--- a/apps/api/tests/test_whatsapp_inbox_media_worker.py
+++ b/apps/api/tests/test_whatsapp_inbox_media_worker.py
@@ -1,0 +1,73 @@
+# apps/api/tests/test_whatsapp_inbox_media_worker.py
+"""Download assíncrono de mídia pendente (worker) — mensagens recebidas com media_status=pending."""
+import pytest
+
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    MEDIA_STATUS_DOWNLOADED,
+    MEDIA_STATUS_FAILED,
+    MEDIA_STATUS_PENDING,
+    WhatsappMessage,
+)
+
+TENANT_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _seed(db):
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-1"
+    db.commit()
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900000009", source="manual")
+    db.add(client)
+    db.flush()
+    msg = WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="image",
+        media_status=MEDIA_STATUS_PENDING, wa_message_id="wamid.media1",
+        meta_media_id="meta-media-1",
+    )
+    db.add(msg)
+    db.commit()
+    return msg
+
+
+def test_process_pending_media_downloads_successfully(db, monkeypatch: pytest.MonkeyPatch):
+    msg = _seed(db)
+    monkeypatch.setattr(
+        whatsapp, "fetch_media_url", lambda **_kw: "https://example.com/file.jpg"
+    )
+    monkeypatch.setattr(whatsapp, "download_media", lambda **_kw: b"fake-image-bytes")
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 1
+    db.refresh(msg)
+    assert msg.media_status == MEDIA_STATUS_DOWNLOADED
+    assert msg.media_attachment_id is not None
+
+
+def test_process_pending_media_marks_failed_on_error(db, monkeypatch: pytest.MonkeyPatch):
+    msg = _seed(db)
+
+    def _boom(**_kw):
+        raise whatsapp.WhatsappApiError("erro de rede")
+
+    monkeypatch.setattr(whatsapp, "fetch_media_url", _boom)
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 1
+    db.refresh(msg)
+    assert msg.media_status == MEDIA_STATUS_FAILED
+
+
+def test_process_pending_media_noop_when_nothing_pending(db):
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-1"
+    db.commit()
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 0

--- a/apps/api/tests/test_whatsapp_inbox_media_worker.py
+++ b/apps/api/tests/test_whatsapp_inbox_media_worker.py
@@ -3,6 +3,8 @@
 import pytest
 
 from app.core import whatsapp
+from app.modules.attachments import service as attachments_service
+from app.modules.attachments.models import Attachment
 from app.modules.crm.models import Client
 from app.modules.settings import service as settings_service
 from app.modules.whatsapp_inbox import service as inbox_service
@@ -17,7 +19,7 @@ from app.modules.whatsapp_inbox.models import (
 TENANT_ID = "33333333-3333-3333-3333-333333333333"
 
 
-def _seed(db):
+def _seed(db, *, wa_message_id="wamid.media1", meta_media_id="meta-media-1"):
     profile = settings_service.get_profile(db, TENANT_ID)
     profile.whatsapp_token = "tok"
     profile.whatsapp_phone_id = "phone-1"
@@ -27,8 +29,8 @@ def _seed(db):
     db.flush()
     msg = WhatsappMessage(
         tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="image",
-        media_status=MEDIA_STATUS_PENDING, wa_message_id="wamid.media1",
-        meta_media_id="meta-media-1",
+        media_status=MEDIA_STATUS_PENDING, wa_message_id=wa_message_id,
+        meta_media_id=meta_media_id,
     )
     db.add(msg)
     db.commit()
@@ -71,3 +73,63 @@ def test_process_pending_media_noop_when_nothing_pending(db):
 
     processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
     assert processed == 0
+
+
+def test_process_pending_media_isolates_failure_between_messages(
+    db, monkeypatch: pytest.MonkeyPatch
+):
+    """Reproduz o cenário exato do finding: `create_attachment` (chamado DENTRO do try de
+    `process_pending_media`) faz seu PRÓPRIO `db.commit()` internamente. Se esse commit falhar no
+    meio (erro real de persistência — aqui simulado por uma violação de NOT NULL, mas na vida real
+    seria um erro transitório de rede/storage/driver para bytes de mídia genuínos de vários MB), a
+    Session do SQLAlchemy 2.0 fica "poisoned": qualquer uso subsequente (inclusive o
+    `db.add`/commit da PRÓXIMA mensagem do mesmo lote) levanta `PendingRollbackError` a menos que
+    um `db.rollback()` explícito rode primeiro.
+
+    Por isso a falha é injetada aqui em `attachments_service.create_attachment` (o passo que
+    REALMENTE persiste/committa), não em `whatsapp.fetch_media_url`/`download_media` (que só
+    lançam uma exceção Python, sem tocar a Session — não reproduzem o "poisoning" real; validado
+    manualmente: uma versão anterior deste teste que falhava só no fetch_media_url PASSAVA mesmo
+    contra o código pré-fix, porque nenhuma escrita tinha ocorrido ainda para a Session
+    'envenenar').
+
+    Ordem importa: a mensagem que FALHA vem primeiro. Sem o `db.rollback()` do fix, a falha da
+    primeira mensagem cascateia e o `create_attachment` da segunda (bem-sucedida) explode com
+    `PendingRollbackError` — capturado pelo `except Exception` genérico e mascarado como
+    `MEDIA_STATUS_FAILED`, quando deveria ter sido `MEDIA_STATUS_DOWNLOADED`."""
+    failing_msg = _seed(db, wa_message_id="wamid.media-fail", meta_media_id="meta-media-fail")
+    ok_msg = _seed(db, wa_message_id="wamid.media-ok", meta_media_id="meta-media-ok")
+
+    monkeypatch.setattr(
+        whatsapp, "fetch_media_url", lambda **_kw: "https://example.com/file.jpg"
+    )
+    monkeypatch.setattr(whatsapp, "download_media", lambda **_kw: b"fake-image-bytes")
+
+    real_create_attachment = attachments_service.create_attachment
+
+    def _create_attachment_side_effect(db_, **kwargs):
+        if kwargs["owner_id"] == failing_msg.id:
+            # Simula uma falha de PERSISTÊNCIA real (não uma exceção Python solta): grava um
+            # Attachment com campo NOT NULL ausente e commita — o commit() levanta IntegrityError
+            # de verdade, deixando a Session no mesmo estado "precisa de rollback" que um erro
+            # transitório de driver/rede deixaria numa falha real de storage/DB.
+            bad = Attachment(
+                tenant_id=kwargs["tenant_id"], owner_type=kwargs["owner_type"],
+                owner_id=kwargs["owner_id"], label="outro",
+                filename=None, content_type=None, size=0,
+            )
+            db_.add(bad)
+            db_.commit()  # IntegrityError real (NOT NULL) — Session fica poisoned sem rollback
+            return bad  # nunca alcançado
+        return real_create_attachment(db_, **kwargs)
+
+    monkeypatch.setattr(attachments_service, "create_attachment", _create_attachment_side_effect)
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 2
+
+    db.refresh(failing_msg)
+    db.refresh(ok_msg)
+    assert failing_msg.media_status == MEDIA_STATUS_FAILED
+    assert ok_msg.media_status == MEDIA_STATUS_DOWNLOADED
+    assert ok_msg.media_attachment_id is not None

--- a/apps/api/tests/test_whatsapp_inbox_models.py
+++ b/apps/api/tests/test_whatsapp_inbox_models.py
@@ -1,0 +1,35 @@
+"""Sanity check dos modelos novos do inbox — colunas esperadas presentes."""
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_inbox.models import (
+    PublicWhatsappAccount,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+
+
+def test_whatsapp_message_columns():
+    cols = {c.name for c in WhatsappMessage.__table__.columns}
+    assert cols == {
+        "id", "tenant_id", "client_id", "direction", "kind", "text_body",
+        "media_attachment_id", "media_status", "wa_message_id", "status",
+        "created_at", "updated_at",
+    }
+
+
+def test_whatsapp_conversation_state_columns():
+    cols = {c.name for c in WhatsappConversationState.__table__.columns}
+    assert cols == {"id", "tenant_id", "client_id", "last_read_at", "created_at", "updated_at"}
+
+
+def test_public_whatsapp_account_columns():
+    cols = {c.name for c in PublicWhatsappAccount.__table__.columns}
+    assert cols == {
+        "phone_number_id", "tenant_id", "app_secret", "verify_token",
+        "created_at", "updated_at",
+    }
+
+
+def test_tenant_profile_has_new_whatsapp_fields():
+    cols = {c.name for c in TenantProfile.__table__.columns}
+    assert "whatsapp_app_secret" in cols
+    assert "whatsapp_verify_token" in cols

--- a/apps/api/tests/test_whatsapp_inbox_models.py
+++ b/apps/api/tests/test_whatsapp_inbox_models.py
@@ -11,7 +11,7 @@ def test_whatsapp_message_columns():
     cols = {c.name for c in WhatsappMessage.__table__.columns}
     assert cols == {
         "id", "tenant_id", "client_id", "direction", "kind", "text_body",
-        "media_attachment_id", "media_status", "wa_message_id", "status",
+        "media_attachment_id", "media_status", "wa_message_id", "meta_media_id", "status",
         "created_at", "updated_at",
     }
 

--- a/apps/api/tests/test_whatsapp_inbox_models.py
+++ b/apps/api/tests/test_whatsapp_inbox_models.py
@@ -1,4 +1,7 @@
 """Sanity check dos modelos novos do inbox — colunas esperadas presentes."""
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
 from app.modules.settings.models import TenantProfile
 from app.modules.whatsapp_inbox.models import (
     PublicWhatsappAccount,
@@ -33,3 +36,36 @@ def test_tenant_profile_has_new_whatsapp_fields():
     cols = {c.name for c in TenantProfile.__table__.columns}
     assert "whatsapp_app_secret" in cols
     assert "whatsapp_verify_token" in cols
+
+
+def test_public_whatsapp_account_app_secret_encrypted_at_rest(db: Session):
+    """Achado da revisão final de branch: `public_whatsapp_accounts.app_secret` guardava o
+    segredo do App da Meta em texto plano — um dump/backup vazado expunha o segredo, permitindo
+    forjar a assinatura do webhook. Agora usa `EncryptedToken` (mesmo padrão de
+    `TenantProfile.whatsapp_app_secret`); este teste bypassa o TypeDecorator (SQL cru) para
+    provar que o valor REALMENTE gravado no banco não é o texto plano."""
+    plaintext = "shh-meta-app-secret-nao-deveria-vazar"
+    db.add(
+        PublicWhatsappAccount(
+            phone_number_id="phone-enc-test",
+            tenant_id="t-enc-test",
+            app_secret=plaintext,
+            verify_token="verify-enc-test",
+        )
+    )
+    db.commit()
+
+    # Via ORM, o TypeDecorator decifra transparentemente — round-trip correto.
+    reloaded = db.get(PublicWhatsappAccount, "phone-enc-test")
+    assert reloaded is not None
+    assert reloaded.app_secret == plaintext
+
+    # Via SQL cru, bypassa o TypeDecorator — prova que o banco NÃO guarda o texto plano.
+    stored_raw = db.execute(
+        text(
+            "SELECT app_secret FROM public_whatsapp_accounts WHERE phone_number_id = "
+            "'phone-enc-test'"
+        )
+    ).scalar()
+    assert stored_raw != plaintext
+    assert stored_raw.startswith("enc:v1:")

--- a/apps/api/tests/test_whatsapp_inbox_reply.py
+++ b/apps/api/tests/test_whatsapp_inbox_reply.py
@@ -1,0 +1,95 @@
+"""Testes dos endpoints autenticados de resposta da inbox (texto/mídia/template).
+
+Nota sobre autenticação: ao contrário do rascunho original do Task 6 (que escrevia direto num
+`TENANT_ID` fixo sem passar `Authorization`), o fixture `client` global (`conftest.py`) só
+sobrescreve `get_tenant_db`/`get_db` — o `user: CurrentUser = Depends(_guard)` das novas rotas
+continua resolvendo `get_current_user` de verdade (token JWT real), mesmo padrão já usado em
+`test_crm.py`/`test_settings.py`. Por isso aqui registramos um tenant de verdade via
+`/auth/register` e usamos o `tenant_id`/token devolvidos, em vez de um UUID inventado.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox.models import DIRECTION_IN, WhatsappMessage
+from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+
+REGISTER = {
+    "legal_name": "Inbox SA",
+    "document": "11222333000181",
+    "slug": "inboxsa",
+    "email": "inbox@example.com",
+    "name": "In",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def auth(client: TestClient) -> tuple[dict[str, str], str]:
+    resp = client.post("/auth/register", json=REGISTER).json()
+    headers = {"Authorization": f"Bearer {resp['access_token']}"}
+    return headers, resp["tenant"]["id"]
+
+
+def _configure(db, tenant_id):
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-1"
+    profile.whatsapp_waba_id = "waba"
+    db.commit()
+
+
+def test_reply_text_endpoint_requires_open_window(client, db, monkeypatch, auth):
+    headers, tenant_id = auth
+    _configure(db, tenant_id)
+    c = Client(tenant_id=tenant_id, name="Cliente", phone="5511900000001", source="manual")
+    db.add(c)
+    db.commit()
+    resp = client.post(
+        f"/whatsapp-conversations/{c.id}/messages/text", json={"text": "oi"}, headers=headers
+    )
+    assert resp.status_code == 422
+
+
+def test_reply_text_endpoint_success_within_window(client, db, monkeypatch, auth):
+    headers, tenant_id = auth
+    _configure(db, tenant_id)
+    c = Client(tenant_id=tenant_id, name="Cliente", phone="5511900000002", source="manual")
+    db.add(c)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=tenant_id, client_id=c.id, direction=DIRECTION_IN, kind="text", text_body="oi",
+    ))
+    db.commit()
+    monkeypatch.setattr(whatsapp, "send_text", lambda **_kw: "sent")
+    resp = client.post(
+        f"/whatsapp-conversations/{c.id}/messages/text",
+        json={"text": "Olá, tudo bem?"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
+
+
+def test_reply_template_endpoint_success(client, db, monkeypatch, auth):
+    headers, tenant_id = auth
+    _configure(db, tenant_id)
+    c = Client(tenant_id=tenant_id, name="Cliente", phone="5511900000003", source="manual")
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="cardapio", language="pt_BR", category_requested="UTILITY",
+        status=STATUS_APPROVED, body_text="Olá {{1}}, segue nosso cardápio!", variable_count=1,
+        variable_examples=["Nome"],
+    )
+    db.add(c)
+    db.add(tpl)
+    db.commit()
+    monkeypatch.setattr(whatsapp, "send_template", lambda **_kw: "sent")
+    resp = client.post(
+        f"/whatsapp-conversations/{c.id}/messages/template",
+        json={"template_id": tpl.id, "variables": ["Fulano"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert "Fulano" in resp.json()["text_body"]

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -357,6 +357,51 @@ def test_ingest_processes_valid_message_even_when_another_in_same_payload_is_mal
     assert good.text_body == "mensagem válida"
 
 
+def test_ingest_persists_valid_message_after_earlier_message_fails_to_encode(db):
+    # ISOLAMENTO EM NÍVEL DE PERSISTÊNCIA (review round 9): diferente do teste-payoff acima (que
+    # prova isolação de uma falha de VALIDAÇÃO, pega por `isinstance` ANTES de qualquer `db.add`),
+    # este prova isolação de uma falha na CAMADA DO BANCO. A primeira mensagem tem `text.body` com
+    # um surrogate solto (`"\ud800"`): passa em TODAS as checagens Python (`text` É um dict, `body`
+    # É uma string), então é staged com `db.add(...)` sem erro — mas o surrogate não codifica em
+    # UTF-8, e o commit levanta (SQLite dá `UnicodeEncodeError` na hora do bind, mesma classe que o
+    # psycopg daria em produção). Com um único commit no fim do laço, esse erro escaparia FORA de
+    # todo try/except (500 não tratado) e/ou o rollback derrubaria a mensagem válida junto. Com
+    # commit POR MENSAGEM, a falha da primeira é isolada em sua própria transação e a segunda,
+    # válida e posterior no MESMO lote, sobrevive.
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": "5511900000005"}],
+                    "messages": [
+                        {
+                            "id": "bad-encode-1", "from": "5511900000005", "type": "text",
+                            "text": {"body": "\ud800"},
+                        },
+                        {
+                            "id": "good-2", "from": "5511900000005", "type": "text",
+                            "text": {"body": "mensagem válida de verdade"},
+                        },
+                    ],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)  # não levanta
+
+    assert db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "bad-encode-1")
+    ) is None
+    good = db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "good-2")
+    )
+    assert good is not None
+    assert good.text_body == "mensagem válida de verdade"
+
+
 def test_is_within_session_window_true_right_after_inbound(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -59,6 +59,38 @@ def _text_message_payload(*, phone_number_id: str, wa_id: str, from_number: str,
     }
 
 
+def test_resolve_account_finds_by_phone_number_id(db):
+    db.add(PublicWhatsappAccount(
+        phone_number_id="phone-resolve-1", tenant_id=TENANT_ID, app_secret="segredo-resolve",
+        verify_token="verify-resolve-1",
+    ))
+    db.commit()
+    account = inbox_service.resolve_account(db, phone_number_id="phone-resolve-1")
+    assert account is not None
+    assert account.tenant_id == TENANT_ID
+    assert account.app_secret == "segredo-resolve"
+
+
+def test_resolve_account_returns_none_for_unknown_number(db):
+    assert inbox_service.resolve_account(db, phone_number_id="numero-inexistente") is None
+
+
+def test_resolve_by_verify_token_finds_by_token(db):
+    db.add(PublicWhatsappAccount(
+        phone_number_id="phone-resolve-2", tenant_id=TENANT_ID, app_secret="segredo-resolve-2",
+        verify_token="verify-resolve-2",
+    ))
+    db.commit()
+    account = inbox_service.resolve_by_verify_token(db, verify_token="verify-resolve-2")
+    assert account is not None
+    assert account.tenant_id == TENANT_ID
+    assert account.phone_number_id == "phone-resolve-2"
+
+
+def test_resolve_by_verify_token_returns_none_for_unknown_token(db):
+    assert inbox_service.resolve_by_verify_token(db, verify_token="token-inexistente") is None
+
+
 def test_ingest_creates_lead_for_unknown_number(db):
     _configure_credentials(db)
     inbox_service.ingest_webhook_payload(

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -60,7 +60,7 @@ def _text_message_payload(*, phone_number_id: str, wa_id: str, from_number: str,
 def test_ingest_creates_lead_for_unknown_number(db):
     _configure_credentials(db)
     inbox_service.ingest_webhook_payload(
-        db, payload=_text_message_payload(
+        db, tenant_id=TENANT_ID, payload=_text_message_payload(
             phone_number_id="phone-123", wa_id="5511999999999",
             from_number="5511999999999", body="Oi, quero saber do cardápio",
         ),
@@ -79,7 +79,7 @@ def test_ingest_reuses_existing_client_by_phone(db):
     db.add(existing)
     db.commit()
     inbox_service.ingest_webhook_payload(
-        db, payload=_text_message_payload(
+        db, tenant_id=TENANT_ID, payload=_text_message_payload(
             phone_number_id="phone-123", wa_id="5511988887777",
             from_number="5511988887777", body="oi",
         ),
@@ -94,8 +94,8 @@ def test_ingest_is_idempotent_on_duplicate_wa_message_id(db):
         phone_number_id="phone-123", wa_id="5511977776666",
         from_number="5511977776666", body="oi", msg_id="wamid.dup",
     )
-    inbox_service.ingest_webhook_payload(db, payload=payload)
-    inbox_service.ingest_webhook_payload(db, payload=payload)
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
     all_rows = db.scalars(
         select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.dup")
     ).all()
@@ -119,7 +119,7 @@ def test_ingest_image_message_marks_media_pending(db):
             }],
         }],
     }
-    inbox_service.ingest_webhook_payload(db, payload=payload)
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
     msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.img"))
     assert msg.kind == "image"
     assert msg.media_status == MEDIA_STATUS_PENDING
@@ -201,6 +201,38 @@ def test_send_reply_text_raises_outside_window(db):
         )
 
 
+def test_send_reply_media_rejects_disallowed_mime_type_before_sending(
+    db, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900005556", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+
+    def _boom(*_a: object, **_k: object) -> None:  # pragma: no cover - não deve ser chamado
+        raise AssertionError("upload_media não deveria ser chamado para mime_type reprovado")
+
+    monkeypatch.setattr(whatsapp, "upload_media", _boom)
+
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_media(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
+            file_bytes=b"fake-audio-bytes", filename="audio.mp3", mime_type="audio/mpeg",
+        )
+
+    count = db.scalar(
+        select(WhatsappMessage).where(
+            WhatsappMessage.client_id == client.id, WhatsappMessage.direction == DIRECTION_OUT
+        )
+    )
+    assert count is None  # nenhuma linha "sent" órfã foi criada
+
+
 def test_send_reply_template_requires_approved_template(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
@@ -209,13 +241,15 @@ def test_send_reply_template_requires_approved_template(db):
         category_requested="UTILITY", status="PENDING", body_text="Olá {{1}}",
         variable_count=1, variable_examples=["Nome"],
     )
+    db.add(client)
     db.add(tpl)
     db.commit()
-    with pytest.raises(inbox_service.WhatsappInboxError):
+    with pytest.raises(inbox_service.WhatsappInboxError) as exc_info:
         inbox_service.send_reply_template(
             db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
             template_id=tpl.id, variables=["Fulano"],
         )
+    assert "não aprovado" in str(exc_info.value)
 
 
 def test_mark_read_updates_state(db):

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -1,0 +1,233 @@
+# apps/api/tests/test_whatsapp_inbox_service.py
+"""Testes do serviço do inbox de WhatsApp: ingestão do webhook, lead automático, timeline
+unificada, janela de 24h, resposta (texto/mídia/template)."""
+import pytest
+from sqlalchemy import select
+
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.notifications.models import Notification
+from app.modules.settings import service as settings_service
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    MEDIA_STATUS_PENDING,
+    PublicWhatsappAccount,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+from app.modules.whatsapp_templates.models import WhatsappTemplate
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _configure_credentials(db) -> TenantProfile:
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-123"
+    profile.whatsapp_waba_id = "waba"
+    profile.whatsapp_app_secret = "secret"
+    profile.whatsapp_verify_token = "verify-abc"
+    db.add(PublicWhatsappAccount(
+        phone_number_id="phone-123", tenant_id=TENANT_ID, app_secret="secret",
+        verify_token="verify-abc",
+    ))
+    db.commit()
+    return profile
+
+
+def _text_message_payload(*, phone_number_id: str, wa_id: str, from_number: str, body: str,
+                           msg_id: str = "wamid.abc") -> dict:
+    return {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": phone_number_id},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": wa_id}],
+                    "messages": [{
+                        "from": from_number, "id": msg_id, "type": "text",
+                        "text": {"body": body},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+
+
+def test_ingest_creates_lead_for_unknown_number(db):
+    _configure_credentials(db)
+    inbox_service.ingest_webhook_payload(
+        db, payload=_text_message_payload(
+            phone_number_id="phone-123", wa_id="5511999999999",
+            from_number="5511999999999", body="Oi, quero saber do cardápio",
+        ),
+    )
+    client = db.scalar(select(Client).where(Client.phone == "5511999999999"))
+    assert client is not None
+    assert client.source == "whatsapp"
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.client_id == client.id))
+    assert msg.direction == DIRECTION_IN
+    assert msg.text_body == "Oi, quero saber do cardápio"
+
+
+def test_ingest_reuses_existing_client_by_phone(db):
+    _configure_credentials(db)
+    existing = Client(tenant_id=TENANT_ID, name="Maria", phone="5511988887777", source="manual")
+    db.add(existing)
+    db.commit()
+    inbox_service.ingest_webhook_payload(
+        db, payload=_text_message_payload(
+            phone_number_id="phone-123", wa_id="5511988887777",
+            from_number="5511988887777", body="oi",
+        ),
+    )
+    clients = db.scalars(select(Client).where(Client.phone == "5511988887777")).all()
+    assert len(clients) == 1  # não duplicou
+
+
+def test_ingest_is_idempotent_on_duplicate_wa_message_id(db):
+    _configure_credentials(db)
+    payload = _text_message_payload(
+        phone_number_id="phone-123", wa_id="5511977776666",
+        from_number="5511977776666", body="oi", msg_id="wamid.dup",
+    )
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    all_rows = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.dup")
+    ).all()
+    assert len(all_rows) == 1
+
+
+def test_ingest_image_message_marks_media_pending(db):
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Cliente"}, "wa_id": "5511911112222"}],
+                    "messages": [{
+                        "from": "5511911112222", "id": "wamid.img", "type": "image",
+                        "image": {"id": "media-999", "mime_type": "image/jpeg"},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.img"))
+    assert msg.kind == "image"
+    assert msg.media_status == MEDIA_STATUS_PENDING
+
+
+def test_is_within_session_window_true_right_after_inbound(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+    assert inbox_service.is_within_session_window(db, client_id=client.id) is True
+
+
+def test_is_within_session_window_false_when_never_messaged(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900002222", source="manual")
+    db.add(client)
+    db.commit()
+    assert inbox_service.is_within_session_window(db, client_id=client.id) is False
+
+
+def test_get_timeline_merges_conversation_and_automated(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900003333", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="Oi",
+    ))
+    db.add(Notification(
+        tenant_id=TENANT_ID, channel="whatsapp", recipient=client.phone, client_id=client.id,
+        message="Lembrete: sua cobrança vence amanhã", status="sent",
+    ))
+    db.commit()
+    timeline = inbox_service.get_timeline(db, client_id=client.id)
+    sources = {e["source"] for e in timeline}
+    assert sources == {"conversation", "automated"}
+
+
+def test_send_reply_text_within_window(db, monkeypatch: pytest.MonkeyPatch):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900004444", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+
+    captured = {}
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda **kw: (captured.update(kw), "sent")[1],
+    )
+    msg = inbox_service.send_reply_text(
+        db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="Olá! Segue o cardápio.",
+    )
+    assert msg.direction == DIRECTION_OUT
+    assert msg.status == "sent"
+    assert captured["token"] == "tok"
+    assert captured["phone_id"] == "phone-123"
+
+
+def test_send_reply_text_raises_outside_window(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900005555", source="manual")
+    db.add(client)
+    db.commit()
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_text(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="oi",
+        )
+
+
+def test_send_reply_template_requires_approved_template(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
+    tpl = WhatsappTemplate(
+        tenant_id=TENANT_ID, name="fora_janela", language="pt_BR",
+        category_requested="UTILITY", status="PENDING", body_text="Olá {{1}}",
+        variable_count=1, variable_examples=["Nome"],
+    )
+    db.add(tpl)
+    db.commit()
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_template(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
+            template_id=tpl.id, variables=["Fulano"],
+        )
+
+
+def test_mark_read_updates_state(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900007777", source="manual")
+    db.add(client)
+    db.commit()
+    inbox_service.mark_read(db, tenant_id=TENANT_ID, client_id=client.id)
+    state = db.scalar(
+        select(WhatsappConversationState).where(
+            WhatsappConversationState.client_id == client.id
+        )
+    )
+    assert state is not None
+    assert state.last_read_at is not None

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -177,6 +177,16 @@ def test_ingest_image_message_marks_media_pending(db):
     assert msg.media_status == MEDIA_STATUS_PENDING
 
 
+def test_ingest_raises_on_non_dict_value(db):
+    # `change["value"]` não é dict — `_extract_messages` agora captura essa classe inteira de
+    # erro de shape (AttributeError/TypeError/KeyError) num único try/except e converte em
+    # `WhatsappInboxError`, em vez de deixar o AttributeError escapar sem tratamento.
+    _configure_credentials(db)
+    payload = {"entry": [{"changes": [{"value": "boom"}]}]}
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
+
+
 def test_is_within_session_window_true_right_after_inbound(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import select
 
 from app.core import whatsapp
+from app.core.audit import AuditEntry
 from app.modules.crm.models import Client
 from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
@@ -71,6 +72,24 @@ def test_ingest_creates_lead_for_unknown_number(db):
     msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.client_id == client.id))
     assert msg.direction == DIRECTION_IN
     assert msg.text_body == "Oi, quero saber do cardápio"
+
+
+def test_ingest_records_audit_entry_for_received_message(db):
+    _configure_credentials(db)
+    existing = Client(tenant_id=TENANT_ID, name="Maria", phone="5511988880000", source="manual")
+    db.add(existing)
+    db.commit()
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID, payload=_text_message_payload(
+            phone_number_id="phone-123", wa_id="5511988880000",
+            from_number="5511988880000", body="oi, já sou cliente",
+        ),
+    )
+    audit_entry = db.scalar(
+        select(AuditEntry).where(AuditEntry.action == "whatsapp_inbox.message.received")
+    )
+    assert audit_entry is not None
+    assert audit_entry.target == existing.id
 
 
 def test_ingest_reuses_existing_client_by_phone(db):
@@ -233,6 +252,38 @@ def test_send_reply_media_rejects_disallowed_mime_type_before_sending(
     assert count is None  # nenhuma linha "sent" órfã foi criada
 
 
+def test_send_reply_media_rejects_empty_file_before_sending(
+    db, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900005557", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+
+    def _boom(*_a: object, **_k: object) -> None:  # pragma: no cover - não deve ser chamado
+        raise AssertionError("upload_media não deveria ser chamado para arquivo vazio")
+
+    monkeypatch.setattr(whatsapp, "upload_media", _boom)
+
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_media(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
+            file_bytes=b"", filename="doc.pdf", mime_type="application/pdf",
+        )
+
+    count = db.scalar(
+        select(WhatsappMessage).where(
+            WhatsappMessage.client_id == client.id, WhatsappMessage.direction == DIRECTION_OUT
+        )
+    )
+    assert count is None  # nenhuma linha "sent" órfã foi criada
+
+
 def test_send_reply_template_requires_approved_template(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
@@ -265,3 +316,8 @@ def test_mark_read_updates_state(db):
     )
     assert state is not None
     assert state.last_read_at is not None
+    audit_entry = db.scalar(
+        select(AuditEntry).where(AuditEntry.action == "whatsapp_inbox.conversation.mark_read")
+    )
+    assert audit_entry is not None
+    assert audit_entry.target == client.id

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -499,7 +499,7 @@ def test_send_reply_media_rejects_disallowed_mime_type_before_sending(
     with pytest.raises(inbox_service.WhatsappInboxError):
         inbox_service.send_reply_media(
             db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
-            file_bytes=b"fake-audio-bytes", filename="audio.mp3", mime_type="audio/mpeg",
+            file_bytes=b"fake-audio-bytes", filename="audio.mp3", mime_type="text/plain",
         )
 
     count = db.scalar(

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -3,6 +3,7 @@
 unificada, janela de 24h, resposta (texto/mídia/template)."""
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.core import whatsapp
 from app.core.audit import AuditEntry
@@ -617,3 +618,57 @@ def test_mark_read_updates_state(db):
     )
     assert audit_entry is not None
     assert audit_entry.target == client.id
+
+
+def test_mark_read_recovers_from_concurrent_insert_race(db, monkeypatch: pytest.MonkeyPatch):
+    """Reproduz o 500 do smoke test manual: duas requests concorrentes para o MESMO client_id
+    disparam `mark_read` quase ao mesmo tempo, ambas veem `state is None` no SELECT (nenhuma
+    commitou ainda) e tentam inserir a mesma linha (tenant_id, client_id) — a que commita por
+    último esbarra em `uq_whatsapp_conv_state_tenant_client` (IntegrityError/UniqueViolation).
+
+    Sem threads reais: um monkeypatch em `db.commit` intercepta a PRIMEIRA chamada (a tentativa
+    de INSERT do nosso `mark_read`, o "perdedor" da corrida) e, antes de levantar o
+    `IntegrityError`, insere e commita de verdade a linha "vencedora" — simulando a OUTRA
+    request que já teria commitado bem antes. Assim o SELECT de recuperação de `mark_read`
+    encontra uma linha genuína no banco, exatamente como aconteceria em produção."""
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
+    db.add(client)
+    db.commit()
+
+    real_commit = db.commit
+    calls = {"n": 0}
+
+    def _commit_with_race(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            db.rollback()  # descarta nosso INSERT + audit.record pendentes (o "perdedor")
+            winner = WhatsappConversationState(tenant_id=TENANT_ID, client_id=client.id)
+            db.add(winner)
+            real_commit()  # a linha da "outra request" agora existe de verdade no banco
+            raise IntegrityError(
+                "INSERT INTO whatsapp_conversation_states ...", {},
+                Exception(
+                    'duplicate key value violates unique constraint '
+                    '"uq_whatsapp_conv_state_tenant_client"'
+                ),
+            )
+        return real_commit(*args, **kwargs)
+
+    monkeypatch.setattr(db, "commit", _commit_with_race)
+
+    inbox_service.mark_read(db, tenant_id=TENANT_ID, client_id=client.id)  # não pode levantar
+
+    states = db.scalars(
+        select(WhatsappConversationState).where(
+            WhatsappConversationState.client_id == client.id
+        )
+    ).all()
+    assert len(states) == 1  # nenhuma linha duplicada — recuperou atualizando a existente
+    assert states[0].last_read_at is not None
+
+    audit_entries = db.scalars(
+        select(AuditEntry).where(AuditEntry.action == "whatsapp_inbox.conversation.mark_read")
+    ).all()
+    assert len(audit_entries) == 1  # o audit da tentativa perdedora foi descartado no rollback
+    assert audit_entries[0].target == client.id

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -100,10 +100,29 @@ def test_resolve_account_rejects_phone_number_id_with_nul_byte(db):
     assert inbox_service.resolve_account(db, phone_number_id="pn\x00id") is None
 
 
+def test_resolve_account_rejects_phone_number_id_with_lone_surrogate(db):
+    # JSON permite um escape de surrogate solto (`"\uD800"`) numa string, e `json.loads` produz
+    # um `str` Python de verdade contendo o surrogate — de um payload/UTF-8 perfeitamente válido.
+    # Diferente do NUL (que o SQLite tolera de boa), um surrogate solto NÃO pode ser codificado
+    # em UTF-8 (`'\ud800'.encode('utf-8')` levanta `UnicodeEncodeError`) e o driver `sqlite3` do
+    # Python também rejeita na hora do bind — sem a guarda, esta chamada RAISES em vez de
+    # retornar None (prova que a guarda discrimina de verdade, ao contrário do caso do NUL).
+    assert inbox_service.resolve_account(db, phone_number_id="\ud800") is None
+
+
 def test_resolve_by_verify_token_rejects_verify_token_with_nul_byte(db):
     # Mesmo raciocínio para o handshake GET: `hub.verify_token` é um query param de um chamador
     # anônimo (Meta ou qualquer um), e um NUL codificado (`%00`) chega intacto como `str`.
     assert inbox_service.resolve_by_verify_token(db, verify_token="tok\x00en") is None
+
+
+def test_resolve_by_verify_token_rejects_verify_token_with_lone_surrogate(db):
+    # Mesmo caso do surrogate solto, mas para o handshake GET. Note que isso é só um teste de
+    # defesa em profundidade do `_is_safe_identifier`: na prática o `verify_token` chega como
+    # query param de URL, e um surrogate inválido percent-decodificado vira `U+FFFD`, não um
+    # surrogate de verdade — então esta entrada específica não é alcançável via HTTP real, mas a
+    # guarda protege ainda assim caso o valor chegue por outro caminho (ex.: chamada direta).
+    assert inbox_service.resolve_by_verify_token(db, verify_token="\ud800") is None
 
 
 def test_ingest_creates_lead_for_unknown_number(db):

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -209,6 +209,120 @@ def test_ingest_skips_or_rejects_non_dict_message_item(db):
         inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
 
 
+def test_ingest_skips_malformed_text_field_without_crashing(db):
+    # Isolamento por mensagem (review round 5): `text` é uma string, não um dict — o acesso
+    # `.get("body")` quebraria. Em vez de derrubar a request inteira, a mensagem malformada é
+    # logada e ignorada; nenhuma linha é criada para ela.
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": "5511900000001"}],
+                    "messages": [{
+                        "id": "w1", "from": "5511900000001", "type": "text",
+                        "text": "not-a-dict",
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)  # não levanta
+    assert db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "w1")
+    ) is None
+
+
+def test_ingest_skips_malformed_media_field_without_crashing(db):
+    # Mesma isolação para mídia: `image` é uma string, não um dict.
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": "5511900000002"}],
+                    "messages": [{
+                        "id": "w2", "from": "5511900000002", "type": "image",
+                        "image": "not-a-dict",
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)  # não levanta
+    assert db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "w2")
+    ) is None
+
+
+def test_ingest_skips_message_with_non_string_contact_name(db):
+    # `contacts[0].profile.name` é um dict aninhado (não uma string) — estruturalmente válido em
+    # `_extract_messages`, mas quebra o `ClientCreate(name=...)` dentro de `_get_or_create_client`
+    # com um pydantic.ValidationError. O `except Exception` por mensagem isola essa falha.
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": {"a": "b"}}, "wa_id": "5511900000003"}],
+                    "messages": [{
+                        "id": "w3", "from": "5511900000003", "type": "text",
+                        "text": {"body": "oi"},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)  # não levanta
+    assert db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "w3")
+    ) is None
+
+
+def test_ingest_processes_valid_message_even_when_another_in_same_payload_is_malformed(db):
+    # O TESTE-PAYOFF desta rodada: prova que o isolamento funciona ponta-a-ponta. Duas mensagens no
+    # MESMO lote — uma malformada (`text` é string) e uma válida. A malformada é ignorada, a válida
+    # é processada normalmente. Uma mensagem ruim NÃO bloqueia as outras válidas do mesmo lote.
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": "5511900000004"}],
+                    "messages": [
+                        {
+                            "id": "bad-1", "from": "5511900000004", "type": "text",
+                            "text": "not-a-dict",
+                        },
+                        {
+                            "id": "good-1", "from": "5511900000004", "type": "text",
+                            "text": {"body": "mensagem válida"},
+                        },
+                    ],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)  # não levanta
+
+    assert db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "bad-1")
+    ) is None
+    good = db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "good-1")
+    )
+    assert good is not None
+    assert good.text_body == "mensagem válida"
+
+
 def test_is_within_session_window_true_right_after_inbound(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -91,6 +91,21 @@ def test_resolve_by_verify_token_returns_none_for_unknown_token(db):
     assert inbox_service.resolve_by_verify_token(db, verify_token="token-inexistente") is None
 
 
+def test_resolve_account_rejects_phone_number_id_with_nul_byte(db):
+    # JSON permite um NUL escapado numa string e `json.loads` produz um `str` Python com NUL de
+    # verdade. No driver de produção (psycopg), fazer bind desse valor num parâmetro de query
+    # levanta `psycopg.DataError` — não capturado em lugar nenhum do caminho do webhook. SQLite
+    # (usado nos testes) tolera NUL em campos de texto, então este teste prova a GUARDA em si
+    # (retorna None em vez de deixar o valor chegar ao `db.get`), não o crash do driver real.
+    assert inbox_service.resolve_account(db, phone_number_id="pn\x00id") is None
+
+
+def test_resolve_by_verify_token_rejects_verify_token_with_nul_byte(db):
+    # Mesmo raciocínio para o handshake GET: `hub.verify_token` é um query param de um chamador
+    # anônimo (Meta ou qualquer um), e um NUL codificado (`%00`) chega intacto como `str`.
+    assert inbox_service.resolve_by_verify_token(db, verify_token="tok\x00en") is None
+
+
 def test_ingest_creates_lead_for_unknown_number(db):
     _configure_credentials(db)
     inbox_service.ingest_webhook_payload(

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from app.core import whatsapp
 from app.core.audit import AuditEntry
+from app.modules.attachments.models import Attachment
 from app.modules.crm.models import Client
 from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
@@ -282,6 +283,44 @@ def test_send_reply_media_rejects_empty_file_before_sending(
         )
     )
     assert count is None  # nenhuma linha "sent" órfã foi criada
+
+
+def test_send_reply_media_success_creates_message_and_attachment(
+    db, monkeypatch: pytest.MonkeyPatch
+):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900005558", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+
+    monkeypatch.setattr(whatsapp, "upload_media", lambda **_kw: "media-fake-1")
+    monkeypatch.setattr(whatsapp, "send_media", lambda **_kw: "sent")
+
+    msg = inbox_service.send_reply_media(
+        db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
+        file_bytes=b"%PDF-1.4 fake pdf bytes", filename="cardapio.pdf",
+        mime_type="application/pdf",
+    )
+
+    assert msg.status == "sent"
+    assert msg.media_attachment_id is not None
+
+    attachment = db.scalar(
+        select(Attachment).where(
+            Attachment.owner_type == "whatsapp_message", Attachment.owner_id == msg.id
+        )
+    )
+    assert attachment is not None
+
+    audit_entry = db.scalar(
+        select(AuditEntry).where(AuditEntry.action == "whatsapp_inbox.reply.media")
+    )
+    assert audit_entry is not None
 
 
 def test_send_reply_template_requires_approved_template(db):

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -187,6 +187,28 @@ def test_ingest_raises_on_non_dict_value(db):
         inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
 
 
+def test_ingest_skips_or_rejects_non_dict_message_item(db):
+    # `value["messages"]` é uma string (não uma lista de dicts) — iterar sobre ela produz
+    # caracteres individuais (strings de 1 char), que `_extract_messages` deve rejeitar ANTES de
+    # devolvê-los para `ingest_webhook_payload`. Sem a guarda, `msg.get("id")` no loop de
+    # `ingest_webhook_payload` levantaria um `AttributeError` cru (Gap B da review round 4).
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": "5511900009999"}],
+                    "messages": "not-a-list",
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, payload=payload)
+
+
 def test_is_within_session_window_true_right_after_inbound(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -97,6 +97,17 @@ def test_webhook_post_rejects_malformed_json(client, db):
     assert resp.status_code == 400
 
 
+def test_webhook_post_rejects_invalid_utf8_body(client, db):
+    # Bytes que não são UTF-8 válido levantam `UnicodeDecodeError` dentro de `json.loads`, uma
+    # exceção IRMÃ de `JSONDecodeError` sob `ValueError` (não subclasse) — sem capturá-la também,
+    # o parse quebra com 500 cru antes de chegar em qualquer resolução de tenant/assinatura.
+    resp = client.post(
+        "/public/whatsapp/webhook", content=b"\xff\xff\xff",
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
 def test_webhook_post_rejects_json_null(client, db):
     # `null` é JSON sintaticamente válido (json.loads não levanta JSONDecodeError), mas não é um
     # dict — sem a checagem de shape, `payload.get("entry", [])` explodiria com AttributeError.

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -127,6 +127,45 @@ def test_webhook_post_rejects_entry_not_a_list(client, db):
     assert resp.status_code == 400
 
 
+def test_webhook_post_rejects_non_dict_value(client, db):
+    # `value` não é dict — `.get("metadata", {})` quebraria com AttributeError sem a extração
+    # estar protegida por um único try/except (round 3 de review).
+    body = json.dumps({"entry": [{"changes": [{"value": "boom"}]}]}).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
+def test_webhook_post_rejects_non_dict_metadata(client, db):
+    # `metadata` não é dict — mesma classe de falha, um nível mais fundo.
+    body = json.dumps({"entry": [{"changes": [{"value": {"metadata": "boom"}}]}]}).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
+def test_webhook_post_rejects_non_string_phone_number_id(client, db):
+    # `phone_number_id` presente mas com tipo errado (dict) — é truthy, então passaria pelo
+    # `if not phone_number_id` e quebraria `resolve_account`'s `db.get()` com
+    # `sqlalchemy.exc.InvalidRequestError` sem a guarda extra logo após a extração.
+    body = json.dumps({
+        "entry": [{
+            "changes": [{
+                "value": {"metadata": {"phone_number_id": {"nested": "x"}}},
+            }],
+        }],
+    }).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
 def test_webhook_post_rejects_unknown_phone_number_id(client, db):
     payload = {
         "entry": [{

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -97,6 +97,36 @@ def test_webhook_post_rejects_malformed_json(client, db):
     assert resp.status_code == 400
 
 
+def test_webhook_post_rejects_json_null(client, db):
+    # `null` é JSON sintaticamente válido (json.loads não levanta JSONDecodeError), mas não é um
+    # dict — sem a checagem de shape, `payload.get("entry", [])` explodiria com AttributeError.
+    resp = client.post(
+        "/public/whatsapp/webhook", content=b"null",
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
+def test_webhook_post_rejects_json_array(client, db):
+    # `[]` também é JSON válido e não-dict — mesma classe de falha.
+    resp = client.post(
+        "/public/whatsapp/webhook", content=b"[]",
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
+def test_webhook_post_rejects_entry_not_a_list(client, db):
+    # Payload é um dict válido, mas `entry` não é uma lista — iterar uma string levaria a
+    # `entry.get(...)` (AttributeError) na próxima linha se não fosse pela guarda isinstance.
+    body = json.dumps({"entry": "not-a-list"}).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
 def test_webhook_post_rejects_unknown_phone_number_id(client, db):
     payload = {
         "entry": [{

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -77,7 +77,14 @@ def test_webhook_post_creates_message_with_valid_signature(client, db):
 
 def test_webhook_post_rejects_invalid_signature(client, db):
     _seed_account(db, phone_number_id="phone-def", tenant_id="t-3", app_secret="segredo-3")
-    payload = {"entry": []}
+    # O payload precisa resolver a conta (via phone_number_id) para a request chegar até a
+    # checagem de assinatura — um `entry` vazio nunca alcança essa validação (cai antes, em
+    # 404 "phone_number_id não encontrado"). Ver `router._extract_phone_number_id`.
+    payload = {
+        "entry": [{
+            "changes": [{"value": {"metadata": {"phone_number_id": "phone-def"}, "messages": []}}],
+        }],
+    }
     body = json.dumps(payload).encode()
     resp = client.post(
         "/public/whatsapp/webhook", content=body,

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -1,0 +1,103 @@
+"""Testes do webhook público de WhatsApp: handshake de verificação + recebimento de mensagem."""
+import hashlib
+import hmac
+import json
+
+from sqlalchemy import select
+
+from app.modules.whatsapp_inbox.models import PublicWhatsappAccount, WhatsappMessage
+
+
+def _seed_account(db, *, phone_number_id="phone-123", tenant_id="t-1", app_secret="shh",
+                   verify_token="verify-me"):
+    db.add(PublicWhatsappAccount(
+        phone_number_id=phone_number_id, tenant_id=tenant_id, app_secret=app_secret,
+        verify_token=verify_token,
+    ))
+    db.commit()
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_webhook_verification_handshake_success(client, db):
+    _seed_account(db)
+    resp = client.get(
+        "/public/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe", "hub.verify_token": "verify-me",
+            "hub.challenge": "challenge-xyz",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.text == "challenge-xyz"
+
+
+def test_webhook_verification_handshake_wrong_token(client, db):
+    _seed_account(db)
+    resp = client.get(
+        "/public/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe", "hub.verify_token": "token-errado",
+            "hub.challenge": "challenge-xyz",
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_webhook_post_creates_message_with_valid_signature(client, db):
+    _seed_account(db, phone_number_id="phone-abc", tenant_id="t-2", app_secret="segredo-2")
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-abc"},
+                    "contacts": [{"profile": {"name": "Cliente Teste"}, "wa_id": "5511900000000"}],
+                    "messages": [{
+                        "from": "5511900000000", "id": "wamid.test1", "type": "text",
+                        "text": {"body": "Olá!"},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    body = json.dumps(payload).encode()
+    sig = _sign(body, "segredo-2")
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": sig},
+    )
+    assert resp.status_code == 200
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.test1"))
+    assert msg is not None
+    assert msg.text_body == "Olá!"
+
+
+def test_webhook_post_rejects_invalid_signature(client, db):
+    _seed_account(db, phone_number_id="phone-def", tenant_id="t-3", app_secret="segredo-3")
+    payload = {"entry": []}
+    body = json.dumps(payload).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=invalido"},
+    )
+    assert resp.status_code == 403
+
+
+def test_webhook_post_rejects_unknown_phone_number_id(client, db):
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {"metadata": {"phone_number_id": "numero-desconhecido"}, "messages": []},
+                "field": "messages",
+            }],
+        }],
+    }
+    body = json.dumps(payload).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 404

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -166,6 +166,32 @@ def test_webhook_post_rejects_non_string_phone_number_id(client, db):
     assert resp.status_code == 400
 
 
+def test_webhook_post_rejects_malformed_messages_field(client, db):
+    # `phone_number_id` é válido e resolve uma conta real (passa extração + assinatura), mas
+    # `contacts`/`messages` são strings em vez de listas — `_extract_messages` (service.py) deve
+    # rejeitar isso com `WhatsappInboxError(400)`, e o router precisa capturar essa exceção (Gap A
+    # da review round 4) e convertê-la em HTTPException(400) em vez de deixar um 500 cru escapar.
+    _seed_account(db, phone_number_id="phone-malformed", tenant_id="t-4", app_secret="segredo-4")
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-malformed"},
+                    "contacts": "x",
+                    "messages": "y",
+                },
+            }],
+        }],
+    }
+    body = json.dumps(payload).encode()
+    sig = _sign(body, "segredo-4")
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": sig},
+    )
+    assert resp.status_code == 400
+
+
 def test_webhook_post_rejects_unknown_phone_number_id(client, db):
     payload = {
         "entry": [{

--- a/apps/api/tests/test_whatsapp_inbox_webhook.py
+++ b/apps/api/tests/test_whatsapp_inbox_webhook.py
@@ -86,6 +86,17 @@ def test_webhook_post_rejects_invalid_signature(client, db):
     assert resp.status_code == 403
 
 
+def test_webhook_post_rejects_malformed_json(client, db):
+    # JSON malformado falha no parse antes mesmo de extrair phone_number_id — não dá pra
+    # resolver a conta nem calcular assinatura correta, então nem uma assinatura válida
+    # evitaria o 400 aqui (a checagem de JSON acontece primeiro).
+    resp = client.post(
+        "/public/whatsapp/webhook", content=b"isto nao e json{{{",
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 400
+
+
 def test_webhook_post_rejects_unknown_phone_number_id(client, db):
     payload = {
         "entry": [{

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -11,6 +11,7 @@ import ContratosPage from "../features/contratos/ContratosPage";
 import PublicContractPage from "../features/contratos/PublicContractPage";
 import ClientDetailPage from "../features/crm/ClientDetailPage";
 import CrmPage from "../features/crm/CrmPage";
+import ConversasPage from "../features/conversas/ConversasPage";
 import EstoquePage from "../features/estoque/EstoquePage";
 import CentrosCustoPage from "../features/financeiro/CentrosCustoPage";
 import ContratoDrePage from "../features/financeiro/ContratoDrePage";
@@ -55,6 +56,7 @@ export default function App() {
           <Route path="/agenda" element={<AgendaPage />} />
           <Route path="/crm" element={<CrmPage />} />
           <Route path="/crm/clients/:id" element={<ClientDetailPage />} />
+          <Route path="/conversas" element={<ConversasPage />} />
           <Route path="/financeiro" element={<FinanceiroPage />} />
           <Route path="/financeiro/plano-contas" element={<PlanoContasPage />} />
           <Route path="/financeiro/centros-custo" element={<CentrosCustoPage />} />

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -12,6 +12,7 @@ import {
   ListTree,
   type LucideIcon,
   Megaphone,
+  MessageCircle,
   Package,
   PieChart,
   Receipt,
@@ -52,6 +53,7 @@ export const navSections: NavSection[] = [
       { label: "Dashboard", to: "/", icon: LayoutDashboard, ready: true },
       { label: "Agenda", to: "/agenda", icon: CalendarDays, ready: true },
       { label: "CRM & Kanban", to: "/crm", icon: Users, ready: true },
+      { label: "Conversas", to: "/conversas", icon: MessageCircle, ready: true },
     ],
   },
   {

--- a/apps/web/src/features/config/WhatsappSection.test.tsx
+++ b/apps/web/src/features/config/WhatsappSection.test.tsx
@@ -37,6 +37,7 @@ function profile(overrides: Partial<TenantProfile> = {}): TenantProfile {
     whatsapp_phone_id: "",
     whatsapp_waba_id: "",
     whatsapp_template_bindings: {},
+    whatsapp_verify_token: "",
     ...overrides,
   };
 }
@@ -143,6 +144,72 @@ describe("WhatsappSection — credenciais", () => {
         whatsapp_phone_id: "",
         whatsapp_waba_id: "",
         whatsapp_token: "meu-token-secreto",
+      }),
+    );
+  });
+
+  it("mostra a URL do webhook e o verify token gerado quando já configurado", async () => {
+    mockGet(
+      profile({
+        whatsapp_configured: true, whatsapp_phone_id: "phone-123",
+        whatsapp_waba_id: "waba-456", whatsapp_verify_token: "abc123xyz",
+      }),
+    );
+    render(<WhatsappSection />);
+
+    await screen.findByText("Conectado");
+    expect(screen.getByText("abc123xyz")).toBeInTheDocument();
+    expect(screen.getByText(/public\/whatsapp\/webhook/)).toBeInTheDocument();
+  });
+
+  it("não mostra o bloco do webhook quando ainda não há verify_token", async () => {
+    mockGet(profile({ whatsapp_configured: false, whatsapp_verify_token: "" }));
+    render(<WhatsappSection />);
+
+    await screen.findByText("Não conectado");
+    expect(screen.queryByText(/public\/whatsapp\/webhook/)).not.toBeInTheDocument();
+  });
+
+  it("inclui whatsapp_app_secret no payload quando o campo é editado", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: false }));
+    vi.mocked(api.patch).mockResolvedValue({ data: profile({ whatsapp_configured: true }) } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Não conectado");
+    const secretInput = screen.getByPlaceholderText("Cole o App Secret do seu App na Meta");
+    await user.type(secretInput, "meu-app-secret");
+
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "",
+        whatsapp_waba_id: "",
+        whatsapp_app_secret: "meu-app-secret",
+      }),
+    );
+  });
+
+  it("não inclui whatsapp_app_secret no payload quando o campo não foi tocado", async () => {
+    const user = userEvent.setup();
+    mockGet(
+      profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-1", whatsapp_waba_id: "waba-1" }),
+    );
+    vi.mocked(api.patch).mockResolvedValue({
+      data: profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-1", whatsapp_waba_id: "waba-1" }),
+    } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Conectado");
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "phone-1",
+        whatsapp_waba_id: "waba-1",
       }),
     );
   });

--- a/apps/web/src/features/config/WhatsappSection.tsx
+++ b/apps/web/src/features/config/WhatsappSection.tsx
@@ -52,6 +52,8 @@ function CredentialsCard() {
   const [profile, setProfile] = useState<TenantProfile | null>(null);
   const [token, setToken] = useState("");
   const [tokenTouched, setTokenTouched] = useState(false);
+  const [appSecret, setAppSecret] = useState("");
+  const [appSecretTouched, setAppSecretTouched] = useState(false);
   const [phoneId, setPhoneId] = useState("");
   const [wabaId, setWabaId] = useState("");
   const [saving, setSaving] = useState(false);
@@ -64,6 +66,8 @@ function CredentialsCard() {
     setWabaId(data.whatsapp_waba_id ?? "");
     setToken("");
     setTokenTouched(false);
+    setAppSecret("");
+    setAppSecretTouched(false);
   }, []);
 
   useEffect(() => {
@@ -76,17 +80,21 @@ function CredentialsCard() {
     try {
       const patch: Pick<TenantProfile, "whatsapp_phone_id" | "whatsapp_waba_id"> & {
         whatsapp_token?: string;
+        whatsapp_app_secret?: string;
       } = {
         whatsapp_phone_id: phoneId.trim(),
         whatsapp_waba_id: wabaId.trim(),
       };
       if (tokenTouched) patch.whatsapp_token = token;
+      if (appSecretTouched) patch.whatsapp_app_secret = appSecret;
       const { data } = await api.patch<TenantProfile>("/settings/profile", patch);
       setProfile(data);
       setPhoneId(data.whatsapp_phone_id ?? "");
       setWabaId(data.whatsapp_waba_id ?? "");
       setToken("");
       setTokenTouched(false);
+      setAppSecret("");
+      setAppSecretTouched(false);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {
@@ -136,6 +144,21 @@ function CredentialsCard() {
                 className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
               />
             </label>
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">
+                App Secret
+              </span>
+              <input
+                type="password"
+                value={appSecret}
+                onChange={(e) => {
+                  setAppSecret(e.target.value);
+                  setAppSecretTouched(true);
+                }}
+                placeholder={configured ? "••••••••" : "Cole o App Secret do seu App na Meta"}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </label>
             <label className="block">
               <span className="mb-1 block text-xs font-medium text-neutral-600">
                 Phone Number ID
@@ -155,6 +178,26 @@ function CredentialsCard() {
               />
             </label>
           </div>
+
+          {profile.whatsapp_verify_token && (
+            <div className="mt-4 rounded-xl border border-neutral-100 bg-neutral-50 p-4">
+              <p className="mb-2 text-xs font-semibold text-neutral-600">
+                Configure o webhook no painel da Meta (WhatsApp → Configuration):
+              </p>
+              <div className="mb-2">
+                <span className="mb-1 block text-xs text-neutral-500">Callback URL</span>
+                <code className="block truncate rounded-lg bg-white px-3 py-2 text-xs">
+                  {`${window.location.origin}/api/public/whatsapp/webhook`}
+                </code>
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-neutral-500">Verify token</span>
+                <code className="block truncate rounded-lg bg-white px-3 py-2 text-xs">
+                  {profile.whatsapp_verify_token}
+                </code>
+              </div>
+            </div>
+          )}
 
           {error && (
             <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -86,4 +86,68 @@ describe("ConversasPage", () => {
     // O texto exato da option ("Selecione um template") é único.
     expect(screen.getByText("Selecione um template")).toBeInTheDocument();
   });
+
+  it("limpa o rascunho e o fio anterior ao trocar de conversa", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [
+            {
+              client_id: "c1", client_name: "Cliente A", client_phone: "5511111111111",
+              last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "prévia A",
+              unread: false,
+            },
+            {
+              client_id: "c2", client_name: "Cliente B", client_phone: "5511222222222",
+              last_message_at: "2026-07-19T11:00:00Z", last_message_preview: "prévia B",
+              unread: false,
+            },
+          ],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/timeline") {
+        return Promise.resolve({
+          data: [{
+            source: "conversation", direction: "in", kind: "text",
+            text_body: "Mensagem da conversa A", media_attachment_id: null, purpose_label: null,
+            created_at: "2026-07-19T10:00:00Z",
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/window") {
+        return Promise.resolve({ data: { within_session_window: true } });
+      }
+      if (url === "/whatsapp-conversations/c2/timeline") {
+        return Promise.resolve({
+          data: [{
+            source: "conversation", direction: "in", kind: "text",
+            text_body: "Mensagem da conversa B", media_attachment_id: null, purpose_label: null,
+            created_at: "2026-07-19T11:00:00Z",
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c2/window") {
+        return Promise.resolve({ data: { within_session_window: true } });
+      }
+      if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: [] });
+    });
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+
+    render(<ConversasPage />);
+    await waitFor(() => screen.getByText("Cliente A"));
+
+    await userEvent.click(screen.getByText("Cliente A"));
+    await waitFor(() => screen.getByText("Mensagem da conversa A"));
+
+    const input = screen.getByPlaceholderText(/mensagem/i) as HTMLInputElement;
+    await userEvent.type(input, "rascunho para A");
+    expect(input).toHaveValue("rascunho para A");
+
+    await userEvent.click(screen.getByText("Cliente B"));
+    await waitFor(() => screen.getByText("Mensagem da conversa B"));
+
+    expect(screen.queryByText("Mensagem da conversa A")).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/mensagem/i)).toHaveValue("");
+  });
 });

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import ConversasPage from "./ConversasPage";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+describe("ConversasPage", () => {
+  it("lista as conversas e mostra o fio ao clicar numa delas", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [{
+            client_id: "c1", client_name: "Doro Eventos", client_phone: "5511999999999",
+            last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "Oi, quero o cardápio",
+            unread: true,
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/timeline") {
+        return Promise.resolve({
+          data: [{
+            source: "conversation", direction: "in", kind: "text",
+            text_body: "Oi, quero o cardápio", media_attachment_id: null, purpose_label: null,
+            created_at: "2026-07-19T10:00:00Z",
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/window") {
+        return Promise.resolve({ data: { within_session_window: true } });
+      }
+      if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: [] });
+    });
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+
+    render(<ConversasPage />);
+    await waitFor(() => screen.getByText("Doro Eventos"));
+    await userEvent.click(screen.getByText("Doro Eventos"));
+    // A prévia da lista e o corpo da mensagem no fio coincidem neste fixture, então mais de um
+    // nó tem o mesmo texto — confirmamos que o fio abriu pela contagem (lista + bolha), não por
+    // unicidade de texto.
+    await waitFor(() => expect(screen.getAllByText("Oi, quero o cardápio")).toHaveLength(2));
+    expect(screen.getByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+  });
+
+  it("troca pro seletor de template quando a janela de 24h está fechada", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [{
+            client_id: "c2", client_name: "Cliente Antigo", client_phone: "5511888888888",
+            last_message_at: "2026-07-01T10:00:00Z", last_message_preview: "oi",
+            unread: false,
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c2/timeline") return Promise.resolve({ data: [] });
+      if (url === "/whatsapp-conversations/c2/window") {
+        return Promise.resolve({ data: { within_session_window: false } });
+      }
+      if (url === "/whatsapp-templates") {
+        return Promise.resolve({
+          data: [{
+            id: "t1", name: "boas_vindas", language: "pt_BR", category_requested: "UTILITY",
+            category_approved: "UTILITY", status: "APPROVED", rejected_reason: null,
+            meta_template_id: "m1", body_text: "Olá {{1}}", variable_count: 1,
+            variable_examples: ["Nome"], created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          }],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    render(<ConversasPage />);
+    await waitFor(() => screen.getByText("Cliente Antigo"));
+    await userEvent.click(screen.getByText("Cliente Antigo"));
+    await waitFor(() => expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument());
+    // Exato (não regex): a mensagem explicativa acima do select também contém a substring
+    // "selecione um template" em minúsculas, então um regex case-insensitive casa os dois nós.
+    // O texto exato da option ("Selecione um template") é único.
+    expect(screen.getByText("Selecione um template")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -1,0 +1,270 @@
+import type {
+  ConversationSummary, TimelineEntry, WhatsappTemplate,
+} from "@e1p/shared-types";
+import { Paperclip, Send } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+const POLL_MS = 7000;
+
+export default function ConversasPage() {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const loadConversations = useCallback(async () => {
+    const { data } = await api.get<ConversationSummary[]>("/whatsapp-conversations");
+    setConversations(data);
+  }, []);
+
+  useEffect(() => {
+    loadConversations();
+    const id = setInterval(loadConversations, POLL_MS);
+    return () => clearInterval(id);
+  }, [loadConversations]);
+
+  return (
+    <div className="flex h-[calc(100vh-8rem)] gap-4">
+      <div className="w-80 shrink-0 overflow-y-auto rounded-2xl bg-white shadow-sm">
+        <div className="border-b border-neutral-100 p-4">
+          <h1 className="font-semibold text-neutral-800">Conversas</h1>
+        </div>
+        {conversations.length === 0 ? (
+          <p className="p-4 text-sm text-neutral-400">Nenhuma conversa ainda.</p>
+        ) : (
+          conversations.map((c) => (
+            <button
+              key={c.client_id}
+              onClick={() => setSelected(c.client_id)}
+              className={`block w-full border-b border-neutral-50 px-4 py-3 text-left hover:bg-neutral-50 ${
+                selected === c.client_id ? "bg-primary-50" : ""
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-neutral-800">{c.client_name}</span>
+                {c.unread && <span className="h-2 w-2 rounded-full bg-primary-600" />}
+              </div>
+              <p className="mt-0.5 truncate text-xs text-neutral-400">
+                {c.last_message_preview}
+              </p>
+            </button>
+          ))
+        )}
+      </div>
+      <div className="flex-1 rounded-2xl bg-white shadow-sm">
+        {selected ? (
+          <ConversationThread clientId={selected} onSent={loadConversations} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-neutral-400">
+            Selecione uma conversa
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConversationThread({
+  clientId, onSent,
+}: { clientId: string; onSent: () => void }) {
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
+  const [withinWindow, setWithinWindow] = useState(true);
+  const [approvedTemplates, setApprovedTemplates] = useState<WhatsappTemplate[]>([]);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    const [tl, win] = await Promise.all([
+      api.get<TimelineEntry[]>(`/whatsapp-conversations/${clientId}/timeline`),
+      api.get<{ within_session_window: boolean }>(`/whatsapp-conversations/${clientId}/window`),
+    ]);
+    setTimeline(tl.data);
+    setWithinWindow(win.data.within_session_window);
+    if (!win.data.within_session_window) {
+      const { data } = await api.get<WhatsappTemplate[]>("/whatsapp-templates", {
+        params: { status: "APPROVED" },
+      });
+      setApprovedTemplates(data);
+    }
+    await api.post(`/whatsapp-conversations/${clientId}/read`);
+  }, [clientId]);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  async function sendText() {
+    if (!text.trim()) return;
+    setError(null);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/text`, { text });
+      setText("");
+      await load();
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  async function sendMedia(file: File) {
+    setError(null);
+    const form = new FormData();
+    form.append("file", file);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/media`, form, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      await load();
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {timeline.map((entry, i) => (
+          <div
+            key={i}
+            className={`max-w-md rounded-xl px-3 py-2 text-sm ${
+              entry.source === "automated"
+                ? "mx-auto bg-neutral-100 text-neutral-500"
+                : entry.direction === "out"
+                  ? "ml-auto bg-primary-600 text-white"
+                  : "bg-neutral-100 text-neutral-800"
+            }`}
+          >
+            {entry.source === "automated" && (
+              <p className="mb-0.5 text-xs font-semibold">🤖 {entry.purpose_label}</p>
+            )}
+            <p>{entry.text_body || `[${entry.kind}]`}</p>
+          </div>
+        ))}
+      </div>
+      {error && <div className="mx-4 mb-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+      <div className="border-t border-neutral-100 p-3">
+        {withinWindow ? (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded-lg border border-neutral-200 p-2 text-neutral-500 hover:bg-neutral-50"
+              title="Anexar arquivo"
+            >
+              <Paperclip size={16} />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) sendMedia(file);
+                e.target.value = "";
+              }}
+            />
+            <input
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && sendText()}
+              placeholder="Digite uma mensagem..."
+              className="flex-1 rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            />
+            <button
+              onClick={sendText}
+              className="rounded-pill bg-primary-600 p-2 text-white hover:bg-primary-700"
+            >
+              <Send size={16} />
+            </button>
+          </div>
+        ) : (
+          <TemplateReplyBox
+            clientId={clientId}
+            templates={approvedTemplates}
+            onSent={async () => {
+              await load();
+              onSent();
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TemplateReplyBox({
+  clientId, templates, onSent,
+}: { clientId: string; templates: WhatsappTemplate[]; onSent: () => void }) {
+  const [templateId, setTemplateId] = useState("");
+  const [variables, setVariables] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const selected = templates.find((t) => t.id === templateId) ?? null;
+
+  async function send() {
+    setError(null);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/template`, {
+        template_id: templateId, variables,
+      });
+      setTemplateId("");
+      setVariables([]);
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-neutral-400">
+        Fora da janela de 24h — selecione um template aprovado para responder.
+      </p>
+      {templates.length === 0 ? (
+        <p className="text-sm text-neutral-400">Nenhum template aprovado ainda.</p>
+      ) : (
+        <>
+          <select
+            value={templateId}
+            onChange={(e) => {
+              setTemplateId(e.target.value);
+              const tpl = templates.find((t) => t.id === e.target.value);
+              setVariables(tpl ? Array(tpl.variable_count).fill("") : []);
+            }}
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+          >
+            <option value="">Selecione um template</option>
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>{t.name} ({t.language})</option>
+            ))}
+          </select>
+          {selected && (
+            <>
+              {Array.from({ length: selected.variable_count }, (_, i) => (
+                <input
+                  key={i}
+                  value={variables[i] ?? ""}
+                  onChange={(e) => {
+                    const next = [...variables];
+                    next[i] = e.target.value;
+                    setVariables(next);
+                  }}
+                  placeholder={selected.variable_examples[i] ?? `Variável ${i + 1}`}
+                  className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+                />
+              ))}
+              {error && <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+              <button
+                onClick={send}
+                className="w-full rounded-pill bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+              >
+                Enviar
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -52,7 +52,7 @@ export default function ConversasPage() {
       </div>
       <div className="flex-1 rounded-2xl bg-white shadow-sm">
         {selected ? (
-          <ConversationThread clientId={selected} onSent={loadConversations} />
+          <ConversationThread key={selected} clientId={selected} onSent={loadConversations} />
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-neutral-400">
             Selecione uma conversa

--- a/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
+++ b/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
@@ -1,0 +1,2890 @@
+# WhatsApp Inbox — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two-way WhatsApp conversation inbox inside the e1p CRM — receive messages via a
+per-tenant webhook, auto-create leads from unknown numbers, let staff reply (text/media/template
+depending on the 24h session window), and show a unified timeline mixing the conversation with
+the automated system notifications already sent.
+
+**Architecture:** New backend module `whatsapp_inbox` (models + service + public webhook router
++ authenticated router) sits alongside the already-shipped `whatsapp_templates`/`settings`
+modules, reusing their credentials, template picker, and Graph API client (`core/whatsapp.py`).
+Media reuses the existing S3/Postgres storage abstraction. A new "Conversas" page in the CRM
+polls the authenticated endpoints every few seconds.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2, Alembic, PostgreSQL 16 (RLS), React 18 + Vite + TS +
+Tailwind, httpx (Graph API calls), pytest, vitest.
+
+## Global Constraints
+
+- RLS is the ONLY tenant isolation mechanism — never add a manual `.where(Model.tenant_id == ...)` filter on a business table; `db.get`/`select` inside a `tenant_session`/`get_tenant_db` are safe by construction.
+- Every mutating service function calls `audit.record(db, tenant_id=..., actor=..., action=..., target=...)`.
+- Every domain error class follows the `Exception` + `status_code: int` pattern (e.g. `FunnelError`, `WhatsappTemplateError`) — never raise a bare `HTTPException` from a `service.py`.
+- `send_text`/`send_template`/`send_media` NEVER raise — they return `"sent"|"logged"|"failed"` (fire-and-forget contract). Admin/management calls to the Graph API (`create_template`, `upload_media`, `fetch_media_url`, `download_media`) DO raise `WhatsappApiError` on failure — the caller decides how to handle it.
+- Idioma do produto e comentários de domínio: PT-BR. Código/identificadores: inglês.
+- Every task ends green: `pytest` for the files it touches, then re-run at the end of the full plan: `cd apps/api && ./.venv/Scripts/python.exe -m pytest -q -m "not rls_e2e"`.
+- Migration numbering: next is `0054` (last applied is `0053_whatsapp_template_bindings.py`).
+
+---
+
+### Task 1: Migration 0054 + new models (WhatsappMessage, WhatsappConversationState, PublicWhatsappAccount) + 2 new TenantProfile columns
+
+**Files:**
+- Create: `apps/api/migrations/versions/0054_whatsapp_inbox.py`
+- Create: `apps/api/app/modules/whatsapp_inbox/__init__.py`
+- Create: `apps/api/app/modules/whatsapp_inbox/models.py`
+- Modify: `apps/api/app/modules/settings/models.py`
+- Modify: `apps/api/app/modules/crm/models.py:26` (`SOURCE_VALUES`)
+- Test: `apps/api/tests/test_whatsapp_inbox_models.py`
+
+**Interfaces:**
+- Produces: `WhatsappMessage` (fields: `id, tenant_id, client_id, direction, kind, text_body, media_attachment_id, media_status, wa_message_id, status, created_at, updated_at`), `WhatsappConversationState` (`id, tenant_id, client_id, last_read_at, created_at, updated_at`), `PublicWhatsappAccount` (`phone_number_id [PK], tenant_id, app_secret, verify_token, created_at, updated_at`, no RLS/no TenantMixin), constants `DIRECTION_IN = "in"`, `DIRECTION_OUT = "out"`, `MEDIA_STATUS_NONE = "none"`, `MEDIA_STATUS_PENDING = "pending"`, `MEDIA_STATUS_DOWNLOADED = "downloaded"`, `MEDIA_STATUS_FAILED = "failed"`, `KINDS = ("text", "image", "audio", "document", "video")`. `TenantProfile.whatsapp_app_secret: str | None` (encrypted, like `whatsapp_token`), `TenantProfile.whatsapp_verify_token: str | None` (plain text, not a secret). `crm.models.SOURCE_VALUES` now includes `"whatsapp"`.
+
+- [ ] **Step 1: Write the model file**
+
+```python
+# apps/api/app/modules/whatsapp_inbox/models.py
+"""Conversa de WhatsApp (inbox): mensagens trocadas com o cliente (RLS) + resolução
+pré-autenticação do webhook (tabela global, sem RLS).
+
+Não confundir com `whatsapp_templates` (templates aprovados pela Meta) — aqui é a conversa de
+verdade, ida-e-volta, entre o tenant e o cliente. Ver docs/superpowers/specs/
+2026-07-19-whatsapp-inbox-design.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+DIRECTION_IN = "in"
+DIRECTION_OUT = "out"
+DIRECTIONS = (DIRECTION_IN, DIRECTION_OUT)
+
+KIND_TEXT = "text"
+KIND_IMAGE = "image"
+KIND_AUDIO = "audio"
+KIND_DOCUMENT = "document"
+KIND_VIDEO = "video"
+KINDS = (KIND_TEXT, KIND_IMAGE, KIND_AUDIO, KIND_DOCUMENT, KIND_VIDEO)
+
+MEDIA_STATUS_NONE = "none"
+MEDIA_STATUS_PENDING = "pending"
+MEDIA_STATUS_DOWNLOADED = "downloaded"
+MEDIA_STATUS_FAILED = "failed"
+
+
+class WhatsappMessage(Base, TenantMixin, TimestampMixin):
+    __tablename__ = "whatsapp_messages"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "wa_message_id", name="uq_whatsapp_messages_tenant_wa_id"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    client_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    direction: Mapped[str] = mapped_column(String(4), nullable=False)
+    kind: Mapped[str] = mapped_column(String(16), default=KIND_TEXT, nullable=False)
+    text_body: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    # Link pro módulo de Anexos já existente (reaproveita storage S3/Postgres).
+    media_attachment_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    # Só relevante pra mídia `in` (baixada de forma assíncrona pelo worker).
+    media_status: Mapped[str] = mapped_column(
+        String(16), default=MEDIA_STATUS_NONE, nullable=False
+    )
+    # ID da própria Meta — evita duplicar se o webhook reentregar a mesma mensagem.
+    wa_message_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Só relevante pra `direction=out` ("sent"|"logged"|"failed", mesmo vocabulário de sempre).
+    status: Mapped[str] = mapped_column(String(16), default="sent", nullable=False)
+
+
+class WhatsappConversationState(Base, TenantMixin, TimestampMixin):
+    """Uma linha por cliente com atividade — só guarda `last_read_at` (compartilhado entre toda
+    a equipe do tenant: "lida por qualquer um" marca lida pra todos, sem granularidade por
+    atendente, mesma decisão de 'inbox compartilhada' do brainstorming)."""
+
+    __tablename__ = "whatsapp_conversation_states"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "client_id", name="uq_whatsapp_conv_state_tenant_client"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    client_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    last_read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class PublicWhatsappAccount(Base, TimestampMixin):
+    """Snapshot GLOBAL (sem RLS, SEM TenantMixin) — resolve `tenant_id` a partir do
+    `phone_number_id` ANTES de qualquer autenticação. O webhook da Meta não manda tenant nenhum,
+    só o `phone_number_id` que recebeu a mensagem; esta tabela é o único jeito de saber de quem é
+    o evento e qual `app_secret` usar pra validar a assinatura. Mesmo padrão de
+    `PublicIntegrationKey`/`published_pages`. Mantida em sincronia (dual-write) por
+    `settings/service.py::update_profile` toda vez que o tenant salva/altera as credenciais.
+    """
+
+    __tablename__ = "public_whatsapp_accounts"
+
+    phone_number_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    app_secret: Mapped[str] = mapped_column(String(255), nullable=False)
+    verify_token: Mapped[str] = mapped_column(String(64), nullable=False)
+```
+
+- [ ] **Step 2: Create the empty `__init__.py`**
+
+```python
+# apps/api/app/modules/whatsapp_inbox/__init__.py
+```//(empty file)
+
+- [ ] **Step 3: Add `whatsapp_app_secret` / `whatsapp_verify_token` to `TenantProfile`**
+
+Open `apps/api/app/modules/settings/models.py`. Find the existing block:
+```python
+    whatsapp_token: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
+    whatsapp_phone_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    whatsapp_waba_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+```
+Replace it with:
+```python
+    whatsapp_token: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
+    whatsapp_phone_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    whatsapp_waba_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Segredo do App da Meta (cifrado, mesmo padrão do token) — valida a assinatura
+    # X-Hub-Signature-256 do webhook de mensagens recebidas (ver whatsapp_inbox).
+    whatsapp_app_secret: Mapped[str | None] = mapped_column(EncryptedToken, nullable=True)
+    # Token de verificação do webhook (texto simples, NÃO é segredo — só combina com o que a
+    # Meta ecoa no handshake GET). Gerado automaticamente na 1ª vez que as 4 credenciais ficam
+    # completas (ver settings/service.py::update_profile).
+    whatsapp_verify_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
+```
+
+- [ ] **Step 4: Add `"whatsapp"` to `SOURCE_VALUES`**
+
+Open `apps/api/app/modules/crm/models.py`. Change:
+```python
+SOURCE_VALUES = {"manual", "landing", "ai", "import", "api"}
+```
+to:
+```python
+SOURCE_VALUES = {"manual", "landing", "ai", "import", "api", "whatsapp"}
+```
+
+- [ ] **Step 5: Write the migration**
+
+```python
+# apps/api/migrations/versions/0054_whatsapp_inbox.py
+"""inbox de whatsapp: mensagens, estado de leitura, resolução pré-auth do webhook
+
+Revision ID: 0054
+Revises: 0053
+Create Date: 2026-07-19
+
+Três peças novas pra suportar a conversa de ida-e-volta com clientes pelo WhatsApp (design em
+docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md):
+
+1. `tenant_profiles` ganha `whatsapp_app_secret` (cifrado, valida a assinatura do webhook) e
+   `whatsapp_verify_token` (texto simples, handshake de verificação da Meta).
+2. `whatsapp_messages` (RLS) — cada mensagem trocada (`in`/`out`), com mídia opcional.
+3. `whatsapp_conversation_states` (RLS) — 1 linha por cliente com atividade, só pra "lida/não
+   lida" (compartilhada, sem granularidade por atendente).
+4. `public_whatsapp_accounts` (GLOBAL, sem RLS) — resolve `phone_number_id -> tenant_id` +
+   `app_secret`/`verify_token` ANTES de qualquer autenticação, mesmo padrão de
+   `public_integration_keys`.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0054"
+down_revision: str | None = "0053"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_app_secret", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "tenant_profiles", sa.Column("whatsapp_verify_token", sa.String(64), nullable=True)
+    )
+
+    op.create_table(
+        "whatsapp_messages",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("client_id", sa.String(36), nullable=False),
+        sa.Column("direction", sa.String(4), nullable=False),
+        sa.Column("kind", sa.String(16), nullable=False, server_default="text"),
+        sa.Column("text_body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("media_attachment_id", sa.String(36), nullable=True),
+        sa.Column("media_status", sa.String(16), nullable=False, server_default="none"),
+        sa.Column("wa_message_id", sa.String(128), nullable=True),
+        sa.Column("status", sa.String(16), nullable=False, server_default="sent"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id", "wa_message_id", name="uq_whatsapp_messages_tenant_wa_id"
+        ),
+    )
+    op.create_index("ix_whatsapp_messages_tenant_id", "whatsapp_messages", ["tenant_id"])
+    op.create_index("ix_whatsapp_messages_client_id", "whatsapp_messages", ["client_id"])
+    op.execute("ALTER TABLE whatsapp_messages ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE whatsapp_messages FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON whatsapp_messages
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+    op.create_table(
+        "whatsapp_conversation_states",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("client_id", sa.String(36), nullable=False),
+        sa.Column("last_read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "tenant_id", "client_id", name="uq_whatsapp_conv_state_tenant_client"
+        ),
+    )
+    op.create_index(
+        "ix_whatsapp_conversation_states_tenant_id",
+        "whatsapp_conversation_states",
+        ["tenant_id"],
+    )
+    op.execute("ALTER TABLE whatsapp_conversation_states ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE whatsapp_conversation_states FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON whatsapp_conversation_states
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+    op.create_table(
+        "public_whatsapp_accounts",
+        sa.Column("phone_number_id", sa.String(64), primary_key=True),
+        sa.Column("tenant_id", sa.String(36), nullable=False),
+        sa.Column("app_secret", sa.String(255), nullable=False),
+        sa.Column("verify_token", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("public_whatsapp_accounts")
+    op.drop_index(
+        "ix_whatsapp_conversation_states_tenant_id", table_name="whatsapp_conversation_states"
+    )
+    op.drop_table("whatsapp_conversation_states")
+    op.drop_index("ix_whatsapp_messages_client_id", table_name="whatsapp_messages")
+    op.drop_index("ix_whatsapp_messages_tenant_id", table_name="whatsapp_messages")
+    op.drop_table("whatsapp_messages")
+    op.drop_column("tenant_profiles", "whatsapp_verify_token")
+    op.drop_column("tenant_profiles", "whatsapp_app_secret")
+```
+
+- [ ] **Step 6: Write the model sanity test**
+
+```python
+# apps/api/tests/test_whatsapp_inbox_models.py
+"""Sanity check dos modelos novos do inbox — colunas esperadas presentes."""
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_inbox.models import (
+    PublicWhatsappAccount,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+
+
+def test_whatsapp_message_columns():
+    cols = {c.name for c in WhatsappMessage.__table__.columns}
+    assert cols == {
+        "id", "tenant_id", "client_id", "direction", "kind", "text_body",
+        "media_attachment_id", "media_status", "wa_message_id", "status",
+        "created_at", "updated_at",
+    }
+
+
+def test_whatsapp_conversation_state_columns():
+    cols = {c.name for c in WhatsappConversationState.__table__.columns}
+    assert cols == {"id", "tenant_id", "client_id", "last_read_at", "created_at", "updated_at"}
+
+
+def test_public_whatsapp_account_columns():
+    cols = {c.name for c in PublicWhatsappAccount.__table__.columns}
+    assert cols == {
+        "phone_number_id", "tenant_id", "app_secret", "verify_token",
+        "created_at", "updated_at",
+    }
+
+
+def test_tenant_profile_has_new_whatsapp_fields():
+    cols = {c.name for c in TenantProfile.__table__.columns}
+    assert "whatsapp_app_secret" in cols
+    assert "whatsapp_verify_token" in cols
+```
+
+- [ ] **Step 7: Run test to verify it fails (models don't exist yet)**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_models.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.modules.whatsapp_inbox'`
+
+- [ ] **Step 8: Create the files from steps 1-4 above, then run again**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_models.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 9: Apply the migration to the real dev Postgres and verify round-trip**
+
+Run (from `apps/api`, adjust the port/credentials to your local dev Postgres — see
+`docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md` precedent commands):
+```bash
+DATABASE_URL="postgresql+psycopg://e1p_app:e1ppass@localhost:5433/e1pdb" ./.venv/Scripts/python.exe -m alembic upgrade head
+DATABASE_URL="postgresql+psycopg://e1p_app:e1ppass@localhost:5433/e1pdb" ./.venv/Scripts/python.exe -m alembic downgrade -1
+DATABASE_URL="postgresql+psycopg://e1p_app:e1ppass@localhost:5433/e1pdb" ./.venv/Scripts/python.exe -m alembic upgrade head
+```
+Expected: all three commands succeed with no errors (upgrade → downgrade → upgrade clean).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/migrations/versions/0054_whatsapp_inbox.py apps/api/app/modules/whatsapp_inbox/ apps/api/app/modules/settings/models.py apps/api/app/modules/crm/models.py apps/api/tests/test_whatsapp_inbox_models.py
+git commit -m "feat: modelos do inbox de WhatsApp (mensagens, estado de leitura, resolução do webhook)"
+```
+
+---
+
+### Task 2: `core/whatsapp.py` — assinatura do webhook, upload/download/envio de mídia
+
+**Files:**
+- Modify: `apps/api/app/core/whatsapp.py`
+- Test: `apps/api/tests/test_whatsapp.py`
+
+**Interfaces:**
+- Consumes: `WhatsappApiError` (already defined in this file from PR #35).
+- Produces: `verify_webhook_signature(*, app_secret: str, body: bytes, signature_header: str | None) -> bool`, `upload_media(*, phone_id: str, token: str, file_bytes: bytes, filename: str, mime_type: str) -> str` (returns `media_id`, raises `WhatsappApiError`), `fetch_media_url(*, token: str, media_id: str) -> str` (raises `WhatsappApiError`), `download_media(*, token: str, url: str) -> bytes` (raises `WhatsappApiError`), `send_media(*, to: str, token: str, phone_id: str, kind: str, media_id: str, caption: str = "") -> str` (returns `"sent"|"logged"|"failed"`, never raises).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/tests/test_whatsapp.py`:
+```python
+import hashlib
+import hmac
+
+
+def test_verify_webhook_signature_valid():
+    body = b'{"hello":"world"}'
+    secret = "shh-its-a-secret"
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    assert whatsapp.verify_webhook_signature(
+        app_secret=secret, body=body, signature_header=sig
+    ) is True
+
+
+def test_verify_webhook_signature_invalid():
+    assert whatsapp.verify_webhook_signature(
+        app_secret="shh-its-a-secret", body=b'{"hello":"world"}',
+        signature_header="sha256=deadbeef",
+    ) is False
+
+
+def test_verify_webhook_signature_missing_header():
+    assert whatsapp.verify_webhook_signature(
+        app_secret="shh-its-a-secret", body=b"{}", signature_header=None
+    ) is False
+
+
+def test_upload_media_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["url"] = url
+        captured["files"] = kwargs.get("files")
+        resp = _FakeResponse(200)
+        resp._json = {"id": "media-123"}
+        return resp
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    media_id = whatsapp.upload_media(
+        phone_id="123456789", token="fake-token", file_bytes=b"fake-bytes",
+        filename="cardapio.pdf", mime_type="application/pdf",
+    )
+    assert media_id == "media-123"
+    assert captured["url"] == "https://graph.facebook.com/v21.0/123456789/media"
+
+
+def test_upload_media_raises_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(httpx, "post", lambda *_a, **_k: _FakeResponse(500))
+    with pytest.raises(whatsapp.WhatsappApiError):
+        whatsapp.upload_media(
+            phone_id="123", token="tok", file_bytes=b"x", filename="a.pdf",
+            mime_type="application/pdf",
+        )
+
+
+def test_fetch_media_url_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(url: str, **_k: object) -> _FakeResponse:
+        resp = _FakeResponse(200)
+        resp._json = {"url": "https://lookaside.fbsbx.com/whatsapp_business/temp/abc"}
+        return resp
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    url = whatsapp.fetch_media_url(token="tok", media_id="media-123")
+    assert url == "https://lookaside.fbsbx.com/whatsapp_business/temp/abc"
+
+
+def test_download_media_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_get(url: str, **_k: object) -> _FakeResponse:
+        resp = _FakeResponse(200)
+        resp._content = b"file-bytes-here"
+        return resp
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    data = whatsapp.download_media(token="tok", url="https://example.com/f")
+    assert data == b"file-bytes-here"
+
+
+def test_send_media_logged_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("httpx.post não deveria ser chamado no caminho 'logged'")
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    status = whatsapp.send_media(
+        to="5511999999999", token="", phone_id="", kind="image", media_id="m1"
+    )
+    assert status == "logged"
+
+
+def test_send_media_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        captured["json"] = kwargs.get("json")
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    status = whatsapp.send_media(
+        to="5511988887777", token="tok", phone_id="123", kind="document",
+        media_id="media-123", caption="Cardápio",
+    )
+    assert status == "sent"
+    assert captured["json"] == {
+        "messaging_product": "whatsapp", "to": "5511988887777", "type": "document",
+        "document": {"id": "media-123", "caption": "Cardápio"},
+    }
+```
+
+Update the `_FakeResponse` helper class near the top of the same test file (it currently only
+supports `raise_for_status`) to also support a `.json()` call and raw `.content`:
+```python
+class _FakeResponse:
+    """Resposta mínima com o contrato usado por send_text/send_template (raise_for_status) +
+    .json()/.content pros novos testes de mídia."""
+
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self._json: dict = {}
+        self._content: bytes = b""
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "erro", request=httpx.Request("POST", "https://x"), response=self
+            )
+
+    def json(self) -> dict:
+        return self._json
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp.py -v -k "signature or media"`
+Expected: FAIL with `AttributeError: module 'app.core.whatsapp' has no attribute 'verify_webhook_signature'` (and similar for the other new functions).
+
+- [ ] **Step 3: Implement in `apps/api/app/core/whatsapp.py`**
+
+Add `import hashlib` and `import hmac` to the top imports. Append at the end of the file:
+```python
+def verify_webhook_signature(
+    *, app_secret: str, body: bytes, signature_header: str | None
+) -> bool:
+    """Valida `X-Hub-Signature-256` (HMAC-SHA256 do corpo CRU do webhook). Comparação de tempo
+    constante — nunca comparar segredos com `==`."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(app_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    provided = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, provided)
+
+
+def upload_media(
+    *, phone_id: str, token: str, file_bytes: bytes, filename: str, mime_type: str
+) -> str:
+    """POST /{phone_id}/media (multipart). Retorna o `media_id` temporário da Meta.
+    Levanta WhatsappApiError em qualquer falha."""
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{phone_id}/media",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"messaging_product": "whatsapp"},
+            files={"file": (filename, file_bytes, mime_type)},
+            timeout=30,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao subir mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.json()["id"]
+
+
+def fetch_media_url(*, token: str, media_id: str) -> str:
+    """GET /{media_id}. Retorna a URL temporária de download. Levanta WhatsappApiError."""
+    try:
+        resp = httpx.get(
+            f"https://graph.facebook.com/v21.0/{media_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao resolver mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.json()["url"]
+
+
+def download_media(*, token: str, url: str) -> bytes:
+    """Baixa os bytes da URL temporária (a Meta exige o Bearer token também neste GET).
+    Levanta WhatsappApiError."""
+    try:
+        resp = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=30)
+    except Exception as exc:
+        raise WhatsappApiError(f"Falha de rede ao baixar mídia: {exc}") from exc
+    _raise_for_error(resp)
+    return resp.content
+
+
+def send_media(
+    *, to: str, token: str, phone_id: str, kind: str, media_id: str, caption: str = ""
+) -> str:
+    """Retorna 'sent' | 'logged' | 'failed'. Mesmo contrato de send_text/send_template: NUNCA
+    propaga exceção."""
+    if not token or not phone_id:
+        logger.info("[whatsapp:logged] mídia para=%s kind=%s", to, kind)
+        return "logged"
+    media_obj: dict[str, str] = {"id": media_id}
+    if caption:
+        media_obj["caption"] = caption
+    try:
+        resp = httpx.post(
+            f"https://graph.facebook.com/v21.0/{phone_id}/messages",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "messaging_product": "whatsapp", "to": to, "type": kind, kind: media_obj,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return "sent"
+    except Exception:
+        logger.exception("[whatsapp:failed] mídia para=%s kind=%s", to, kind)
+        return "failed"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp.py -v`
+Expected: all tests in the file PASS (existing + the ~9 new ones).
+
+- [ ] **Step 5: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/core/whatsapp.py tests/test_whatsapp.py`
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/core/whatsapp.py apps/api/tests/test_whatsapp.py
+git commit -m "feat: validação de assinatura do webhook + upload/download/envio de mídia (WhatsApp)"
+```
+
+---
+
+### Task 3: Settings — credenciais estendidas (app_secret, verify_token) + sincronização com `public_whatsapp_accounts`
+
+**Files:**
+- Modify: `apps/api/app/modules/settings/schemas.py`
+- Modify: `apps/api/app/modules/settings/service.py`
+- Modify: `apps/api/app/modules/settings/router.py`
+- Test: `apps/api/tests/test_settings.py`
+
+**Interfaces:**
+- Consumes: `TenantProfile.whatsapp_app_secret`/`whatsapp_verify_token` (Task 1), `PublicWhatsappAccount` (Task 1).
+- Produces: `ProfileOut.whatsapp_verify_token: str` (read-only, `""` if unset), `ProfileUpdate.whatsapp_app_secret: str | None` (write-only, same None/"" convention as `whatsapp_token`). `update_profile` now also upserts/clears `PublicWhatsappAccount` as a side effect.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/tests/test_settings.py`:
+```python
+def test_whatsapp_verify_token_generated_when_fully_configured(client, db) -> None:
+    """Ao completar as 4 credenciais (token/phone_id/waba_id/app_secret), o backend gera
+    sozinho o verify_token e cria o snapshot público."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    _register_and_login(client)  # assume o helper já usado pelos outros testes deste arquivo
+    resp = client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok-abc", "whatsapp_phone_id": "phone-123",
+            "whatsapp_waba_id": "waba-456", "whatsapp_app_secret": "secret-xyz",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["whatsapp_verify_token"]  # gerado, não vazio
+    assert "whatsapp_app_secret" not in body  # nunca exposto em claro
+
+    snap = db.get(PublicWhatsappAccount, "phone-123")
+    assert snap is not None
+    assert snap.app_secret == "secret-xyz"
+    assert snap.verify_token == body["whatsapp_verify_token"]
+
+
+def test_whatsapp_public_snapshot_removed_when_incomplete(client, db) -> None:
+    """Se as credenciais ficam incompletas de novo (ex.: limpar o app_secret), o snapshot
+    público é removido — o webhook não deve mais resolver esse phone_number_id."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    _register_and_login(client)
+    client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok", "whatsapp_phone_id": "phone-999",
+            "whatsapp_waba_id": "waba", "whatsapp_app_secret": "secret",
+        },
+    )
+    assert db.get(PublicWhatsappAccount, "phone-999") is not None
+
+    client.patch("/settings/profile", json={"whatsapp_app_secret": ""})
+    assert db.get(PublicWhatsappAccount, "phone-999") is None
+
+
+def test_whatsapp_public_snapshot_moves_when_phone_id_changes(client, db) -> None:
+    """Trocar o phone_id remove o snapshot antigo e cria um novo na chave certa."""
+    from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+    _register_and_login(client)
+    client.patch(
+        "/settings/profile",
+        json={
+            "whatsapp_token": "tok", "whatsapp_phone_id": "phone-old",
+            "whatsapp_waba_id": "waba", "whatsapp_app_secret": "secret",
+        },
+    )
+    client.patch("/settings/profile", json={"whatsapp_phone_id": "phone-new"})
+    assert db.get(PublicWhatsappAccount, "phone-old") is None
+    assert db.get(PublicWhatsappAccount, "phone-new") is not None
+```
+
+Check the existing top of `test_settings.py` for the exact name of the register+login helper
+already used by the other tests in this file (e.g. `_register_and_login(client)` or similar) and
+use that exact name instead of guessing — grep the file for `def test_` to find one that already
+does register+login and copy its setup call.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_settings.py -v -k whatsapp_verify or whatsapp_public`
+Expected: FAIL — `whatsapp_verify_token` not in response body / `app_secret` field rejected as unknown by `ProfileUpdate`.
+
+- [ ] **Step 3: Extend `apps/api/app/modules/settings/schemas.py`**
+
+In `ProfileOut`, after the existing `whatsapp_waba_id: str` line, add:
+```python
+    whatsapp_verify_token: str
+```
+In `ProfileUpdate`, after the existing `whatsapp_waba_id: str | None = Field(default=None, max_length=64)` line, add:
+```python
+    whatsapp_app_secret: str | None = Field(default=None)
+```
+
+- [ ] **Step 4: Extend `apps/api/app/modules/settings/service.py`**
+
+Add the import at the top (alongside the existing `whatsapp_templates` import):
+```python
+import secrets
+
+from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+```
+Add `"whatsapp_app_secret"` to the `_FIELDS` tuple:
+```python
+_FIELDS = (
+    "display_name", "document", "email", "phone", "address", "website", "about",
+    "logo_url", "primary_color", "secondary_color", "accent_color", "text_color",
+    "bg_color", "font", "timezone",
+    "whatsapp_token", "whatsapp_phone_id", "whatsapp_waba_id", "whatsapp_app_secret",
+)
+```
+Add a new helper function right before `update_profile`:
+```python
+def _sync_whatsapp_webhook_snapshot(db: Session, profile: TenantProfile) -> None:
+    """Mantém `public_whatsapp_accounts` em sincronia com as credenciais do tenant — dual-write
+    no mesmo espírito de `integration_keys`/`public_integration_keys`. Remove qualquer snapshot
+    antigo do tenant (cobre o caso de `phone_id` ter mudado) e recria só se as 4 credenciais
+    (token/phone_id/waba_id/app_secret) estiverem TODAS presentes. Gera `verify_token`
+    automaticamente na primeira vez que isso acontece."""
+    existing = db.scalars(
+        select(PublicWhatsappAccount).where(
+            PublicWhatsappAccount.tenant_id == profile.tenant_id
+        )
+    ).all()
+    for row in existing:
+        db.delete(row)
+
+    fully_configured = bool(
+        profile.whatsapp_token
+        and profile.whatsapp_phone_id
+        and profile.whatsapp_waba_id
+        and profile.whatsapp_app_secret
+    )
+    if not fully_configured:
+        profile.whatsapp_verify_token = None
+        return
+
+    if not profile.whatsapp_verify_token:
+        profile.whatsapp_verify_token = secrets.token_urlsafe(24)
+
+    db.add(
+        PublicWhatsappAccount(
+            phone_number_id=profile.whatsapp_phone_id,
+            tenant_id=profile.tenant_id,
+            app_secret=profile.whatsapp_app_secret,
+            verify_token=profile.whatsapp_verify_token,
+        )
+    )
+```
+Then call it inside `update_profile`, right before `audit.record(...)`:
+```python
+    _sync_whatsapp_webhook_snapshot(db, profile)
+    audit.record(db, tenant_id=tenant_id, actor=actor, action="settings.profile.update",
+                 target=profile.id)
+```
+Note: `TenantProfile` doesn't currently expose `.tenant_id` as an attribute name collision issue
+— it's the `TenantMixin` column, already present; `profile.tenant_id` works as-is.
+
+- [ ] **Step 5: Extend `apps/api/app/modules/settings/router.py`**
+
+In `_out()`, after the existing `whatsapp_waba_id=p.whatsapp_waba_id or "",` line, add:
+```python
+        whatsapp_verify_token=p.whatsapp_verify_token or "",
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_settings.py -v`
+Expected: all PASS (existing + 3 new).
+
+- [ ] **Step 7: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/modules/settings/ tests/test_settings.py`
+Expected: `All checks passed!`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/settings/ apps/api/tests/test_settings.py
+git commit -m "feat: 4ª credencial do WhatsApp (app_secret) + verify_token auto-gerado + snapshot do webhook"
+```
+
+---
+
+### Task 4: `whatsapp_inbox` — schemas + service (ingestão, lead automático, timeline, janela de 24h, resposta)
+
+**Files:**
+- Create: `apps/api/app/modules/whatsapp_inbox/schemas.py`
+- Create: `apps/api/app/modules/whatsapp_inbox/service.py`
+- Test: `apps/api/tests/test_whatsapp_inbox_service.py`
+
+**Interfaces:**
+- Consumes: `WhatsappMessage`, `WhatsappConversationState`, `PublicWhatsappAccount`, direction/kind/media_status constants (Task 1); `whatsapp.verify_webhook_signature/upload_media/fetch_media_url/download_media/send_media/send_text` (Task 2, PR #35); `whatsapp.send_template` (PR #35); `crm_service.create_client`, `ClientCreate`, `SOURCE_VALUES` (existing, Task 1 addition); `attachments.service.create_attachment` (existing); `settings_service.get_profile` (existing); `Notification` model (existing); `WhatsappTemplate`, `STATUS_APPROVED`, `PURPOSE_LABELS` (existing, PR #35).
+- Produces: `WhatsappInboxError(Exception)` (message, status_code), `ingest_webhook_payload(db, *, payload: dict) -> None` (idempotent, creates/looks-up client, writes `WhatsappMessage`), `list_conversations(db, tenant_id: str) -> list[dict]` (one row per client with activity: `client_id`, `client_name`, `last_message_at`, `last_message_preview`, `unread`), `get_timeline(db, *, client_id: str) -> list[dict]` (merged `WhatsappMessage` + `Notification` rows, each `{"source": "conversation"|"automated", "direction": "in"|"out", "kind": str, "text_body": str, "media_attachment_id": str|None, "created_at": datetime, "purpose_label": str|None}`), `is_within_session_window(db, *, client_id: str) -> bool`, `mark_read(db, *, tenant_id: str, client_id: str) -> None`, `send_reply_text(db, *, tenant_id: str, actor: str, client_id: str, text: str) -> WhatsappMessage`, `send_reply_media(db, *, tenant_id: str, actor: str, client_id: str, file_bytes: bytes, filename: str, mime_type: str, caption: str) -> WhatsappMessage`, `send_reply_template(db, *, tenant_id: str, actor: str, client_id: str, template_id: str, variables: list[str]) -> WhatsappMessage`.
+
+- [ ] **Step 1: Write `schemas.py`**
+
+```python
+# apps/api/app/modules/whatsapp_inbox/schemas.py
+"""Schemas do inbox de WhatsApp: lista de conversas, linha do tempo, resposta."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ConversationSummary(BaseModel):
+    client_id: str
+    client_name: str
+    client_phone: str | None
+    last_message_at: datetime | None
+    last_message_preview: str
+    unread: bool
+
+
+class TimelineEntry(BaseModel):
+    source: str  # "conversation" | "automated"
+    direction: str  # "in" | "out"
+    kind: str
+    text_body: str
+    media_attachment_id: str | None
+    purpose_label: str | None
+    created_at: datetime
+
+
+class SendTextRequest(BaseModel):
+    text: str
+
+
+class SendTemplateRequest(BaseModel):
+    template_id: str
+    variables: list[str] = []
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+# apps/api/tests/test_whatsapp_inbox_service.py
+"""Testes do serviço do inbox de WhatsApp: ingestão do webhook, lead automático, timeline
+unificada, janela de 24h, resposta (texto/mídia/template)."""
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.notifications.models import Notification
+from app.modules.settings import service as settings_service
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    MEDIA_STATUS_PENDING,
+    PublicWhatsappAccount,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _configure_credentials(db) -> TenantProfile:
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-123"
+    profile.whatsapp_waba_id = "waba"
+    profile.whatsapp_app_secret = "secret"
+    profile.whatsapp_verify_token = "verify-abc"
+    db.add(PublicWhatsappAccount(
+        phone_number_id="phone-123", tenant_id=TENANT_ID, app_secret="secret",
+        verify_token="verify-abc",
+    ))
+    db.commit()
+    return profile
+
+
+def _text_message_payload(*, phone_number_id: str, wa_id: str, from_number: str, body: str,
+                           msg_id: str = "wamid.abc") -> dict:
+    return {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": phone_number_id},
+                    "contacts": [{"profile": {"name": "Fulano"}, "wa_id": wa_id}],
+                    "messages": [{
+                        "from": from_number, "id": msg_id, "type": "text",
+                        "text": {"body": body},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+
+
+def test_ingest_creates_lead_for_unknown_number(db):
+    _configure_credentials(db)
+    inbox_service.ingest_webhook_payload(
+        db, payload=_text_message_payload(
+            phone_number_id="phone-123", wa_id="5511999999999",
+            from_number="5511999999999", body="Oi, quero saber do cardápio",
+        ),
+    )
+    client = db.scalar(select(Client).where(Client.phone == "5511999999999"))
+    assert client is not None
+    assert client.source == "whatsapp"
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.client_id == client.id))
+    assert msg.direction == DIRECTION_IN
+    assert msg.text_body == "Oi, quero saber do cardápio"
+
+
+def test_ingest_reuses_existing_client_by_phone(db):
+    _configure_credentials(db)
+    existing = Client(tenant_id=TENANT_ID, name="Maria", phone="5511988887777", source="manual")
+    db.add(existing)
+    db.commit()
+    inbox_service.ingest_webhook_payload(
+        db, payload=_text_message_payload(
+            phone_number_id="phone-123", wa_id="5511988887777",
+            from_number="5511988887777", body="oi",
+        ),
+    )
+    clients = db.scalars(select(Client).where(Client.phone == "5511988887777")).all()
+    assert len(clients) == 1  # não duplicou
+
+
+def test_ingest_is_idempotent_on_duplicate_wa_message_id(db):
+    _configure_credentials(db)
+    payload = _text_message_payload(
+        phone_number_id="phone-123", wa_id="5511977776666",
+        from_number="5511977776666", body="oi", msg_id="wamid.dup",
+    )
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    count = db.scalar(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.dup")
+    )
+    all_rows = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.dup")
+    ).all()
+    assert len(all_rows) == 1
+
+
+def test_ingest_image_message_marks_media_pending(db):
+    _configure_credentials(db)
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-123"},
+                    "contacts": [{"profile": {"name": "Cliente"}, "wa_id": "5511911112222"}],
+                    "messages": [{
+                        "from": "5511911112222", "id": "wamid.img", "type": "image",
+                        "image": {"id": "media-999", "mime_type": "image/jpeg"},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    inbox_service.ingest_webhook_payload(db, payload=payload)
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.img"))
+    assert msg.kind == "image"
+    assert msg.media_status == MEDIA_STATUS_PENDING
+
+
+def test_is_within_session_window_true_right_after_inbound(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+    assert inbox_service.is_within_session_window(db, client_id=client.id) is True
+
+
+def test_is_within_session_window_false_when_never_messaged(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900002222", source="manual")
+    db.add(client)
+    db.commit()
+    assert inbox_service.is_within_session_window(db, client_id=client.id) is False
+
+
+def test_get_timeline_merges_conversation_and_automated(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900003333", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="Oi",
+    ))
+    db.add(Notification(
+        tenant_id=TENANT_ID, channel="whatsapp", recipient=client.phone, client_id=client.id,
+        message="Lembrete: sua cobrança vence amanhã", status="sent",
+    ))
+    db.commit()
+    timeline = inbox_service.get_timeline(db, client_id=client.id)
+    sources = {e["source"] for e in timeline}
+    assert sources == {"conversation", "automated"}
+
+
+def test_send_reply_text_within_window(db, monkeypatch: pytest.MonkeyPatch):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900004444", source="manual")
+    db.add(client)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="text",
+        text_body="oi",
+    ))
+    db.commit()
+
+    captured = {}
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda **kw: (captured.update(kw), "sent")[1],
+    )
+    msg = inbox_service.send_reply_text(
+        db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="Olá! Segue o cardápio.",
+    )
+    assert msg.direction == DIRECTION_OUT
+    assert msg.status == "sent"
+    assert captured["token"] == "tok"
+    assert captured["phone_id"] == "phone-123"
+
+
+def test_send_reply_text_raises_outside_window(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900005555", source="manual")
+    db.add(client)
+    db.commit()
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_text(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="oi",
+        )
+
+
+def test_send_reply_template_requires_approved_template(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
+    db.add(client)
+    tpl = WhatsappTemplate(
+        tenant_id=TENANT_ID, name="fora_janela", language="pt_BR",
+        category_requested="UTILITY", status="PENDING", body_text="Olá {{1}}",
+        variable_count=1, variable_examples=["Nome"],
+    )
+    db.add(tpl)
+    db.commit()
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.send_reply_template(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id,
+            template_id=tpl.id, variables=["Fulano"],
+        )
+
+
+def test_mark_read_updates_state(db):
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900007777", source="manual")
+    db.add(client)
+    db.commit()
+    inbox_service.mark_read(db, tenant_id=TENANT_ID, client_id=client.id)
+    state = db.scalar(
+        select(WhatsappConversationState).where(
+            WhatsappConversationState.client_id == client.id
+        )
+    )
+    assert state is not None
+    assert state.last_read_at is not None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_service.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.modules.whatsapp_inbox.service'`
+
+- [ ] **Step 4: Write `service.py`**
+
+```python
+# apps/api/app/modules/whatsapp_inbox/service.py
+"""Inbox de WhatsApp: ingestão do webhook, lead automático, linha do tempo unificada, janela
+de 24h e envio de resposta (texto/mídia/template).
+
+Ver docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md para o desenho completo.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import whatsapp
+from app.modules.attachments import service as attachments_service
+from app.modules.crm.models import Client
+from app.modules.notifications.models import Notification
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    KIND_TEXT,
+    MEDIA_STATUS_NONE,
+    MEDIA_STATUS_PENDING,
+    WhatsappConversationState,
+    WhatsappMessage,
+)
+from app.modules.whatsapp_templates.models import PURPOSE_LABELS, STATUS_APPROVED, WhatsappTemplate
+
+logger = logging.getLogger("e1p.whatsapp_inbox")
+
+SESSION_WINDOW = timedelta(hours=24)
+
+
+class WhatsappInboxError(Exception):
+    def __init__(self, message: str, status_code: int = 422) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+# ── Ingestão (webhook) ──────────────────────────────────────────────────────
+
+
+def _extract_messages(payload: dict) -> list[tuple[dict, str]]:
+    """Devolve [(mensagem, nome_do_contato)] achatando o formato aninhado do payload da Meta."""
+    out: list[tuple[dict, str]] = []
+    for entry in payload.get("entry", []):
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            contacts = value.get("contacts", [])
+            name = contacts[0]["profile"]["name"] if contacts else "Cliente"
+            for msg in value.get("messages", []):
+                out.append((msg, name))
+    return out
+
+
+def _get_or_create_client(db: Session, *, tenant_id: str, phone: str, name: str) -> Client:
+    client = db.scalar(select(Client).where(Client.phone == phone))
+    if client is not None:
+        return client
+    from app.modules.crm import service as crm_service
+    from app.modules.crm.schemas import ClientCreate
+
+    return crm_service.create_client(
+        db, tenant_id=tenant_id, actor="whatsapp:inbox",
+        data=ClientCreate(name=name or phone, phone=phone, source="whatsapp"),
+    )
+
+
+def ingest_webhook_payload(db: Session, *, tenant_id: str, payload: dict) -> None:
+    """Processa UM payload de webhook, já dentro da tenant_session correta (o roteamento por
+    `phone_number_id` -> `tenant_id` acontece no router, ANTES de chamar esta função —
+    ver Task 5). `tenant_id` é sempre conhecido pelo chamador nesse ponto."""
+    for msg, contact_name in _extract_messages(payload):
+        wa_message_id = msg.get("id")
+        if wa_message_id and db.scalar(
+            select(WhatsappMessage).where(WhatsappMessage.wa_message_id == wa_message_id)
+        ):
+            continue  # duplicata (Meta reentrega o mesmo evento às vezes) — ignora
+
+        from_number = msg.get("from", "")
+        kind = msg.get("type", "text")
+        text_body = ""
+        media_status = MEDIA_STATUS_NONE
+
+        if kind == "text":
+            text_body = msg.get("text", {}).get("body", "")
+        elif kind in ("image", "audio", "document", "video"):
+            media_obj = msg.get(kind, {})
+            text_body = media_obj.get("caption", "")
+            media_status = MEDIA_STATUS_PENDING
+        else:
+            kind = "text"
+            text_body = "[tipo de mensagem não suportado]"
+
+        client = _get_or_create_client(
+            db, tenant_id=tenant_id, phone=from_number, name=contact_name
+        )
+        db.add(WhatsappMessage(
+            tenant_id=tenant_id, client_id=client.id, direction=DIRECTION_IN, kind=kind,
+            text_body=text_body, media_status=media_status, wa_message_id=wa_message_id,
+            status="sent",
+        ))
+    db.commit()
+```
+
+- [ ] **Step 4b: Continue `service.py` — timeline, janela de 24h, mark_read, envio de resposta**
+
+Append to the same file:
+```python
+# ── Timeline unificada + janela de 24h ──────────────────────────────────────
+
+
+def list_conversations(db: Session, tenant_id: str) -> list[dict]:
+    """Uma linha por cliente com pelo menos 1 WhatsappMessage, ordenada pela mais recente."""
+    last_msgs: dict[str, WhatsappMessage] = {}
+    for msg in db.scalars(
+        select(WhatsappMessage).order_by(WhatsappMessage.created_at)
+    ).all():
+        last_msgs[msg.client_id] = msg  # a última iteração (ordem crescente) vence
+
+    states = {
+        s.client_id: s
+        for s in db.scalars(select(WhatsappConversationState)).all()
+    }
+
+    out = []
+    for client_id, last_msg in last_msgs.items():
+        client = db.get(Client, client_id)
+        if client is None:
+            continue
+        state = states.get(client_id)
+        unread = (
+            last_msg.direction == DIRECTION_IN
+            and (state is None or state.last_read_at is None or last_msg.created_at > state.last_read_at)
+        )
+        out.append({
+            "client_id": client_id,
+            "client_name": client.name,
+            "client_phone": client.phone,
+            "last_message_at": last_msg.created_at,
+            "last_message_preview": last_msg.text_body or f"[{last_msg.kind}]",
+            "unread": unread,
+        })
+    out.sort(key=lambda c: c["last_message_at"], reverse=True)
+    return out
+
+
+def get_timeline(db: Session, *, client_id: str) -> list[dict]:
+    """Mescla WhatsappMessage (conversa) + Notification(channel=whatsapp) do mesmo cliente
+    (avisos automáticos já existentes: cobrança, contrato, etc.) — leitura combinada, SEM
+    migrar nenhum dado antigo (ver design doc §2)."""
+    entries: list[dict] = []
+    for msg in db.scalars(
+        select(WhatsappMessage)
+        .where(WhatsappMessage.client_id == client_id)
+        .order_by(WhatsappMessage.created_at)
+    ).all():
+        entries.append({
+            "source": "conversation",
+            "direction": msg.direction,
+            "kind": msg.kind,
+            "text_body": msg.text_body,
+            "media_attachment_id": msg.media_attachment_id,
+            "purpose_label": None,
+            "created_at": msg.created_at,
+        })
+    for notif in db.scalars(
+        select(Notification)
+        .where(Notification.client_id == client_id, Notification.channel == "whatsapp")
+        .order_by(Notification.created_at)
+    ).all():
+        entries.append({
+            "source": "automated",
+            "direction": "out",
+            "kind": "text",
+            "text_body": notif.message,
+            "media_attachment_id": None,
+            "purpose_label": PURPOSE_LABELS.get(
+                _guess_purpose(notif.message), "Aviso automático"
+            ),
+            "created_at": notif.created_at,
+        })
+    entries.sort(key=lambda e: e["created_at"])
+    return entries
+
+
+def _guess_purpose(_message: str) -> str:
+    """Placeholder simples: hoje `Notification` não guarda o propósito explicitamente, então
+    todo aviso automático cai no rótulo genérico. Refinamento (guardar o propósito na própria
+    Notification) fica para depois — não bloqueia esta feature."""
+    return "__generic__"
+
+
+def is_within_session_window(db: Session, *, client_id: str) -> bool:
+    last_inbound = db.scalar(
+        select(WhatsappMessage)
+        .where(WhatsappMessage.client_id == client_id, WhatsappMessage.direction == DIRECTION_IN)
+        .order_by(WhatsappMessage.created_at.desc())
+        .limit(1)
+    )
+    if last_inbound is None:
+        return False
+    return datetime.now(UTC) - last_inbound.created_at < SESSION_WINDOW
+
+
+def mark_read(db: Session, *, tenant_id: str, client_id: str) -> None:
+    state = db.scalar(
+        select(WhatsappConversationState).where(
+            WhatsappConversationState.client_id == client_id
+        )
+    )
+    if state is None:
+        state = WhatsappConversationState(tenant_id=tenant_id, client_id=client_id)
+        db.add(state)
+    state.last_read_at = datetime.now(UTC)
+    db.commit()
+
+
+# ── Envio de resposta ────────────────────────────────────────────────────────
+
+
+def send_reply_text(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, text: str
+) -> WhatsappMessage:
+    if not is_within_session_window(db, client_id=client_id):
+        raise WhatsappInboxError(
+            "Fora da janela de 24h — use um template aprovado para responder", 422
+        )
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    profile = settings_service.get_profile(db, tenant_id)
+    status = whatsapp.send_text(
+        to=client.phone or "", text=text, token=profile.whatsapp_token,
+        phone_id=profile.whatsapp_phone_id,
+    )
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=KIND_TEXT,
+        text_body=text, status=status,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+def send_reply_media(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, file_bytes: bytes,
+    filename: str, mime_type: str, caption: str = "",
+) -> WhatsappMessage:
+    if not is_within_session_window(db, client_id=client_id):
+        raise WhatsappInboxError(
+            "Fora da janela de 24h — use um template aprovado para responder", 422
+        )
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    kind_map = {"image/jpeg": "image", "image/png": "image", "application/pdf": "document",
+                "audio/mpeg": "audio", "audio/ogg": "audio"}
+    kind = kind_map.get(mime_type, "document")
+    profile = settings_service.get_profile(db, tenant_id)
+    try:
+        media_id = whatsapp.upload_media(
+            phone_id=profile.whatsapp_phone_id or "", token=profile.whatsapp_token or "",
+            file_bytes=file_bytes, filename=filename, mime_type=mime_type,
+        )
+    except whatsapp.WhatsappApiError as exc:
+        raise WhatsappInboxError(f"Falha ao subir mídia: {exc}", 502) from exc
+    status = whatsapp.send_media(
+        to=client.phone or "", token=profile.whatsapp_token or "",
+        phone_id=profile.whatsapp_phone_id or "", kind=kind, media_id=media_id, caption=caption,
+    )
+    attachment = attachments_service.create_attachment(
+        db, tenant_id=tenant_id, actor=actor, owner_type="whatsapp_message",
+        owner_id="pending", label="outro", filename=filename, content_type=mime_type,
+        data=file_bytes,
+    )
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=kind,
+        text_body=caption, media_attachment_id=attachment.id, status=status,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    attachment.owner_id = msg.id
+    db.commit()
+    return msg
+
+
+def send_reply_template(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, template_id: str,
+    variables: list[str],
+) -> WhatsappMessage:
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    template = db.get(WhatsappTemplate, template_id)
+    if template is None or template.status != STATUS_APPROVED:
+        raise WhatsappInboxError("Template não encontrado ou ainda não aprovado pela Meta", 422)
+    profile = settings_service.get_profile(db, tenant_id)
+    status = whatsapp.send_template(
+        to=client.phone or "", token=profile.whatsapp_token or "",
+        phone_id=profile.whatsapp_phone_id or "", template_name=template.name,
+        language=template.language, variables=variables,
+    )
+    rendered = template.body_text
+    for i, value in enumerate(variables, start=1):
+        rendered = rendered.replace(f"{{{{{i}}}}}", value)
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_OUT, kind=KIND_TEXT,
+        text_body=rendered, status=status,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_service.py -v`
+Expected: all 11 tests PASS.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/modules/whatsapp_inbox/ tests/test_whatsapp_inbox_service.py`
+Expected: `All checks passed!` (this file was assembled across Steps 4 and 4b of this task — if
+ruff reports an unused import, it means one of the two blocks pulled in a name the other block
+didn't end up needing; remove it).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/schemas.py apps/api/app/modules/whatsapp_inbox/service.py apps/api/tests/test_whatsapp_inbox_service.py
+git commit -m "feat: serviço do inbox de WhatsApp (ingestão, lead automático, timeline unificada, resposta)"
+```
+
+---
+
+### Task 5: Webhook público (GET verificação + POST recebimento) + roteamento multi-tenant
+
+**Files:**
+- Modify: `apps/api/app/modules/whatsapp_inbox/service.py` (add tenant-resolution helpers)
+- Create: `apps/api/app/modules/whatsapp_inbox/router.py`
+- Test: `apps/api/tests/test_whatsapp_inbox_webhook.py`
+
+**Interfaces:**
+- Consumes: `PublicWhatsappAccount` (Task 1), `whatsapp.verify_webhook_signature` (Task 2), `ingest_webhook_payload` (Task 4), `get_db`/`get_tenant_session_factory` (existing, `app.db.session`).
+- Produces: `public_router` (prefix `/public/whatsapp`) with `GET /webhook` and `POST /webhook`; `resolve_tenant_and_secret(db, *, phone_number_id: str) -> PublicWhatsappAccount | None` (new, in `service.py`).
+
+- [ ] **Step 1: Add the resolution helper to `service.py`**
+
+Append to `apps/api/app/modules/whatsapp_inbox/service.py`:
+```python
+from app.modules.whatsapp_inbox.models import PublicWhatsappAccount
+
+
+def resolve_account(db: Session, *, phone_number_id: str) -> PublicWhatsappAccount | None:
+    """Resolve tenant/app_secret pelo `phone_number_id` — chamado numa sessão SEM tenant
+    (`get_db`), ANTES de qualquer autenticação, mesmo padrão de `PublicIntegrationKey`."""
+    return db.get(PublicWhatsappAccount, phone_number_id)
+
+
+def resolve_by_verify_token(db: Session, *, verify_token: str) -> PublicWhatsappAccount | None:
+    """Usado só no handshake GET — confere se o token bate com ALGUM tenant cadastrado."""
+    return db.scalar(
+        select(PublicWhatsappAccount).where(
+            PublicWhatsappAccount.verify_token == verify_token
+        )
+    )
+```
+(Add `select` to the existing `from sqlalchemy import select` import already at the top of the
+file — it's already imported from Task 4, no new import line needed.)
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+# apps/api/tests/test_whatsapp_inbox_webhook.py
+"""Testes do webhook público de WhatsApp: handshake de verificação + recebimento de mensagem."""
+import hashlib
+import hmac
+import json
+
+from sqlalchemy import select
+
+from app.modules.crm.models import Client
+from app.modules.whatsapp_inbox.models import PublicWhatsappAccount, WhatsappMessage
+
+
+def _seed_account(db, *, phone_number_id="phone-123", tenant_id="t-1", app_secret="shh",
+                   verify_token="verify-me"):
+    db.add(PublicWhatsappAccount(
+        phone_number_id=phone_number_id, tenant_id=tenant_id, app_secret=app_secret,
+        verify_token=verify_token,
+    ))
+    db.commit()
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_webhook_verification_handshake_success(client, db):
+    _seed_account(db)
+    resp = client.get(
+        "/public/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe", "hub.verify_token": "verify-me",
+            "hub.challenge": "challenge-xyz",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.text == "challenge-xyz"
+
+
+def test_webhook_verification_handshake_wrong_token(client, db):
+    _seed_account(db)
+    resp = client.get(
+        "/public/whatsapp/webhook",
+        params={
+            "hub.mode": "subscribe", "hub.verify_token": "token-errado",
+            "hub.challenge": "challenge-xyz",
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_webhook_post_creates_message_with_valid_signature(client, db):
+    _seed_account(db, phone_number_id="phone-abc", tenant_id="t-2", app_secret="segredo-2")
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "metadata": {"phone_number_id": "phone-abc"},
+                    "contacts": [{"profile": {"name": "Cliente Teste"}, "wa_id": "5511900000000"}],
+                    "messages": [{
+                        "from": "5511900000000", "id": "wamid.test1", "type": "text",
+                        "text": {"body": "Olá!"},
+                    }],
+                },
+                "field": "messages",
+            }],
+        }],
+    }
+    body = json.dumps(payload).encode()
+    sig = _sign(body, "segredo-2")
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": sig},
+    )
+    assert resp.status_code == 200
+    msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.test1"))
+    assert msg is not None
+    assert msg.text_body == "Olá!"
+
+
+def test_webhook_post_rejects_invalid_signature(client, db):
+    _seed_account(db, phone_number_id="phone-def", tenant_id="t-3", app_secret="segredo-3")
+    payload = {"entry": []}
+    body = json.dumps(payload).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=invalido"},
+    )
+    assert resp.status_code == 403
+
+
+def test_webhook_post_rejects_unknown_phone_number_id(client, db):
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {"metadata": {"phone_number_id": "numero-desconhecido"}, "messages": []},
+                "field": "messages",
+            }],
+        }],
+    }
+    body = json.dumps(payload).encode()
+    resp = client.post(
+        "/public/whatsapp/webhook", content=body,
+        headers={"content-type": "application/json", "x-hub-signature-256": "sha256=irrelevante"},
+    )
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_webhook.py -v`
+Expected: FAIL — `404 Not Found` for a route that doesn't exist yet (router not registered).
+
+- [ ] **Step 4: Write `router.py`**
+
+```python
+# apps/api/app/modules/whatsapp_inbox/router.py
+"""Webhook público de WhatsApp (recebimento de mensagens) + rotas autenticadas da inbox."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.db.session import get_db, get_tenant_session_factory
+from app.modules.whatsapp_inbox import service
+
+public_router = APIRouter(prefix="/public/whatsapp", tags=["whatsapp-inbox-public"])
+router = APIRouter(prefix="/whatsapp-conversations", tags=["whatsapp-inbox"])
+
+_guard = require_module("crm")
+
+
+@public_router.get("/webhook")
+def verify_webhook(
+    hub_mode: str = Query(alias="hub.mode"),
+    hub_verify_token: str = Query(alias="hub.verify_token"),
+    hub_challenge: str = Query(alias="hub.challenge"),
+    db: Session = Depends(get_db),
+) -> PlainTextResponse:
+    """Handshake de verificação chamado 1x pela Meta quando o tenant configura o webhook no
+    painel dele. Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_whatsapp_accounts`,
+    tabela GLOBAL sem RLS, pelo verify_token — não toca tabela de negócio."""
+    if hub_mode != "subscribe" or service.resolve_by_verify_token(
+        db, verify_token=hub_verify_token
+    ) is None:
+        raise HTTPException(status_code=403, detail="Token de verificação inválido")
+    return PlainTextResponse(content=hub_challenge)
+
+
+@public_router.post("/webhook")
+async def receive_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    session_factory=Depends(get_tenant_session_factory),
+) -> dict:
+    """Recebe o evento da Meta. Descobre o tenant pelo `phone_number_id` do payload ANTES de
+    validar a assinatura (a assinatura usa o `app_secret` DAQUELE tenant, então precisamos saber
+    quem é primeiro). Se a assinatura não bater, rejeita sem processar nada."""
+    body = await request.body()
+    import json
+
+    payload = json.loads(body) if body else {}
+    phone_number_id = None
+    for entry in payload.get("entry", []):
+        for change in entry.get("changes", []):
+            phone_number_id = change.get("value", {}).get("metadata", {}).get("phone_number_id")
+            if phone_number_id:
+                break
+        if phone_number_id:
+            break
+
+    if not phone_number_id:
+        raise HTTPException(status_code=404, detail="phone_number_id não encontrado no payload")
+
+    account = service.resolve_account(db, phone_number_id=phone_number_id)
+    if account is None:
+        raise HTTPException(status_code=404, detail="Número não configurado nesta plataforma")
+
+    from app.core import whatsapp
+
+    signature = request.headers.get("x-hub-signature-256")
+    if not whatsapp.verify_webhook_signature(
+        app_secret=account.app_secret, body=body, signature_header=signature
+    ):
+        raise HTTPException(status_code=403, detail="Assinatura inválida")
+
+    with session_factory(account.tenant_id) as tdb:
+        service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
+
+    return {"status": "ok"}
+
+
+# ── Rotas autenticadas (tela de Conversas) ──────────────────────────────────
+
+
+def _err(e: service.WhatsappInboxError) -> HTTPException:
+    return HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("")
+def list_conversations(
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> list[dict]:
+    return service.list_conversations(db, user.tenant_id)
+
+
+@router.get("/{client_id}/timeline")
+def get_timeline(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> list[dict]:
+    return service.get_timeline(db, client_id=client_id)
+
+
+@router.get("/{client_id}/window")
+def get_window(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+) -> dict:
+    return {"within_session_window": service.is_within_session_window(db, client_id=client_id)}
+
+
+@router.post("/{client_id}/read", status_code=204)
+def mark_read(
+    client_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+):
+    service.mark_read(db, tenant_id=user.tenant_id, client_id=client_id)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_webhook.py -v`
+Expected: FAIL still — the router isn't registered in `app/main.py`/`app/modules/__init__.py`
+yet. That's Task 8. Note in this task's own run that it will fail with 404 on ALL routes until
+Task 8 registers them; this is expected and acceptable — commit anyway, since the code itself is
+correct and self-contained (matches the pattern the rest of this plan already used in the
+previous WhatsApp PR, where router registration was deliberately deferred to a final wiring
+task to avoid file-ownership conflicts between parallel workers).
+
+- [ ] **Step 6: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/modules/whatsapp_inbox/`
+Expected: `All checks passed!`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/router.py apps/api/app/modules/whatsapp_inbox/service.py apps/api/tests/test_whatsapp_inbox_webhook.py
+git commit -m "feat: webhook público do inbox de WhatsApp (verificação + recebimento)"
+```
+
+---
+
+### Task 6: Endpoints autenticados de resposta (texto / mídia / template) + registro dos routers
+
+**Files:**
+- Modify: `apps/api/app/modules/whatsapp_inbox/router.py`
+- Modify: `apps/api/app/modules/__init__.py`
+- Test: `apps/api/tests/test_whatsapp_inbox_reply.py`
+
+**Interfaces:**
+- Consumes: `send_reply_text/send_reply_media/send_reply_template` (Task 4), `SendTextRequest`/`SendTemplateRequest` (Task 4).
+- Produces: `POST /whatsapp-conversations/{client_id}/messages/text`, `POST /whatsapp-conversations/{client_id}/messages/media` (multipart), `POST /whatsapp-conversations/{client_id}/messages/template`. `ALL_ROUTERS` now includes `whatsapp_inbox_router` and `whatsapp_inbox_public_router`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# apps/api/tests/test_whatsapp_inbox_reply.py
+"""Testes dos endpoints autenticados de resposta da inbox (texto/mídia/template)."""
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox.models import DIRECTION_IN, WhatsappMessage
+from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+
+TENANT_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def _configure(db):
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-1"
+    profile.whatsapp_waba_id = "waba"
+    db.commit()
+
+
+def test_reply_text_endpoint_requires_open_window(client, db, monkeypatch):
+    _configure(db)
+    c = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900000001", source="manual")
+    db.add(c)
+    db.commit()
+    resp = client.post(f"/whatsapp-conversations/{c.id}/messages/text", json={"text": "oi"})
+    assert resp.status_code == 422
+
+
+def test_reply_text_endpoint_success_within_window(client, db, monkeypatch):
+    _configure(db)
+    c = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900000002", source="manual")
+    db.add(c)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=c.id, direction=DIRECTION_IN, kind="text", text_body="oi",
+    ))
+    db.commit()
+    monkeypatch.setattr(whatsapp, "send_text", lambda **_kw: "sent")
+    resp = client.post(
+        f"/whatsapp-conversations/{c.id}/messages/text", json={"text": "Olá, tudo bem?"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "sent"
+
+
+def test_reply_template_endpoint_success(client, db, monkeypatch):
+    _configure(db)
+    c = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900000003", source="manual")
+    tpl = WhatsappTemplate(
+        tenant_id=TENANT_ID, name="cardapio", language="pt_BR", category_requested="UTILITY",
+        status=STATUS_APPROVED, body_text="Olá {{1}}, segue nosso cardápio!", variable_count=1,
+        variable_examples=["Nome"],
+    )
+    db.add(c)
+    db.add(tpl)
+    db.commit()
+    monkeypatch.setattr(whatsapp, "send_template", lambda **_kw: "sent")
+    resp = client.post(
+        f"/whatsapp-conversations/{c.id}/messages/template",
+        json={"template_id": tpl.id, "variables": ["Fulano"]},
+    )
+    assert resp.status_code == 200
+    assert "Fulano" in resp.json()["text_body"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_reply.py -v`
+Expected: FAIL — 404 (routes don't exist yet / router not registered).
+
+- [ ] **Step 3: Add the 3 endpoints to `router.py`**
+
+Add these imports to the top of `apps/api/app/modules/whatsapp_inbox/router.py`:
+```python
+from fastapi import File, Form, UploadFile
+
+from app.modules.whatsapp_inbox.schemas import SendTemplateRequest, SendTextRequest
+```
+Append at the end of the file:
+```python
+def _msg_out(msg) -> dict:
+    return {
+        "id": msg.id, "direction": msg.direction, "kind": msg.kind,
+        "text_body": msg.text_body, "status": msg.status, "created_at": msg.created_at,
+    }
+
+
+@router.post("/{client_id}/messages/text")
+def send_text_reply(
+    client_id: str, data: SendTextRequest,
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    try:
+        msg = service.send_reply_text(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id, text=data.text,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)
+
+
+@router.post("/{client_id}/messages/media")
+async def send_media_reply(
+    client_id: str, caption: str = Form(""), file: UploadFile = File(...),
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    data = await file.read()
+    try:
+        msg = service.send_reply_media(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id,
+            file_bytes=data, filename=file.filename or "arquivo",
+            mime_type=file.content_type or "application/octet-stream", caption=caption,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)
+
+
+@router.post("/{client_id}/messages/template")
+def send_template_reply(
+    client_id: str, data: SendTemplateRequest,
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    try:
+        msg = service.send_reply_template(
+            db, tenant_id=user.tenant_id, actor=user.user_id, client_id=client_id,
+            template_id=data.template_id, variables=data.variables,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return _msg_out(msg)
+```
+
+- [ ] **Step 4: Register both routers in `apps/api/app/modules/__init__.py`**
+
+Add the import (alphabetically near the other `whatsapp`-prefixed import):
+```python
+from app.modules.whatsapp_inbox.router import public_router as whatsapp_inbox_public_router
+from app.modules.whatsapp_inbox.router import router as whatsapp_inbox_router
+```
+Add both to `ALL_ROUTERS`, near `whatsapp_templates_router`:
+```python
+    whatsapp_templates_router,
+    whatsapp_inbox_router,
+    whatsapp_inbox_public_router,
+```
+
+- [ ] **Step 5: Run ALL whatsapp_inbox tests to verify they pass (this also un-blocks Task 5's webhook tests)**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_reply.py tests/test_whatsapp_inbox_webhook.py -v`
+Expected: all PASS now that the routers are registered.
+
+- [ ] **Step 6: Run the FULL backend suite to check for regressions**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest -q -m "not rls_e2e"`
+Expected: all passing, no regressions in unrelated modules.
+
+- [ ] **Step 7: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/`
+Expected: `All checks passed!`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/router.py apps/api/app/modules/__init__.py apps/api/tests/test_whatsapp_inbox_reply.py
+git commit -m "feat: endpoints de resposta da inbox (texto/mídia/template) + registro dos routers"
+```
+
+---
+
+### Task 7: Worker — download assíncrono de mídia recebida
+
+**Files:**
+- Modify: `apps/api/app/modules/whatsapp_inbox/service.py`
+- Modify: `apps/api/app/worker.py`
+- Test: `apps/api/tests/test_whatsapp_inbox_media_worker.py`
+
+**Interfaces:**
+- Consumes: `whatsapp.fetch_media_url/download_media` (Task 2), `attachments.service.create_attachment` (existing), `settings_service.get_profile` (existing).
+- Produces: `process_pending_media(db, *, tenant_id: str) -> int` (returns count processed) in `whatsapp_inbox/service.py`; `run_sweep` now also calls it per-tenant.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# apps/api/tests/test_whatsapp_inbox_media_worker.py
+"""Download assíncrono de mídia pendente (worker) — mensagens recebidas com media_status=pending."""
+import pytest
+from sqlalchemy import select
+
+from app.core import whatsapp
+from app.modules.crm.models import Client
+from app.modules.settings import service as settings_service
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    DIRECTION_IN,
+    MEDIA_STATUS_DOWNLOADED,
+    MEDIA_STATUS_FAILED,
+    MEDIA_STATUS_PENDING,
+    WhatsappMessage,
+)
+
+TENANT_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _seed(db):
+    profile = settings_service.get_profile(db, TENANT_ID)
+    profile.whatsapp_token = "tok"
+    profile.whatsapp_phone_id = "phone-1"
+    db.commit()
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900000009", source="manual")
+    db.add(client)
+    db.flush()
+    msg = WhatsappMessage(
+        tenant_id=TENANT_ID, client_id=client.id, direction=DIRECTION_IN, kind="image",
+        media_status=MEDIA_STATUS_PENDING, wa_message_id="wamid.media1",
+    )
+    db.add(msg)
+    db.commit()
+    return msg
+
+
+def test_process_pending_media_downloads_successfully(db, monkeypatch: pytest.MonkeyPatch):
+    msg = _seed(db)
+    monkeypatch.setattr(
+        whatsapp, "fetch_media_url", lambda **_kw: "https://example.com/file.jpg"
+    )
+    monkeypatch.setattr(whatsapp, "download_media", lambda **_kw: b"fake-image-bytes")
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 1
+    db.refresh(msg)
+    assert msg.media_status == MEDIA_STATUS_DOWNLOADED
+    assert msg.media_attachment_id is not None
+
+
+def test_process_pending_media_marks_failed_on_error(db, monkeypatch: pytest.MonkeyPatch):
+    msg = _seed(db)
+
+    def _boom(**_kw):
+        raise whatsapp.WhatsappApiError("erro de rede")
+
+    monkeypatch.setattr(whatsapp, "fetch_media_url", _boom)
+
+    processed = inbox_service.process_pending_media(db, tenant_id=TENANT_ID)
+    assert processed == 1
+    db.refresh(msg)
+    assert msg.media_status == MEDIA_STATUS_FAILED
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_media_worker.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'process_pending_media'`
+
+- [ ] **Step 3: Add `process_pending_media` to `service.py`**
+
+Append to `apps/api/app/modules/whatsapp_inbox/service.py` (note: this uses `wa_message_id` as
+the media_id at the Meta API layer is WRONG — the actual media identifier for image/audio/etc.
+messages is stored separately from `wa_message_id`; since the model as designed in Task 1 does
+NOT have a dedicated `meta_media_id` column, add one now):
+
+First, go back and add one more nullable column to `WhatsappMessage` in
+`apps/api/app/modules/whatsapp_inbox/models.py`:
+```python
+    # ID de mídia da Meta (distinto de wa_message_id, que é o ID da MENSAGEM) — só setado
+    # quando kind != "text" e ainda não baixamos os bytes.
+    meta_media_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+```
+And add the matching column to the migration `0054_whatsapp_inbox.py`'s `whatsapp_messages`
+table creation (insert right after the `wa_message_id` column line):
+```python
+        sa.Column("meta_media_id", sa.String(128), nullable=True),
+```
+And update `_populate` logic in `ingest_webhook_payload` (Task 4) to also capture it — go back to
+that function in `service.py` and change the media branch:
+```python
+        elif kind in ("image", "audio", "document", "video"):
+            media_obj = msg.get(kind, {})
+            text_body = media_obj.get("caption", "")
+            media_status = MEDIA_STATUS_PENDING
+            meta_media_id = media_obj.get("id")
+        else:
+            kind = "text"
+            text_body = "[tipo de mensagem não suportado]"
+            meta_media_id = None
+```
+and add `meta_media_id=meta_media_id if kind != "text" else None,` to the
+`WhatsappMessage(...)` constructor call a few lines below it (also initialize
+`meta_media_id = None` in the `if kind == "text":` branch above it, so the variable always
+exists before the constructor call).
+
+Now append the worker function:
+```python
+def process_pending_media(db: Session, *, tenant_id: str) -> int:
+    """Baixa mídia pendente de mensagens recebidas (chamado pelo worker, IV2: uma falha isolada
+    não trava as demais)."""
+    profile = settings_service.get_profile(db, tenant_id)
+    pending = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.media_status == MEDIA_STATUS_PENDING)
+    ).all()
+    processed = 0
+    for msg in pending:
+        try:
+            url = whatsapp.fetch_media_url(
+                token=profile.whatsapp_token or "", media_id=msg.meta_media_id or ""
+            )
+            data = whatsapp.download_media(token=profile.whatsapp_token or "", url=url)
+            mime_type = {
+                "image": "image/jpeg", "audio": "audio/ogg", "document": "application/octet-stream",
+                "video": "video/mp4",
+            }.get(msg.kind, "application/octet-stream")
+            attachment = attachments_service.create_attachment(
+                db, tenant_id=tenant_id, actor="system:worker", owner_type="whatsapp_message",
+                owner_id=msg.id, label="outro", filename=f"{msg.kind}-{msg.id}",
+                content_type=mime_type, data=data,
+            )
+            msg.media_attachment_id = attachment.id
+            msg.media_status = MEDIA_STATUS_DOWNLOADED
+        except Exception:  # noqa: BLE001 — isola a falha por mensagem (IV2)
+            logger.exception("[whatsapp_inbox] falha ao baixar mídia msg=%s", msg.id)
+            msg.media_status = MEDIA_STATUS_FAILED
+        processed += 1
+    db.commit()
+    return processed
+```
+`attachments_service.create_attachment`'s `content_type` param doesn't validate against
+`ALLOWED_TYPES` for this call path — double check: `apps/api/app/modules/attachments/models.py`
+currently restricts `ALLOWED_TYPES = {"application/pdf", "image/jpeg", "image/png"}`. Audio/video
+mime types would be REJECTED by `create_attachment`'s check. Extend `ALLOWED_TYPES` in
+`apps/api/app/modules/attachments/models.py` to also include the WhatsApp media types:
+```python
+ALLOWED_TYPES = {
+    "application/pdf", "image/jpeg", "image/png",
+    "audio/ogg", "audio/mpeg", "video/mp4", "application/octet-stream",
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_media_worker.py tests/test_whatsapp_inbox_service.py tests/test_whatsapp_inbox_webhook.py tests/test_attachments.py -v`
+Expected: all PASS (including the pre-existing attachments tests — confirm the `ALLOWED_TYPES`
+widening didn't break any negative test that expected one of the newly-added types to be
+rejected; if one does, that test was asserting behavior this feature intentionally changes —
+update it to use a truly-disallowed type like `"text/plain"` instead).
+
+- [ ] **Step 5: Wire into `apps/api/app/worker.py`**
+
+Add the import:
+```python
+from app.modules.whatsapp_inbox import service as whatsapp_inbox_service
+```
+Inside `run_sweep`, add a third stage after the notifications stage (before the closing
+`logger.info` call):
+```python
+        # Etapa 3 — mídia pendente do inbox de WhatsApp (sessão SEPARADA das outras duas).
+        try:
+            with tenant_session_factory(tenant_id) as db:
+                media_processed = whatsapp_inbox_service.process_pending_media(
+                    db, tenant_id=tenant_id
+                )
+            result["whatsapp_media_processed"] = (
+                result.get("whatsapp_media_processed", 0) + media_processed
+            )
+        except Exception as exc:  # noqa: BLE001 — idem: isola a falha por tenant (IV2)
+            logger.exception("[worker] mídia do whatsapp falhou tenant=%s", tenant_id)
+            result["errors"].append(
+                {"tenant_id": tenant_id, "stage": "whatsapp_media", "error": str(exc)}
+            )
+```
+Also initialize the key in the `result` dict at the top of `run_sweep`:
+```python
+    result = {
+        "tenants_checked": 0,
+        "funnel_resumed": 0,
+        "notifications_processed": 0,
+        "whatsapp_media_processed": 0,
+        "errors": [],
+    }
+```
+
+- [ ] **Step 6: Update `apps/api/tests/test_worker.py`**
+
+Check the existing tests asserting the exact shape of `run_sweep`'s return dict (grep for
+`"tenants_checked"` in that file) — add `"whatsapp_media_processed": 0` to any dict literal
+they compare against, matching the new key.
+
+- [ ] **Step 7: Run the full backend suite**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m pytest -q -m "not rls_e2e"`
+Expected: all passing, no regressions.
+
+- [ ] **Step 8: Lint**
+
+Run: `cd apps/api && ./.venv/Scripts/python.exe -m ruff check app/`
+Expected: `All checks passed!`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/ apps/api/app/modules/attachments/models.py apps/api/app/worker.py apps/api/migrations/versions/0054_whatsapp_inbox.py apps/api/tests/test_whatsapp_inbox_media_worker.py apps/api/tests/test_worker.py
+git commit -m "feat: download assíncrono de mídia recebida via worker"
+```
+
+---
+
+### Task 8: `shared-types` — tipos novos pro frontend
+
+**Files:**
+- Modify: `packages/shared-types/src/index.ts`
+
+**Interfaces:**
+- Produces: `TenantProfile.whatsapp_verify_token: string`, `ConversationSummary`, `TimelineEntry`, `WhatsappMessageOut`.
+
+- [ ] **Step 1: Extend `TenantProfile` and add the new interfaces**
+
+Open `packages/shared-types/src/index.ts`. Find the `TenantProfile` interface (has
+`whatsapp_configured`, `whatsapp_phone_id`, `whatsapp_waba_id`, `whatsapp_token?`) and add, right
+after `whatsapp_waba_id: string;`:
+```typescript
+  /** Combina com o que a Meta ecoa no handshake do webhook — nunca é segredo de verdade. */
+  whatsapp_verify_token: string;
+```
+And add `whatsapp_app_secret?: string;` right after the existing `whatsapp_token?: string;` line
+(same write-only convention).
+
+Then append near the existing `WhatsappTemplate*` types:
+```typescript
+// ── Inbox de WhatsApp (conversa de verdade com clientes) ────
+export interface ConversationSummary {
+  client_id: UUID;
+  client_name: string;
+  client_phone: string | null;
+  last_message_at: string | null;
+  last_message_preview: string;
+  unread: boolean;
+}
+
+export interface TimelineEntry {
+  source: "conversation" | "automated";
+  direction: "in" | "out";
+  kind: "text" | "image" | "audio" | "document" | "video";
+  text_body: string;
+  media_attachment_id: string | null;
+  purpose_label: string | null;
+  created_at: string;
+}
+
+export interface WhatsappMessageOut {
+  id: UUID;
+  direction: "in" | "out";
+  kind: "text" | "image" | "audio" | "document" | "video";
+  text_body: string;
+  status: "sent" | "logged" | "failed";
+  created_at: string;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/shared-types/src/index.ts
+git commit -m "feat: tipos do inbox de WhatsApp em shared-types"
+```
+
+---
+
+### Task 9: Frontend — estender `WhatsappSection.tsx` com App Secret + URL/Verify Token do webhook
+
+**Files:**
+- Modify: `apps/web/src/features/config/WhatsappSection.tsx`
+- Modify: `apps/web/src/features/config/WhatsappSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `TenantProfile.whatsapp_verify_token`, `whatsapp_app_secret?` (Task 8).
+
+- [ ] **Step 1: Write the failing tests**
+
+First, update the `profile()` factory near the top of
+`apps/web/src/features/config/WhatsappSection.test.tsx` (it currently returns a `TenantProfile`
+literal with `whatsapp_template_bindings: {}` as the last field before `...overrides`) — add the
+new required field right after it:
+```typescript
+    whatsapp_template_bindings: {},
+    whatsapp_verify_token: "",
+    ...overrides,
+```
+
+Then add these two tests inside the existing `describe("WhatsappSection — credenciais", ...)`
+block, right after the `"inclui whatsapp_token no payload quando o campo é editado"` test
+(same file, same `mockGet`/`profile`/`userEvent` helpers already imported at the top):
+```typescript
+  it("mostra a URL do webhook e o verify token gerado quando já configurado", async () => {
+    mockGet(
+      profile({
+        whatsapp_configured: true, whatsapp_phone_id: "phone-123",
+        whatsapp_waba_id: "waba-456", whatsapp_verify_token: "abc123xyz",
+      }),
+    );
+    render(<WhatsappSection />);
+
+    await screen.findByText("Conectado");
+    expect(screen.getByText("abc123xyz")).toBeInTheDocument();
+    expect(screen.getByText(/public\/whatsapp\/webhook/)).toBeInTheDocument();
+  });
+
+  it("não mostra o bloco do webhook quando ainda não há verify_token", async () => {
+    mockGet(profile({ whatsapp_configured: false, whatsapp_verify_token: "" }));
+    render(<WhatsappSection />);
+
+    await screen.findByText("Não conectado");
+    expect(screen.queryByText(/public\/whatsapp\/webhook/)).not.toBeInTheDocument();
+  });
+
+  it("inclui whatsapp_app_secret no payload quando o campo é editado", async () => {
+    const user = userEvent.setup();
+    mockGet(profile({ whatsapp_configured: false }));
+    vi.mocked(api.patch).mockResolvedValue({ data: profile({ whatsapp_configured: true }) } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Não conectado");
+    const secretInput = screen.getByPlaceholderText("Cole o App Secret do seu App na Meta");
+    await user.type(secretInput, "meu-app-secret");
+
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "",
+        whatsapp_waba_id: "",
+        whatsapp_app_secret: "meu-app-secret",
+      }),
+    );
+  });
+
+  it("não inclui whatsapp_app_secret no payload quando o campo não foi tocado", async () => {
+    const user = userEvent.setup();
+    mockGet(
+      profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-1", whatsapp_waba_id: "waba-1" }),
+    );
+    vi.mocked(api.patch).mockResolvedValue({
+      data: profile({ whatsapp_configured: true, whatsapp_phone_id: "phone-1", whatsapp_waba_id: "waba-1" }),
+    } as never);
+    render(<WhatsappSection />);
+
+    await screen.findByText("Conectado");
+    const saveButtons = screen.getAllByRole("button", { name: /Salvar/ });
+    await user.click(saveButtons[0]);
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/settings/profile", {
+        whatsapp_phone_id: "phone-1",
+        whatsapp_waba_id: "waba-1",
+      }),
+    );
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/features/config/WhatsappSection.test.tsx`
+Expected: FAIL — the new assertions don't find the expected text/inputs yet.
+
+- [ ] **Step 3: Extend `CredentialsCard` in `WhatsappSection.tsx`**
+
+In the `CredentialsCard` function, add state for the app secret (mirroring `token`/`tokenTouched`
+exactly):
+```typescript
+  const [appSecret, setAppSecret] = useState("");
+  const [appSecretTouched, setAppSecretTouched] = useState(false);
+```
+In `load()`, reset it alongside `token`:
+```typescript
+    setAppSecret("");
+    setAppSecretTouched(false);
+```
+In `save()`, extend the patch type and conditionally include it:
+```typescript
+      const patch: Pick<TenantProfile, "whatsapp_phone_id" | "whatsapp_waba_id"> & {
+        whatsapp_token?: string;
+        whatsapp_app_secret?: string;
+      } = {
+        whatsapp_phone_id: phoneId.trim(),
+        whatsapp_waba_id: wabaId.trim(),
+      };
+      if (tokenTouched) patch.whatsapp_token = token;
+      if (appSecretTouched) patch.whatsapp_app_secret = appSecret;
+```
+and reset `appSecret`/`appSecretTouched` in the success branch alongside `token`/`tokenTouched`.
+
+Add the input field in the JSX, right after the existing "Token de acesso" `<label>` block:
+```tsx
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">
+                App Secret
+              </span>
+              <input
+                type="password"
+                value={appSecret}
+                onChange={(e) => {
+                  setAppSecret(e.target.value);
+                  setAppSecretTouched(true);
+                }}
+                placeholder={configured ? "••••••••" : "Cole o App Secret do seu App na Meta"}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </label>
+```
+
+Then, after the grid of inputs (still inside the `!profile ? ... : (<>...)` block, right before
+its closing `</>`), add a new block showing the webhook URL + verify token (only once
+`profile.whatsapp_verify_token` is set):
+```tsx
+          {profile.whatsapp_verify_token && (
+            <div className="mt-4 rounded-xl border border-neutral-100 bg-neutral-50 p-4">
+              <p className="mb-2 text-xs font-semibold text-neutral-600">
+                Configure o webhook no painel da Meta (WhatsApp → Configuration):
+              </p>
+              <div className="mb-2">
+                <span className="mb-1 block text-xs text-neutral-500">Callback URL</span>
+                <code className="block truncate rounded-lg bg-white px-3 py-2 text-xs">
+                  {`${window.location.origin}/api/public/whatsapp/webhook`}
+                </code>
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-neutral-500">Verify token</span>
+                <code className="block truncate rounded-lg bg-white px-3 py-2 text-xs">
+                  {profile.whatsapp_verify_token}
+                </code>
+              </div>
+            </div>
+          )}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/features/config/WhatsappSection.test.tsx`
+Expected: all PASS.
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd apps/web && npx tsc --noEmit && npx eslint src/features/config/WhatsappSection.tsx src/features/config/WhatsappSection.test.tsx --max-warnings 0`
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/config/WhatsappSection.tsx apps/web/src/features/config/WhatsappSection.test.tsx
+git commit -m "feat: App Secret + URL/verify token do webhook na tela de credenciais do WhatsApp"
+```
+
+---
+
+### Task 10: Frontend — tela "Conversas" (lista + fio + resposta)
+
+**Files:**
+- Create: `apps/web/src/features/conversas/ConversasPage.tsx`
+- Create: `apps/web/src/features/conversas/ConversasPage.test.tsx`
+- Modify: `apps/web/src/app/navigation.ts`
+- Modify: `apps/web/src/app/App.tsx`
+
+**Interfaces:**
+- Consumes: `ConversationSummary`, `TimelineEntry`, `WhatsappMessageOut`, `WhatsappTemplate` (Task 8), `GET /whatsapp-conversations`, `GET /whatsapp-conversations/{id}/timeline`, `GET /whatsapp-conversations/{id}/window`, `POST /whatsapp-conversations/{id}/read`, `POST /whatsapp-conversations/{id}/messages/text|media|template` (Task 6), `GET /whatsapp-templates?status=APPROVED` (existing, PR #35).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// apps/web/src/features/conversas/ConversasPage.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import ConversasPage from "./ConversasPage";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+const mockedApi = vi.mocked(api);
+
+describe("ConversasPage", () => {
+  it("lista as conversas e mostra o fio ao clicar numa delas", async () => {
+    mockedApi.get.mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [{
+            client_id: "c1", client_name: "Doro Eventos", client_phone: "5511999999999",
+            last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "Oi, quero o cardápio",
+            unread: true,
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/timeline") {
+        return Promise.resolve({
+          data: [{
+            source: "conversation", direction: "in", kind: "text",
+            text_body: "Oi, quero o cardápio", media_attachment_id: null, purpose_label: null,
+            created_at: "2026-07-19T10:00:00Z",
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/window") {
+        return Promise.resolve({ data: { within_session_window: true } });
+      }
+      if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: [] });
+    });
+    mockedApi.post.mockResolvedValue({ data: {} });
+
+    render(<ConversasPage />);
+    await waitFor(() => screen.getByText("Doro Eventos"));
+    await userEvent.click(screen.getByText("Doro Eventos"));
+    await waitFor(() => screen.getByText("Oi, quero o cardápio"));
+    expect(screen.getByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+  });
+
+  it("troca pro seletor de template quando a janela de 24h está fechada", async () => {
+    mockedApi.get.mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [{
+            client_id: "c2", client_name: "Cliente Antigo", client_phone: "5511888888888",
+            last_message_at: "2026-07-01T10:00:00Z", last_message_preview: "oi",
+            unread: false,
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c2/timeline") return Promise.resolve({ data: [] });
+      if (url === "/whatsapp-conversations/c2/window") {
+        return Promise.resolve({ data: { within_session_window: false } });
+      }
+      if (url === "/whatsapp-templates") {
+        return Promise.resolve({
+          data: [{
+            id: "t1", name: "boas_vindas", language: "pt_BR", category_requested: "UTILITY",
+            category_approved: "UTILITY", status: "APPROVED", rejected_reason: null,
+            meta_template_id: "m1", body_text: "Olá {{1}}", variable_count: 1,
+            variable_examples: ["Nome"], created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          }],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    render(<ConversasPage />);
+    await waitFor(() => screen.getByText("Cliente Antigo"));
+    await userEvent.click(screen.getByText("Cliente Antigo"));
+    await waitFor(() => expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument());
+    expect(screen.getByText(/selecione um template/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && npx vitest run src/features/conversas/ConversasPage.test.tsx`
+Expected: FAIL — module doesn't exist yet.
+
+- [ ] **Step 3: Write `ConversasPage.tsx`**
+
+```tsx
+// apps/web/src/features/conversas/ConversasPage.tsx
+import type {
+  ConversationSummary, TimelineEntry, WhatsappTemplate,
+} from "@e1p/shared-types";
+import { Paperclip, Send } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+const POLL_MS = 7000;
+
+export default function ConversasPage() {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const loadConversations = useCallback(async () => {
+    const { data } = await api.get<ConversationSummary[]>("/whatsapp-conversations");
+    setConversations(data);
+  }, []);
+
+  useEffect(() => {
+    loadConversations();
+    const id = setInterval(loadConversations, POLL_MS);
+    return () => clearInterval(id);
+  }, [loadConversations]);
+
+  return (
+    <div className="flex h-[calc(100vh-8rem)] gap-4">
+      <div className="w-80 shrink-0 overflow-y-auto rounded-2xl bg-white shadow-sm">
+        <div className="border-b border-neutral-100 p-4">
+          <h1 className="font-semibold text-neutral-800">Conversas</h1>
+        </div>
+        {conversations.length === 0 ? (
+          <p className="p-4 text-sm text-neutral-400">Nenhuma conversa ainda.</p>
+        ) : (
+          conversations.map((c) => (
+            <button
+              key={c.client_id}
+              onClick={() => setSelected(c.client_id)}
+              className={`block w-full border-b border-neutral-50 px-4 py-3 text-left hover:bg-neutral-50 ${
+                selected === c.client_id ? "bg-primary-50" : ""
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-neutral-800">{c.client_name}</span>
+                {c.unread && <span className="h-2 w-2 rounded-full bg-primary-600" />}
+              </div>
+              <p className="mt-0.5 truncate text-xs text-neutral-400">
+                {c.last_message_preview}
+              </p>
+            </button>
+          ))
+        )}
+      </div>
+      <div className="flex-1 rounded-2xl bg-white shadow-sm">
+        {selected ? (
+          <ConversationThread clientId={selected} onSent={loadConversations} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-neutral-400">
+            Selecione uma conversa
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConversationThread({
+  clientId, onSent,
+}: { clientId: string; onSent: () => void }) {
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
+  const [withinWindow, setWithinWindow] = useState(true);
+  const [approvedTemplates, setApprovedTemplates] = useState<WhatsappTemplate[]>([]);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    const [tl, win] = await Promise.all([
+      api.get<TimelineEntry[]>(`/whatsapp-conversations/${clientId}/timeline`),
+      api.get<{ within_session_window: boolean }>(`/whatsapp-conversations/${clientId}/window`),
+    ]);
+    setTimeline(tl.data);
+    setWithinWindow(win.data.within_session_window);
+    if (!win.data.within_session_window) {
+      const { data } = await api.get<WhatsappTemplate[]>("/whatsapp-templates", {
+        params: { status: "APPROVED" },
+      });
+      setApprovedTemplates(data);
+    }
+    await api.post(`/whatsapp-conversations/${clientId}/read`);
+  }, [clientId]);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  async function sendText() {
+    if (!text.trim()) return;
+    setError(null);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/text`, { text });
+      setText("");
+      await load();
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  async function sendMedia(file: File) {
+    setError(null);
+    const form = new FormData();
+    form.append("file", file);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/media`, form, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      await load();
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {timeline.map((entry, i) => (
+          <div
+            key={i}
+            className={`max-w-md rounded-xl px-3 py-2 text-sm ${
+              entry.source === "automated"
+                ? "mx-auto bg-neutral-100 text-neutral-500"
+                : entry.direction === "out"
+                  ? "ml-auto bg-primary-600 text-white"
+                  : "bg-neutral-100 text-neutral-800"
+            }`}
+          >
+            {entry.source === "automated" && (
+              <p className="mb-0.5 text-xs font-semibold">🤖 {entry.purpose_label}</p>
+            )}
+            <p>{entry.text_body || `[${entry.kind}]`}</p>
+          </div>
+        ))}
+      </div>
+      {error && <div className="mx-4 mb-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+      <div className="border-t border-neutral-100 p-3">
+        {withinWindow ? (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded-lg border border-neutral-200 p-2 text-neutral-500 hover:bg-neutral-50"
+              title="Anexar arquivo"
+            >
+              <Paperclip size={16} />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) sendMedia(file);
+                e.target.value = "";
+              }}
+            />
+            <input
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && sendText()}
+              placeholder="Digite uma mensagem..."
+              className="flex-1 rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            />
+            <button
+              onClick={sendText}
+              className="rounded-pill bg-primary-600 p-2 text-white hover:bg-primary-700"
+            >
+              <Send size={16} />
+            </button>
+          </div>
+        ) : (
+          <TemplateReplyBox
+            clientId={clientId}
+            templates={approvedTemplates}
+            onSent={async () => {
+              await load();
+              onSent();
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TemplateReplyBox({
+  clientId, templates, onSent,
+}: { clientId: string; templates: WhatsappTemplate[]; onSent: () => void }) {
+  const [templateId, setTemplateId] = useState("");
+  const [variables, setVariables] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const selected = templates.find((t) => t.id === templateId) ?? null;
+
+  async function send() {
+    setError(null);
+    try {
+      await api.post(`/whatsapp-conversations/${clientId}/messages/template`, {
+        template_id: templateId, variables,
+      });
+      setTemplateId("");
+      setVariables([]);
+      onSent();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-neutral-400">
+        Fora da janela de 24h — selecione um template aprovado para responder.
+      </p>
+      {templates.length === 0 ? (
+        <p className="text-sm text-neutral-400">Nenhum template aprovado ainda.</p>
+      ) : (
+        <>
+          <select
+            value={templateId}
+            onChange={(e) => {
+              setTemplateId(e.target.value);
+              const tpl = templates.find((t) => t.id === e.target.value);
+              setVariables(tpl ? Array(tpl.variable_count).fill("") : []);
+            }}
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+          >
+            <option value="">Selecione um template</option>
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>{t.name} ({t.language})</option>
+            ))}
+          </select>
+          {selected && (
+            <>
+              {Array.from({ length: selected.variable_count }, (_, i) => (
+                <input
+                  key={i}
+                  value={variables[i] ?? ""}
+                  onChange={(e) => {
+                    const next = [...variables];
+                    next[i] = e.target.value;
+                    setVariables(next);
+                  }}
+                  placeholder={selected.variable_examples[i] ?? `Variável ${i + 1}`}
+                  className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+                />
+              ))}
+              {error && <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>}
+              <button
+                onClick={send}
+                className="w-full rounded-pill bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+              >
+                Enviar
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run src/features/conversas/ConversasPage.test.tsx`
+Expected: PASS. If the "Selecione um template" text-match assertion fails due to exact wording,
+adjust the test's regex (not the component) to match — the design intent (empty option present,
+disabled/no reply box until picked) is what matters, not the exact string.
+
+- [ ] **Step 5: Register the route + nav item**
+
+In `apps/web/src/app/navigation.ts`, add to the FIRST section's `items` array (right after
+`"CRM & Kanban"`, since conversations are a daily-use CRM-adjacent tool):
+```typescript
+      { label: "Conversas", to: "/conversas", icon: MessageCircle, ready: true },
+```
+Add `MessageCircle` to the `lucide-react` import list at the top of the file.
+
+In `apps/web/src/app/App.tsx`, add the import near the other feature imports:
+```typescript
+import ConversasPage from "../features/conversas/ConversasPage";
+```
+Add the route inside the authenticated `<Route>` block, near `/crm`:
+```tsx
+          <Route path="/conversas" element={<ConversasPage />} />
+```
+
+- [ ] **Step 6: Typecheck + lint + full frontend test suite**
+
+Run:
+```bash
+cd apps/web
+npx tsc --noEmit
+npx vitest run
+npx eslint . --max-warnings 0
+```
+Expected: all clean, no regressions in other test files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/conversas/ apps/web/src/app/navigation.ts apps/web/src/app/App.tsx
+git commit -m "feat: tela de Conversas (inbox de WhatsApp) no CRM"
+```
+
+---
+
+### Task 11: Verificação manual fim-a-fim (smoke test local)
+
+**Files:** none (validação, sem código novo)
+
+- [ ] **Step 1: Subir o stack local**
+
+```bash
+docker start infra-postgres-1 infra-api-1
+cd apps/web && pnpm dev
+```
+
+- [ ] **Step 2: Rodar a suíte completa uma última vez**
+
+```bash
+cd apps/api && ./.venv/Scripts/python.exe -m pytest -q -m "not rls_e2e" && ./.venv/Scripts/python.exe -m ruff check app/
+cd ../../apps/web && npx tsc --noEmit && npx vitest run && npx eslint . --max-warnings 0
+```
+Expected: tudo verde.
+
+- [ ] **Step 2: Testar o webhook manualmente com curl (simula a Meta)**
+
+Com um tenant de teste logado e credenciais configuradas via UI (token/phone_id/waba_id/
+app_secret — podem ser valores fake para este teste local, já que o Graph API real não é
+chamado no caminho de INGESTÃO, só na resposta):
+```bash
+# 1. Handshake de verificação (troque VERIFY_TOKEN pelo valor mostrado na tela de Configurações)
+curl "http://localhost:8000/public/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=VERIFY_TOKEN&hub.challenge=teste123"
+# Esperado: corpo da resposta = "teste123", status 200
+
+# 2. Simula uma mensagem recebida (troque PHONE_NUMBER_ID pelo phone_id configurado)
+BODY='{"entry":[{"changes":[{"value":{"metadata":{"phone_number_id":"PHONE_NUMBER_ID"},"contacts":[{"profile":{"name":"Teste Manual"}},{"wa_id":"5511999999999"}],"messages":[{"from":"5511999999999","id":"wamid.manual1","type":"text","text":{"body":"Oi, teste manual"}}]}}]}]}'
+SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "APP_SECRET" | sed 's/^.* //')"
+curl -X POST "http://localhost:8000/public/whatsapp/webhook" \
+  -H "Content-Type: application/json" -H "X-Hub-Signature-256: $SIG" -d "$BODY"
+# Esperado: {"status":"ok"}
+```
+
+- [ ] **Step 3: Confirmar no navegador**
+
+Abra `http://localhost:5173/crm` e confirme que um novo lead "Teste Manual" apareceu (source
+whatsapp). Abra `http://localhost:5173/conversas` e confirme que a conversa aparece na lista
+com a mensagem "Oi, teste manual", e que a caixa de resposta mostra texto livre (dentro da
+janela de 24h, já que acabou de chegar).
+
+- [ ] **Step 4: Nenhum commit nesta task** (é só validação).

--- a/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
+++ b/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
@@ -1683,7 +1683,7 @@ async def receive_webhook(
         raise HTTPException(status_code=403, detail="Assinatura inválida")
 
     with session_factory(account.tenant_id) as tdb:
-        service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
+        service.ingest_webhook_payload(tdb, payload=payload)
 
     return {"status": "ok"}
 

--- a/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
+++ b/docs/superpowers/plans/2026-07-19-whatsapp-inbox-plan.md
@@ -1683,7 +1683,7 @@ async def receive_webhook(
         raise HTTPException(status_code=403, detail="Assinatura inválida")
 
     with session_factory(account.tenant_id) as tdb:
-        service.ingest_webhook_payload(tdb, payload=payload)
+        service.ingest_webhook_payload(tdb, tenant_id=account.tenant_id, payload=payload)
 
     return {"status": "ok"}
 

--- a/docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md
+++ b/docs/superpowers/specs/2026-07-19-whatsapp-inbox-design.md
@@ -1,0 +1,187 @@
+# Inbox de WhatsApp (conversa de verdade com clientes)
+
+**Data:** 2026-07-19
+**Status:** Aprovado (brainstorming), aguardando plano de implementação
+**Precedente direto:** PRs #35 (credenciais + templates por tenant) e a issue #36 (webhook de
+aprovação de template) — esta feature reaproveita boa parte da infraestrutura das duas.
+
+## 1. Problema
+
+Hoje o e1p só manda WhatsApp (outbound): credenciais por tenant + templates aprovados pela Meta
+(PR #35), usados no nó do funil e em 5 fluxos automáticos (cobrança, contrato, orçamento,
+convite de staff, aviso de card movido). Não existe nenhum jeito de **receber** o que o cliente
+responde, nem de ter uma conversa de ida-e-volta dentro do produto — o dono responde direto no
+celular dele, fora do e1p, e esse histórico se perde pro sistema.
+
+Motivador concreto: o primeiro cliente real (Doro Eventos) precisa mandar **cardápio** (imagem/
+PDF) pelos WhatsApp dos clientes dele, e o atendente humano precisa ver a conversa inteira
+(incluindo os avisos automáticos que o sistema já manda) pra ter contexto completo antes de
+responder.
+
+## 2. Escopo (o que foi decidido no brainstorming)
+
+- **Inbox de verdade dentro do CRM** (não só "avisar que o cliente respondeu") — dono e
+  funcionários (sub_users) leem e respondem de dentro do e1p.
+- **Inbox compartilhada, sem atribuição formal** — qualquer atendente vê e responde qualquer
+  conversa. Sem fila, sem "pegar atendimento".
+- **Número desconhecido vira lead automaticamente** — mesmo padrão já usado pra captura de lead
+  externa (`source=api`), aqui com `source=whatsapp`.
+- **Atualização por polling** (5-10s), sem WebSocket — mais simples, mesmo espírito de custo do
+  projeto (Golden Rule §4).
+- **Mídia completa nos dois sentidos** — cliente manda foto/áudio/documento e aparece de
+  verdade (não só "cliente enviou uma imagem"); atendente também consegue MANDAR mídia de volta
+  (essencial pro caso de uso do cardápio).
+- **Janela de 24h detectada automaticamente** — dentro da janela, texto/mídia livre; fora,
+  troca sozinha pro seletor de template aprovado (mesmo componente já usado no funil).
+- **Conversa unificada** — o fio mostra tanto as mensagens da inbox quanto os avisos automáticos
+  já existentes (cobrança, contrato, etc.), sem migrar nada: é uma leitura combinada, não uma
+  tabela nova pros dados antigos.
+- **Cada tenant tem seu próprio App na Meta** (auto-atendimento, mesmo modelo da PR #35) — não
+  somos "Tech Provider" da Meta. Implica: cada tenant configura o próprio webhook no painel dele.
+
+### Fora de escopo (decisão explícita, não esquecimento)
+
+- Recibos de entrega/leitura (`statuses` do webhook — "entregue"/"visto") — não pedido, fica
+  pra depois.
+- Atribuição de conversa a um atendente específico / fila — inbox compartilhada resolve por
+  ora.
+- "Não-lida" por atendente individual — é compartilhado (lida por qualquer um = lida pra todos).
+- Onboarding automatizado do webhook na Meta (Embedded Signup) — o tenant cola a URL e o
+  verify_token manualmente no painel dele, uma vez.
+
+## 3. Arquitetura
+
+```
+Cliente manda WhatsApp
+        │
+        ▼
+Meta Cloud API ──POST──▶ /public/whatsapp/webhook
+        │                         │
+        │                  valida assinatura (app_secret do tenant, achado via phone_number_id)
+        │                         │
+        │                  cliente já existe (por telefone)? não → cria lead (source=whatsapp)
+        │                         │
+        │                  grava WhatsappMessage (direction=in); mídia fica "pendente"
+        │                         │
+        │                  responde 200 rápido pra Meta
+        │
+        ▼
+Worker (já existe) baixa mídia pendente em background
+        │
+        ▼
+Tela "Conversas" no CRM (polling 5-10s)
+   • fio = WhatsappMessage + Notification(channel=whatsapp) do mesmo client_id, mesclados por data
+        │
+   atendente responde (texto / mídia / template, conforme janela de 24h)
+        │
+        ▼
+grava WhatsappMessage (direction=out)
+```
+
+## 4. Credenciais (extensão da PR #35)
+
+`TenantProfile` ganha 2 campos novos, além dos 3 já existentes (`whatsapp_token`,
+`whatsapp_phone_id`, `whatsapp_waba_id`):
+
+- `whatsapp_app_secret` (cifrado, mesmo padrão do token) — usado só pra validar a assinatura do
+  webhook (`X-Hub-Signature-256`).
+- `whatsapp_verify_token` (texto simples, não é segredo) — gerado automaticamente na primeira
+  vez que o tenant salva as credenciais; mostrado na UI pra ele colar no painel de configuração
+  do webhook da Meta, junto com a URL (`https://{domínio}/api/public/whatsapp/webhook`).
+
+Uma tabela GLOBAL nova (sem RLS, mesmo padrão de `public_integration_keys`/`published_pages`):
+`public_whatsapp_accounts` (`phone_number_id` único, `tenant_id`, `app_secret`,
+`verify_token`) — mantida em sincronia (dual-write) toda vez que o tenant salva/altera as
+credenciais em Configurações. É essa tabela que resolve "de qual tenant é esse evento?" e "qual
+app_secret usar pra validar a assinatura?" ANTES de qualquer sessão de tenant existir.
+
+## 5. Modelo de dados novo
+
+### `WhatsappMessage` (RLS, por tenant)
+
+| Campo | Tipo | Observação |
+|---|---|---|
+| `client_id` | string | cliente da conversa |
+| `direction` | `in` \| `out` | quem mandou |
+| `kind` | `text`\|`image`\|`audio`\|`document`\|`video` | tipo de conteúdo |
+| `text_body` | text, nullable | texto ou legenda |
+| `media_attachment_id` | string, nullable | link pro módulo de Anexos já existente (reaproveita storage S3/Postgres) |
+| `media_status` | `none`\|`pending`\|`downloaded`\|`failed` | só relevante pra mídia `in` (download assíncrono pelo worker) |
+| `wa_message_id` | string, unique por tenant | ID da própria Meta — evita duplicata de webhook reentregue |
+| `status` | string | só relevante pra `out` (`sent`\|`logged`\|`failed`, mesmo vocabulário de sempre) |
+
+### `WhatsappConversationState` (RLS, por tenant) — 1 linha por cliente com atividade
+
+| Campo | Tipo |
+|---|---|
+| `client_id` | string |
+| `last_read_at` | datetime, nullable |
+
+Usado só pra calcular "não lida" (qualquer mensagem `in` mais nova que `last_read_at` = não
+lida). Marcar como lida é um PATCH simples quando a conversa é aberta — compartilhado entre
+toda a equipe do tenant (sem granularidade por atendente).
+
+## 6. Webhook de entrada
+
+- `GET /public/whatsapp/webhook`: handshake de verificação da Meta (`hub.mode`,
+  `hub.verify_token`, `hub.challenge`) — confere o token contra `public_whatsapp_accounts`,
+  ecoa `hub.challenge` se bater.
+- `POST /public/whatsapp/webhook`:
+  1. Extrai `phone_number_id` do payload (`entry[].changes[].value.metadata.phone_number_id`).
+  2. Busca `tenant_id` + `app_secret` em `public_whatsapp_accounts`.
+  3. Valida `X-Hub-Signature-256` (HMAC-SHA256 do corpo CRU, comparação de tempo constante) —
+     falha = 403, não processa nada.
+  4. Abre `tenant_session(tenant_id)`. Pra cada mensagem no payload: resolve/cria o `Client`
+     pelo telefone; grava `WhatsappMessage(direction=in, ...)` (mídia entra com
+     `media_status=pending`, sem baixar ainda); ignora se `wa_message_id` já existe.
+  5. Responde 200 rápido (a Meta exige resposta em poucos segundos).
+- Um novo tick do worker já existente (`app.worker`) varre `WhatsappMessage` com
+  `media_status=pending`, baixa o arquivo (média_id → URL temporária → bytes → `core/storage.py`)
+  e atualiza pra `downloaded`/`failed` — mesmo princípio de isolamento de falha (IV2) já usado
+  na fila de notificações.
+
+## 7. Fluxo de resposta
+
+- **Janela de 24h**: calculada a partir do `WhatsappMessage(direction=in)` mais recente daquele
+  cliente. Dentro → texto/mídia livres. Fora (ou nunca houve mensagem `in`) → só template.
+- **Texto livre**: reaproveita `whatsapp.send_text` (já ciente do tenant, desde a PR #35).
+- **Mídia** (novo): upload pra Meta a cada envio (`POST /{phone_id}/media` → `media_id`
+  temporário, sem cache — validade curta) + envio referenciando esse ID.
+- **Template** (fora da janela): reaproveita o MESMO seletor de template + variáveis já
+  construído pro nó do funil — não duplica esse componente.
+- Endpoint novo: `POST /whatsapp-conversations/{client_id}/messages` (texto, upload
+  multipart, ou `template_id`+variáveis).
+
+## 8. Frontend — tela de Conversas
+
+Duas colunas, novo item de menu:
+- **Esquerda**: lista de conversas por cliente, ordenada pela mensagem mais recente, indicador
+  de não-lida (via `WhatsappConversationState`).
+- **Direita**: fio da conversa — `WhatsappMessage` + `Notification(channel=whatsapp)` do mesmo
+  `client_id`, mesclados por data/hora numa lista só; mensagem automática ganha uma etiqueta
+  (reaproveita `PURPOSE_LABELS` já criado na Fase 2 — ex: "🤖 Lembrete de cobrança").
+- **Caixa de resposta**: dentro da janela de 24h → texto + botão de anexo; fora da janela →
+  troca sozinha pro seletor de template.
+- **Atualização**: polling a cada 5-10s, sem WebSocket.
+
+## 9. Erros e testes
+
+- Assinatura inválida → 403, log de tentativa suspeita, nada processado.
+- Falha ao baixar mídia → fica `failed`, isolada (não trava outras mensagens da fila).
+- Mensagem duplicada da Meta → ignorada via `wa_message_id`.
+- Testes: mock da Graph API (envio de texto/mídia/upload); payloads de exemplo reais da
+  documentação da Meta pro webhook (texto, imagem, duplicata, assinatura inválida, tenant
+  desconhecido); isolamento de tenant (RLS) na resolução do webhook e no endpoint de conversas;
+  detecção correta da janela de 24h (limite exato, sem mensagem `in` nenhuma, mensagem `in`
+  antiga).
+
+## 10. Reaproveitamento explícito (não reinventar)
+
+- Credenciais/token cifrado: `core/token_crypto.py::EncryptedToken` (já existe).
+- Storage de mídia: `core/storage.py` + módulo de Anexos (já existe).
+- Padrão global-snapshot-pra-resolver-antes-de-autenticar: mesmo de
+  `integration_keys`/`public_integration_keys` (PR #32) e `published_pages`/`Page`.
+- Seletor de template + variáveis: o mesmo componente já construído pro nó do funil (PR #35).
+- Fila assíncrona resiliente (IV2): o worker e o padrão de isolamento de falha já usados em
+  `notifications/service.py::process_pending`.
+- Rótulos de propósito automático: `PURPOSE_LABELS` (Fase 2 da PR #35).

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -738,6 +738,35 @@ export interface WhatsappTemplateCreate {
   variable_examples: string[];
 }
 
+// ── Inbox de WhatsApp (conversa de verdade com clientes) ────
+export interface ConversationSummary {
+  client_id: UUID;
+  client_name: string;
+  client_phone: string | null;
+  last_message_at: string | null;
+  last_message_preview: string;
+  unread: boolean;
+}
+
+export interface TimelineEntry {
+  source: "conversation" | "automated";
+  direction: "in" | "out";
+  kind: "text" | "image" | "audio" | "document" | "video";
+  text_body: string;
+  media_attachment_id: string | null;
+  purpose_label: string | null;
+  created_at: string;
+}
+
+export interface WhatsappMessageOut {
+  id: UUID;
+  direction: "in" | "out";
+  kind: "text" | "image" | "audio" | "document" | "video";
+  text_body: string;
+  status: "sent" | "logged" | "failed";
+  created_at: string;
+}
+
 // ── Integrações (captura de lead de sites externos) ────
 export interface IntegrationKey {
   id: UUID;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -665,9 +665,15 @@ export interface TenantProfile {
   whatsapp_configured: boolean;
   whatsapp_phone_id: string;
   whatsapp_waba_id: string;
+  /** Só-leitura: token de verificação do webhook (auto-gerado pelo backend), usado para
+   * configurar o callback no painel da Meta. */
+  whatsapp_verify_token: string;
   /** Só-escrita: nunca vem preenchido no GET (o token nunca é devolvido em claro).
    * Setar antes do PATCH para configurar/trocar; "" limpa a credencial. */
   whatsapp_token?: string;
+  /** Só-escrita: App Secret do App na Meta, usado para validar a assinatura do webhook.
+   * Nunca vem preenchido no GET. Setar antes do PATCH para configurar/trocar. */
+  whatsapp_app_secret?: string;
   /** Vínculo propósito→template_id para os fluxos FIXOS do sistema (lembrete de cobrança,
    * envio de contrato/orçamento, convite de staff, aviso de card movido) — diferente do nó
    * livre do Funil de Vendas, aqui o tenant vincula UM template aprovado por propósito.


### PR DESCRIPTION
## Resumo

Inbox de WhatsApp completa para o CRM: cada tenant conecta seu próprio WhatsApp Cloud API (Meta), recebe mensagens de clientes via webhook público, tem leads novos criados automaticamente, e responde por texto/mídia (dentro da janela de 24h) ou template aprovado (fora dela). Nova tela "Conversas" (dois painéis: lista + fio unificado, misturando conversa real com notificações automáticas do sistema).

- Webhook público assinado (HMAC-SHA256), roteado por tenant via tabela global pré-autenticação (mesmo padrão de `public_integration_keys`)
- Download assíncrono de mídia recebida via worker existente
- Lead automático no CRM para número desconhecido (`source=whatsapp`)
- Resposta por texto/mídia/template conforme janela de 24h da Meta
- Tela "Conversas" com polling, sem WebSocket
- Credenciais + App Secret + templates por tenant (`/config` → Integrações)

## Processo

Implementado via Subagent-Driven Development (10 tasks + smoke test manual), com revisão dedicada por tarefa — a mais profunda foi o webhook público (10 rodadas de revisão, todas em torno de "nunca travar com entrada não confiável": JSON malformado, formatos inesperados aninhados, bytes UTF-8 inválidos, NUL byte, surrogate solto, isolamento de falha por mensagem). Um smoke test manual fim-a-fim (Postgres real, container reconstruído) encontrou e corrigiu uma race condition real em `mark_read` (dois cliques quase simultâneos derrubavam a request com 500). Revisão final de branch (30 commits) resultou em dois ajustes de segurança antes do merge: `app_secret` passou de texto plano pra criptografado (mesmo padrão já usado pro token), e a migration que tinha sido editada in-place duas vezes foi desmembrada numa nova migration própria (evita drift de schema entre ambientes).

## Test plan

- [x] Suíte backend: 740 testes passando (`pytest -q -m "not rls_e2e"`), ruff limpo
- [x] Suíte frontend: 124 testes passando (vitest), tsc limpo, eslint limpo
- [x] `alembic heads` → uma única head, cadeia linear de migrations
- [x] Smoke test manual fim-a-fim: handshake do webhook, mensagem simulada via curl (assinatura HMAC real) → lead criado no CRM + conversa aparece na tela, resposta de texto enviada com sucesso
- [x] Isolamento de tenant no caminho do webhook (pré-autenticação) traçado manualmente pelo revisor final
- [x] Criptografia do `app_secret` confirmada via SQL bruto (bypassa o ORM) — valor armazenado não é o texto plano

## Dívida conhecida (não bloqueia este merge, documentada para follow-up)

- `mark_read` audita a cada poll de 7s enquanto a conversa fica aberta (não só ao abrir) — ok para piloto de 1 tenant, precisa de guarda de idempotência antes de escalar
- `list_conversations` carrega todas as mensagens do tenant em memória a cada poll — ok na escala atual, precisa de agregação (`GROUP BY`) antes de escalar
- Mídia recebida >10MB falha silenciosamente (limite dos Anexos não foi desenhado pro WhatsApp, que permite até ~100MB)
- Content-Type da mídia baixada é adivinhado pelo tipo da mensagem, não o mime real que a Meta envia

🤖 Gerado com [Claude Code](https://claude.com/claude-code)