### PR TITLE
feat: inserir etapa do funil do CRM em qualquer posição (after_stage_id)

### DIFF
--- a/apps/api/app/modules/crm/schemas.py
+++ b/apps/api/app/modules/crm/schemas.py
@@ -14,6 +14,7 @@ from app.modules.crm.models import GENDER_VALUES, SOURCE_VALUES
 class StageCreate(BaseModel):
     name: str = Field(min_length=1, max_length=64)
     position: int | None = None
+    after_stage_id: str | None = None
     is_won: bool = False
     is_lost: bool = False
 

--- a/apps/api/app/modules/crm/schemas.py
+++ b/apps/api/app/modules/crm/schemas.py
@@ -18,6 +18,14 @@ class StageCreate(BaseModel):
     is_won: bool = False
     is_lost: bool = False
 
+    @field_validator("name")
+    @classmethod
+    def _name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("nome não pode ser vazio")
+        return v
+
     @model_validator(mode="after")
     def _validate(self) -> StageCreate:
         if self.is_won and self.is_lost:

--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -55,18 +55,28 @@ def ensure_stages(db: Session, tenant_id: str) -> list[PipelineStage]:
 
 
 def create_stage(db: Session, *, tenant_id: str, actor: str, data: StageCreate) -> PipelineStage:
-    if data.position is None:
-        max_pos = db.scalar(select(func.max(PipelineStage.position)))
-        position = 0 if max_pos is None else max_pos + 1
+    active = _ordered_stages(db)
+    if data.after_stage_id is not None:
+        try:
+            after_index = next(
+                i for i, s in enumerate(active) if s.id == data.after_stage_id
+            )
+        except StopIteration as e:
+            raise CrmError("Etapa de referência não encontrada", 422) from e
+        insert_index = after_index + 1
     else:
-        position = data.position
+        insert_index = len(active)
+
     stage = PipelineStage(
         tenant_id=tenant_id,
         name=data.name,
-        position=position,
         is_won=data.is_won,
         is_lost=data.is_lost,
     )
+    ordered = active[:insert_index] + [stage] + active[insert_index:]
+    for index, s in enumerate(ordered):
+        s.position = index
+
     db.add(stage)
     audit.record(db, tenant_id=tenant_id, actor=actor, action="crm.stage.create", target=stage.id)
     try:

--- a/apps/api/tests/test_crm.py
+++ b/apps/api/tests/test_crm.py
@@ -144,6 +144,62 @@ def test_create_custom_stage(client: TestClient, headers):
     assert resp.json()["name"] == "Negociação"
 
 
