### PR TITLE
feat: campos customizados no bloco Formulário do Sites

### DIFF
--- a/apps/api/app/modules/pages/router.py
+++ b/apps/api/app/modules/pages/router.py
@@ -151,6 +151,7 @@ def public_submit(
             name=data.name,
             email=str(data.email) if data.email else None,
             phone=data.phone,
+            fields=data.fields,
             session_factory=session_factory,
         )
     except service.PageError as e:

--- a/apps/api/app/modules/pages/schemas.py
+++ b/apps/api/app/modules/pages/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 
 class PageCreate(BaseModel):
@@ -64,3 +64,17 @@ class LeadSubmit(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     email: EmailStr | None = None
     phone: str = Field(default="", max_length=32)
+    # Respostas dos campos customizados do bloco Formulário (ex.: "Qual a ocasião?" → "Casamento")
+    # sem equivalente direto no CRM — viram um bloco de texto anexado às notas do lead, mesmo
+    # padrão de `integrations.LeadCapture.fields`.
+    fields: dict[str, str] | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _blank_email_to_none(cls, v: object) -> object:
+        # Formulário externo com campo opcional vazio manda "", não omite a chave — sem isso o
+        # EmailStr rejeita string vazia com 422 e o lead se perde (mesmo bug já corrigido em
+        # integrations.LeadCapture).
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v

--- a/apps/api/app/modules/pages/service.py
+++ b/apps/api/app/modules/pages/service.py
@@ -31,7 +31,7 @@ def _btn(label: str, url: str = "") -> dict:
 
 
 def _form(button: str = "Enviar") -> dict:
-    return {"type": "form", "fields": ["name", "email", "phone"], "button": button}
+    return {"type": "form", "button": button, "showEmail": True, "extraFields": [], "disclaimer": ""}
 
 
 # Templates iniciais por modelo de página (mesmos modelos dos nós-página do funil).
@@ -189,8 +189,22 @@ def public_view(db: Session, *, slug: str) -> dict:
     return snap.data
 
 
+def _format_fields(fields: dict[str, str] | None) -> str:
+    if not fields:
+        return ""
+    lines = "\n".join(f"{k}: {v}" for k, v in fields.items() if v)
+    return f"Campos do formulário:\n{lines}" if lines else ""
+
+
 def public_submit(
-    db: Session, *, slug: str, name: str, email: str | None, phone: str, session_factory
+    db: Session,
+    *,
+    slug: str,
+    name: str,
+    email: str | None,
+    phone: str,
+    fields: dict[str, str] | None = None,
+    session_factory,
 ) -> None:
     """Formulário de captura → cria um LEAD no CRM do tenant dono da página."""
     snap = db.get(PublishedPage, slug)
@@ -202,5 +216,8 @@ def public_submit(
     with session_factory(snap.tenant_id) as tdb:
         crm_service.create_client(
             tdb, tenant_id=snap.tenant_id, actor="pagina:lead",
-            data=ClientCreate(name=name, email=email, phone=phone or None, source="landing"),
+            data=ClientCreate(
+                name=name, email=email, phone=phone or None, source="landing",
+                notes=_format_fields(fields),
+            ),
         )

--- a/apps/api/app/modules/pages/service.py
+++ b/apps/api/app/modules/pages/service.py
@@ -31,7 +31,9 @@ def _btn(label: str, url: str = "") -> dict:
 
 
 def _form(button: str = "Enviar") -> dict:
-    return {"type": "form", "button": button, "showEmail": True, "extraFields": [], "disclaimer": ""}
+    return {
+        "type": "form", "button": button, "showEmail": True, "extraFields": [], "disclaimer": "",
+    }
 
 
 # Templates iniciais por modelo de página (mesmos modelos dos nós-página do funil).

--- a/apps/api/tests/test_pages.py
+++ b/apps/api/tests/test_pages.py
@@ -51,6 +51,25 @@ def test_form_submit_creates_lead(client: TestClient, headers):
     assert lead and lead[0]["source"] == "landing"
 
 
+def test_form_submit_with_extra_fields_goes_to_notes(client: TestClient, headers):
+    p = client.post("/pages", json={"title": "Captura", "model": "captura"}, headers=headers).json()
+    client.post(f"/pages/{p['id']}/publish", headers=headers)
+    resp = client.post(
+        f"/public/pages/{p['public_slug']}/submit",
+        json={
+            "name": "Lead com campos extras",
+            "phone": "11999",
+            "fields": {"Qual a ocasião?": "Casamento", "Convidados": "150"},
+        },
+    )
+    assert resp.status_code == 200
+    clients = client.get("/crm/clients", headers=headers).json()
+    lead = [c for c in clients if c["name"] == "Lead com campos extras"][0]
+    assert lead["source"] == "landing"
+    assert "Casamento" in lead["notes"]
+    assert "150" in lead["notes"]
+
+
 def test_update_blocks_and_publish_sync(client: TestClient, headers):
     p = client.post("/pages", json={"title": "X", "model": "conteudo"}, headers=headers).json()
     client.post(f"/pages/{p['id']}/publish", headers=headers)

--- a/apps/web/src/features/sites/PageBlocks.tsx
+++ b/apps/web/src/features/sites/PageBlocks.tsx
@@ -1,6 +1,18 @@
 import type { PageBlock, PageStyle } from "@e1p/shared-types";
 import { useState } from "react";
 
+export type LeadPayload = { name: string; email: string; phone: string; fields: Record<string, string> };
+
+export type ExtraField = {
+  key: string;
+  label: string;
+  kind: "text" | "select";
+  placeholder?: string;
+  helper?: string;
+  options?: string[];
+  fullWidth?: boolean;
+};
+
 const safeSrc = (u: unknown) =>
   typeof u === "string" && /^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "";
 
@@ -12,7 +24,7 @@ export default function PageBlocks({
 }: {
   blocks: PageBlock[];
   style: PageStyle;
-  onLead?: (lead: { name: string; email: string; phone: string }) => Promise<void>;
+  onLead?: (lead: LeadPayload) => Promise<void>;
 }) {
   return (
     <div
@@ -36,7 +48,7 @@ function Block({
 }: {
   block: PageBlock;
   style: PageStyle;
-  onLead?: (lead: { name: string; email: string; phone: string }) => Promise<void>;
+  onLead?: (lead: LeadPayload) => Promise<void>;
 }) {
   const s = (k: string) => (typeof block[k] === "string" ? (block[k] as string) : "");
   switch (block.type) {
@@ -79,7 +91,7 @@ function Block({
         </div>
       );
     case "form":
-      return <LeadForm button={s("button") || "Enviar"} style={style} onLead={onLead} />;
+      return <LeadForm block={block} style={style} onLead={onLead} />;
     case "divider":
       return <hr className="border-black/10" />;
     default:
@@ -88,25 +100,37 @@ function Block({
 }
 
 function LeadForm({
-  button,
+  block,
   style,
   onLead,
 }: {
-  button: string;
+  block: PageBlock;
   style: PageStyle;
-  onLead?: (lead: { name: string; email: string; phone: string }) => Promise<void>;
+  onLead?: (lead: LeadPayload) => Promise<void>;
 }) {
+  const s = (k: string) => (typeof block[k] === "string" ? (block[k] as string) : "");
+  const showEmail = block.showEmail === true;
+  const extraFields: ExtraField[] = Array.isArray(block.extraFields) ? (block.extraFields as ExtraField[]) : [];
+  const button = s("button") || "Enviar";
+  const disclaimer = s("disclaimer");
+
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  const [values, setValues] = useState<Record<string, string>>({});
   const [done, setDone] = useState(false);
   const [busy, setBusy] = useState(false);
 
   async function submit() {
-    if (!name.trim() || !onLead) return;
+    if (!name.trim() || !phone.trim() || !onLead) return;
     setBusy(true);
     try {
-      await onLead({ name, email, phone });
+      const fields: Record<string, string> = {};
+      for (const f of extraFields) {
+        const v = values[f.key];
+        if (v && v.trim()) fields[f.label] = v.trim();
+      }
+      await onLead({ name, email, phone, fields });
       setDone(true);
     } finally {
       setBusy(false);
@@ -121,20 +145,93 @@ function LeadForm({
     );
   }
 
-  const inp = "w-full rounded-lg border border-black/10 bg-white px-3 py-2 text-sm text-neutral-800 outline-none";
+  const border = `${style.text_color}33`;
+  const inputBg = `${style.text_color}0d`;
+  const mutedText = `${style.text_color}99`;
+  const label = "mb-1 block text-sm font-semibold";
+  const inp = "w-full rounded-lg px-3 py-2.5 text-sm outline-none";
+  const inpStyle = { background: inputBg, border: `1px solid ${border}`, color: style.text_color };
+
   return (
-    <div className="space-y-2 rounded-xl bg-black/5 p-4">
-      <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Seu nome" className={inp} />
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Seu e-mail" className={inp} />
-      <input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Seu WhatsApp" className={inp} />
+    <div
+      className="rounded-2xl p-6 sm:p-7"
+      style={{ background: `${style.accent_color}14`, border: `1px solid ${border}` }}
+    >
+      <div className="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
+        <div>
+          <span className={label}>{s("nameLabel") || "Seu nome"}</span>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={s("namePlaceholder") || "Como podemos te chamar?"}
+            className={inp}
+            style={inpStyle}
+          />
+        </div>
+        <div>
+          <span className={label}>{s("phoneLabel") || "Seu WhatsApp"}</span>
+          <input
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder={s("phonePlaceholder") || "(43) 9 9999-9999"}
+            className={inp}
+            style={inpStyle}
+          />
+          {s("phoneHelper") && (
+            <p className="mt-1 text-xs" style={{ color: mutedText }}>{s("phoneHelper")}</p>
+          )}
+        </div>
+        {showEmail && (
+          <div className="sm:col-span-2">
+            <span className={label}>{s("emailLabel") || "Seu e-mail"}</span>
+            <input
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={s("emailPlaceholder") || "seu@email.com"}
+              className={inp}
+              style={inpStyle}
+            />
+          </div>
+        )}
+        {extraFields.map((f) => (
+          <div key={f.key} className={f.fullWidth ? "sm:col-span-2" : undefined}>
+            <span className={label}>{f.label}</span>
+            {f.kind === "select" ? (
+              <select
+                value={values[f.key] ?? ""}
+                onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
+                className={inp}
+                style={inpStyle}
+              >
+                <option value="">{f.placeholder || "Selecione"}</option>
+                {(f.options ?? []).map((o) => (
+                  <option key={o} value={o}>{o}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                value={values[f.key] ?? ""}
+                onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
+                placeholder={f.placeholder}
+                className={inp}
+                style={inpStyle}
+              />
+            )}
+            {f.helper && <p className="mt-1 text-xs" style={{ color: mutedText }}>{f.helper}</p>}
+          </div>
+        ))}
+      </div>
       <button
         onClick={submit}
-        disabled={busy || !name.trim() || !onLead}
-        className="w-full rounded-pill py-2.5 font-bold text-white disabled:opacity-60"
-        style={{ background: style.accent_color }}
+        disabled={busy || !name.trim() || !phone.trim() || !onLead}
+        className="mt-5 w-full rounded-pill py-3 text-base font-bold disabled:opacity-60"
+        style={{ background: style.accent_color, color: style.primary_color }}
       >
         {busy ? "Enviando..." : button}
       </button>
+      {disclaimer && (
+        <p className="mt-3 text-center text-xs" style={{ color: mutedText }}>{disclaimer}</p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/sites/PageBuilderPage.tsx
+++ b/apps/web/src/features/sites/PageBuilderPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import ImageUploadButton from "../../components/ImageUploadButton";
 import { api, apiErrorMessage } from "../../lib/api";
-import PageBlocks from "./PageBlocks";
+import PageBlocks, { type ExtraField } from "./PageBlocks";
 
 const BLOCK_TYPES: [string, string][] = [
   ["heading", "Título"], ["text", "Texto"], ["image", "Imagem"], ["button", "Botão"],
@@ -18,7 +18,8 @@ function blankBlock(type: string): PageBlock {
     case "text": return { type, text: "Novo texto" };
     case "image": return { type, url: "" };
     case "button": return { type, label: "Clique aqui", url: "" };
-    case "form": return { type, fields: ["name", "email", "phone"], button: "Enviar" };
+    case "form":
+      return { type, button: "Enviar", showEmail: true, extraFields: [] as ExtraField[], disclaimer: "" };
     case "video": return { type, url: "" };
     default: return { type: "divider" };
   }
@@ -214,8 +215,78 @@ function BlockFields({ block, onChange }: { block: PageBlock; onChange: (p: Part
         </div>
       );
     case "form":
-      return <input value={v("button")} onChange={(e) => onChange({ button: e.target.value })} placeholder="Texto do botão" className={inp} />;
+      return <FormBlockFields block={block} onChange={onChange} />;
     default:
       return <p className="text-xs text-neutral-400">Linha divisória</p>;
   }
+}
+
+function FormBlockFields({ block, onChange }: { block: PageBlock; onChange: (p: Partial<PageBlock>) => void }) {
+  const v = (k: string) => (typeof block[k] === "string" ? (block[k] as string) : "");
+  const extraFields: ExtraField[] = Array.isArray(block.extraFields) ? (block.extraFields as ExtraField[]) : [];
+  const inp = "w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-primary-400";
+
+  function setFields(next: ExtraField[]) {
+    onChange({ extraFields: next });
+  }
+  function addField() {
+    setFields([
+      ...extraFields,
+      { key: `campo_${Date.now()}`, label: "Nova pergunta", kind: "text", placeholder: "" },
+    ]);
+  }
+  function patchField(i: number, patch: Partial<ExtraField>) {
+    setFields(extraFields.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+  }
+  function removeField(i: number) {
+    setFields(extraFields.filter((_, idx) => idx !== i));
+  }
+
+  return (
+    <div className="space-y-2">
+      <input value={v("button")} onChange={(e) => onChange({ button: e.target.value })} placeholder="Texto do botão" className={inp} />
+      <label className="flex items-center gap-1.5 text-xs text-neutral-500">
+        <input type="checkbox" checked={block.showEmail !== false} onChange={(e) => onChange({ showEmail: e.target.checked })} />
+        Mostrar campo de e-mail
+      </label>
+      <input value={v("phoneHelper")} onChange={(e) => onChange({ phoneHelper: e.target.value })} placeholder="Texto de ajuda abaixo do WhatsApp (opcional)" className={inp} />
+      <textarea value={v("disclaimer")} onChange={(e) => onChange({ disclaimer: e.target.value })} placeholder="Aviso abaixo do botão (opcional)" rows={2} className={inp} />
+
+      <div className="space-y-2 rounded-lg bg-neutral-50 p-2">
+        <p className="text-xs font-semibold text-neutral-500">Campos extras</p>
+        {extraFields.map((f, i) => (
+          <div key={i} className="space-y-1 rounded-lg border border-neutral-200 bg-white p-2">
+            <div className="flex items-center gap-1">
+              <input value={f.label} onChange={(e) => patchField(i, { label: e.target.value })} placeholder="Pergunta (rótulo)" className={`${inp} flex-1`} />
+              <button onClick={() => removeField(i)} className="text-neutral-300 hover:text-danger"><Trash2 size={14} /></button>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <select value={f.kind} onChange={(e) => patchField(i, { kind: e.target.value as ExtraField["kind"] })} className={inp}>
+                <option value="text">Texto livre</option>
+                <option value="select">Lista de opções</option>
+              </select>
+              <label className="flex items-center gap-1 whitespace-nowrap text-xs text-neutral-500">
+                <input type="checkbox" checked={!!f.fullWidth} onChange={(e) => patchField(i, { fullWidth: e.target.checked })} />
+                Largura total
+              </label>
+            </div>
+            {f.kind === "select" ? (
+              <input
+                value={(f.options ?? []).join(", ")}
+                onChange={(e) => patchField(i, { options: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+                placeholder="Opções separadas por vírgula"
+                className={inp}
+              />
+            ) : (
+              <input value={f.placeholder ?? ""} onChange={(e) => patchField(i, { placeholder: e.target.value })} placeholder="Placeholder" className={inp} />
+            )}
+            <input value={f.helper ?? ""} onChange={(e) => patchField(i, { helper: e.target.value })} placeholder="Texto de ajuda abaixo do campo (opcional)" className={inp} />
+          </div>
+        ))}
+        <button onClick={addField} className="flex items-center gap-1 text-xs font-medium text-primary-600">
+          <Plus size={12} /> Adicionar campo
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/features/sites/PublicPage.tsx
+++ b/apps/web/src/features/sites/PublicPage.tsx
@@ -2,7 +2,7 @@ import type { PublicPage as PublicPageT } from "@e1p/shared-types";
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { publicApi } from "../../lib/api";
-import PageBlocks from "./PageBlocks";
+import PageBlocks, { type LeadPayload } from "./PageBlocks";
 
 /** Página pública (visitante abre sem login). */
 export default function PublicPage() {
@@ -25,11 +25,12 @@ export default function PublicPage() {
     load();
   }, [load]);
 
-  async function lead(l: { name: string; email: string; phone: string }) {
+  async function lead(l: LeadPayload) {
     await publicApi.post(`/public/pages/${slug}/submit`, {
       name: l.name,
       email: l.email || null,
       phone: l.phone,
+      fields: Object.keys(l.fields).length ? l.fields : null,
     });
   }
 


### PR DESCRIPTION
## Summary
- Bloco "Formulário" do construtor de páginas (Sites) agora suporta campos extras configuráveis (texto livre ou lista de opções), texto de ajuda por campo, aviso abaixo do botão e toggle de e-mail.
- Respostas dos campos extras viram notas do lead (`ClientCreate.notes`), mesmo padrão do módulo Integrações — mas via `source=landing`, sem precisar gerar chave de API para páginas hospedadas no próprio e1p.
- Motivação: landing page com perguntas específicas (ex.: data do evento, ocasião, nº de convidados) sem depender do mecanismo de Integrações.

## Test plan
- [x] `pytest tests/test_pages.py` — 7 passed (inclui novo teste `test_form_submit_with_extra_fields_goes_to_notes`)
- [x] `tsc --noEmit` limpo
- [x] `eslint` limpo nos arquivos alterados
- [x] `vitest run src/features/sites` — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)