### PR TITLE
fix: permitir iframe nas páginas públicas /p/* (Traefik)

### DIFF
--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -129,6 +129,34 @@ services:
       - traefik.http.routers.e1p-web.middlewares=security-headers@file
       - traefik.http.services.e1p-web.loadbalancer.server.port=80
 
+      # Páginas públicas (Sites/Páginas — `/p/:slug`, sem login) são feitas pra serem embutidas
+      # via <iframe> no site externo do próprio tenant (ex.: formulário de captura). O middleware
+      # `security-headers@file` compartilhado do Traefik seta `frameDeny: true` (X-Frame-Options:
+      # DENY) em TODA resposta de e1p-web — correto pro app autenticado (login/CRM/dashboard,
+      # onde framing é risco real de clickjacking), mas quebra esse embed de propósito, sem
+      # exceção por rota. Em vez de editar o arquivo compartilhado (fora deste repo, arriscado —
+      # afeta outros projetos na mesma VPS), definimos aqui um middleware PRÓPRIO com os mesmos
+      # headers (HSTS, nosniff, referrer-policy, esconder Server) exceto frameDeny, e um router
+      # mais específico (maior prioridade) só pra `/p/`. `/p/:slug` já é público/sem-sessão por
+      # design (mesmo padrão de CORS aberto de `/public/leads/*` — ver PublicLeadsCORSMiddleware),
+      # então não há dado sensível em jogo pra esse risco de clickjacking valer a pena.
+      - traefik.http.middlewares.e1p-public-headers.headers.stsSeconds=31536000
+      - traefik.http.middlewares.e1p-public-headers.headers.stsIncludeSubdomains=true
+      - traefik.http.middlewares.e1p-public-headers.headers.stsPreload=true
+      - traefik.http.middlewares.e1p-public-headers.headers.contentTypeNosniff=true
+      - traefik.http.middlewares.e1p-public-headers.headers.referrerPolicy=strict-origin-when-cross-origin
+      - traefik.http.middlewares.e1p-public-headers.headers.customResponseHeaders.Server=
+      - traefik.http.routers.e1p-web-public.rule=(Host(`${DOMAIN}`) || HostRegexp(`^[a-z0-9-]+\.${ROOT_DOMAIN}$`)) && PathPrefix(`/p/`)
+      - traefik.http.routers.e1p-web-public.entrypoints=websecure
+      - traefik.http.routers.e1p-web-public.tls.certresolver=letsencrypt-dns
+      - traefik.http.routers.e1p-web-public.tls.domains[0].main=${ROOT_DOMAIN}
+      - traefik.http.routers.e1p-web-public.tls.domains[0].sans=*.${ROOT_DOMAIN}
+      # Maior que o catch-all (1), menor que /api (20) — não há sobreposição real com /api de
+      # qualquer forma (prefixos distintos), só segue o mesmo estilo explícito já usado acima.
+      - traefik.http.routers.e1p-web-public.priority=15
+      - traefik.http.routers.e1p-web-public.middlewares=e1p-public-headers@docker
+      - traefik.http.routers.e1p-web-public.service=e1p-web
+
 networks:
   db_internal:
     internal: true


### PR DESCRIPTION
## Summary
- O `security-headers@file` compartilhado do Traefik (definido fora deste repo, em `/opt/infra/proxy/`) seta `X-Frame-Options: DENY` em toda resposta de `e1p-web` — bloqueava o embed via `<iframe>` das páginas públicas do módulo Sites (`/p/:slug`), que são feitas de propósito pra serem embutidas no site externo do tenant (confirmado em produção com o embed real da Doro Eventos: "conexão recusada" no navegador).
- Em vez de editar o arquivo compartilhado (fora deste repo, afetaria outros projetos na mesma VPS), define um middleware próprio (`e1p-public-headers`, via labels Docker) com os mesmos headers de segurança (HSTS, nosniff, referrer-policy, esconder `Server`) **exceto** `frameDeny`, e um router mais específico (`e1p-web-public`, prioridade 15) só pra `PathPrefix(/p/)`.
- O resto do app (login, CRM, dashboard, API) continua exatamente como antes — `X-Frame-Options: DENY` intacto, protegido contra clickjacking.

## Test plan
- [x] `docker compose --env-file .env.prod -f docker-compose.traefik.yml config` — sem erros, labels resolvem corretamente (mesmo padrão já usado no router `/api`)
- [ ] Validar em produção: recarregar o iframe já embutido em doroeventos.com.br após o deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)