+def test_create_stage_without_after_appends_to_end(client: TestClient, headers):
+    client.get("/crm/board", headers=headers)  # seed
+    resp = client.post("/crm/stages", json={"name": "Fechamento"}, headers=headers)
+    assert resp.status_code == 201
+    names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+    assert names[-1] == "Fechamento"
+
+
+def test_create_stage_after_stage_inserts_in_the_middle(client: TestClient, headers):
+    stages = client.get("/crm/stages", headers=headers).json()
+    em_contato = next(s for s in stages if s["name"] == "Em contato")
+    resp = client.post(
+        "/crm/stages",
+        json={"name": "Qualificação", "after_stage_id": em_contato["id"]},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+    assert names == ["Entrada", "Em contato", "Qualificação", "Proposta", "Ganho", "Perda"]
+
+
+def test_create_stage_after_last_stage_is_equivalent_to_append(client: TestClient, headers):
+    stages = client.get("/crm/stages", headers=headers).json()
+    perda = next(s for s in stages if s["name"] == "Perda")
+    resp = client.post(
+        "/crm/stages",
+        json={"name": "Pós-venda", "after_stage_id": perda["id"]},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+    assert names[-1] == "Pós-venda"
+
+
+def test_create_stage_after_archived_stage_rejected(client: TestClient, headers):
+    stages = client.get("/crm/stages", headers=headers).json()
+    proposta = next(s for s in stages if s["name"] == "Proposta")
+    client.post(f"/crm/stages/{proposta['id']}/archive", headers=headers)
+    resp = client.post(
+        "/crm/stages",
+        json={"name": "Depois", "after_stage_id": proposta["id"]},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_create_stage_after_unknown_id_rejected(client: TestClient, headers):
+    client.get("/crm/board", headers=headers)  # seed
+    resp = client.post(
+        "/crm/stages",
+        json={"name": "X", "after_stage_id": "nao-existe"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
 def test_stage_cannot_be_won_and_lost(client: TestClient, headers):
     resp = client.post(
         "/crm/stages", json={"name": "Bug", "is_won": True, "is_lost": True}, headers=headers

--- a/apps/api/tests/test_crm.py
+++ b/apps/api/tests/test_crm.py
@@ -200,6 +200,33 @@ def test_create_stage_after_unknown_id_rejected(client: TestClient, headers):
     assert resp.status_code == 422
 
 
+def test_create_stage_after_empty_string_id_rejected(client: TestClient, headers):
+    client.get("/crm/board", headers=headers)  # seed
+    resp = client.post(
+        "/crm/stages",
+        json={"name": "X", "after_stage_id": ""},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_stage_name_is_trimmed(client: TestClient, headers):
+    client.get("/crm/board", headers=headers)  # seed
+    resp = client.post(
+        "/crm/stages", json={"name": "  Negociação  "}, headers=headers
+    )
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "Negociação"
+
+
+def test_blank_stage_name_rejected(client: TestClient, headers):
+    client.get("/crm/board", headers=headers)  # seed
+    resp = client.post(
+        "/crm/stages", json={"name": "   "}, headers=headers
+    )
+    assert resp.status_code == 422
+
+
 def test_stage_cannot_be_won_and_lost(client: TestClient, headers):
     resp = client.post(
         "/crm/stages", json={"name": "Bug", "is_won": True, "is_lost": True}, headers=headers

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -1,4 +1,4 @@
-import type { Board, BoardColumn, Client } from "@e1p/shared-types";
+import type { Board, BoardColumn, Client, PipelineStage } from "@e1p/shared-types";
 import { Archive, ArrowUpRight, GripVertical, Plus } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -9,6 +9,7 @@ import { usePrimaryAction } from "../../store/pageActions";
 export default function CrmPage() {
   const [board, setBoard] = useState<Board>({ columns: [] });
   const [open, setOpen] = useState(false);
+  const [stageModalOpen, setStageModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [dragOver, setDragOver] = useState<string | null>(null);
 
@@ -34,18 +35,6 @@ export default function CrmPage() {
     setBoard((b) => optimisticMove(b, clientId, stageId));
     try {
       await api.post(`/crm/clients/${clientId}/move`, { stage_id: stageId });
-    } finally {
-      load();
-    }
-  }
-
-  async function createStage() {
-    const name = window.prompt("Nome da nova etapa:")?.trim();
-    if (!name) return;
-    try {
-      await api.post("/crm/stages", { name });
-    } catch (err) {
-      alert(apiErrorMessage(err));
     } finally {
       load();
     }
@@ -89,7 +78,7 @@ export default function CrmPage() {
             />
           ))}
           <button
-            onClick={createStage}
+            onClick={() => setStageModalOpen(true)}
             className="flex h-12 w-56 shrink-0 items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-neutral-200 text-sm font-medium text-neutral-400 hover:border-primary-300 hover:text-primary-600"
           >
             <Plus size={16} />
@@ -99,6 +88,12 @@ export default function CrmPage() {
       )}
 
       <NewClientModal open={open} onClose={() => setOpen(false)} onCreated={load} />
+      <NewStageModal
+        open={stageModalOpen}
+        onClose={() => setStageModalOpen(false)}
+        stages={board.columns.map((c) => c.stage)}
+        onCreated={load}
+      />
     </div>
   );
 }
@@ -268,6 +263,78 @@ function NewClientModal({
           className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
         >
           {saving ? "Salvando..." : "Criar cliente"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function NewStageModal({
+  open,
+  onClose,
+  stages,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  stages: PipelineStage[];
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [afterStageId, setAfterStageId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setError(null);
+    setAfterStageId(stages.length > 0 ? stages[stages.length - 1].id : "");
+  }, [open, stages]);
+
+  async function save() {
+    setError(null);
+    setSaving(true);
+    try {
+      await api.post("/crm/stages", { name, after_stage_id: afterStageId || null });
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title="Nova etapa" open={open} onClose={onClose}>
+      <div className="space-y-3">
+        <Field label="Nome da etapa" value={name} onChange={setName} placeholder="Negociação" />
+        {stages.length > 0 && (
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-neutral-600">
+              Inserir depois de
+            </span>
+            <select
+              value={afterStageId}
+              onChange={(e) => setAfterStageId(e.target.value)}
+              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+            >
+              {stages.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
+        <button
+          onClick={save}
+          disabled={saving || !name.trim()}
+          className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
+        >
+          {saving ? "Salvando..." : "Criar etapa"}
         </button>
       </div>
     </Modal>

--- a/docs/superpowers/plans/2026-07-20-crm-inserir-etapa-posicao.md
+++ b/docs/superpowers/plans/2026-07-20-crm-inserir-etapa-posicao.md
@@ -1,0 +1,476 @@
+# Inserir etapa do Funil (CRM) em qualquer posição — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the "+ Nova etapa" button on the CRM Kanban board (`/crm`) insert the new stage
+immediately after any existing stage the user picks, instead of always appending it at the end.
+
+**Architecture:** No schema change. `pipeline_stages.position` already exists and ordering is
+already `ORDER BY position, id`. `POST /crm/stages` gains an optional `after_stage_id` field; on
+create, the backend renumbers all active (non-archived) stages sequentially (`0..N-1`) with the
+new stage spliced in at the right index, inside the existing single-transaction commit. The
+frontend replaces the current `window.prompt` with a small modal (name + "insert after" select,
+defaulting to the last stage so unattended confirmation still appends like today).
+
+**Tech Stack:** FastAPI + SQLAlchemy 2 (backend, `apps/api`), React 18 + TypeScript + Tailwind
+(frontend, `apps/web`), pytest (backend tests). No new frontend test infra — this codebase's
+convention (see `apps/web/vitest.config.ts` comment, "9 testes de lógica pura") is pure-logic
+`.test.ts` files only; no existing component ever gained a `.test.tsx`. This feature is pure UI
+wiring with no extractable pure logic worth its own test, so it is verified manually in the
+running app, consistent with that convention.
+
+## Global Constraints
+
+- Rely exclusively on RLS for tenant isolation — never add a manual `tenant_id` filter to a
+  query (Regra de Ouro nº 1, `apps/api/CLAUDE.md`).
+- `after_stage_id` omitted/`None` MUST behave exactly like today (append to the end). Do not
+  make it mean "insert at the start" — that was an error caught in the design's self-review and
+  corrected in `docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md`.
+- No reordering of already-existing stages beyond what a new insertion requires (renumbering),
+  and no drag-to-reorder UI — explicitly out of scope.
+- Idioma do produto: PT-BR nas strings de UI e nomes de teste/asserts de domínio; identificadores
+  de código em inglês (convenção do projeto, `CLAUDE.md` §8).
+
+---
+
+### Task 1: Backend — `after_stage_id` on `POST /crm/stages`
+
+**Files:**
+- Modify: `apps/api/app/modules/crm/schemas.py:14-24` (`StageCreate`)
+- Modify: `apps/api/app/modules/crm/service.py:57-78` (`create_stage`)
+- Test: `apps/api/tests/test_crm.py` (append new tests after `test_create_custom_stage`, i.e.
+  after line 145)
+- Regenerate (mechanical, no hand edits): `packages/shared-types/openapi.json`,
+  `packages/shared-types/src/generated.ts`
+
+**Interfaces:**
+- Consumes: existing `PipelineStage` model (`apps/api/app/modules/crm/models.py:38-48`),
+  existing `_ordered_stages(db) -> list[PipelineStage]` (`service.py:28-36`, already filters
+  `is_archived=False` and orders by `position, id`).
+- Produces: `StageCreate.after_stage_id: str | None` — later consumed by the frontend (Task 2),
+  which will `POST /crm/stages` with `{ name, after_stage_id }`. No change to `StageOut` — the
+  response shape is unchanged, so Task 2 doesn't need new response fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Open `apps/api/tests/test_crm.py` and insert the following five tests immediately after
+  `test_create_custom_stage` (which currently ends at line 145, right before
+  `test_stage_cannot_be_won_and_lost`):
+
+  ```python
+  def test_create_stage_without_after_appends_to_end(client: TestClient, headers):
+      client.get("/crm/board", headers=headers)  # seed
+      resp = client.post("/crm/stages", json={"name": "Fechamento"}, headers=headers)
+      assert resp.status_code == 201
+      names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+      assert names[-1] == "Fechamento"
+
+
+  def test_create_stage_after_stage_inserts_in_the_middle(client: TestClient, headers):
+      stages = client.get("/crm/stages", headers=headers).json()
+      em_contato = next(s for s in stages if s["name"] == "Em contato")
+      resp = client.post(
+          "/crm/stages",
+          json={"name": "Qualificação", "after_stage_id": em_contato["id"]},
+          headers=headers,
+      )
+      assert resp.status_code == 201
+      names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+      assert names == ["Entrada", "Em contato", "Qualificação", "Proposta", "Ganho", "Perda"]
+
+
+  def test_create_stage_after_last_stage_is_equivalent_to_append(client: TestClient, headers):
+      stages = client.get("/crm/stages", headers=headers).json()
+      perda = next(s for s in stages if s["name"] == "Perda")
+      resp = client.post(
+          "/crm/stages",
+          json={"name": "Pós-venda", "after_stage_id": perda["id"]},
+          headers=headers,
+      )
+      assert resp.status_code == 201
+      names = [s["name"] for s in client.get("/crm/stages", headers=headers).json()]
+      assert names[-1] == "Pós-venda"
+
+
+  def test_create_stage_after_archived_stage_rejected(client: TestClient, headers):
+      stages = client.get("/crm/stages", headers=headers).json()
+      proposta = next(s for s in stages if s["name"] == "Proposta")
+      client.post(f"/crm/stages/{proposta['id']}/archive", headers=headers)
+      resp = client.post(
+          "/crm/stages",
+          json={"name": "Depois", "after_stage_id": proposta["id"]},
+          headers=headers,
+      )
+      assert resp.status_code == 422
+
+
+  def test_create_stage_after_unknown_id_rejected(client: TestClient, headers):
+      client.get("/crm/board", headers=headers)  # seed
+      resp = client.post(
+          "/crm/stages",
+          json={"name": "X", "after_stage_id": "nao-existe"},
+          headers=headers,
+      )
+      assert resp.status_code == 422
+  ```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  Run: `cd apps/api && python -m pytest tests/test_crm.py -k "after_stage or without_after" -v`
+
+  Expected: all 5 new tests FAIL — `test_create_stage_without_after_appends_to_end` fails only if
+  order assertions don't match (it may actually pass by coincidence today since append-by-default
+  already works); the other 4 MUST fail with either a Pydantic "extra fields not permitted"-style
+  422 (if the model is strict) or, more likely, a 201 that silently ignores `after_stage_id`
+  (Pydantic ignores unknown fields by default, so the request succeeds but the new stage lands at
+  the position computed by the OLD `data.position` logic — always the end — so the middle-insert
+  and archived/unknown-id rejection tests fail their assertions).
+
+- [ ] **Step 3: Add `after_stage_id` to `StageCreate`**
+
+  In `apps/api/app/modules/crm/schemas.py`, modify the `StageCreate` class (currently lines
+  14-24):
+
+  ```python
+  class StageCreate(BaseModel):
+      name: str = Field(min_length=1, max_length=64)
+      position: int | None = None
+      after_stage_id: str | None = None
+      is_won: bool = False
+      is_lost: bool = False
+
+      @model_validator(mode="after")
+      def _validate(self) -> StageCreate:
+          if self.is_won and self.is_lost:
+              raise ValueError("um estágio não pode ser 'ganho' e 'perda' ao mesmo tempo")
+          return self
+  ```
+
+  (Only the new `after_stage_id: str | None = None` line is added; `position` stays as-is,
+  unused by this flow, matching the design doc.)
+
+- [ ] **Step 4: Rewrite `create_stage` to renumber on insert**
+
+  In `apps/api/app/modules/crm/service.py`, replace the current `create_stage` function (lines
+  57-78):
+
+  ```python
+  def create_stage(db: Session, *, tenant_id: str, actor: str, data: StageCreate) -> PipelineStage:
+      active = _ordered_stages(db)
+      if data.after_stage_id is not None:
+          try:
+              after_index = next(
+                  i for i, s in enumerate(active) if s.id == data.after_stage_id
+              )
+          except StopIteration as e:
+              raise CrmError("Etapa de referência não encontrada", 422) from e
+          insert_index = after_index + 1
+      else:
+          insert_index = len(active)
+
+      stage = PipelineStage(
+          tenant_id=tenant_id,
+          name=data.name,
+          is_won=data.is_won,
+          is_lost=data.is_lost,
+      )
+      ordered = active[:insert_index] + [stage] + active[insert_index:]
+      for index, s in enumerate(ordered):
+          s.position = index
+
+      db.add(stage)
+      audit.record(db, tenant_id=tenant_id, actor=actor, action="crm.stage.create", target=stage.id)
+      try:
+          db.commit()
+      except IntegrityError as e:
+          db.rollback()
+          raise CrmError("Já existe um estágio com esse nome", 409) from e
+      db.refresh(stage)
+      return stage
+  ```
+
+  Note `stage.position` is intentionally not set in the constructor — the `for index, s in
+  enumerate(ordered)` loop assigns it (along with every existing active stage's `position`)
+  right before commit, covering the new stage too since it's part of `ordered`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+  Run: `cd apps/api && python -m pytest tests/test_crm.py -v`
+
+  Expected: all tests in the file PASS, including the 5 new ones and all pre-existing CRM tests
+  (in particular `test_create_custom_stage`, `test_duplicate_stage_name_rejected`,
+  `test_delete_empty_stage_succeeds`, `test_archive_stage_moves_clients` — none of these assert
+  stage order, so the renumbering doesn't affect their outcomes).
+
+- [ ] **Step 6: Run the full backend suite**
+
+  Run: `cd apps/api && python -m pytest -q`
+
+  Expected: PASS (no regressions in other modules — nothing else calls `service.create_stage`,
+  confirmed by `grep -rn "create_stage" apps/api/app` during design research).
+
+- [ ] **Step 7: Regenerate shared types**
+
+  From the repo root:
+
+  Run: `pnpm generate:types`
+
+  If it fails to connect to a real database (e.g. no local Postgres reachable from this shell),
+  run the two underlying steps with a harmless SQLite URL instead (the export script only needs
+  to import the FastAPI app, not open a real connection — see the docstring in
+  `apps/api/scripts/export_openapi.py`):
+
+  ```bash
+  cd apps/api && DATABASE_URL=sqlite:// python scripts/export_openapi.py
+  cd .. && pnpm --filter @e1p/shared-types generate
+  ```
+
+  Expected: `packages/shared-types/openapi.json` and `packages/shared-types/src/generated.ts` are
+  rewritten (the `StageCreate` schema in both files now includes `after_stage_id`). Do not hand-
+  edit either file.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add apps/api/app/modules/crm/schemas.py apps/api/app/modules/crm/service.py \
+    apps/api/tests/test_crm.py packages/shared-types/openapi.json \
+    packages/shared-types/src/generated.ts
+  git commit -m "feat: permite inserir etapa do funil em qualquer posição via after_stage_id"
+  ```
+
+---
+
+### Task 2: Frontend — "Nova etapa" modal with insertion point
+
+**Files:**
+- Modify: `apps/web/src/features/crm/CrmPage.tsx`
+
+**Interfaces:**
+- Consumes: `PipelineStage` type from `@e1p/shared-types` (`{ id, name, position, is_won,
+  is_lost }`); `Modal`/`Field` from `../../components/Modal` (existing, unchanged); `api`,
+  `apiErrorMessage` from `../../lib/api` (existing, unchanged); `POST /crm/stages` now accepts
+  `{ name: string, after_stage_id: string | null }` (Task 1).
+- Produces: nothing consumed by later tasks — this is the last task.
+
+- [ ] **Step 1: Add the `PipelineStage` type import**
+
+  In `apps/web/src/features/crm/CrmPage.tsx`, change line 1 from:
+
+  ```typescript
+  import type { Board, BoardColumn, Client } from "@e1p/shared-types";
+  ```
+
+  to:
+
+  ```typescript
+  import type { Board, BoardColumn, Client, PipelineStage } from "@e1p/shared-types";
+  ```
+
+- [ ] **Step 2: Replace `createStage` with modal state**
+
+  In the same file, replace the `createStage` function (currently lines 42-52):
+
+  ```typescript
+    async function createStage() {
+      const name = window.prompt("Nome da nova etapa:")?.trim();
+      if (!name) return;
+      try {
+        await api.post("/crm/stages", { name });
+      } catch (err) {
+        alert(apiErrorMessage(err));
+      } finally {
+        load();
+      }
+    }
+  ```
+
+  with a boolean modal-open state (no function needed anymore — the modal component does the
+  API call). Add this state declaration next to the existing `open`/`loading`/`dragOver` state
+  (currently lines 10-13):
+
+  ```typescript
+    const [board, setBoard] = useState<Board>({ columns: [] });
+    const [open, setOpen] = useState(false);
+    const [stageModalOpen, setStageModalOpen] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [dragOver, setDragOver] = useState<string | null>(null);
+  ```
+
+  And delete the old `createStage` function body entirely (it's fully replaced by the
+  `NewStageModal` component added in Step 4).
+
+- [ ] **Step 3: Wire the "+ Nova etapa" button and render the modal**
+
+  Still in `CrmPage.tsx`, change the button (currently lines 91-97) from:
+
+  ```tsx
+            <button
+              onClick={createStage}
+              className="flex h-12 w-56 shrink-0 items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-neutral-200 text-sm font-medium text-neutral-400 hover:border-primary-300 hover:text-primary-600"
+            >
+              <Plus size={16} />
+              Nova etapa
+            </button>
+  ```
+
+  to:
+
+  ```tsx
+            <button
+              onClick={() => setStageModalOpen(true)}
+              className="flex h-12 w-56 shrink-0 items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-neutral-200 text-sm font-medium text-neutral-400 hover:border-primary-300 hover:text-primary-600"
+            >
+              <Plus size={16} />
+              Nova etapa
+            </button>
+  ```
+
+  Then add the modal render next to the existing `<NewClientModal .../>` (currently line 101),
+  so that block reads:
+
+  ```tsx
+        <NewClientModal open={open} onClose={() => setOpen(false)} onCreated={load} />
+        <NewStageModal
+          open={stageModalOpen}
+          onClose={() => setStageModalOpen(false)}
+          stages={board.columns.map((c) => c.stage)}
+          onCreated={load}
+        />
+  ```
+
+- [ ] **Step 4: Add the `NewStageModal` component**
+
+  Add this new function to `CrmPage.tsx`, right after the existing `NewClientModal` function
+  (which currently ends at line 275, just before the file's final line):
+
+  ```tsx
+  function NewStageModal({
+    open,
+    onClose,
+    stages,
+    onCreated,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    stages: PipelineStage[];
+    onCreated: () => void;
+  }) {
+    const [name, setName] = useState("");
+    const [afterStageId, setAfterStageId] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+      if (!open) return;
+      setName("");
+      setError(null);
+      setAfterStageId(stages.length > 0 ? stages[stages.length - 1].id : "");
+    }, [open, stages]);
+
+    async function save() {
+      setError(null);
+      setSaving(true);
+      try {
+        await api.post("/crm/stages", { name, after_stage_id: afterStageId || null });
+        onCreated();
+        onClose();
+      } catch (err) {
+        setError(apiErrorMessage(err));
+      } finally {
+        setSaving(false);
+      }
+    }
+
+    return (
+      <Modal title="Nova etapa" open={open} onClose={onClose}>
+        <div className="space-y-3">
+          <Field label="Nome da etapa" value={name} onChange={setName} placeholder="Negociação" />
+          {stages.length > 0 && (
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">
+                Inserir depois de
+              </span>
+              <select
+                value={afterStageId}
+                onChange={(e) => setAfterStageId(e.target.value)}
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+              >
+                {stages.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
+          <button
+            onClick={save}
+            disabled={saving || !name.trim()}
+            className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
+          >
+            {saving ? "Salvando..." : "Criar etapa"}
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+  ```
+
+  This closes over `stages` (always the board's current active stages, in order) and defaults
+  `afterStageId` to the last one whenever the modal opens — reproducing today's "always appends"
+  behavior for anyone who just types a name and confirms, per the approved design.
+
+- [ ] **Step 5: Typecheck and lint**
+
+  Run: `cd apps/web && pnpm typecheck`
+  Expected: no errors.
+
+  Run: `cd apps/web && pnpm lint`
+  Expected: no errors (0 warnings — `--max-warnings 0` is configured).
+
+- [ ] **Step 6: Manual verification in the running app**
+
+  Bring the stack up (per `apps/api/CLAUDE.md` §9):
+
+  ```bash
+  docker start infra-postgres-1 infra-api-1
+  pnpm --filter @e1p/web dev
+  ```
+
+  Open `http://127.0.0.1:5173/crm` (use `127.0.0.1`, not `localhost` — this repo's Vite dev
+  server can collide with another local project on `localhost:5173`).
+
+  Verify all of the following:
+  1. Click "+ Nova etapa" → a modal titled "Nova etapa" opens (not a native browser prompt).
+  2. The "Inserir depois de" select is pre-filled with the last column's name (e.g. "Perda").
+  3. Type a name, leave the select on its default, click "Criar etapa" → the new column appears
+     as the last column, same as the old behavior.
+  4. Click "+ Nova etapa" again, pick a middle stage (e.g. "Em contato") from the select, type a
+     name, confirm → the new column appears immediately after "Em contato" and before whatever
+     came next.
+  5. Reload the page (`F5`) → the inserted column stays in the same place (confirms the order
+     came from the backend, not just local optimistic state).
+  6. Try to confirm with an empty name → the "Criar etapa" button stays disabled.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  cd apps/web
+  git add src/features/crm/CrmPage.tsx
+  git commit -m "feat: modal de nova etapa do funil com seleção de posição de inserção"
+  ```
+
+## Self-Review Notes
+
+- **Spec coverage:** Design doc §2 (scope: insert-only, no reorder) → Task 1 + Task 2 fully cover
+  it; §3 backend algorithm → Task 1 Step 4 implements it verbatim; §3 frontend modal + default-
+  to-last → Task 2 Steps 2-4; §4 test list → Task 1 Step 1 (all 5 cases, cross-tenant case
+  explicitly and deliberately omitted per the design doc's own note on SQLite/RLS).
+- **Placeholder scan:** no TBD/TODO; every step has literal code or literal commands with
+  expected output.
+- **Type consistency:** `after_stage_id: str | None` matches from schema (Task 1 Step 3) through
+  service (Step 4) through the frontend payload (Task 2 Step 4, `after_stage_id: afterStageId ||
+  null`). `PipelineStage` shape used in Task 2 matches `packages/shared-types/src/index.ts:197-203`
+  exactly (`id`, `name`, `position`, `is_won`, `is_lost` — no `is_archived`, which is fine since
+  `board.columns` already only contains active stages).

--- a/docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md
+++ b/docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md
@@ -43,14 +43,19 @@ simples, sem risco de colisão e sem depender de constraint de unicidade que nã
 - **`service.py`, `create_stage()`**:
   1. Buscar etapas ativas ordenadas do tenant (`_ordered_stages()` já existe, filtrando
      `is_archived=False`).
-  2. Validar `after_stage_id`, se enviado: deve pertencer ao tenant e não estar arquivada; senão
-     `422`.
-  3. Calcular índice de inserção: `after_stage_id is None` → índice `0` (início da lista);
-     senão, índice = posição da etapa referenciada na lista ordenada `+ 1`.
-  4. Numa única transação: montar a lista final de ids (etapas existentes + a nova, no índice
-     calculado) e escrever `position = 0..N-1` para cada uma, na ordem.
+  2. Validar `after_stage_id`, se enviado: deve existir entre as etapas ativas do tenant (a
+     query já é filtrada por RLS); senão `422`. Referenciar uma etapa arquivada também cai
+     nesse `422`, pois `_ordered_stages()` já as exclui da lista de ativas.
+  3. Calcular índice de inserção: `after_stage_id` **ausente/`None`** → **acrescenta ao final**
+     (idêntico ao comportamento atual — preserva compatibilidade para qualquer chamador que não
+     use o campo novo); caso contrário, índice = posição da etapa referenciada na lista ordenada
+     `+ 1`. **Não há suporte a inserir antes da primeira etapa** nesta entrega — não é alcançável
+     pela UI (o select sempre lista etapas reais) e evita ambiguidade entre "campo omitido" e
+     "inserir no início" (que o JSON não distingue).
+  4. Numa única transação: montar a lista final de objetos (etapas existentes + a nova, no
+     índice calculado) e escrever `position = 0..N-1` para cada um, na ordem.
   5. Etapas arquivadas mantêm seu `position` atual (não entram na renumeração, não aparecem no
-     board mesmo assim).
+     board mesmo assim, e não são um `after_stage_id` válido).
 - **`router.py`** — `POST /crm/stages` já recebe o body completo; só passa o novo campo adiante,
   sem mudança de assinatura de rota.
 
@@ -70,11 +75,15 @@ simples, sem risco de colisão e sem depender de constraint de unicidade que nã
 ## 4. Testes
 
 Estender `apps/api/tests/test_crm.py`:
-- Inserir etapa no início (`after_stage_id=None`) → nova etapa fica em `position=0`, demais
-  deslocadas.
+- Criar etapa sem `after_stage_id` → continua indo para o final (comportamento atual
+  preservado).
 - Inserir etapa no meio (`after_stage_id` de uma etapa intermediária) → ordem final correta.
-- Inserir etapa no fim (`after_stage_id` da última etapa, comportamento default do frontend) →
-  equivalente ao comportamento atual (append).
-- Etapa arquivada não é afetada pela renumeração e não aparece como opção válida de
-  `after_stage_id` (referenciar uma arquivada → `422`).
-- `after_stage_id` de outro tenant → `422`/não encontrado (isolamento RLS).
+- Inserir etapa depois da última etapa (`after_stage_id` da última) → equivalente a acrescentar
+  ao final.
+- `after_stage_id` de uma etapa arquivada → `422`.
+- `after_stage_id` desconhecido/inexistente → `422`.
+
+(Teste de isolamento cross-tenant fica de fora da suíte unitária: os testes de `test_crm.py`
+rodam sobre SQLite, que não aplica RLS — a mesma lacuna já documentada no `CLAUDE.md` §6.1 para
+todo o módulo. `after_stage_id` de outro tenant já cai automaticamente no caso "não encontrado"
+em produção, porque `_ordered_stages()` só enxerga o tenant da sessão via RLS.)

--- a/docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md
+++ b/docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md
@@ -1,0 +1,80 @@
+# Inserir etapa do Funil (CRM) em qualquer posição
+
+**Data:** 2026-07-20
+**Status:** Aprovado (brainstorming), aguardando plano de implementação
+
+## 1. Problema
+
+Hoje, no Kanban do CRM (`/crm` → "Funil de clientes"), o botão **"+ Nova etapa"** só permite
+criar uma coluna nova **no final** da sequência (Entrada → Em contato → Proposta → Ganho → Perda
+→ nova). Não existe jeito de inserir uma etapa **no meio** do funil (ex.: entre "Em contato" e
+"Proposta") sem editar manualmente cada etapa depois.
+
+## 2. Escopo (decidido no brainstorming)
+
+- **Somente inserção em posição arbitrária ao criar uma nova etapa.** Etapas já existentes
+  continuam na ordem em que estão — **não** há reordenação de etapas existentes (ex.: arrastar
+  colunas) nesta entrega.
+- UI: o atual `window.prompt` de "Nova etapa" vira um **modal** com campo de nome + um select
+  **"Inserir depois de"** listando as etapas atuais na ordem, com a **última etapa pré-selecionada
+  por padrão** (preserva o comportamento atual — quem só confirma sem mexer no select, cria no
+  fim, como hoje).
+- Etapas arquivadas (`is_archived`) não entram no select nem são afetadas pela renumeração.
+
+### Fora de escopo (decisão explícita)
+
+- Arrastar/reordenar colunas já existentes.
+- Editar `is_won`/`is_lost` de uma etapa (dívida já registrada no `CLAUDE.md`).
+
+## 3. Arquitetura
+
+Nenhuma mudança de schema é necessária. `pipeline_stages.position` (`INTEGER`, sem constraint de
+unicidade) já existe, e a ordenação já é `ORDER BY position, id`
+(`apps/api/app/modules/crm/service.py`, `_ordered_stages()`).
+
+**Estratégia:** ao criar uma etapa em qualquer posição, **renumerar sequencialmente** (0, 1, 2,
+…) todas as etapas ativas (não arquivadas) do tenant, em vez de fazer aritmética de gaps. Mais
+simples, sem risco de colisão e sem depender de constraint de unicidade que não existe hoje.
+
+### Backend (`apps/api/app/modules/crm/`)
+
+- **`schemas.py`** — `StageCreate` ganha `after_stage_id: str | None = None` (o campo `position`
+  existente permanece no schema, sem uso por este fluxo).
+- **`service.py`, `create_stage()`**:
+  1. Buscar etapas ativas ordenadas do tenant (`_ordered_stages()` já existe, filtrando
+     `is_archived=False`).
+  2. Validar `after_stage_id`, se enviado: deve pertencer ao tenant e não estar arquivada; senão
+     `422`.
+  3. Calcular índice de inserção: `after_stage_id is None` → índice `0` (início da lista);
+     senão, índice = posição da etapa referenciada na lista ordenada `+ 1`.
+  4. Numa única transação: montar a lista final de ids (etapas existentes + a nova, no índice
+     calculado) e escrever `position = 0..N-1` para cada uma, na ordem.
+  5. Etapas arquivadas mantêm seu `position` atual (não entram na renumeração, não aparecem no
+     board mesmo assim).
+- **`router.py`** — `POST /crm/stages` já recebe o body completo; só passa o novo campo adiante,
+  sem mudança de assinatura de rota.
+
+### Frontend (`apps/web/src/features/crm/CrmPage.tsx`)
+
+- Substituir o `window.prompt` de `createStage()` (linhas 42-52) por um modal novo
+  (`NewStageModal` ou estado local de modal na própria página, seguindo o padrão de outros
+  modais já existentes no CRM, se houver):
+  - Campo texto: nome da etapa (obrigatório, não-vazio).
+  - Select "Inserir depois de": opções = etapas ativas atuais, na ordem do board; **default =
+    última etapa** da lista.
+  - Botões Cancelar / Criar.
+- Ao confirmar: `POST /crm/stages { name, after_stage_id }`.
+- Após sucesso: **recarregar `/crm/board`** (não tentar reordenar otimisticamente no client — como
+  todas as posições podem mudar, é mais simples e seguro buscar o estado real do servidor).
+
+## 4. Testes
+
+Estender `apps/api/tests/test_crm.py`:
+- Inserir etapa no início (`after_stage_id=None`) → nova etapa fica em `position=0`, demais
+  deslocadas.
+- Inserir etapa no meio (`after_stage_id` de uma etapa intermediária) → ordem final correta.
+- Inserir etapa no fim (`after_stage_id` da última etapa, comportamento default do frontend) →
+  equivalente ao comportamento atual (append).
+- Etapa arquivada não é afetada pela renumeração e não aparece como opção válida de
+  `after_stage_id` (referenciar uma arquivada → `422`).
+- `after_stage_id` de outro tenant → `422`/não encontrado (isolamento RLS).

--- a/packages/shared-types/openapi.json
+++ b/packages/shared-types/openapi.json
@@ -161,7 +161,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Forgot Password Auth Forgot Password Post"
                 }
@@ -204,7 +203,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Reset Password Route Auth Reset Password Post"
                 }
@@ -2596,17 +2594,36 @@
           "receivables"
         ],
         "summary": "Payment Webhook",
-        "description": "Webhook do gateway: reconhece o pagamento AUTOMATICAMENTE (sem login). Em produção,\ndefina GATEWAY_WEBHOOK_SECRET para que só o gateway confirme; em dev (segredo vazio) fica\naberto para testes. O dono NUNCA marca pago manualmente — só saca o que entra por aqui.",
+        "description": "Webhook do gateway: reconhece o pagamento AUTOMATICAMENTE (sem login). Aceita o payload\nREAL do provedor (Asaas: {event, payment.externalReference}) OU o payload interno de dev/teste\n({tenant_id, charge_id, status, secret}) — o link 'simular pgto' continua funcionando.\n\nSegurança (fail-closed): com GATEWAY_WEBHOOK_SECRET definido, só o gateway confirma — para o\npayload real valida o token do header (`asaas-access-token`), para o interno valida `secret`\nno corpo. Segredo vazio (dev) = aberto para testes. O dono NUNCA marca pago manualmente.\n\nNota (No Invention): o nome do header de autenticação do Asaas deve ser confirmado contra a\ndocumentação vigente do provedor antes do go-live.",
         "operationId": "payment_webhook_receivables_webhook_post",
+        "parameters": [
+          {
+            "name": "asaas-access-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Asaas-Access-Token"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/WebhookPayment"
+                "type": "object",
+                "title": "Body"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2614,7 +2631,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Payment Webhook Receivables Webhook Post"
                 }
@@ -3429,6 +3445,56 @@
         }
       }
     },
+    "/payables/queue": {
+      "get": {
+        "tags": [
+          "payables"
+        ],
+        "summary": "Payment Queue",
+        "description": "Story 5.9 — fila de pagamentos: Payables em aberto agrupados por janela de vencimento.\nMesmo módulo/guard (`require_module('payables')`), sem autorização nova.",
+        "operationId": "payment_queue_payables_queue_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentQueueOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/payables/categories": {
       "get": {
         "tags": [
@@ -3831,6 +3897,1369 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PayableOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chart-of-accounts": {
+      "get": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "List Accounts",
+        "operationId": "list_accounts_chart_of_accounts_get",
+        "parameters": [
+          {
+            "name": "grupo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Grupo"
+            }
+          },
+          {
+            "name": "include_archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Archived"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChartAccountOut"
+                  },
+                  "title": "Response List Accounts Chart Of Accounts Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "Create Account",
+        "operationId": "create_account_chart_of_accounts_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChartAccountCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChartAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chart-of-accounts/hierarchy": {
+      "get": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "Hierarchy",
+        "operationId": "hierarchy_chart_of_accounts_hierarchy_get",
+        "parameters": [
+          {
+            "name": "include_archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Archived"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChartGroupOut"
+                  },
+                  "title": "Response Hierarchy Chart Of Accounts Hierarchy Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chart-of-accounts/{account_id}": {
+      "patch": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "Update Account",
+        "operationId": "update_account_chart_of_accounts__account_id__patch",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChartAccountUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChartAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chart-of-accounts/{account_id}/archive": {
+      "post": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "Archive Account",
+        "operationId": "archive_account_chart_of_accounts__account_id__archive_post",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChartAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chart-of-accounts/seed": {
+      "post": {
+        "tags": [
+          "chart_of_accounts"
+        ],
+        "summary": "Seed",
+        "operationId": "seed_chart_of_accounts_seed_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChartAccountOut"
+                  },
+                  "title": "Response Seed Chart Of Accounts Seed Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cost-centers": {
+      "get": {
+        "tags": [
+          "cost_centers"
+        ],
+        "summary": "List Cost Centers",
+        "operationId": "list_cost_centers_cost_centers_get",
+        "parameters": [
+          {
+            "name": "include_archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Archived"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CostCenterOut"
+                  },
+                  "title": "Response List Cost Centers Cost Centers Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "cost_centers"
+        ],
+        "summary": "Create Cost Center",
+        "operationId": "create_cost_center_cost_centers_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostCenterCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCenterOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cost-centers/{cost_center_id}": {
+      "patch": {
+        "tags": [
+          "cost_centers"
+        ],
+        "summary": "Update Cost Center",
+        "operationId": "update_cost_center_cost_centers__cost_center_id__patch",
+        "parameters": [
+          {
+            "name": "cost_center_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cost Center Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostCenterUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCenterOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cost-centers/{cost_center_id}/archive": {
+      "post": {
+        "tags": [
+          "cost_centers"
+        ],
+        "summary": "Archive Cost Center",
+        "operationId": "archive_cost_center_cost_centers__cost_center_id__archive_post",
+        "parameters": [
+          {
+            "name": "cost_center_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cost Center Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCenterOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/financial-intelligence/dre": {
+      "get": {
+        "tags": [
+          "financial_intelligence"
+        ],
+        "summary": "Dre",
+        "operationId": "dre_financial_intelligence_dre_get",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Início do período (data de competência), YYYY-MM-DD",
+              "title": "Start"
+            },
+            "description": "Início do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Fim do período (data de competência), YYYY-MM-DD",
+              "title": "End"
+            },
+            "description": "Fim do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "cost_center_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Story 5.5: filtra a DRE por centro de custo (2ª dimensão). Omitir = tudo.",
+              "title": "Cost Center Id"
+            },
+            "description": "Story 5.5: filtra a DRE por centro de custo (2ª dimensão). Omitir = tudo."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DreReportOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/financial-intelligence/by-cost-center": {
+      "get": {
+        "tags": [
+          "financial_intelligence"
+        ],
+        "summary": "By Cost Center",
+        "description": "Cruza o resultado do período por centro de custo (2ª dimensão), incluindo o bucket 'Não\natribuído' — comparação lado a lado de sócios/áreas/unidades (Story 5.5, AC2/AC3).",
+        "operationId": "by_cost_center_financial_intelligence_by_cost_center_get",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Início do período (data de competência), YYYY-MM-DD",
+              "title": "Start"
+            },
+            "description": "Início do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Fim do período (data de competência), YYYY-MM-DD",
+              "title": "End"
+            },
+            "description": "Fim do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCenterReportOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/financial-intelligence/projection": {
+      "get": {
+        "tags": [
+          "financial_intelligence"
+        ],
+        "summary": "Projection",
+        "description": "Projeta o saldo de caixa para 30/60/90 dias e o runway (Story 5.7), em regime de CAIXA.\n\nSOMENTE LEITURA: usa a data de pagamento prevista (vencimento dos itens em aberto), nunca a de\ncompetência — não escreve nem cria contas (IV1/IV2).",
+        "operationId": "projection_financial_intelligence_projection_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/financial-intelligence/contracts/{contract_id}/dre": {
+      "get": {
+        "tags": [
+          "financial_intelligence"
+        ],
+        "summary": "Contract Dre",
+        "operationId": "contract_dre_financial_intelligence_contracts__contract_id__dre_get",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Contract Id"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Início do período (data de competência), YYYY-MM-DD",
+              "title": "Start"
+            },
+            "description": "Início do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Fim do período (data de competência), YYYY-MM-DD",
+              "title": "End"
+            },
+            "description": "Fim do período (data de competência), YYYY-MM-DD"
+          },
+          {
+            "name": "include_overhead",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Inclui o rateio de overhead do bucket 'Empresa' (só na visão analítica).",
+              "default": false,
+              "title": "Include Overhead"
+            },
+            "description": "Inclui o rateio de overhead do bucket 'Empresa' (só na visão analítica)."
+          },
+          {
+            "name": "cost_center_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Story 5.5: filtra a DRE do contrato por centro de custo (2ª dimensão).",
+              "title": "Cost Center Id"
+            },
+            "description": "Story 5.5: filtra a DRE do contrato por centro de custo (2ª dimensão)."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDreOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/financial-intelligence/diagnostics": {
+      "get": {
+        "tags": [
+          "financial_intelligence"
+        ],
+        "summary": "Diagnostics",
+        "description": "Diagnóstico financeiro (Story 5.8): sinais determinísticos 🟢🟡🔴 (motor PURO) + narrativa.\n\nO motor SEMPRE calcula e retorna os sinais, mesmo sem `ANTHROPIC_API_KEY` (AC2/IV3): a narrativa\nda IA é isolada e cai num fallback por template em qualquer erro/chave ausente — nunca derruba o\nendpoint. Quando a IA narra de fato, o texto passa pelo anonimizador ANTES do Claude (Regra de\nOuro nº 2) e grava rastro \"Ação executada pela IA\" (Regra de Ouro nº 3).",
+        "operationId": "diagnostics_financial_intelligence_diagnostics_get",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Início do período (competência), YYYY-MM-DD",
+              "title": "Start"
+            },
+            "description": "Início do período (competência), YYYY-MM-DD"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Fim do período (competência), YYYY-MM-DD",
+              "title": "End"
+            },
+            "description": "Fim do período (competência), YYYY-MM-DD"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiagnosticsOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/investments": {
+      "get": {
+        "tags": [
+          "investments"
+        ],
+        "summary": "List Accounts",
+        "operationId": "list_accounts_investments_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InvestmentAccountOut"
+                  },
+                  "title": "Response List Accounts Investments Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "investments"
+        ],
+        "summary": "Create Account",
+        "operationId": "create_account_investments_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvestmentAccountCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvestmentAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/investments/{account_id}": {
+      "patch": {
+        "tags": [
+          "investments"
+        ],
+        "summary": "Update Account",
+        "operationId": "update_account_investments__account_id__patch",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvestmentAccountUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvestmentAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/investments/{account_id}/yield": {
+      "post": {
+        "tags": [
+          "investments"
+        ],
+        "summary": "Register Yield",
+        "operationId": "register_yield_investments__account_id__yield_post",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterYieldRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvestmentAccountOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/investments/{account_id}/rentability": {
+      "get": {
+        "tags": [
+          "investments"
+        ],
+        "summary": "Rentability",
+        "operationId": "rentability_investments__account_id__rentability_get",
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RentabilityOut"
                 }
               }
             }
@@ -4957,7 +6386,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Public Accept Public Proposals  Slug  Accept Post"
                 }
               }
@@ -5058,7 +6486,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TemplateOut"
+                    "$ref": "#/components/schemas/app__modules__contracts__schemas__TemplateOut"
                   },
                   "title": "Response List Templates Contracts Templates Get"
                 }
@@ -5106,7 +6534,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TemplateCreate"
+                "$ref": "#/components/schemas/app__modules__contracts__schemas__TemplateCreate"
               }
             }
           }
@@ -5117,7 +6545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TemplateOut"
+                  "$ref": "#/components/schemas/app__modules__contracts__schemas__TemplateOut"
                 }
               }
             }
@@ -5595,7 +7023,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Public Sign Public Contracts  Slug  Sign Post"
                 }
               }
@@ -6103,7 +7530,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Get Skill Juridico Skills  Skill  Get"
                 }
               }
@@ -7872,6 +9298,753 @@
         }
       }
     },
+    "/whatsapp-templates": {
+      "get": {
+        "tags": [
+          "whatsapp-templates"
+        ],
+        "summary": "List Templates",
+        "operationId": "list_templates_whatsapp_templates_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/app__modules__whatsapp_templates__schemas__TemplateOut"
+                  },
+                  "title": "Response List Templates Whatsapp Templates Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "whatsapp-templates"
+        ],
+        "summary": "Create Template",
+        "operationId": "create_template_whatsapp_templates_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/app__modules__whatsapp_templates__schemas__TemplateCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app__modules__whatsapp_templates__schemas__TemplateOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-templates/{template_id}/sync": {
+      "post": {
+        "tags": [
+          "whatsapp-templates"
+        ],
+        "summary": "Sync Template",
+        "operationId": "sync_template_whatsapp_templates__template_id__sync_post",
+        "parameters": [
+          {
+            "name": "template_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Template Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app__modules__whatsapp_templates__schemas__TemplateOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-templates/{template_id}": {
+      "delete": {
+        "tags": [
+          "whatsapp-templates"
+        ],
+        "summary": "Delete Template",
+        "operationId": "delete_template_whatsapp_templates__template_id__delete",
+        "parameters": [
+          {
+            "name": "template_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Template Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations": {
+      "get": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "List Conversations",
+        "operationId": "list_conversations_whatsapp_conversations_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "title": "Response List Conversations Whatsapp Conversations Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/timeline": {
+      "get": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Get Timeline",
+        "operationId": "get_timeline_whatsapp_conversations__client_id__timeline_get",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "title": "Response Get Timeline Whatsapp Conversations  Client Id  Timeline Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/window": {
+      "get": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Get Window",
+        "operationId": "get_window_whatsapp_conversations__client_id__window_get",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Get Window Whatsapp Conversations  Client Id  Window Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/read": {
+      "post": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Mark Read",
+        "operationId": "mark_read_whatsapp_conversations__client_id__read_post",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/messages/text": {
+      "post": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Send Text Reply",
+        "operationId": "send_text_reply_whatsapp_conversations__client_id__messages_text_post",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Send Text Reply Whatsapp Conversations  Client Id  Messages Text Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/messages/media": {
+      "post": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Send Media Reply",
+        "operationId": "send_media_reply_whatsapp_conversations__client_id__messages_media_post",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Send Media Reply Whatsapp Conversations  Client Id  Messages Media Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/whatsapp-conversations/{client_id}/messages/template": {
+      "post": {
+        "tags": [
+          "whatsapp-inbox"
+        ],
+        "summary": "Send Template Reply",
+        "operationId": "send_template_reply_whatsapp_conversations__client_id__messages_template_post",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Send Template Reply Whatsapp Conversations  Client Id  Messages Template Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/whatsapp/webhook": {
+      "get": {
+        "tags": [
+          "whatsapp-inbox-public"
+        ],
+        "summary": "Verify Webhook",
+        "description": "Handshake de verificação chamado 1x pela Meta quando o tenant configura o webhook no\npainel dele. Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_whatsapp_accounts`,\ntabela GLOBAL sem RLS, pelo verify_token — não toca tabela de negócio.",
+        "operationId": "verify_webhook_public_whatsapp_webhook_get",
+        "parameters": [
+          {
+            "name": "hub.mode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Hub.Mode"
+            }
+          },
+          {
+            "name": "hub.verify_token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Hub.Verify Token"
+            }
+          },
+          {
+            "name": "hub.challenge",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Hub.Challenge"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "whatsapp-inbox-public"
+        ],
+        "summary": "Receive Webhook",
+        "description": "Recebe o evento da Meta. Descobre o tenant pelo `phone_number_id` do payload ANTES de\nvalidar a assinatura (a assinatura usa o `app_secret` DAQUELE tenant, então precisamos saber\nquem é primeiro). Se a assinatura não bater, rejeita sem processar nada.",
+        "operationId": "receive_webhook_public_whatsapp_webhook_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Receive Webhook Public Whatsapp Webhook Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pages": {
       "get": {
         "tags": [
@@ -8349,7 +10522,6 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true,
                   "title": "Response Public Submit Public Pages  Slug  Submit Post"
                 }
               }
@@ -8603,6 +10775,541 @@
         }
       }
     },
+    "/attachments/public-images": {
+      "post": {
+        "tags": [
+          "attachments"
+        ],
+        "summary": "Upload Public Image",
+        "description": "Upload autenticado de imagem intencionalmente pública (logo/foto). A leitura depois é\npública (ver `serve_public_image`). Devolve o caminho da rota de leitura no backend; o\nfrontend prefixa o proxy `/api` para obter a URL renderável em `<img src>`.",
+        "operationId": "upload_public_image_attachments_public_images_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_public_image_attachments_public_images_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicImageOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public-images/{image_id}": {
+      "get": {
+        "tags": [
+          "attachments-public"
+        ],
+        "summary": "Serve Public Image",
+        "description": "Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `public_images`, tabela GLOBAL\nsem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design. Serve os\nbytes inline (sem `Content-Disposition: attachment`) para renderizar como `<img>`.",
+        "operationId": "serve_public_image_public_images__image_id__get",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Image Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/google/status": {
+      "get": {
+        "tags": [
+          "google-calendar"
+        ],
+        "summary": "Status",
+        "operationId": "status_integrations_google_status_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleStatusOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/google/connect": {
+      "get": {
+        "tags": [
+          "google-calendar"
+        ],
+        "summary": "Connect",
+        "operationId": "connect_integrations_google_connect_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleConnectOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/google/disconnect": {
+      "post": {
+        "tags": [
+          "google-calendar"
+        ],
+        "summary": "Disconnect",
+        "operationId": "disconnect_integrations_google_disconnect_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Disconnect Integrations Google Disconnect Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/google/callback": {
+      "get": {
+        "tags": [
+          "google-calendar-public"
+        ],
+        "summary": "Callback",
+        "description": "O Google redireciona para cá após o consent. Valida o `state`, troca o `code` por tokens\ne persiste a credencial no tenant. Sempre redireciona de volta ao frontend.",
+        "operationId": "callback_integrations_google_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/leads/keys": {
+      "get": {
+        "tags": [
+          "integrations-leads"
+        ],
+        "summary": "List Keys",
+        "operationId": "list_keys_integrations_leads_keys_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IntegrationKeyOut"
+                  },
+                  "title": "Response List Keys Integrations Leads Keys Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "integrations-leads"
+        ],
+        "summary": "Create Key",
+        "operationId": "create_key_integrations_leads_keys_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrationKeyCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationKeyCreated"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/leads/keys/{key_id}/revoke": {
+      "post": {
+        "tags": [
+          "integrations-leads"
+        ],
+        "summary": "Revoke Key",
+        "operationId": "revoke_key_integrations_leads_keys__key_id__revoke_post",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationKeyOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/leads/{key}": {
+      "post": {
+        "tags": [
+          "integrations-leads-public"
+        ],
+        "summary": "Capture Lead",
+        "description": "Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_integration_keys`, snapshot\nGLOBAL sem RLS, pelo hash da chave. Nunca toca tabela de negócio por aqui — a escrita\nreal acontece dentro de `session_factory(tenant_id)` (ver service.capture_lead).",
+        "operationId": "capture_lead_public_leads__key__post",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeadCapture"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Response Capture Lead Public Leads  Key  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -8640,7 +11347,14 @@
             "$ref": "#/components/schemas/UserOut"
           },
           "temp_password": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Temp Password"
           },
           "delivery": {
@@ -8656,7 +11370,6 @@
         "required": [
           "tenant",
           "owner",
-          "temp_password",
           "delivery",
           "delivery_status"
         ],
@@ -8857,6 +11570,25 @@
         ],
         "title": "Body_extract_juridico_extract_post"
       },
+      "Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post": {
+        "properties": {
+          "caption": {
+            "type": "string",
+            "title": "Caption",
+            "default": ""
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post"
+      },
       "Body_upload_attachment_attachments_post": {
         "properties": {
           "owner_type": {
@@ -8885,6 +11617,20 @@
           "file"
         ],
         "title": "Body_upload_attachment_attachments_post"
+      },
+      "Body_upload_public_image_attachments_public_images_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_public_image_attachments_public_images_post"
       },
       "CarouselCreate": {
         "properties": {
@@ -9254,6 +12000,51 @@
             "format": "date",
             "title": "Due Date"
           },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
           "recurrence": {
             "type": "string",
             "title": "Recurrence",
@@ -9329,6 +12120,63 @@
             "format": "date",
             "title": "Due Date"
           },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "paid_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paid At"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
           "status": {
             "type": "string",
             "title": "Status"
@@ -9383,6 +12231,28 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At"
+          },
+          "gateway_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Provider"
+          },
+          "gateway_status_raw": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Status Raw"
           }
         },
         "type": "object",
@@ -9396,6 +12266,11 @@
           "method",
           "amount_cents",
           "due_date",
+          "competence_date",
+          "paid_at",
+          "chart_account_id",
+          "contract_id",
+          "cost_center_id",
           "status",
           "is_overdue",
           "protested_at",
@@ -9443,6 +12318,51 @@
               }
             ],
             "title": "Due Date"
+          },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
           }
         },
         "type": "object",
@@ -9480,6 +12400,109 @@
           "overdue_count"
         ],
         "title": "ChargesSummary"
+      },
+      "ChartAccountCreate": {
+        "properties": {
+          "grupo_dre": {
+            "type": "string",
+            "title": "Grupo Dre"
+          },
+          "categoria": {
+            "type": "string",
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Categoria"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grupo_dre",
+          "categoria"
+        ],
+        "title": "ChartAccountCreate"
+      },
+      "ChartAccountOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "grupo_dre": {
+            "type": "string",
+            "title": "Grupo Dre"
+          },
+          "categoria": {
+            "type": "string",
+            "title": "Categoria"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "grupo_dre",
+          "categoria",
+          "archived_at",
+          "created_at"
+        ],
+        "title": "ChartAccountOut"
+      },
+      "ChartAccountUpdate": {
+        "properties": {
+          "categoria": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 80,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Categoria"
+          }
+        },
+        "type": "object",
+        "title": "ChartAccountUpdate"
+      },
+      "ChartGroupOut": {
+        "properties": {
+          "grupo_dre": {
+            "type": "string",
+            "title": "Grupo Dre"
+          },
+          "categorias": {
+            "items": {
+              "$ref": "#/components/schemas/ChartAccountOut"
+            },
+            "type": "array",
+            "title": "Categorias"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grupo_dre",
+          "categorias"
+        ],
+        "title": "ChartGroupOut",
+        "description": "Um grupo DRE com suas categorias (nó da hierarquia grupo → categorias — AC3)."
       },
       "Clause": {
         "properties": {
@@ -9992,6 +13015,112 @@
         ],
         "title": "ContractCreate"
       },
+      "ContractDreOut": {
+        "properties": {
+          "contract_id": {
+            "type": "string",
+            "title": "Contract Id"
+          },
+          "start": {
+            "type": "string",
+            "format": "date",
+            "title": "Start"
+          },
+          "end": {
+            "type": "string",
+            "format": "date",
+            "title": "End"
+          },
+          "receita": {
+            "$ref": "#/components/schemas/DreGroupOut"
+          },
+          "custo_direto": {
+            "$ref": "#/components/schemas/DreGroupOut"
+          },
+          "receita_cents": {
+            "type": "integer",
+            "title": "Receita Cents"
+          },
+          "custo_direto_cents": {
+            "type": "integer",
+            "title": "Custo Direto Cents"
+          },
+          "margem_contribuicao_cents": {
+            "type": "integer",
+            "title": "Margem Contribuicao Cents"
+          },
+          "margem_contribuicao_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Margem Contribuicao Pct"
+          },
+          "outros_resultado_cents": {
+            "type": "integer",
+            "title": "Outros Resultado Cents"
+          },
+          "fixed_costs_allocated_cents": {
+            "type": "integer",
+            "title": "Fixed Costs Allocated Cents"
+          },
+          "overhead_allocated_cents": {
+            "type": "integer",
+            "title": "Overhead Allocated Cents"
+          },
+          "resultado_cents": {
+            "type": "integer",
+            "title": "Resultado Cents"
+          },
+          "break_even_cents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Break Even Cents"
+          },
+          "break_even_reachable": {
+            "type": "boolean",
+            "title": "Break Even Reachable"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "contract_id",
+          "start",
+          "end",
+          "receita",
+          "custo_direto",
+          "receita_cents",
+          "custo_direto_cents",
+          "margem_contribuicao_cents",
+          "margem_contribuicao_pct",
+          "outros_resultado_cents",
+          "fixed_costs_allocated_cents",
+          "overhead_allocated_cents",
+          "resultado_cents",
+          "break_even_cents",
+          "break_even_reachable",
+          "notes"
+        ],
+        "title": "ContractDreOut",
+        "description": "DRE de margem de contribuição de UM contrato (Story 5.4), em regime de competência.\n\nSinal canônico (herdado da 5.3): totais já ASSINADOS (Receber=+, Pagar=−). `custo_direto_cents`\nnormalmente é NEGATIVO; a margem é a SOMA `receita_cents + custo_direto_cents` (não subtração).\n`margem_contribuicao_pct` é a RAZÃO MC/Receita (fração, ex.: 0.6 = 60%; multiplique por 100 para\nexibir %), ou None quando não há receita (proteção contra divisão por zero). `break_even_cents`\né a receita necessária para empatar os custos fixos; None + `break_even_reachable=false` quando\na margem não-positiva impede o break-even (estado explícito, nunca erro 500).\n`overhead_allocated_cents` só é != 0 quando o rateio é solicitado (`include_overhead=true`) —\ncalculado na leitura, JAMAIS gravado no lançamento (AC3/IV2).\n\n`outros_resultado_cents` é a soma assinada dos lançamentos do contrato em grupos de resultado\nALÉM da margem (Despesa Fixa/Tributos/Financeiro): NÃO entra na margem de contribuição, mas\nCOMPÕE o resultado (`resultado = margem + outros_resultado − custos fixos − overhead`).\nINVESTIMENTO e lançamentos sem categoria ficam fora do resultado (sinalizados em `notes`)."
+      },
       "ContractOut": {
         "properties": {
           "id": {
@@ -10061,6 +13190,17 @@
             ],
             "title": "Public Slug"
           },
+          "fixed_costs_allocated_cents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fixed Costs Allocated Cents"
+          },
           "signer_name": {
             "type": "string",
             "title": "Signer Name"
@@ -10098,6 +13238,7 @@
           "clauses",
           "status",
           "public_slug",
+          "fixed_costs_allocated_cents",
           "signer_name",
           "signer_document",
           "signed_at",
@@ -10144,6 +13285,18 @@
               }
             ],
             "title": "Clauses"
+          },
+          "fixed_costs_allocated_cents": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fixed Costs Allocated Cents"
           }
         },
         "type": "object",
@@ -10171,6 +13324,190 @@
           "signed_count"
         ],
         "title": "ContractsSummary"
+      },
+      "CostCenterBucketOut": {
+        "properties": {
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "receita_cents": {
+            "type": "integer",
+            "title": "Receita Cents"
+          },
+          "resultado_cents": {
+            "type": "integer",
+            "title": "Resultado Cents"
+          },
+          "lancamentos": {
+            "type": "integer",
+            "title": "Lancamentos"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cost_center_id",
+          "name",
+          "kind",
+          "receita_cents",
+          "resultado_cents",
+          "lancamentos"
+        ],
+        "title": "CostCenterBucketOut",
+        "description": "Resultado do período agregado por um centro de custo (2ª dimensão). `cost_center_id=None` e\n`name='Não atribuído'` é o bucket sintético dos lançamentos sem centro de custo (AC3).\n`resultado_cents` usa a MESMA fórmula/exclusões da DRE (Story 5.3)."
+      },
+      "CostCenterCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 16,
+            "title": "Kind",
+            "default": "outro"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CostCenterCreate"
+      },
+      "CostCenterOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "kind",
+          "archived_at",
+          "created_at"
+        ],
+        "title": "CostCenterOut"
+      },
+      "CostCenterReportOut": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date",
+            "title": "Start"
+          },
+          "end": {
+            "type": "string",
+            "format": "date",
+            "title": "End"
+          },
+          "buckets": {
+            "items": {
+              "$ref": "#/components/schemas/CostCenterBucketOut"
+            },
+            "type": "array",
+            "title": "Buckets"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end",
+          "buckets",
+          "notes"
+        ],
+        "title": "CostCenterReportOut",
+        "description": "Comparação lado a lado do resultado por centro de custo no período (Story 5.5, AC2).\n\n`buckets` traz um item por centro de custo do tenant (mesmo os sem movimento, para comparar\nsócios/áreas) mais o bucket 'Não atribuído' (quando há lançamentos sem a 2ª dimensão). `notes`\ndocumenta o regime e as exclusões — não silenciosamente."
+      },
+      "CostCenterUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 120,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 16
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          }
+        },
+        "type": "object",
+        "title": "CostCenterUpdate"
       },
       "CouponCreate": {
         "properties": {
@@ -10537,6 +13874,45 @@
         "title": "CustomerOut",
         "description": "Cliente comprador (aluno/matrícula) — ainda não é um User de login, vive em Enrollment."
       },
+      "DiagnosticsOut": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date",
+            "title": "Start"
+          },
+          "end": {
+            "type": "string",
+            "format": "date",
+            "title": "End"
+          },
+          "signals": {
+            "items": {
+              "$ref": "#/components/schemas/SignalOut"
+            },
+            "type": "array",
+            "title": "Signals"
+          },
+          "narrative": {
+            "type": "string",
+            "title": "Narrative"
+          },
+          "narrative_source": {
+            "type": "string",
+            "title": "Narrative Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end",
+          "signals",
+          "narrative",
+          "narrative_source"
+        ],
+        "title": "DiagnosticsOut",
+        "description": "Resposta do diagnóstico (Story 5.8). `signals` é o resultado DETERMINÍSTICO do motor —\nexiste e está correto INDEPENDENTEMENTE da IA (AC2/IV3). `narrative` é a leitura em linguagem\nnatural: quando a IA está disponível, é gerada por ela (após anonimização — Regra de Ouro nº 2);\nsenão, é um fallback por template a partir dos MESMOS sinais. `narrative_source` diz qual foi\n('ai' | 'template') — a UI deixa claro ao usuário que os números vêm primeiro."
+      },
       "DocumentCreate": {
         "properties": {
           "skill": {
@@ -10544,7 +13920,6 @@
             "title": "Skill"
           },
           "answers": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Answers",
             "default": {}
@@ -10625,7 +14000,6 @@
             "title": "Metadata Raw"
           },
           "answers": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Answers"
           },
@@ -10726,6 +14100,101 @@
           "created_at"
         ],
         "title": "DocumentSummary"
+      },
+      "DreCategoryOut": {
+        "properties": {
+          "categoria": {
+            "type": "string",
+            "title": "Categoria"
+          },
+          "amount_cents": {
+            "type": "integer",
+            "title": "Amount Cents"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "categoria",
+          "amount_cents",
+          "count"
+        ],
+        "title": "DreCategoryOut"
+      },
+      "DreGroupOut": {
+        "properties": {
+          "grupo_dre": {
+            "type": "string",
+            "title": "Grupo Dre"
+          },
+          "total_cents": {
+            "type": "integer",
+            "title": "Total Cents"
+          },
+          "categorias": {
+            "items": {
+              "$ref": "#/components/schemas/DreCategoryOut"
+            },
+            "type": "array",
+            "title": "Categorias"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grupo_dre",
+          "total_cents",
+          "categorias"
+        ],
+        "title": "DreGroupOut"
+      },
+      "DreReportOut": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date",
+            "title": "Start"
+          },
+          "end": {
+            "type": "string",
+            "format": "date",
+            "title": "End"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/DreGroupOut"
+            },
+            "type": "array",
+            "title": "Groups"
+          },
+          "sem_categoria": {
+            "$ref": "#/components/schemas/DreGroupOut"
+          },
+          "resultado_cents": {
+            "type": "integer",
+            "title": "Resultado Cents"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end",
+          "groups",
+          "sem_categoria",
+          "resultado_cents",
+          "notes"
+        ],
+        "title": "DreReportOut",
+        "description": "DRE hierárquica do período (grupo DRE → categoria), em regime de competência.\n\n`groups` traz sempre os 6 grupos na ordem canônica (mesmo vazios). `sem_categoria` é o bucket\ndos lançamentos não classificados (fora do `resultado_cents`). `notes` documenta as exclusões\n(INVESTIMENTO / sem categoria) e o regime — não silenciosamente."
       },
       "DunningResult": {
         "properties": {
@@ -11033,6 +14502,17 @@
             ],
             "title": "External Ref"
           },
