### PR TITLE
feat: botão de copiar código iframe no construtor de páginas

### DIFF
--- a/apps/web/src/features/sites/PageBuilderPage.test.tsx
+++ b/apps/web/src/features/sites/PageBuilderPage.test.tsx
@@ -132,3 +132,21 @@ describe("PageBuilderPage — publicar: tratamento de erro (Story 7.19)", () => 
     expect(screen.getByRole("button", { name: "Publicar" })).toBeEnabled();
   });
 });
+
+describe("PageBuilderPage — copiar código do iframe", () => {
+  it("salva a página e copia o <iframe> pronto pra colar em outro site", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    vi.mocked(api.patch).mockResolvedValue({ data: draftPage } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Copiar código/ }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const snippet = writeText.mock.calls[0][0] as string;
+    expect(snippet).toContain("<iframe");
+    expect(snippet).toContain(`src="${window.location.origin}/p/slug-teste"`);
+    expect(await screen.findByRole("button", { name: /Copiado!/ })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sites/PageBuilderPage.tsx
+++ b/apps/web/src/features/sites/PageBuilderPage.tsx
@@ -1,5 +1,5 @@
 import type { Page, PageBlock } from "@e1p/shared-types";
-import { ArrowLeft, ChevronDown, ChevronUp, Eye, Globe, Plus, Save, Trash2 } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, ChevronUp, Code2, Eye, Globe, Plus, Save, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import ImageUploadButton from "../../components/ImageUploadButton";
@@ -34,6 +34,7 @@ export default function PageBuilderPage() {
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const load = useCallback(async () => {
     const { data } = await api.get<Page>(`/pages/${id}`);
@@ -97,6 +98,31 @@ export default function PageBuilderPage() {
     if (page.public_slug) window.open(`/p/${page.public_slug}`, "_blank");
   };
 
+  const copyEmbed = async () => {
+    const saved = await save();
+    const slug = (saved ?? page).public_slug;
+    if (!slug) return;
+    const url = `${window.location.origin}/p/${slug}`;
+    const safeTitle = page.title.replace(/"/g, "&quot;");
+    const snippet = [
+      "<iframe",
+      `  src="${url}"`,
+      `  title="${safeTitle}"`,
+      '  width="100%"',
+      '  height="620"',
+      '  style="border: none; border-radius: 16px; max-width: 640px;"',
+      '  loading="lazy">',
+      "</iframe>",
+    ].join("\n");
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Não foi possível copiar automaticamente — copie o link da página (botão Ver) e monte o iframe manualmente.");
+    }
+  };
+
   const published = page.status === "published";
 
   return (
@@ -110,6 +136,13 @@ export default function PageBuilderPage() {
           {savedAt && <span className="text-xs text-neutral-400">{savedAt === "publicada" ? "Publicada" : `Salvo ${savedAt}`}</span>}
           <button onClick={view} className="flex items-center gap-1.5 rounded-pill bg-neutral-100 px-3 py-2 text-sm font-semibold text-neutral-600 hover:bg-neutral-200">
             <Eye size={14} /> Ver
+          </button>
+          <button
+            onClick={copyEmbed}
+            title="Copia o código <iframe> pronto pra colar em outro site"
+            className="flex items-center gap-1.5 rounded-pill bg-neutral-100 px-3 py-2 text-sm font-semibold text-neutral-600 hover:bg-neutral-200"
+          >
+            {copied ? <Check size={14} /> : <Code2 size={14} />} {copied ? "Copiado!" : "Copiar código (iframe)"}
           </button>
           <button onClick={publish} className="flex items-center gap-1.5 rounded-pill bg-primary-500 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-600">
             <Globe size={14} /> {published ? "Republicar" : "Publicar"}


### PR DESCRIPTION
## Summary
- Novo botão **"Copiar código (iframe)"** na tela de edição de páginas (Sites), ao lado de "Ver" — salva a página e copia pro clipboard um snippet `<iframe>` pronto pra colar em outro site (mesmo formato entregue manualmente antes para o embed do formulário da Doro Eventos).
- Feedback visual simples ("Copiado!" por 2s) sem precisar de um sistema de toast novo.

## Test plan
- [x] `vitest run src/features/sites` — 5 passed (novo teste do clipboard)
- [x] `tsc --noEmit` e `eslint` limpos

🤖 Generated with [Claude Code](https://claude.com/claude-code)