### PR TITLE
feat: placeholders {{cliente.*}} no e-mail do funil

### DIFF
--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -177,12 +177,17 @@ class FunnelError(Exception):
         self.status_code = status_code
 
 
-# ── WhatsApp: resolução de variáveis de template ({{cliente.*}} ou texto literal) ──
+# ── WhatsApp/E-mail: resolução de placeholders ({{cliente.*}} ou texto literal) ──
 _CLIENT_KEYWORDS = {
     "cliente.nome": lambda c: c.name,
     "cliente.telefone": lambda c: c.phone or "",
     "cliente.email": lambda c: c.email or "",
+    # Bloco de Observações do lead — já traz as respostas de campos customizados de
+    # formulários (Sites/Integrações), sem precisar de uma keyword por campo (que varia
+    # de página pra página).
+    "cliente.notas": lambda c: c.notes or "",
 }
+_KEYWORD_PATTERN = re.compile(r"\{\{\s*(cliente\.\w+)\s*\}\}")
 
 
 def _resolve_template_variable(raw: str, client) -> str:
@@ -192,6 +197,18 @@ def _resolve_template_variable(raw: str, client) -> str:
         if resolver is not None:
             return resolver(client) or ""
     return raw  # texto fixo, literal
+
+
+def _render_client_placeholders(text: str, client) -> str:
+    """Substitui `{{cliente.*}}` NO MEIO de um texto livre (assunto/corpo de e-mail) — ao
+    contrário de `_resolve_template_variable` (variável posicional inteira do WhatsApp), aqui
+    o placeholder pode aparecer misturado com texto fixo."""
+
+    def _sub(m: re.Match[str]) -> str:
+        resolver = _CLIENT_KEYWORDS.get(m.group(1))
+        return (resolver(client) or "") if resolver else m.group(0)
+
+    return _KEYWORD_PATTERN.sub(_sub, text)
 
 
 def _render_template_preview(body_text: str, variables: list[str]) -> str:
@@ -408,7 +425,8 @@ def run_node(
             raise FunnelError("Escreva a mensagem (ou gere com IA) antes de enviar", 422)
         to_team = params.get("recipient") == "team"
         recipient = _team_email() if to_team else (c.email or c.name)
-        subject = (params.get("subject") or "Mensagem").strip()
+        subject = _render_client_placeholders((params.get("subject") or "Mensagem").strip(), c)
+        msg = _render_client_placeholders(msg, c)
         status = email.send_email(to=recipient, subject=subject, body=msg)
         db.add(Notification(
             tenant_id=tenant_id, channel="email", recipient=recipient,

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -296,6 +296,37 @@ def test_run_send_email_to_team(client: TestClient, headers):
     )
 
 
+def test_run_send_email_resolves_client_placeholders(client: TestClient, headers):
+    # {{cliente.*}} no assunto/corpo do e-mail é substituído pelos dados reais do lead — inclui
+    # {{cliente.notas}}, que traz as respostas de campos customizados sem precisar de uma
+    # keyword por campo (formulário varia de página pra página).
+    cl = client.post(
+        "/crm/clients",
+        json={"name": "Raissa", "phone": "43996823962",
+              "notes": "Ocasião: Casamento\nConvidados: 160"},
+        headers=headers,
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_email", "client_id": cl["id"],
+              "params": {
+                  "subject": "Novo lead: {{cliente.nome}}",
+                  "message": "Nome: {{cliente.nome}}\nWhatsApp: {{cliente.telefone}}\n\n"
+                             "{{cliente.notas}}",
+                  "recipient": "team",
+              }},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    notifs = client.get("/notifications", headers=headers).json()
+    notif = next(n for n in notifs if n["client_id"] == cl["id"])
+    assert "Nome: Raissa" in notif["message"]
+    assert "WhatsApp: 43996823962" in notif["message"]
+    assert "Ocasião: Casamento" in notif["message"]
+    assert "Convidados: 160" in notif["message"]
+    assert "{{" not in notif["message"]
+
+
 def test_run_requires_client(client: TestClient, headers):
     resp = client.post(
         "/funnels/run-node",

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -688,6 +688,9 @@ function Field({ label, value, onChange, placeholder }: {
 }
 
 const TEMPLATE_KEYWORDS = ["cliente.nome", "cliente.telefone", "cliente.email"] as const;
+// E-mail (texto livre, não posicional): mesmas + notas — traz as respostas de campos
+// customizados do formulário (Sites/Integrações) sem precisar de uma keyword por campo.
+const EMAIL_KEYWORDS = [...TEMPLATE_KEYWORDS, "cliente.notas"] as const;
 
 function NodeContentEditor({
   node,
@@ -868,6 +871,22 @@ function NodeContentEditor({
             <label className="mb-4 block">
               <span className="mb-1 block text-xs font-medium text-neutral-600">{bodyLabel}</span>
               <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={isEmail ? 8 : 5} placeholder={`Escreva ${bodyLabel.toLowerCase()}...`} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+              {isEmail && (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  <span className="text-[11px] text-neutral-400">Inserir dado do lead:</span>
+                  {EMAIL_KEYWORDS.map((kw) => (
+                    <button
+                      key={kw}
+                      type="button"
+                      onClick={() => setBody((b) => `${b}${b && !b.endsWith("\n") ? " " : ""}{{${kw}}}`)}
+                      title={`Inserir {{${kw}}}`}
+                      className="shrink-0 rounded-lg bg-neutral-100 px-2 py-0.5 text-[10px] font-semibold text-neutral-600 hover:bg-neutral-200"
+                    >
+                      {kw.split(".")[1]}
+                    </button>
+                  ))}
+                </div>
+              )}
             </label>
           </>
         )}


### PR DESCRIPTION
## Summary
- `{{cliente.nome}}`, `{{cliente.telefone}}`, `{{cliente.email}}` e `{{cliente.notas}}` agora funcionam no assunto/corpo de e-mail dos nós de Comunicação do funil (antes só existiam como variável posicional de template do WhatsApp).
- `{{cliente.notas}}` injeta o bloco de Observações do lead — que já contém as respostas de campos customizados de formulários (Sites/Integrações) — sem precisar mapear uma keyword por campo (cada página pode ter perguntas diferentes).
- Editor do nó ganha botões de inserção rápida (nome/telefone/email/notas) no corpo do e-mail.

## Test plan
- [x] `pytest tests/test_funnels.py` — 21 passed (novo `test_run_send_email_resolves_client_placeholders`)
- [x] Suíte completa — 743 passed, 0 failed
- [x] `tsc --noEmit` e `eslint` limpos

🤖 Generated with [Claude Code](https://claude.com/claude-code)