+          "google_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Event Id"
+          },
           "client_name": {
             "anyOf": [
               {
@@ -11245,7 +14725,6 @@
           },
           "nodes": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -11253,7 +14732,6 @@
           },
           "edges": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -11282,7 +14760,6 @@
           },
           "nodes": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -11290,7 +14767,6 @@
           },
           "edges": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -11532,7 +15008,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -11547,7 +15022,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -11637,6 +15111,50 @@
         ],
         "title": "GenerateResult"
       },
+      "GoogleConnectOut": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "GoogleConnectOut",
+        "description": "URL de autorização do Google para o frontend redirecionar o usuário."
+      },
+      "GoogleStatusOut": {
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "title": "Configured"
+          },
+          "connected": {
+            "type": "boolean",
+            "title": "Connected"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "configured",
+          "connected"
+        ],
+        "title": "GoogleStatusOut",
+        "description": "Estado da integração para o frontend decidir a UI (botões conectar/desconectar)."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -11649,6 +15167,255 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "IntegrationKeyCreate": {
+        "properties": {
+          "label": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Label"
+          }
+        },
+        "type": "object",
+        "required": [
+          "label"
+        ],
+        "title": "IntegrationKeyCreate"
+      },
+      "IntegrationKeyCreated": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "key_prefix": {
+            "type": "string",
+            "title": "Key Prefix"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "raw_key": {
+            "type": "string",
+            "title": "Raw Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "label",
+          "key_prefix",
+          "revoked_at",
+          "created_at",
+          "raw_key"
+        ],
+        "title": "IntegrationKeyCreated",
+        "description": "Retorno da criação: única vez em que a chave crua fica visível."
+      },
+      "IntegrationKeyOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "key_prefix": {
+            "type": "string",
+            "title": "Key Prefix"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "label",
+          "key_prefix",
+          "revoked_at",
+          "created_at"
+        ],
+        "title": "IntegrationKeyOut"
+      },
+      "InvestmentAccountCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 24,
+            "title": "Kind",
+            "default": ""
+          },
+          "index_rate_label": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Index Rate Label",
+            "default": ""
+          },
+          "principal_cents": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Principal Cents",
+            "default": 0
+          },
+          "opened_at": {
+            "type": "string",
+            "format": "date",
+            "title": "Opened At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "opened_at"
+        ],
+        "title": "InvestmentAccountCreate"
+      },
+      "InvestmentAccountOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "index_rate_label": {
+            "type": "string",
+            "title": "Index Rate Label"
+          },
+          "principal_cents": {
+            "type": "integer",
+            "title": "Principal Cents"
+          },
+          "accrued_yield_cents": {
+            "type": "integer",
+            "title": "Accrued Yield Cents"
+          },
+          "opened_at": {
+            "type": "string",
+            "format": "date",
+            "title": "Opened At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "kind",
+          "index_rate_label",
+          "principal_cents",
+          "accrued_yield_cents",
+          "opened_at",
+          "created_at"
+        ],
+        "title": "InvestmentAccountOut"
+      },
+      "InvestmentAccountUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 120,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "index_rate_label": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Rate Label"
+          },
+          "principal_cents": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Principal Cents"
+          }
+        },
+        "type": "object",
+        "title": "InvestmentAccountUpdate"
       },
       "ItemCreate": {
         "properties": {
@@ -11876,6 +15643,71 @@
         "type": "object",
         "title": "ItemUpdate"
       },
+      "LeadCapture": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 32
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fields"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "LeadCapture"
+      },
       "LeadSubmit": {
         "properties": {
           "name": {
@@ -11901,6 +15733,20 @@
             "maxLength": 32,
             "title": "Phone",
             "default": ""
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fields"
           }
         },
         "type": "object",
@@ -12097,7 +15943,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -12135,7 +15980,6 @@
           },
           "blocks": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -12270,7 +16114,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -12384,6 +16227,51 @@
             "format": "date",
             "title": "Due Date"
           },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
           "recurrence": {
             "type": "string",
             "title": "Recurrence",
@@ -12445,6 +16333,51 @@
             "type": "string",
             "format": "date",
             "title": "Due Date"
+          },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
           },
           "status": {
             "type": "string",
@@ -12508,6 +16441,10 @@
           "supplier",
           "amount_cents",
           "due_date",
+          "competence_date",
+          "chart_account_id",
+          "contract_id",
+          "cost_center_id",
           "status",
           "is_overdue",
           "paid_at",
@@ -12579,6 +16516,51 @@
             ],
             "title": "Due Date"
           },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "contract_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contract Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
           "recurrence": {
             "anyOf": [
               {
@@ -12649,6 +16631,100 @@
           "paid_month_cents"
         ],
         "title": "PayablesSummary"
+      },
+      "PaymentQueueOut": {
+        "properties": {
+          "atrasados": {
+            "items": {
+              "$ref": "#/components/schemas/PayableOut"
+            },
+            "type": "array",
+            "title": "Atrasados"
+          },
+          "hoje": {
+            "items": {
+              "$ref": "#/components/schemas/PayableOut"
+            },
+            "type": "array",
+            "title": "Hoje"
+          },
+          "proximos_7_dias": {
+            "items": {
+              "$ref": "#/components/schemas/PayableOut"
+            },
+            "type": "array",
+            "title": "Proximos 7 Dias"
+          },
+          "proximos_30_dias": {
+            "items": {
+              "$ref": "#/components/schemas/PayableOut"
+            },
+            "type": "array",
+            "title": "Proximos 30 Dias"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/PaymentQueueSummary"
+          }
+        },
+        "type": "object",
+        "required": [
+          "atrasados",
+          "hoje",
+          "proximos_7_dias",
+          "proximos_30_dias",
+          "summary"
+        ],
+        "title": "PaymentQueueOut",
+        "description": "Fila agrupada em 4 baldes de PayableOut (reaproveitado) + o resumo por balde."
+      },
+      "PaymentQueueSummary": {
+        "properties": {
+          "atrasados_count": {
+            "type": "integer",
+            "title": "Atrasados Count"
+          },
+          "atrasados_cents": {
+            "type": "integer",
+            "title": "Atrasados Cents"
+          },
+          "hoje_count": {
+            "type": "integer",
+            "title": "Hoje Count"
+          },
+          "hoje_cents": {
+            "type": "integer",
+            "title": "Hoje Cents"
+          },
+          "proximos_7_dias_count": {
+            "type": "integer",
+            "title": "Proximos 7 Dias Count"
+          },
+          "proximos_7_dias_cents": {
+            "type": "integer",
+            "title": "Proximos 7 Dias Cents"
+          },
+          "proximos_30_dias_count": {
+            "type": "integer",
+            "title": "Proximos 30 Dias Count"
+          },
+          "proximos_30_dias_cents": {
+            "type": "integer",
+            "title": "Proximos 30 Dias Cents"
+          }
+        },
+        "type": "object",
+        "required": [
+          "atrasados_count",
+          "atrasados_cents",
+          "hoje_count",
+          "hoje_cents",
+          "proximos_7_dias_count",
+          "proximos_7_dias_cents",
+          "proximos_30_dias_count",
+          "proximos_30_dias_cents"
+        ],
+        "title": "PaymentQueueSummary",
+        "description": "Contagem e soma (centavos) por balde — mesmo padrão de PayablesSummary, sem os itens."
       },
       "PayoutResult": {
         "properties": {
@@ -12980,6 +17056,40 @@
           "timezone": {
             "type": "string",
             "title": "Timezone"
+          },
+          "default_entry_funnel_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Entry Funnel Id"
+          },
+          "whatsapp_configured": {
+            "type": "boolean",
+            "title": "Whatsapp Configured"
+          },
+          "whatsapp_phone_id": {
+            "type": "string",
+            "title": "Whatsapp Phone Id"
+          },
+          "whatsapp_waba_id": {
+            "type": "string",
+            "title": "Whatsapp Waba Id"
+          },
+          "whatsapp_verify_token": {
+            "type": "string",
+            "title": "Whatsapp Verify Token"
+          },
+          "whatsapp_template_bindings": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Whatsapp Template Bindings"
           }
         },
         "type": "object",
