### PR TITLE
fix: contraste do select em tema escuro + tooltips das cores

### DIFF
--- a/apps/web/src/features/sites/PageBlocks.tsx
+++ b/apps/web/src/features/sites/PageBlocks.tsx
@@ -203,9 +203,17 @@ function LeadForm({
                 className={inp}
                 style={inpStyle}
               >
-                <option value="">{f.placeholder || "Selecione"}</option>
+                {/* A lista aberta é renderizada pelo navegador/SO, não pelo CSS da página — em
+                    temas escuros o texto claro herdado do <select> fica ilegível num popup que
+                    normalmente vem com fundo claro. Forçamos texto escuro sobre fundo claro só
+                    nas <option>, garantindo contraste independente do tema da página. */}
+                <option value="" style={{ color: "#1f2937", background: "#ffffff" }}>
+                  {f.placeholder || "Selecione"}
+                </option>
                 {(f.options ?? []).map((o) => (
-                  <option key={o} value={o}>{o}</option>
+                  <option key={o} value={o} style={{ color: "#1f2937", background: "#ffffff" }}>
+                    {o}
+                  </option>
                 ))}
               </select>
             ) : (

--- a/apps/web/src/features/sites/PageBuilderPage.tsx
+++ b/apps/web/src/features/sites/PageBuilderPage.tsx
@@ -159,8 +159,13 @@ export default function PageBuilderPage() {
         <div className="flex flex-col gap-3 overflow-auto rounded-2xl bg-white p-4 shadow-sm">
           {/* Aparência */}
           <div className="grid grid-cols-2 gap-2 rounded-xl bg-neutral-50 p-3">
-            {([["Primária", "primary_color"], ["Fundo", "bg_color"], ["Texto", "text_color"], ["Destaque", "accent_color"]] as [string, keyof Page][]).map(([label, key]) => (
-              <div key={key} className="flex items-center gap-1.5">
+            {([
+              ["Primária", "primary_color", "Cor do título e do texto do botão"],
+              ["Fundo", "bg_color", "Cor de fundo da página inteira"],
+              ["Texto", "text_color", "Cor dos rótulos, textos de ajuda e do que você digita nos campos"],
+              ["Destaque", "accent_color", "Cor de fundo do botão e do cartão do formulário"],
+            ] as [string, keyof Page, string][]).map(([label, key, hint]) => (
+              <div key={key} className="flex items-center gap-1.5" title={hint}>
                 <input type="color" value={page[key] as string} onChange={(e) => setStyle({ [key]: e.target.value } as Partial<Page>)} className="h-7 w-8 cursor-pointer rounded border border-neutral-200" />
                 <span className="text-xs text-neutral-500">{label}</span>
               </div>


### PR DESCRIPTION
## Summary
- A lista aberta de um campo "Lista de opções" (formulário do Sites) usava o `color` herdado do `<select>` — em páginas com tema escuro (texto claro), o popup nativo do navegador/SO (geralmente fundo claro) deixava o texto quase ilegível. Agora as `<option>` forçam texto escuro/fundo claro explicitamente, com contraste garantido independente do tema.
- Tooltip em cada cor da Aparência (Primária/Fundo/Texto/Destaque) explicando o que cada uma controla no formulário renderizado — reportado como confuso ("não sei qual das cores são elas").

## Test plan
- [x] `vitest run src/features/sites` — 5 passed
- [x] `tsc --noEmit` e `eslint` limpos

🤖 Generated with [Claude Code](https://claude.com/claude-code)