### PR TITLE
fix: fallback (não informado) pra placeholders vazios no e-mail do funil

### DIFF
--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -180,11 +180,11 @@ class FunnelError(Exception):
 # ── WhatsApp/E-mail: resolução de placeholders ({{cliente.*}} ou texto literal) ──
 _CLIENT_KEYWORDS = {
     "cliente.nome": lambda c: c.name,
-    "cliente.telefone": lambda c: c.phone or "",
-    "cliente.email": lambda c: c.email or "",
+    "cliente.telefone": lambda c: c.phone or "(não informado)",
+    "cliente.email": lambda c: c.email or "(não informado)",
     # Bloco de Observações do lead — já traz as respostas de campos customizados de
     # formulários (Sites/Integrações), sem precisar de uma keyword por campo (que varia
-    # de página pra página).
+    # de página pra página). Vazio fica "" (não é um valor único tipo telefone/e-mail).
     "cliente.notas": lambda c: c.notes or "",
 }
 _KEYWORD_PATTERN = re.compile(r"\{\{\s*(cliente\.\w+)\s*\}\}")

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -327,6 +327,26 @@ def test_run_send_email_resolves_client_placeholders(client: TestClient, headers
     assert "{{" not in notif["message"]
 
 
+def test_run_send_email_placeholder_shows_fallback_when_empty(client: TestClient, headers):
+    # {{cliente.email}}/{{cliente.telefone}} sem valor viram "(não informado)" em vez de
+    # deixar a linha em branco no e-mail (ex.: "E-mail: " sem nada depois, confuso pra quem lê).
+    cl = client.post("/crm/clients", json={"name": "Sem Contato"}, headers=headers).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_email", "client_id": cl["id"],
+              "params": {
+                  "subject": "x",
+                  "message": "E-mail: {{cliente.email}}\nWhatsApp: {{cliente.telefone}}",
+                  "recipient": "team",
+              }},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    notifs = client.get("/notifications", headers=headers).json()
+    notif = next(n for n in notifs if n["client_id"] == cl["id"])
+    assert notif["message"] == "E-mail: (não informado)\nWhatsApp: (não informado)"
+
+
 def test_run_requires_client(client: TestClient, headers):
     resp = client.post(
         "/funnels/run-node",


### PR DESCRIPTION
## Summary
- `{{cliente.telefone}}` e `{{cliente.email}}` no corpo/assunto de e-mail agora caem em `"(não informado)"` quando o lead não tem esse dado, em vez de deixar a linha em branco (ex.: `E-mail: ` sem nada depois).
- `{{cliente.notas}}` continua vazio (`""`) quando não há Observações — é um bloco opcional, não um valor único.

## Test plan
- [x] `pytest tests/test_funnels.py` — 22 passed (novo `test_run_send_email_placeholder_shows_fallback_when_empty`)
- [x] Suíte completa — 744 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)