@@ -12998,7 +17108,13 @@
           "text_color",
           "bg_color",
           "font",
-          "timezone"
+          "timezone",
+          "default_entry_funnel_id",
+          "whatsapp_configured",
+          "whatsapp_phone_id",
+          "whatsapp_waba_id",
+          "whatsapp_verify_token",
+          "whatsapp_template_bindings"
         ],
         "title": "ProfileOut"
       },
@@ -13182,10 +17298,156 @@
               }
             ],
             "title": "Timezone"
+          },
+          "default_entry_funnel_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 36
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Entry Funnel Id"
+          },
+          "whatsapp_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Token"
+          },
+          "whatsapp_phone_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone Id"
+          },
+          "whatsapp_waba_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Waba Id"
+          },
+          "whatsapp_app_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp App Secret"
+          },
+          "whatsapp_template_bindings": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Template Bindings"
           }
         },
         "type": "object",
         "title": "ProfileUpdate"
+      },
+      "ProjectionOut": {
+        "properties": {
+          "today": {
+            "type": "string",
+            "format": "date",
+            "title": "Today"
+          },
+          "saldo_inicial_cents": {
+            "type": "integer",
+            "title": "Saldo Inicial Cents"
+          },
+          "overdue_inflow_cents": {
+            "type": "integer",
+            "title": "Overdue Inflow Cents"
+          },
+          "overdue_outflow_cents": {
+            "type": "integer",
+            "title": "Overdue Outflow Cents"
+          },
+          "windows": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectionWindowOut"
+            },
+            "type": "array",
+            "title": "Windows"
+          },
+          "runway": {
+            "$ref": "#/components/schemas/RunwayOut"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "today",
+          "saldo_inicial_cents",
+          "overdue_inflow_cents",
+          "overdue_outflow_cents",
+          "windows",
+          "runway",
+          "notes"
+        ],
+        "title": "ProjectionOut",
+        "description": "Projeção de fluxo de caixa 30/60/90 dias + runway (Story 5.7), em regime de CAIXA.\n\nOPOSTO da DRE (que usa competência): aqui a data é a de PAGAMENTO PREVISTO (vencimento dos itens\nem aberto), nunca `competence_date`. `saldo_inicial_cents` é o disponível da Carteira (mesmo\nnúmero do Cockpit). `windows` traz uma janela por horizonte pedido (default 30/60/90), com o\nsaldo projetado e o sinal `alert`. `notes` documenta o regime e as exclusões — não em silêncio.\n\n`overdue_inflow_cents`/`overdue_outflow_cents`: parcela de itens em aberto JÁ VENCIDOS\n(`due_date < hoje`) que a projeção conta como caixa esperado imediato — já embutida em todas as\n`windows`, exposta à parte para o consumidor risk-ajustar (vencidos podem não se concretizar)."
+      },
+      "ProjectionWindowOut": {
+        "properties": {
+          "days": {
+            "type": "integer",
+            "title": "Days"
+          },
+          "saldo_projetado_cents": {
+            "type": "integer",
+            "title": "Saldo Projetado Cents"
+          },
+          "alert": {
+            "type": "boolean",
+            "title": "Alert"
+          }
+        },
+        "type": "object",
+        "required": [
+          "days",
+          "saldo_projetado_cents",
+          "alert"
+        ],
+        "title": "ProjectionWindowOut",
+        "description": "Saldo de caixa projetado para uma janela (dias a partir de hoje), em regime de CAIXA.\n\n`saldo_projetado_cents` é CUMULATIVO: saldo inicial da Carteira + entradas abertas − saídas\nabertas cujo vencimento cai até o fim da janela. `alert=True` quando o saldo fica NEGATIVO nessa\njanela — sinal explícito que a Story 5.8 consome como indicador 🔴 sem recalcular."
       },
       "PublicAccept": {
         "properties": {
@@ -13253,6 +17515,25 @@
         ],
         "title": "PublicContract"
       },
