### PR TITLE
fix: registra rota e item de menu de Lucratividade por Contrato

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -20,6 +20,7 @@ import DrePage from "../features/financeiro/DrePage";
 import FilaPagamentosPage from "../features/financeiro/FilaPagamentosPage";
 import FinanceiroPage from "../features/financeiro/FinanceiroPage";
 import InvestimentosPage from "../features/financeiro/InvestimentosPage";
+import LucratividadePage from "../features/financeiro/LucratividadePage";
 import PlanoContasPage from "../features/financeiro/PlanoContasPage";
 import ProjecaoCaixaPage from "../features/financeiro/ProjecaoCaixaPage";
 import FunisPage from "../features/funis/FunisPage";
@@ -62,6 +63,7 @@ export default function App() {
           <Route path="/financeiro/centros-custo" element={<CentrosCustoPage />} />
           <Route path="/financeiro/investimentos" element={<InvestimentosPage />} />
           <Route path="/financeiro/dre" element={<DrePage />} />
+          <Route path="/financeiro/lucratividade" element={<LucratividadePage />} />
           <Route path="/financeiro/projecao-caixa" element={<ProjecaoCaixaPage />} />
           <Route path="/financeiro/fila-pagamentos" element={<FilaPagamentosPage />} />
           <Route path="/financeiro/diagnostico" element={<DiagnosticoPage />} />

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -20,6 +20,7 @@ import {
   Settings,
   ShoppingBag,
   TrendingUp,
+  Trophy,
   Users,
   Wallet,
   Workflow,
@@ -75,6 +76,7 @@ export const navSections: NavSection[] = [
     title: "Análise & Configuração Financeira",
     items: [
       { label: "DRE", to: "/financeiro/dre", icon: PieChart, ready: true },
+      { label: "Lucratividade", to: "/financeiro/lucratividade", icon: Trophy, ready: true },
       { label: "Projeção de caixa", to: "/financeiro/projecao-caixa", icon: LineChart, ready: true },
       { label: "Diagnóstico", to: "/financeiro/diagnostico", icon: Activity, ready: true },
       { label: "Investimentos", to: "/financeiro/investimentos", icon: TrendingUp, ready: true },


### PR DESCRIPTION
## Summary
- `LucratividadePage.tsx` (mergeada na PR #47) nunca foi ligada ao roteamento (`App.tsx`) nem ao menu lateral (`navigation.ts`) — a página existia mas era inacessível pela UI, por isso não aparecia no sidebar.
- Adiciona `<Route path="/financeiro/lucratividade" element={<LucratividadePage />} />` e o item "Lucratividade" no menu Financeiro (entre DRE e Projeção de caixa).

## Test plan
- [ ] CI verde
- [ ] Visual: item "Lucratividade" aparece no sidebar em Financeiro e abre `/financeiro/lucratividade`