### PR TITLE
feat: nós de e-mail/WhatsApp do funil podem alertar a equipe

### DIFF
--- a/apps/api/app/modules/funnels/engine.py
+++ b/apps/api/app/modules/funnels/engine.py
@@ -97,9 +97,11 @@ def _params(data: dict) -> dict:
                 "amount_cents": cfg.get("amount_cents", 0)}
     if action == "send_email":
         return {"subject": cfg.get("subject", ""),
-                "message": cfg.get("body") or cfg.get("message", "")}
+                "message": cfg.get("body") or cfg.get("message", ""),
+                "recipient": cfg.get("recipient", "client")}
     if action == "send_message":
-        return {"template_id": cfg.get("template_id"), "variables": cfg.get("variables") or []}
+        return {"template_id": cfg.get("template_id"), "variables": cfg.get("variables") or [],
+                "recipient": cfg.get("recipient", "client")}
     if action == "create_client":
         return {"name": cfg.get("name", "")}
     return {}

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -313,6 +313,7 @@ def run_node(
     from datetime import UTC, datetime, timedelta
 
     from app.core import email, whatsapp
+    from app.modules.auth.models import User
     from app.modules.crm import service as crm_service
     from app.modules.crm.models import Client
     from app.modules.crm.schemas import ClientCreate
@@ -329,6 +330,27 @@ def run_node(
         if c is None:
             raise FunnelError("Selecione um cliente para executar esta ação", 422)
         return c
+
+    def _team_owner() -> User | None:
+        return db.scalar(select(User).where(User.tenant_id == tenant_id, User.role == "owner"))
+
+    def _team_email() -> str:
+        """E-mail da equipe (nó com destinatário="team"): TenantProfile.email → User.email
+        do owner (fallback — sempre existe, garante que o nó funcione mesmo sem configurar)."""
+        profile = settings_service.get_profile(db, tenant_id)
+        if profile.email:
+            return profile.email
+        owner = _team_owner()
+        return owner.email if owner else ""
+
+    def _team_phone() -> str:
+        """Telefone da equipe (nó com destinatário="team"): TenantProfile.phone → User.phone
+        do owner."""
+        profile = settings_service.get_profile(db, tenant_id)
+        if profile.phone:
+            return profile.phone
+        owner = _team_owner()
+        return (owner.phone or "") if owner else ""
 
     if action == "create_client":
         name = (params.get("name") or "").strip()
@@ -384,7 +406,8 @@ def run_node(
         msg = (params.get("message") or "").strip()
         if not msg:
             raise FunnelError("Escreva a mensagem (ou gere com IA) antes de enviar", 422)
-        recipient = c.email or c.name
+        to_team = params.get("recipient") == "team"
+        recipient = _team_email() if to_team else (c.email or c.name)
         subject = (params.get("subject") or "Mensagem").strip()
         status = email.send_email(to=recipient, subject=subject, body=msg)
         db.add(Notification(
@@ -393,7 +416,8 @@ def run_node(
         ))
         audit.record(db, tenant_id=tenant_id, actor=actor, action="funnel.run.message", target=c.id)
         db.commit()
-        return {"message": f"Mensagem registrada para {c.name} (email)", "kind": "message",
+        who = "equipe" if to_team else c.name
+        return {"message": f"Mensagem registrada para {who} (email)", "kind": "message",
                 "ref_id": c.id}
 
     if action == "send_message":
@@ -404,11 +428,13 @@ def run_node(
         tpl = db.get(WhatsappTemplate, template_id)
         if tpl is None or tpl.status != STATUS_APPROVED:
             raise FunnelError("Template não encontrado ou ainda não aprovado pela Meta", 422)
-        recipient = c.phone or c.name
+        to_team = params.get("recipient") == "team"
+        to_phone = _team_phone() if to_team else (c.phone or "")
+        recipient = to_phone or c.name
         resolved_vars = [_resolve_template_variable(v, c) for v in (params.get("variables") or [])]
         profile = settings_service.get_profile(db, tenant_id)
         status = whatsapp.send_template(
-            to=c.phone or "", token=profile.whatsapp_token or "",
+            to=to_phone, token=profile.whatsapp_token or "",
             phone_id=profile.whatsapp_phone_id or "",
             template_name=tpl.name, language=tpl.language, variables=resolved_vars,
         )
@@ -419,7 +445,8 @@ def run_node(
         ))
         audit.record(db, tenant_id=tenant_id, actor=actor, action="funnel.run.message", target=c.id)
         db.commit()
-        return {"message": f"Mensagem registrada para {c.name} (whatsapp)", "kind": "message",
+        who = "equipe" if to_team else c.name
+        return {"message": f"Mensagem registrada para {who} (whatsapp)", "kind": "message",
                 "ref_id": c.id}
 
     raise FunnelError("Este componente ainda não executa uma ação automática", 400)

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -273,6 +273,29 @@ def test_run_send_email(client: TestClient, headers):
     )
 
 
+def test_run_send_email_to_team(client: TestClient, headers):
+    # Nó configurado com destinatário="team" (ex.: alertar a equipe de um lead novo) envia pro
+    # e-mail do escritório (perfil), não pro cliente — sem perfil.email configurado, cai no
+    # e-mail do owner (fallback, garante que o nó funcione fora da caixa).
+    cl = client.post(
+        "/crm/clients", json={"name": "Lead Site", "email": "lead@example.com"}, headers=headers
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_email", "client_id": cl["id"],
+              "params": {"subject": "Novo lead", "message": "Chegou um lead novo!",
+                         "recipient": "team"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    notifs = client.get("/notifications", headers=headers).json()
+    assert any(
+        n["message"] == "Chegou um lead novo!" and n["channel"] == "email"
+        and n["recipient"] == "funil@example.com"  # owner (REGISTER["email"]), não o lead
+        for n in notifs
+    )
+
+
 def test_run_requires_client(client: TestClient, headers):
     resp = client.post(
         "/funnels/run-node",

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -33,6 +33,9 @@ type NodeConfig = {
   amount_cents?: number; method?: "boleto" | "pix"; tag?: string;
   // WhatsApp: template Meta aprovado + valores posicionais (literal ou {{cliente.*}}).
   template_id?: string; variables?: string[];
+  // E-mail/WhatsApp: para quem vai — o lead (padrão) ou a equipe (alerta interno, ex.: "novo
+  // lead chegou"). "team" resolve pro e-mail/telefone do escritório (Configurações → Perfil).
+  recipient?: "client" | "team";
 };
 type NodeData = {
   label: string; description: string; color: string; category: string; key: string;
@@ -577,10 +580,12 @@ function RunNodeModal({
     if (action === "send_email") {
       params.subject = subject;
       params.message = message;
+      params.recipient = node.data.config?.recipient ?? "client";
     }
     if (action === "send_message") {
       params.template_id = node.data.config?.template_id;
       params.variables = node.data.config?.variables ?? [];
+      params.recipient = node.data.config?.recipient ?? "client";
     }
     try {
       const { data } = await api.post<{ message: string }>("/funnels/run-node", {
@@ -634,6 +639,12 @@ function RunNodeModal({
             </>
           )}
           {money && <Field label="Valor (R$)" value={amount} onChange={setAmount} placeholder="0,00" />}
+          {(action === "send_email" || action === "send_message") && node.data.config?.recipient === "team" && (
+            <p className="rounded-lg bg-primary-50 p-2 text-xs text-primary-700">
+              Destinatário configurado no nó: <strong>Equipe</strong> — vai pro e-mail/telefone do
+              escritório, não pro cliente selecionado.
+            </p>
+          )}
           {action === "send_email" && <Field label="Assunto" value={subject} onChange={setSubject} />}
           {action === "send_email" && (
             <label className="block">
@@ -701,6 +712,7 @@ function NodeContentEditor({
   const [templates, setTemplates] = useState<WhatsappTemplate[]>([]);
   const [templateId, setTemplateId] = useState(node.data.config?.template_id ?? "");
   const [variables, setVariables] = useState<string[]>(node.data.config?.variables ?? []);
+  const [recipient, setRecipient] = useState<"client" | "team">(node.data.config?.recipient ?? "client");
 
   useEffect(() => {
     if (!isWhatsapp) return;
@@ -753,6 +765,26 @@ function NodeContentEditor({
           <h3 className="text-lg font-bold text-neutral-800">{title}</h3>
         </div>
         <p className="mb-4 text-xs text-neutral-400">{node.data.label}</p>
+
+        {(isEmail || isWhatsapp) && (
+          <label className="mb-3 block">
+            <span className="mb-1 block text-xs font-medium text-neutral-600">Destinatário</span>
+            <select
+              value={recipient}
+              onChange={(e) => setRecipient(e.target.value as "client" | "team")}
+              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            >
+              <option value="client">Cliente (o lead da jornada)</option>
+              <option value="team">Equipe (alerta interno — e-mail/telefone do escritório)</option>
+            </select>
+            {recipient === "team" && (
+              <p className="mt-1 text-[11px] text-neutral-400">
+                Usa o e-mail/telefone de Configurações → Perfil da empresa (ou o do dono da conta,
+                se não estiver preenchido).
+              </p>
+            )}
+          </label>
+        )}
 
         {isPage && (
           <label className="mb-3 block">
@@ -846,8 +878,11 @@ function NodeContentEditor({
             onClick={() =>
               onSave(
                 isWhatsapp
-                  ? { template_id: templateId, variables }
-                  : { subject: isEmail ? subject : "", body, model: isPage ? model : undefined },
+                  ? { template_id: templateId, variables, recipient }
+                  : {
+                      subject: isEmail ? subject : "", body, model: isPage ? model : undefined,
+                      recipient: isEmail ? recipient : undefined,
+                    },
               )
             }
             disabled={isWhatsapp && !templateId}


### PR DESCRIPTION
## Summary
- Nós de e-mail e WhatsApp no Construtor de Funil de Vendas ganham um seletor **Destinatário**: "Cliente" (padrão, comportamento atual) ou "Equipe" (alerta interno).
- Com "Equipe", o envio resolve para `TenantProfile.email`/`TenantProfile.phone` (Configurações → Perfil da empresa), com fallback para o e-mail/telefone do dono da conta.
- Motivação: permitir configurar visualmente, dentro do próprio funil, um alerta de "novo lead chegou" (ex.: nó logo após a entrada do funil "Boas-vindas site") — sem precisar de um assinante de evento fixo no backend específico para esse caso.
- Funciona tanto na execução automática (motor do funil, `engine._params`) quanto no teste manual ("Executar ação" no builder).

## Test plan
- [x] `pytest tests/test_funnels.py tests/test_funnel_automation.py` — 30 passed (inclui novo `test_run_send_email_to_team`)
- [x] `pytest` suíte completa — 744 passed
- [x] `tsc --noEmit` e `eslint` limpos no arquivo alterado

🤖 Generated with [Claude Code](https://claude.com/claude-code)