+      "PublicImageOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "url"
+        ],
+        "title": "PublicImageOut",
+        "description": "Retorno do upload de imagem pública. ``url`` é o caminho da rota de leitura no backend\n(``/public-images/{id}``); o frontend prefixa o proxy ``/api`` para obter a URL renderável."
+      },
       "PublicPage": {
         "properties": {
           "title": {
@@ -13261,7 +17542,6 @@
           },
           "blocks": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -14160,6 +18440,116 @@
         ],
         "title": "RegisterRequest"
       },
+      "RegisterYieldRequest": {
+        "properties": {
+          "amount_cents": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Amount Cents"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "title": "Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "amount_cents",
+          "date"
+        ],
+        "title": "RegisterYieldRequest",
+        "description": "Registrar rendimento (juro) de uma aplicação num período (Task 2/3).\n\n`amount_cents` > 0 (rendimento positivo). `date` é a data de competência do lançamento (regime\nde competência — entra na DRE nesse período). `chart_account_id` (opcional) DEVE apontar a uma\nconta do grupo `FINANCEIRO` quando informado (422 caso contrário) — ver service."
+      },
+      "RentabilityOut": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "principal_cents": {
+            "type": "integer",
+            "title": "Principal Cents"
+          },
+          "accrued_yield_cents": {
+            "type": "integer",
+            "title": "Accrued Yield Cents"
+          },
+          "total_rentability_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Rentability Pct"
+          },
+          "period_rentability_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Period Rentability Pct"
+          },
+          "period_yield_cents": {
+            "type": "integer",
+            "title": "Period Yield Cents"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "principal_cents",
+          "accrued_yield_cents",
+          "total_rentability_pct",
+          "period_rentability_pct",
+          "period_yield_cents",
+          "start",
+          "end"
+        ],
+        "title": "RentabilityOut"
+      },
       "ResetPasswordRequest": {
         "properties": {
           "token": {
@@ -14200,7 +18590,6 @@
             "title": "Client Id"
           },
           "params": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Params"
           }
@@ -14281,6 +18670,32 @@
         },
         "type": "object",
         "title": "RunStep"
+      },
+      "RunwayOut": {
+        "properties": {
+          "days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days"
+          },
+          "burn_rate_cents_per_day": {
+            "type": "integer",
+            "title": "Burn Rate Cents Per Day"
+          }
+        },
+        "type": "object",
+        "required": [
+          "days",
+          "burn_rate_cents_per_day"
+        ],
+        "title": "RunwayOut",
+        "description": "Runway: fôlego de caixa no ritmo de queima atual.\n\n`days` = dias até o saldo inicial zerar na queima líquida diária (saídas − entradas da maior\njanela / dias), ou `None` quando não há queima (caixa crescendo/estável) — \"sem risco\", sem\ndivisão por zero. `burn_rate_cents_per_day` é a queima diária (0 quando não há queima)."
       },
       "ScheduleStage": {
         "properties": {
@@ -14380,6 +18795,40 @@
         ],
         "title": "SellRequest"
       },
+      "SendTemplateRequest": {
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "title": "Template Id"
+          },
+          "variables": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Variables",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_id"
+        ],
+        "title": "SendTemplateRequest"
+      },
+      "SendTextRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "SendTextRequest"
+      },
       "SessionInfo": {
         "properties": {
           "user": {
@@ -14423,6 +18872,35 @@
           "document"
         ],
         "title": "SignRequest"
+      },
+      "SignalOut": {
+        "properties": {
+          "level": {
+            "type": "string",
+            "title": "Level"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "explanation": {
+            "type": "string",
+            "title": "Explanation"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "level",
+          "title",
+          "explanation",
+          "source"
+        ],
+        "title": "SignalOut",
+        "description": "Um sinal de diagnóstico calculado pelo motor PURO (Story 5.8). `level` é verde/amarelo/\nvermelho; `explanation` SEMPRE traz o número que o justifica; `source` identifica a origem\n(lucratividade 5.4 / projecao 5.7 / investimento 5.6)."
       },
       "SkillSummary": {
         "properties": {
@@ -14538,7 +19016,14 @@
             "$ref": "#/components/schemas/UserOut"
           },
           "temp_password": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Temp Password"
           },
           "delivery": {
@@ -14553,7 +19038,6 @@
         "type": "object",
         "required": [
           "user",
-          "temp_password",
           "delivery",
           "delivery_status"
         ],
@@ -14611,6 +19095,17 @@
               }
             ],
             "title": "Position"
+          },
+          "after_stage_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "After Stage Id"
           },
           "is_won": {
             "type": "boolean",
@@ -14719,62 +19214,6 @@
           "low_stock_count"
         ],
         "title": "StockSummary"
-      },
-      "TemplateCreate": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "clauses": {
-            "items": {
-              "$ref": "#/components/schemas/Clause"
-            },
-            "type": "array",
-            "minItems": 1,
-            "title": "Clauses"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "clauses"
-        ],
-        "title": "TemplateCreate"
-      },
-      "TemplateOut": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "clauses": {
-            "items": {
-              "$ref": "#/components/schemas/Clause"
-            },
-            "type": "array",
-            "title": "Clauses"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "clauses",
-          "created_at"
-        ],
-        "title": "TemplateOut"
       },
       "TemplatePreset": {
         "properties": {
@@ -14962,6 +19401,40 @@
               }
             ],
             "title": "External Ref"
+          },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
           }
         },
         "type": "object",
@@ -15032,6 +19505,40 @@
             ],
             "title": "External Ref"
           },
+          "competence_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Competence Date"
+          },
+          "chart_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chart Account Id"
+          },
+          "cost_center_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Center Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15051,6 +19558,9 @@
           "status",
           "client_id",
           "external_ref",
+          "competence_date",
+          "chart_account_id",
+          "cost_center_id",
           "created_at"
         ],
         "title": "TransactionOut"
@@ -15290,35 +19800,6 @@
         ],
         "title": "WalletSummary"
       },
-      "WebhookPayment": {
-        "properties": {
-          "tenant_id": {
-            "type": "string",
-            "title": "Tenant Id"
-          },
-          "charge_id": {
-            "type": "string",
-            "title": "Charge Id"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "paid"
-          },
-          "secret": {
-            "type": "string",
-            "title": "Secret",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "tenant_id",
-          "charge_id"
-        ],
-        "title": "WebhookPayment",
-        "description": "Confirmação de pagamento vinda do gateway (Pix/cartão/boleto compensado)."
-      },
       "app__modules__agenda__schemas__RescheduleRequest": {
         "properties": {
           "starts_at": {
@@ -15339,6 +19820,62 @@
         ],
         "title": "RescheduleRequest"
       },
+      "app__modules__contracts__schemas__TemplateCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "clauses": {
+            "items": {
+              "$ref": "#/components/schemas/Clause"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Clauses"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "clauses"
+        ],
+        "title": "TemplateCreate"
+      },
+      "app__modules__contracts__schemas__TemplateOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "clauses": {
+            "items": {
+              "$ref": "#/components/schemas/Clause"
+            },
+            "type": "array",
+            "title": "Clauses"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "clauses",
+          "created_at"
+        ],
+        "title": "TemplateOut"
+      },
       "app__modules__receivables__schemas__RescheduleRequest": {
         "properties": {
           "due_date": {
@@ -15352,6 +19889,147 @@
           "due_date"
         ],
         "title": "RescheduleRequest"
+      },
+      "app__modules__whatsapp_templates__schemas__TemplateCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]+$",
+            "title": "Name"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "default": "pt_BR"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "MARKETING",
+              "UTILITY",
+              "AUTHENTICATION"
+            ],
+            "title": "Category"
+          },
+          "body_text": {
+            "type": "string",
+            "title": "Body Text"
+          },
+          "variable_examples": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Variable Examples",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "category",
+          "body_text"
+        ],
+        "title": "TemplateCreate"
+      },
+      "app__modules__whatsapp_templates__schemas__TemplateOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "category_requested": {
+            "type": "string",
+            "title": "Category Requested"
+          },
+          "category_approved": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Approved"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "rejected_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rejected Reason"
+          },
+          "meta_template_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta Template Id"
+          },
+          "body_text": {
+            "type": "string",
+            "title": "Body Text"
+          },
+          "variable_count": {
+            "type": "integer",
+            "title": "Variable Count"
+          },
+          "variable_examples": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Variable Examples"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "language",
+          "category_requested",
+          "category_approved",
+          "status",
+          "rejected_reason",
+          "meta_template_id",
+          "body_text",
+          "variable_count",
+          "variable_examples",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "TemplateOut"
       }
     }
   }

--- a/packages/shared-types/src/generated.ts
+++ b/packages/shared-types/src/generated.ts
@@ -612,9 +612,16 @@ export interface paths {
         put?: never;
         /**
          * Payment Webhook
-         * @description Webhook do gateway: reconhece o pagamento AUTOMATICAMENTE (sem login). Em produção,
-         *     defina GATEWAY_WEBHOOK_SECRET para que só o gateway confirme; em dev (segredo vazio) fica
-         *     aberto para testes. O dono NUNCA marca pago manualmente — só saca o que entra por aqui.
+         * @description Webhook do gateway: reconhece o pagamento AUTOMATICAMENTE (sem login). Aceita o payload
+         *     REAL do provedor (Asaas: {event, payment.externalReference}) OU o payload interno de dev/teste
+         *     ({tenant_id, charge_id, status, secret}) — o link 'simular pgto' continua funcionando.
+         *
+         *     Segurança (fail-closed): com GATEWAY_WEBHOOK_SECRET definido, só o gateway confirma — para o
+         *     payload real valida o token do header (`asaas-access-token`), para o interno valida `secret`
+         *     no corpo. Segredo vazio (dev) = aberto para testes. O dono NUNCA marca pago manualmente.
+         *
+         *     Nota (No Invention): o nome do header de autenticação do Asaas deve ser confirmado contra a
+         *     documentação vigente do provedor antes do go-live.
          */
         post: operations["payment_webhook_receivables_webhook_post"];
         delete?: never;
@@ -815,6 +822,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/payables/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Payment Queue
+         * @description Story 5.9 — fila de pagamentos: Payables em aberto agrupados por janela de vencimento.
+         *     Mesmo módulo/guard (`require_module('payables')`), sem autorização nova.
+         */
+        get: operations["payment_queue_payables_queue_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/payables/categories": {
         parameters: {
             query?: never;
@@ -896,6 +924,316 @@ export interface paths {
         put?: never;
         /** Cancel Bill */
         post: operations["cancel_bill_payables_bills__payable_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chart-of-accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Accounts */
+        get: operations["list_accounts_chart_of_accounts_get"];
+        put?: never;
+        /** Create Account */
+        post: operations["create_account_chart_of_accounts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chart-of-accounts/hierarchy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Hierarchy */
+        get: operations["hierarchy_chart_of_accounts_hierarchy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chart-of-accounts/{account_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Account */
+        patch: operations["update_account_chart_of_accounts__account_id__patch"];
+        trace?: never;
+    };
+    "/chart-of-accounts/{account_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Archive Account */
+        post: operations["archive_account_chart_of_accounts__account_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chart-of-accounts/seed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Seed */
+        post: operations["seed_chart_of_accounts_seed_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/cost-centers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Cost Centers */
+        get: operations["list_cost_centers_cost_centers_get"];
+        put?: never;
+        /** Create Cost Center */
+        post: operations["create_cost_center_cost_centers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/cost-centers/{cost_center_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Cost Center */
+        patch: operations["update_cost_center_cost_centers__cost_center_id__patch"];
+        trace?: never;
+    };
+    "/cost-centers/{cost_center_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Archive Cost Center */
+        post: operations["archive_cost_center_cost_centers__cost_center_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/financial-intelligence/dre": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dre */
+        get: operations["dre_financial_intelligence_dre_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/financial-intelligence/by-cost-center": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * By Cost Center
+         * @description Cruza o resultado do período por centro de custo (2ª dimensão), incluindo o bucket 'Não
+         *     atribuído' — comparação lado a lado de sócios/áreas/unidades (Story 5.5, AC2/AC3).
+         */
+        get: operations["by_cost_center_financial_intelligence_by_cost_center_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/financial-intelligence/projection": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Projection
+         * @description Projeta o saldo de caixa para 30/60/90 dias e o runway (Story 5.7), em regime de CAIXA.
+         *
+         *     SOMENTE LEITURA: usa a data de pagamento prevista (vencimento dos itens em aberto), nunca a de
+         *     competência — não escreve nem cria contas (IV1/IV2).
+         */
+        get: operations["projection_financial_intelligence_projection_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/financial-intelligence/contracts/{contract_id}/dre": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Contract Dre */
+        get: operations["contract_dre_financial_intelligence_contracts__contract_id__dre_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/financial-intelligence/diagnostics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Diagnostics
+         * @description Diagnóstico financeiro (Story 5.8): sinais determinísticos 🟢🟡🔴 (motor PURO) + narrativa.
+         *
+         *     O motor SEMPRE calcula e retorna os sinais, mesmo sem `ANTHROPIC_API_KEY` (AC2/IV3): a narrativa
+         *     da IA é isolada e cai num fallback por template em qualquer erro/chave ausente — nunca derruba o
+         *     endpoint. Quando a IA narra de fato, o texto passa pelo anonimizador ANTES do Claude (Regra de
+         *     Ouro nº 2) e grava rastro "Ação executada pela IA" (Regra de Ouro nº 3).
+         */
+        get: operations["diagnostics_financial_intelligence_diagnostics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/investments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Accounts */
+        get: operations["list_accounts_investments_get"];
+        put?: never;
+        /** Create Account */
+        post: operations["create_account_investments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/investments/{account_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Account */
+        patch: operations["update_account_investments__account_id__patch"];
+        trace?: never;
+    };
+    "/investments/{account_id}/yield": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register Yield */
+        post: operations["register_yield_investments__account_id__yield_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/investments/{account_id}/rentability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Rentability */
+        get: operations["rentability_investments__account_id__rentability_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1803,6 +2141,205 @@ export interface paths {
         patch: operations["update_profile_settings_profile_patch"];
         trace?: never;
     };
+    "/whatsapp-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Templates */
+        get: operations["list_templates_whatsapp_templates_get"];
+        put?: never;
+        /** Create Template */
+        post: operations["create_template_whatsapp_templates_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-templates/{template_id}/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Template */
+        post: operations["sync_template_whatsapp_templates__template_id__sync_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Template */
+        delete: operations["delete_template_whatsapp_templates__template_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Conversations */
+        get: operations["list_conversations_whatsapp_conversations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Timeline */
+        get: operations["get_timeline_whatsapp_conversations__client_id__timeline_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/window": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Window */
+        get: operations["get_window_whatsapp_conversations__client_id__window_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark Read */
+        post: operations["mark_read_whatsapp_conversations__client_id__read_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/messages/text": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Text Reply */
+        post: operations["send_text_reply_whatsapp_conversations__client_id__messages_text_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/messages/media": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Media Reply */
+        post: operations["send_media_reply_whatsapp_conversations__client_id__messages_media_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/whatsapp-conversations/{client_id}/messages/template": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send Template Reply */
+        post: operations["send_template_reply_whatsapp_conversations__client_id__messages_template_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/public/whatsapp/webhook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Verify Webhook
+         * @description Handshake de verificação chamado 1x pela Meta quando o tenant configura o webhook no
+         *     painel dele. Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_whatsapp_accounts`,
+         *     tabela GLOBAL sem RLS, pelo verify_token — não toca tabela de negócio.
+         */
+        get: operations["verify_webhook_public_whatsapp_webhook_get"];
+        put?: never;
+        /**
+         * Receive Webhook
+         * @description Recebe o evento da Meta. Descobre o tenant pelo `phone_number_id` do payload ANTES de
+         *     validar a assinatura (a assinatura usa o `app_secret` DAQUELE tenant, então precisamos saber
+         *     quem é primeiro). Se a assinatura não bater, rejeita sem processar nada.
+         */
+        post: operations["receive_webhook_public_whatsapp_webhook_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/pages": {
         parameters: {
             query?: never;
@@ -1965,6 +2502,179 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/attachments/public-images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload Public Image
+         * @description Upload autenticado de imagem intencionalmente pública (logo/foto). A leitura depois é
+         *     pública (ver `serve_public_image`). Devolve o caminho da rota de leitura no backend; o
+         *     frontend prefixa o proxy `/api` para obter a URL renderável em `<img src>`.
+         */
+        post: operations["upload_public_image_attachments_public_images_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/public-images/{image_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serve Public Image
+         * @description Uso LEGÍTIMO de `get_db` (sem tenant): rota pública lê `public_images`, tabela GLOBAL
+         *     sem RLS. NÃO toca `users` nem tabelas de negócio por tenant — seguro por design. Serve os
+         *     bytes inline (sem `Content-Disposition: attachment`) para renderizar como `<img>`.
+         */
+        get: operations["serve_public_image_public_images__image_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/google/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Status */
+        get: operations["status_integrations_google_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/google/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Connect */
+        get: operations["connect_integrations_google_connect_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/google/disconnect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Disconnect */
+        post: operations["disconnect_integrations_google_disconnect_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/google/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Callback
+         * @description O Google redireciona para cá após o consent. Valida o `state`, troca o `code` por tokens
+         *     e persiste a credencial no tenant. Sempre redireciona de volta ao frontend.
+         */
+        get: operations["callback_integrations_google_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/leads/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Keys */
+        get: operations["list_keys_integrations_leads_keys_get"];
+        put?: never;
+        /** Create Key */
+        post: operations["create_key_integrations_leads_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/integrations/leads/keys/{key_id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Revoke Key */
+        post: operations["revoke_key_integrations_leads_keys__key_id__revoke_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/public/leads/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Capture Lead
+         * @description Uso LEGÍTIMO de `get_db` (sem tenant): resolve `public_integration_keys`, snapshot
+         *     GLOBAL sem RLS, pelo hash da chave. Nunca toca tabela de negócio por aqui — a escrita
+         *     real acontece dentro de `session_factory(tenant_id)` (ver service.capture_lead).
+         */
+        post: operations["capture_lead_public_leads__key__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -1994,7 +2704,7 @@ export interface components {
             tenant: components["schemas"]["TenantOut"];
             owner: components["schemas"]["UserOut"];
             /** Temp Password */
-            temp_password: string;
+            temp_password?: string | null;
             /** Delivery */
             delivery: string;
             /** Delivery Status */
@@ -2085,6 +2795,19 @@ export interface components {
              */
             file: string;
         };
+        /** Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post */
+        Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post: {
+            /**
+             * Caption
+             * @default
+             */
+            caption: string;
+            /**
+             * File
+             * Format: binary
+             */
+            file: string;
+        };
         /** Body_upload_attachment_attachments_post */
         Body_upload_attachment_attachments_post: {
             /** Owner Type */
@@ -2096,6 +2819,14 @@ export interface components {
              * @default outro
              */
             label: string;
+            /**
+             * File
+             * Format: binary
+             */
+            file: string;
+        };
+        /** Body_upload_public_image_attachments_public_images_post */
+        Body_upload_public_image_attachments_public_images_post: {
             /**
              * File
              * Format: binary
@@ -2244,6 +2975,14 @@ export interface components {
              * Format: date
              */
             due_date: string;
+            /** Competence Date */
+            competence_date?: string | null;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+            /** Contract Id */
+            contract_id?: string | null;
+            /** Cost Center Id */
+            cost_center_id?: string | null;
             /**
              * Recurrence
              * @default none
@@ -2278,6 +3017,16 @@ export interface components {
              * Format: date
              */
             due_date: string;
+            /** Competence Date */
+            competence_date: string | null;
+            /** Paid At */
+            paid_at: string | null;
+            /** Chart Account Id */
+            chart_account_id: string | null;
+            /** Contract Id */
+            contract_id: string | null;
+            /** Cost Center Id */
+            cost_center_id: string | null;
             /** Status */
             status: string;
             /** Is Overdue */
@@ -2297,6 +3046,10 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /** Gateway Provider */
+            gateway_provider?: string | null;
+            /** Gateway Status Raw */
+            gateway_status_raw?: string | null;
         };
         /** ChargeUpdate */
         ChargeUpdate: {
@@ -2306,6 +3059,14 @@ export interface components {
             amount_cents?: number | null;
             /** Due Date */
             due_date?: string | null;
+            /** Competence Date */
+            competence_date?: string | null;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+            /** Contract Id */
+            contract_id?: string | null;
+            /** Cost Center Id */
+            cost_center_id?: string | null;
         };
         /** ChargesSummary */
         ChargesSummary: {
@@ -2319,6 +3080,44 @@ export interface components {
             open_count: number;
             /** Overdue Count */
             overdue_count: number;
+        };
+        /** ChartAccountCreate */
+        ChartAccountCreate: {
+            /** Grupo Dre */
+            grupo_dre: string;
+            /** Categoria */
+            categoria: string;
+        };
+        /** ChartAccountOut */
+        ChartAccountOut: {
+            /** Id */
+            id: string;
+            /** Grupo Dre */
+            grupo_dre: string;
+            /** Categoria */
+            categoria: string;
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** ChartAccountUpdate */
+        ChartAccountUpdate: {
+            /** Categoria */
+            categoria?: string | null;
+        };
+        /**
+         * ChartGroupOut
+         * @description Um grupo DRE com suas categorias (nó da hierarquia grupo → categorias — AC3).
+         */
+        ChartGroupOut: {
+            /** Grupo Dre */
+            grupo_dre: string;
+            /** Categorias */
+            categorias: components["schemas"]["ChartAccountOut"][];
         };
         /** Clause */
         Clause: {
@@ -2489,6 +3288,62 @@ export interface components {
                 [key: string]: string;
             };
         };
+        /**
+         * ContractDreOut
+         * @description DRE de margem de contribuição de UM contrato (Story 5.4), em regime de competência.
+         *
+         *     Sinal canônico (herdado da 5.3): totais já ASSINADOS (Receber=+, Pagar=−). `custo_direto_cents`
+         *     normalmente é NEGATIVO; a margem é a SOMA `receita_cents + custo_direto_cents` (não subtração).
+         *     `margem_contribuicao_pct` é a RAZÃO MC/Receita (fração, ex.: 0.6 = 60%; multiplique por 100 para
+         *     exibir %), ou None quando não há receita (proteção contra divisão por zero). `break_even_cents`
+         *     é a receita necessária para empatar os custos fixos; None + `break_even_reachable=false` quando
+         *     a margem não-positiva impede o break-even (estado explícito, nunca erro 500).
+         *     `overhead_allocated_cents` só é != 0 quando o rateio é solicitado (`include_overhead=true`) —
+         *     calculado na leitura, JAMAIS gravado no lançamento (AC3/IV2).
+         *
+         *     `outros_resultado_cents` é a soma assinada dos lançamentos do contrato em grupos de resultado
+         *     ALÉM da margem (Despesa Fixa/Tributos/Financeiro): NÃO entra na margem de contribuição, mas
+         *     COMPÕE o resultado (`resultado = margem + outros_resultado − custos fixos − overhead`).
+         *     INVESTIMENTO e lançamentos sem categoria ficam fora do resultado (sinalizados em `notes`).
+         */
+        ContractDreOut: {
+            /** Contract Id */
+            contract_id: string;
+            /**
+             * Start
+             * Format: date
+             */
+            start: string;
+            /**
+             * End
+             * Format: date
+             */
+            end: string;
+            receita: components["schemas"]["DreGroupOut"];
+            custo_direto: components["schemas"]["DreGroupOut"];
+            /** Receita Cents */
+            receita_cents: number;
+            /** Custo Direto Cents */
+            custo_direto_cents: number;
+            /** Margem Contribuicao Cents */
+            margem_contribuicao_cents: number;
+            /** Margem Contribuicao Pct */
+            margem_contribuicao_pct: number | null;
+            /** Outros Resultado Cents */
+            outros_resultado_cents: number;
+            /** Fixed Costs Allocated Cents */
+            fixed_costs_allocated_cents: number;
+            /** Overhead Allocated Cents */
+            overhead_allocated_cents: number;
+            /** Resultado Cents */
+            resultado_cents: number;
+            /** Break Even Cents */
+            break_even_cents: number | null;
+            /** Break Even Reachable */
+            break_even_reachable: boolean;
+            /** Notes */
+            notes: string[];
+        };
         /** ContractOut */
         ContractOut: {
             /** Id */
@@ -2509,6 +3364,8 @@ export interface components {
             status: string;
             /** Public Slug */
             public_slug: string | null;
+            /** Fixed Costs Allocated Cents */
+            fixed_costs_allocated_cents: number | null;
             /** Signer Name */
             signer_name: string;
             /** Signer Document */
@@ -2529,6 +3386,8 @@ export interface components {
             client_id?: string | null;
             /** Clauses */
             clauses?: components["schemas"]["Clause"][] | null;
+            /** Fixed Costs Allocated Cents */
+            fixed_costs_allocated_cents?: number | null;
         };
         /** ContractsSummary */
         ContractsSummary: {
@@ -2538,6 +3397,83 @@ export interface components {
             sent_count: number;
             /** Signed Count */
             signed_count: number;
+        };
+        /**
+         * CostCenterBucketOut
+         * @description Resultado do período agregado por um centro de custo (2ª dimensão). `cost_center_id=None` e
+         *     `name='Não atribuído'` é o bucket sintético dos lançamentos sem centro de custo (AC3).
+         *     `resultado_cents` usa a MESMA fórmula/exclusões da DRE (Story 5.3).
+         */
+        CostCenterBucketOut: {
+            /** Cost Center Id */
+            cost_center_id: string | null;
+            /** Name */
+            name: string;
+            /** Kind */
+            kind: string | null;
+            /** Receita Cents */
+            receita_cents: number;
+            /** Resultado Cents */
+            resultado_cents: number;
+            /** Lancamentos */
+            lancamentos: number;
+        };
+        /** CostCenterCreate */
+        CostCenterCreate: {
+            /** Name */
+            name: string;
+            /**
+             * Kind
+             * @default outro
+             */
+            kind: string;
+        };
+        /** CostCenterOut */
+        CostCenterOut: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Kind */
+            kind: string;
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /**
+         * CostCenterReportOut
+         * @description Comparação lado a lado do resultado por centro de custo no período (Story 5.5, AC2).
+         *
+         *     `buckets` traz um item por centro de custo do tenant (mesmo os sem movimento, para comparar
+         *     sócios/áreas) mais o bucket 'Não atribuído' (quando há lançamentos sem a 2ª dimensão). `notes`
+         *     documenta o regime e as exclusões — não silenciosamente.
+         */
+        CostCenterReportOut: {
+            /**
+             * Start
+             * Format: date
+             */
+            start: string;
+            /**
+             * End
+             * Format: date
+             */
+            end: string;
+            /** Buckets */
+            buckets: components["schemas"]["CostCenterBucketOut"][];
+            /** Notes */
+            notes: string[];
+        };
+        /** CostCenterUpdate */
+        CostCenterUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Kind */
+            kind?: string | null;
         };
         /** CouponCreate */
         CouponCreate: {
@@ -2683,6 +3619,32 @@ export interface components {
              */
             purchases: number;
         };
+        /**
+         * DiagnosticsOut
+         * @description Resposta do diagnóstico (Story 5.8). `signals` é o resultado DETERMINÍSTICO do motor —
+         *     existe e está correto INDEPENDENTEMENTE da IA (AC2/IV3). `narrative` é a leitura em linguagem
+         *     natural: quando a IA está disponível, é gerada por ela (após anonimização — Regra de Ouro nº 2);
+         *     senão, é um fallback por template a partir dos MESMOS sinais. `narrative_source` diz qual foi
+         *     ('ai' | 'template') — a UI deixa claro ao usuário que os números vêm primeiro.
+         */
+        DiagnosticsOut: {
+            /**
+             * Start
+             * Format: date
+             */
+            start: string;
+            /**
+             * End
+             * Format: date
+             */
+            end: string;
+            /** Signals */
+            signals: components["schemas"]["SignalOut"][];
+            /** Narrative */
+            narrative: string;
+            /** Narrative Source */
+            narrative_source: string;
+        };
         /** DocumentCreate */
         DocumentCreate: {
             /** Skill */
@@ -2691,9 +3653,7 @@ export interface components {
              * Answers
              * @default {}
              */
-            answers: {
-                [key: string]: unknown;
-            };
+            answers: Record<string, never>;
             /** Client Id */
             client_id?: string | null;
             /**
@@ -2723,9 +3683,7 @@ export interface components {
             /** Metadata Raw */
             metadata_raw: string;
             /** Answers */
-            answers: {
-                [key: string]: unknown;
-            };
+            answers: Record<string, never>;
             /** Input Tokens */
             input_tokens: number;
             /** Output Tokens */
@@ -2759,6 +3717,51 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /** DreCategoryOut */
+        DreCategoryOut: {
+            /** Categoria */
+            categoria: string;
+            /** Amount Cents */
+            amount_cents: number;
+            /** Count */
+            count: number;
+        };
+        /** DreGroupOut */
+        DreGroupOut: {
+            /** Grupo Dre */
+            grupo_dre: string;
+            /** Total Cents */
+            total_cents: number;
+            /** Categorias */
+            categorias: components["schemas"]["DreCategoryOut"][];
+        };
+        /**
+         * DreReportOut
+         * @description DRE hierárquica do período (grupo DRE → categoria), em regime de competência.
+         *
+         *     `groups` traz sempre os 6 grupos na ordem canônica (mesmo vazios). `sem_categoria` é o bucket
+         *     dos lançamentos não classificados (fora do `resultado_cents`). `notes` documenta as exclusões
+         *     (INVESTIMENTO / sem categoria) e o regime — não silenciosamente.
+         */
+        DreReportOut: {
+            /**
+             * Start
+             * Format: date
+             */
+            start: string;
+            /**
+             * End
+             * Format: date
+             */
+            end: string;
+            /** Groups */
+            groups: components["schemas"]["DreGroupOut"][];
+            sem_categoria: components["schemas"]["DreGroupOut"];
+            /** Resultado Cents */
+            resultado_cents: number;
+            /** Notes */
+            notes: string[];
         };
         /** DunningResult */
         DunningResult: {
@@ -2888,6 +3891,8 @@ export interface components {
             amount_cents: number | null;
             /** External Ref */
             external_ref: string | null;
+            /** Google Event Id */
+            google_event_id?: string | null;
             /** Client Name */
             client_name?: string | null;
             /** Created By Ai */
@@ -2952,13 +3957,9 @@ export interface components {
             /** Name */
             name: string;
             /** Nodes */
-            nodes?: {
-                [key: string]: unknown;
-            }[];
+            nodes?: Record<string, never>[];
             /** Edges */
-            edges?: {
-                [key: string]: unknown;
-            }[];
+            edges?: Record<string, never>[];
         };
         /** FunnelOut */
         FunnelOut: {
@@ -2969,13 +3970,9 @@ export interface components {
             /** Name */
             name: string;
             /** Nodes */
-            nodes: {
-                [key: string]: unknown;
-            }[];
+            nodes: Record<string, never>[];
             /** Edges */
-            edges: {
-                [key: string]: unknown;
-            }[];
+            edges: Record<string, never>[];
             /**
              * Created At
              * Format: date-time
@@ -3056,13 +4053,9 @@ export interface components {
             /** Name */
             name?: string | null;
             /** Nodes */
-            nodes?: {
-                [key: string]: unknown;
-            }[] | null;
+            nodes?: Record<string, never>[] | null;
             /** Edges */
-            edges?: {
-                [key: string]: unknown;
-            }[] | null;
+            edges?: Record<string, never>[] | null;
         };
         /** GalleryImage */
         GalleryImage: {
@@ -3104,10 +4097,133 @@ export interface components {
              */
             hashtags: string;
         };
+        /**
+         * GoogleConnectOut
+         * @description URL de autorização do Google para o frontend redirecionar o usuário.
+         */
+        GoogleConnectOut: {
+            /** Url */
+            url: string;
+        };
+        /**
+         * GoogleStatusOut
+         * @description Estado da integração para o frontend decidir a UI (botões conectar/desconectar).
+         */
+        GoogleStatusOut: {
+            /** Configured */
+            configured: boolean;
+            /** Connected */
+            connected: boolean;
+            /** Email */
+            email?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /** IntegrationKeyCreate */
+        IntegrationKeyCreate: {
+            /** Label */
+            label: string;
+        };
+        /**
+         * IntegrationKeyCreated
+         * @description Retorno da criação: única vez em que a chave crua fica visível.
+         */
+        IntegrationKeyCreated: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Key Prefix */
+            key_prefix: string;
+            /** Revoked At */
+            revoked_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Raw Key */
+            raw_key: string;
+        };
+        /** IntegrationKeyOut */
+        IntegrationKeyOut: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Key Prefix */
+            key_prefix: string;
+            /** Revoked At */
+            revoked_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** InvestmentAccountCreate */
+        InvestmentAccountCreate: {
+            /** Name */
+            name: string;
+            /**
+             * Kind
+             * @default
+             */
+            kind: string;
+            /**
+             * Index Rate Label
+             * @default
+             */
+            index_rate_label: string;
+            /**
+             * Principal Cents
+             * @default 0
+             */
+            principal_cents: number;
+            /**
+             * Opened At
+             * Format: date
+             */
+            opened_at: string;
+        };
+        /** InvestmentAccountOut */
+        InvestmentAccountOut: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Kind */
+            kind: string;
+            /** Index Rate Label */
+            index_rate_label: string;
+            /** Principal Cents */
+            principal_cents: number;
+            /** Accrued Yield Cents */
+            accrued_yield_cents: number;
+            /**
+             * Opened At
+             * Format: date
+             */
+            opened_at: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /** InvestmentAccountUpdate */
+        InvestmentAccountUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Kind */
+            kind?: string | null;
+            /** Index Rate Label */
+            index_rate_label?: string | null;
+            /** Principal Cents */
+            principal_cents?: number | null;
         };
         /** ItemCreate */
         ItemCreate: {
@@ -3190,6 +4306,21 @@ export interface components {
             /** Active */
             active?: boolean | null;
         };
+        /** LeadCapture */
+        LeadCapture: {
+            /** Name */
+            name: string;
+            /** Email */
+            email?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Notes */
+            notes?: string | null;
+            /** Fields */
+            fields?: {
+                [key: string]: string;
+            } | null;
+        };
         /** LeadSubmit */
         LeadSubmit: {
             /** Name */
@@ -3201,6 +4332,10 @@ export interface components {
              * @default
              */
             phone: string;
+            /** Fields */
+            fields?: {
+                [key: string]: string;
+            } | null;
         };
         /** LoginRequest */
         LoginRequest: {
@@ -3286,9 +4421,7 @@ export interface components {
              */
             model: string;
             /** Blocks */
-            blocks?: {
-                [key: string]: unknown;
-            }[] | null;
+            blocks?: Record<string, never>[] | null;
         };
         /** PageOut */
         PageOut: {
@@ -3301,9 +4434,7 @@ export interface components {
             /** Model */
             model: string;
             /** Blocks */
-            blocks: {
-                [key: string]: unknown;
-            }[];
+            blocks: Record<string, never>[];
             /** Status */
             status: string;
             /** Public Slug */
@@ -3349,9 +4480,7 @@ export interface components {
             /** Title */
             title?: string | null;
             /** Blocks */
-            blocks?: {
-                [key: string]: unknown;
-            }[] | null;
+            blocks?: Record<string, never>[] | null;
             /** Primary Color */
             primary_color?: string | null;
             /** Bg Color */
@@ -3389,6 +4518,14 @@ export interface components {
              * Format: date
              */
             due_date: string;
+            /** Competence Date */
+            competence_date?: string | null;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+            /** Contract Id */
+            contract_id?: string | null;
+            /** Cost Center Id */
+            cost_center_id?: string | null;
             /**
              * Recurrence
              * @default none
@@ -3429,6 +4566,14 @@ export interface components {
              * Format: date
              */
             due_date: string;
+            /** Competence Date */
+            competence_date: string | null;
+            /** Chart Account Id */
+            chart_account_id: string | null;
+            /** Contract Id */
+            contract_id: string | null;
+            /** Cost Center Id */
+            cost_center_id: string | null;
             /** Status */
             status: string;
             /** Is Overdue */
@@ -3463,6 +4608,14 @@ export interface components {
             amount_cents?: number | null;
             /** Due Date */
             due_date?: string | null;
+            /** Competence Date */
+            competence_date?: string | null;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+            /** Contract Id */
+            contract_id?: string | null;
+            /** Cost Center Id */
+            cost_center_id?: string | null;
             /** Recurrence */
             recurrence?: string | null;
             /** Payment Code */
@@ -3482,6 +4635,43 @@ export interface components {
             month_cents: number;
             /** Paid Month Cents */
             paid_month_cents: number;
+        };
+        /**
+         * PaymentQueueOut
+         * @description Fila agrupada em 4 baldes de PayableOut (reaproveitado) + o resumo por balde.
+         */
+        PaymentQueueOut: {
+            /** Atrasados */
+            atrasados: components["schemas"]["PayableOut"][];
+            /** Hoje */
+            hoje: components["schemas"]["PayableOut"][];
+            /** Proximos 7 Dias */
+            proximos_7_dias: components["schemas"]["PayableOut"][];
+            /** Proximos 30 Dias */
+            proximos_30_dias: components["schemas"]["PayableOut"][];
+            summary: components["schemas"]["PaymentQueueSummary"];
+        };
+        /**
+         * PaymentQueueSummary
+         * @description Contagem e soma (centavos) por balde — mesmo padrão de PayablesSummary, sem os itens.
+         */
+        PaymentQueueSummary: {
+            /** Atrasados Count */
+            atrasados_count: number;
+            /** Atrasados Cents */
+            atrasados_cents: number;
+            /** Hoje Count */
+            hoje_count: number;
+            /** Hoje Cents */
+            hoje_cents: number;
+            /** Proximos 7 Dias Count */
+            proximos_7_dias_count: number;
+            /** Proximos 7 Dias Cents */
+            proximos_7_dias_cents: number;
+            /** Proximos 30 Dias Count */
+            proximos_30_dias_count: number;
+            /** Proximos 30 Dias Cents */
+            proximos_30_dias_cents: number;
         };
         /** PayoutResult */
         PayoutResult: {
@@ -3614,6 +4804,20 @@ export interface components {
             font: string;
             /** Timezone */
             timezone: string;
+            /** Default Entry Funnel Id */
+            default_entry_funnel_id: string | null;
+            /** Whatsapp Configured */
+            whatsapp_configured: boolean;
+            /** Whatsapp Phone Id */
+            whatsapp_phone_id: string;
+            /** Whatsapp Waba Id */
+            whatsapp_waba_id: string;
+            /** Whatsapp Verify Token */
+            whatsapp_verify_token: string;
+            /** Whatsapp Template Bindings */
+            whatsapp_template_bindings: {
+                [key: string]: string;
+            };
         };
         /** ProfileUpdate */
         ProfileUpdate: {
@@ -3647,6 +4851,67 @@ export interface components {
             font?: string | null;
             /** Timezone */
             timezone?: string | null;
+            /** Default Entry Funnel Id */
+            default_entry_funnel_id?: string | null;
+            /** Whatsapp Token */
+            whatsapp_token?: string | null;
+            /** Whatsapp Phone Id */
+            whatsapp_phone_id?: string | null;
+            /** Whatsapp Waba Id */
+            whatsapp_waba_id?: string | null;
+            /** Whatsapp App Secret */
+            whatsapp_app_secret?: string | null;
+            /** Whatsapp Template Bindings */
+            whatsapp_template_bindings?: {
+                [key: string]: string;
+            } | null;
+        };
+        /**
+         * ProjectionOut
+         * @description Projeção de fluxo de caixa 30/60/90 dias + runway (Story 5.7), em regime de CAIXA.
+         *
+         *     OPOSTO da DRE (que usa competência): aqui a data é a de PAGAMENTO PREVISTO (vencimento dos itens
+         *     em aberto), nunca `competence_date`. `saldo_inicial_cents` é o disponível da Carteira (mesmo
+         *     número do Cockpit). `windows` traz uma janela por horizonte pedido (default 30/60/90), com o
+         *     saldo projetado e o sinal `alert`. `notes` documenta o regime e as exclusões — não em silêncio.
+         *
+         *     `overdue_inflow_cents`/`overdue_outflow_cents`: parcela de itens em aberto JÁ VENCIDOS
+         *     (`due_date < hoje`) que a projeção conta como caixa esperado imediato — já embutida em todas as
+         *     `windows`, exposta à parte para o consumidor risk-ajustar (vencidos podem não se concretizar).
+         */
+        ProjectionOut: {
+            /**
+             * Today
+             * Format: date
+             */
+            today: string;
+            /** Saldo Inicial Cents */
+            saldo_inicial_cents: number;
+            /** Overdue Inflow Cents */
+            overdue_inflow_cents: number;
+            /** Overdue Outflow Cents */
+            overdue_outflow_cents: number;
+            /** Windows */
+            windows: components["schemas"]["ProjectionWindowOut"][];
+            runway: components["schemas"]["RunwayOut"];
+            /** Notes */
+            notes: string[];
+        };
+        /**
+         * ProjectionWindowOut
+         * @description Saldo de caixa projetado para uma janela (dias a partir de hoje), em regime de CAIXA.
+         *
+         *     `saldo_projetado_cents` é CUMULATIVO: saldo inicial da Carteira + entradas abertas − saídas
+         *     abertas cujo vencimento cai até o fim da janela. `alert=True` quando o saldo fica NEGATIVO nessa
+         *     janela — sinal explícito que a Story 5.8 consome como indicador 🔴 sem recalcular.
+         */
+        ProjectionWindowOut: {
+            /** Days */
+            days: number;
+            /** Saldo Projetado Cents */
+            saldo_projetado_cents: number;
+            /** Alert */
+            alert: boolean;
         };
         /** PublicAccept */
         PublicAccept: {
@@ -3668,14 +4933,23 @@ export interface components {
             /** Signed At */
             signed_at: string | null;
         };
+        /**
+         * PublicImageOut
+         * @description Retorno do upload de imagem pública. ``url`` é o caminho da rota de leitura no backend
+         *     (``/public-images/{id}``); o frontend prefixa o proxy ``/api`` para obter a URL renderável.
+         */
+        PublicImageOut: {
+            /** Id */
+            id: string;
+            /** Url */
+            url: string;
+        };
         /** PublicPage */
         PublicPage: {
             /** Title */
             title: string;
             /** Blocks */
-            blocks: {
-                [key: string]: unknown;
-            }[];
+            blocks: Record<string, never>[];
             /** Primary Color */
             primary_color: string;
             /** Bg Color */
@@ -3986,6 +5260,44 @@ export interface components {
             /** Password */
             password: string;
         };
+        /**
+         * RegisterYieldRequest
+         * @description Registrar rendimento (juro) de uma aplicação num período (Task 2/3).
+         *
+         *     `amount_cents` > 0 (rendimento positivo). `date` é a data de competência do lançamento (regime
+         *     de competência — entra na DRE nesse período). `chart_account_id` (opcional) DEVE apontar a uma
+         *     conta do grupo `FINANCEIRO` quando informado (422 caso contrário) — ver service.
+         */
+        RegisterYieldRequest: {
+            /** Amount Cents */
+            amount_cents: number;
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+        };
+        /** RentabilityOut */
+        RentabilityOut: {
+            /** Account Id */
+            account_id: string;
+            /** Principal Cents */
+            principal_cents: number;
+            /** Accrued Yield Cents */
+            accrued_yield_cents: number;
+            /** Total Rentability Pct */
+            total_rentability_pct: number | null;
+            /** Period Rentability Pct */
+            period_rentability_pct: number | null;
+            /** Period Yield Cents */
+            period_yield_cents: number;
+            /** Start */
+            start: string | null;
+            /** End */
+            end: string | null;
+        };
         /** ResetPasswordRequest */
         ResetPasswordRequest: {
             /** Token */
@@ -4000,9 +5312,7 @@ export interface components {
             /** Client Id */
             client_id?: string | null;
             /** Params */
-            params?: {
-                [key: string]: unknown;
-            };
+            params?: Record<string, never>;
         };
         /** RunNodeResult */
         RunNodeResult: {
@@ -4046,6 +5356,20 @@ export interface components {
              */
             at: string;
         };
+        /**
+         * RunwayOut
+         * @description Runway: fôlego de caixa no ritmo de queima atual.
+         *
+         *     `days` = dias até o saldo inicial zerar na queima líquida diária (saídas − entradas da maior
+         *     janela / dias), ou `None` quando não há queima (caixa crescendo/estável) — "sem risco", sem
+         *     divisão por zero. `burn_rate_cents_per_day` é a queima diária (0 quando não há queima).
+         */
+        RunwayOut: {
+            /** Days */
+            days: number | null;
+            /** Burn Rate Cents Per Day */
+            burn_rate_cents_per_day: number;
+        };
         /** ScheduleStage */
         ScheduleStage: {
             /** Title */
@@ -4085,6 +5409,21 @@ export interface components {
             /** Coupon Code */
             coupon_code?: string | null;
         };
+        /** SendTemplateRequest */
+        SendTemplateRequest: {
+            /** Template Id */
+            template_id: string;
+            /**
+             * Variables
+             * @default []
+             */
+            variables: string[];
+        };
+        /** SendTextRequest */
+        SendTextRequest: {
+            /** Text */
+            text: string;
+        };
         /**
          * SessionInfo
          * @description Retorno de /auth/me — apenas identidade, SEM reemitir credencial.
@@ -4104,6 +5443,22 @@ export interface components {
              * @default true
              */
             accept: boolean;
+        };
+        /**
+         * SignalOut
+         * @description Um sinal de diagnóstico calculado pelo motor PURO (Story 5.8). `level` é verde/amarelo/
+         *     vermelho; `explanation` SEMPRE traz o número que o justifica; `source` identifica a origem
+         *     (lucratividade 5.4 / projecao 5.7 / investimento 5.6).
+         */
+        SignalOut: {
+            /** Level */
+            level: string;
+            /** Title */
+            title: string;
+            /** Explanation */
+            explanation: string;
+            /** Source */
+            source: string;
         };
         /** SkillSummary */
         SkillSummary: {
@@ -4172,7 +5527,7 @@ export interface components {
         StaffInviteOut: {
             user: components["schemas"]["UserOut"];
             /** Temp Password */
-            temp_password: string;
+            temp_password?: string | null;
             /** Delivery */
             delivery: string;
             /** Delivery Status */
@@ -4197,6 +5552,8 @@ export interface components {
             name: string;
             /** Position */
             position?: number | null;
+            /** After Stage Id */
+            after_stage_id?: string | null;
             /**
              * Is Won
              * @default false
@@ -4241,27 +5598,6 @@ export interface components {
             total_value_cents: number;
             /** Low Stock Count */
             low_stock_count: number;
-        };
-        /** TemplateCreate */
-        TemplateCreate: {
-            /** Name */
-            name: string;
-            /** Clauses */
-            clauses: components["schemas"]["Clause"][];
-        };
-        /** TemplateOut */
-        TemplateOut: {
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
-            /** Clauses */
-            clauses: components["schemas"]["Clause"][];
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
         };
         /** TemplatePreset */
         TemplatePreset: {
@@ -4336,6 +5672,12 @@ export interface components {
             client_id?: string | null;
             /** External Ref */
             external_ref?: string | null;
+            /** Competence Date */
+            competence_date?: string | null;
+            /** Chart Account Id */
+            chart_account_id?: string | null;
+            /** Cost Center Id */
+            cost_center_id?: string | null;
         };
         /** TransactionOut */
         TransactionOut: {
@@ -4361,6 +5703,12 @@ export interface components {
             client_id: string | null;
             /** External Ref */
             external_ref: string | null;
+            /** Competence Date */
+            competence_date: string | null;
+            /** Chart Account Id */
+            chart_account_id: string | null;
+            /** Cost Center Id */
+            cost_center_id: string | null;
             /**
              * Created At
              * Format: date-time
@@ -4446,26 +5794,6 @@ export interface components {
             /** Fees Total Cents */
             fees_total_cents: number;
         };
-        /**
-         * WebhookPayment
-         * @description Confirmação de pagamento vinda do gateway (Pix/cartão/boleto compensado).
-         */
-        WebhookPayment: {
-            /** Tenant Id */
-            tenant_id: string;
-            /** Charge Id */
-            charge_id: string;
-            /**
-             * Status
-             * @default paid
-             */
-            status: string;
-            /**
-             * Secret
-             * @default
-             */
-            secret: string;
-        };
         /** RescheduleRequest */
         app__modules__agenda__schemas__RescheduleRequest: {
             /**
@@ -4479,6 +5807,27 @@ export interface components {
              */
             ends_at: string;
         };
+        /** TemplateCreate */
+        app__modules__contracts__schemas__TemplateCreate: {
+            /** Name */
+            name: string;
+            /** Clauses */
+            clauses: components["schemas"]["Clause"][];
+        };
+        /** TemplateOut */
+        app__modules__contracts__schemas__TemplateOut: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Clauses */
+            clauses: components["schemas"]["Clause"][];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
         /** RescheduleRequest */
         app__modules__receivables__schemas__RescheduleRequest: {
             /**
@@ -4486,6 +5835,63 @@ export interface components {
              * Format: date
              */
             due_date: string;
+        };
+        /** TemplateCreate */
+        app__modules__whatsapp_templates__schemas__TemplateCreate: {
+            /** Name */
+            name: string;
+            /**
+             * Language
+             * @default pt_BR
+             */
+            language: string;
+            /**
+             * Category
+             * @enum {string}
+             */
+            category: "MARKETING" | "UTILITY" | "AUTHENTICATION";
+            /** Body Text */
+            body_text: string;
+            /**
+             * Variable Examples
+             * @default []
+             */
+            variable_examples: string[];
+        };
+        /** TemplateOut */
+        app__modules__whatsapp_templates__schemas__TemplateOut: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Language */
+            language: string;
+            /** Category Requested */
+            category_requested: string;
+            /** Category Approved */
+            category_approved: string | null;
+            /** Status */
+            status: string;
+            /** Rejected Reason */
+            rejected_reason: string | null;
+            /** Meta Template Id */
+            meta_template_id: string | null;
+            /** Body Text */
+            body_text: string;
+            /** Variable Count */
+            variable_count: number;
+            /** Variable Examples */
+            variable_examples: string[];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
     };
     responses: never;
@@ -4612,9 +6018,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -4647,9 +6051,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -5949,13 +7351,15 @@ export interface operations {
     payment_webhook_receivables_webhook_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "asaas-access-token"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["WebhookPayment"];
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -5965,9 +7369,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -6421,6 +7823,37 @@ export interface operations {
             };
         };
     };
+    payment_queue_payables_queue_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaymentQueueOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     categories_payables_categories_get: {
         parameters: {
             query?: never;
@@ -6643,6 +8076,706 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PayableOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_accounts_chart_of_accounts_get: {
+        parameters: {
+            query?: {
+                grupo?: string | null;
+                include_archived?: boolean;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartAccountOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_account_chart_of_accounts_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChartAccountCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    hierarchy_chart_of_accounts_hierarchy_get: {
+        parameters: {
+            query?: {
+                include_archived?: boolean;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartGroupOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_account_chart_of_accounts__account_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChartAccountUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_account_chart_of_accounts__account_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    seed_chart_of_accounts_seed_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartAccountOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_cost_centers_cost_centers_get: {
+        parameters: {
+            query?: {
+                include_archived?: boolean;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostCenterOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_cost_center_cost_centers_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CostCenterCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostCenterOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_cost_center_cost_centers__cost_center_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                cost_center_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CostCenterUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostCenterOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_cost_center_cost_centers__cost_center_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                cost_center_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostCenterOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dre_financial_intelligence_dre_get: {
+        parameters: {
+            query: {
+                /** @description Início do período (data de competência), YYYY-MM-DD */
+                start: string;
+                /** @description Fim do período (data de competência), YYYY-MM-DD */
+                end: string;
+                /** @description Story 5.5: filtra a DRE por centro de custo (2ª dimensão). Omitir = tudo. */
+                cost_center_id?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DreReportOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    by_cost_center_financial_intelligence_by_cost_center_get: {
+        parameters: {
+            query: {
+                /** @description Início do período (data de competência), YYYY-MM-DD */
+                start: string;
+                /** @description Fim do período (data de competência), YYYY-MM-DD */
+                end: string;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostCenterReportOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    projection_financial_intelligence_projection_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectionOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    contract_dre_financial_intelligence_contracts__contract_id__dre_get: {
+        parameters: {
+            query: {
+                /** @description Início do período (data de competência), YYYY-MM-DD */
+                start: string;
+                /** @description Fim do período (data de competência), YYYY-MM-DD */
+                end: string;
+                /** @description Inclui o rateio de overhead do bucket 'Empresa' (só na visão analítica). */
+                include_overhead?: boolean;
+                /** @description Story 5.5: filtra a DRE do contrato por centro de custo (2ª dimensão). */
+                cost_center_id?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                contract_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContractDreOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    diagnostics_financial_intelligence_diagnostics_get: {
+        parameters: {
+            query: {
+                /** @description Início do período (competência), YYYY-MM-DD */
+                start: string;
+                /** @description Fim do período (competência), YYYY-MM-DD */
+                end: string;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiagnosticsOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_accounts_investments_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvestmentAccountOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_account_investments_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvestmentAccountCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvestmentAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_account_investments__account_id__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvestmentAccountUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvestmentAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_yield_investments__account_id__yield_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterYieldRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvestmentAccountOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rentability_investments__account_id__rentability_get: {
+        parameters: {
+            query?: {
+                start?: string | null;
+                end?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RentabilityOut"];
                 };
             };
             /** @description Validation Error */
@@ -7284,9 +9417,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -7348,7 +9479,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TemplateOut"][];
+                    "application/json": components["schemas"]["app__modules__contracts__schemas__TemplateOut"][];
                 };
             };
             /** @description Validation Error */
@@ -7373,7 +9504,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["TemplateCreate"];
+                "application/json": components["schemas"]["app__modules__contracts__schemas__TemplateCreate"];
             };
         };
         responses: {
@@ -7383,7 +9514,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TemplateOut"];
+                    "application/json": components["schemas"]["app__modules__contracts__schemas__TemplateOut"];
                 };
             };
             /** @description Validation Error */
@@ -7654,9 +9785,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -7953,9 +10082,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -8973,6 +11100,430 @@ export interface operations {
             };
         };
     };
+    list_templates_whatsapp_templates_get: {
+        parameters: {
+            query?: {
+                status?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["app__modules__whatsapp_templates__schemas__TemplateOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_template_whatsapp_templates_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["app__modules__whatsapp_templates__schemas__TemplateCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["app__modules__whatsapp_templates__schemas__TemplateOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_template_whatsapp_templates__template_id__sync_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["app__modules__whatsapp_templates__schemas__TemplateOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_template_whatsapp_templates__template_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_conversations_whatsapp_conversations_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_timeline_whatsapp_conversations__client_id__timeline_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_window_whatsapp_conversations__client_id__window_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mark_read_whatsapp_conversations__client_id__read_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_text_reply_whatsapp_conversations__client_id__messages_text_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendTextRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_media_reply_whatsapp_conversations__client_id__messages_media_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_send_media_reply_whatsapp_conversations__client_id__messages_media_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_template_reply_whatsapp_conversations__client_id__messages_template_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    verify_webhook_public_whatsapp_webhook_get: {
+        parameters: {
+            query: {
+                "hub.mode": string;
+                "hub.verify_token": string;
+                "hub.challenge": string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    receive_webhook_public_whatsapp_webhook_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
     list_pages_pages_get: {
         parameters: {
             query?: never;
@@ -9258,9 +11809,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -9395,6 +11944,331 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_public_image_attachments_public_images_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_upload_public_image_attachments_public_images_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicImageOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    serve_public_image_public_images__image_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                image_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    status_integrations_google_status_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoogleStatusOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_integrations_google_connect_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoogleConnectOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    disconnect_integrations_google_disconnect_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    callback_integrations_google_callback_get: {
+        parameters: {
+            query?: {
+                code?: string | null;
+                state?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_keys_integrations_leads_keys_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationKeyOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_key_integrations_leads_keys_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntegrationKeyCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationKeyCreated"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_key_integrations_leads_keys__key_id__revoke_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntegrationKeyOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    capture_lead_public_leads__key__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LeadCapture"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Resumo

O botão "+ Nova etapa" do Kanban do CRM antes sempre adicionava a nova etapa do funil **no final**. Agora o usuário pode escolher **"inserir após \<etapa existente\>"** por meio de um modal apropriado (substituindo o antigo `window.prompt`).

## O que mudou

**Backend**
- `POST /crm/stages` ganhou o campo opcional `after_stage_id`.
- `create_stage` renumera todas as posições das etapas ativas em uma única transação para encaixar a nova etapa na posição escolhida.
- `after_stage_id` omitido/nulo mantém **exatamente** o comportamento atual (append no final) — 100% retrocompatível.
- Nome da etapa agora é normalizado (trim) e nomes vazios são rejeitados.

**Frontend**
- `CrmPage.tsx`: modal de nova etapa com seleção da posição de inserção, no lugar do `window.prompt`.

**Sem** mudança de schema/migration. **Sem** drag-to-reorder (explicitamente fora de escopo).

## Documentação
- Design: `docs/superpowers/specs/2026-07-20-crm-inserir-etapa-posicao-design.md`
- Plano: `docs/superpowers/plans/2026-07-20-crm-inserir-etapa-posicao.md`

## Verificação (executada)

- **Backend — suíte completa (pytest):** 762 passed, 1 skipped, 0 failed. Nesta re-execução do gate: 752 passed / 1 skipped / 10 deselected (rls_e2e roda em job próprio no CI).
- **Backend — `test_crm.py`:** 29/29 passando, incluindo 7 testes novos cobrindo `after_stage_id` (append default, inserir no meio, inserir após a última, rejeitar referência arquivada, rejeitar id desconhecido, rejeitar string vazia, trim/rejeição de nome em branco).
- **Backend — lint (ruff):** limpo.
- **Frontend — typecheck (tsc):** limpo.
- **Frontend — lint (eslint):** limpo em todos os arquivos tocados por esta feature (`CrmPage.tsx`).

> Nota: há um warning de lint pré-existente em `apps/web/src/features/financeiro/ChartAccountSelect.tsx` (diretiva `eslint-disable` não utilizada), introduzido no commit `14b94fc` em `main`, **não relacionado** a esta feature e fora do escopo deste PR.

## Arquivos tocados
- `apps/api/app/modules/crm/schemas.py`
- `apps/api/app/modules/crm/service.py`
- `apps/api/tests/test_crm.py`
- `apps/web/src/features/crm/CrmPage.tsx`
- `packages/shared-types/openapi.json`
- `packages/shared-types/src/generated.ts` (gerado, mecânico)

## Nota sobre os commits
Este PR inclui 6 commits: 3 de implementação + 3 de documentação (design/plano) desta mesma feature. Os commits de docs estão presentes porque `origin/main` estava atrás do `main` local; todos pertencem coerentemente a esta feature.
