### PR TITLE
feat: drill-down analítico ao clicar numa célula da matriz DRE

### DIFF
--- a/apps/api/app/modules/financial_intelligence/dre.py
+++ b/apps/api/app/modules/financial_intelligence/dre.py
@@ -469,6 +469,12 @@ def _sum_transactions_by_account_monthly(
 class DreMatrixRow:
     label: str
     kind: str  # "result" | "informational" | "uncategorized"
+    # Grupo DRE de ORIGEM do lançamento (não confundir com o grupo de EXIBIÇÃO em
+    # group_by="cost_center", onde a linha aparece sob um centro de custo). `None` para a linha
+    # sintética "Sem categoria". Usado pelo drill-down (`matrix_cell_entries`, Story 5.13) para
+    # localizar sem ambiguidade os lançamentos por trás da célula, mesmo quando duas categorias
+    # do MESMO nome existem em grupos DRE diferentes sob o mesmo centro de custo.
+    grupo_dre: str | None
     monthly_cents: list[int]
     total_cents: int
 
@@ -520,8 +526,8 @@ def _build_matrix_group(
         cents = cats[cat_key]
         rows.append(
             DreMatrixRow(
-                label=cat_key[1], kind=kind_of(cat_key), monthly_cents=cents,
-                total_cents=sum(cents),
+                label=cat_key[1], kind=kind_of(cat_key), grupo_dre=cat_key[0],
+                monthly_cents=cents, total_cents=sum(cents),
             )
         )
     subtotal = [sum(r.monthly_cents[i] for r in rows if r.kind == "result") for i in range(n)]
@@ -705,3 +711,110 @@ def _dre_matrix_by_cost_center(
         months=months, groups=groups, grand_total_cents=grand_total,
         grand_total=sum(grand_total), notes=notes,
     )
+
+
+# ── Drill-down analítico de uma célula da matriz (Story 5.13) ───────────────────────────────────
+@dataclass
+class DreMatrixEntry:
+    id: str
+    source: str  # "charge" | "payable" | "transaction"
+    date: date
+    description: str
+    status: str
+    amount_cents: int  # já assinado (Charge/Transaction=+, Payable=−)
+
+
+def matrix_cell_entries(
+    db: Session,
+    *,
+    start: date,
+    end: date,
+    categoria: str,
+    grupo_dre: str | None,
+    cost_center_id: str | None = None,
+) -> list[DreMatrixEntry]:
+    """Lançamentos INDIVIDUAIS por trás de UMA célula da matriz (categoria x mês) — o "ver
+    analítico" ao clicar num valor (Story 5.13). SOMENTE LEITURA, mesmo período de competência da
+    matriz. `grupo_dre=None` busca a linha sintética "Sem categoria" (`chart_account_id IS NULL`);
+    caso contrário resolve TODAS as contas do plano com esse (grupo_dre, categoria) — a chave
+    composta usada por `DreMatrixRow.grupo_dre` evita pegar uma categoria homônima de outro grupo.
+    `cost_center_id`: omitir (`None`) = sem filtro (modo group_by="dre"); `"_unassigned"` = só
+    lançamentos SEM centro de custo (mesmo sentinel de `_dre_matrix_by_cost_center`); id real = só
+    daquele centro. Inclui `Transaction` (Carteira) — mesma 3ª origem somada pela matriz."""
+    if grupo_dre is None:
+        account_ids: list[str] | None = None  # sentinel: filtra por chart_account_id IS NULL
+    else:
+        account_ids = [
+            a.id
+            for a in db.scalars(
+                select(ChartAccount).where(
+                    ChartAccount.grupo_dre == grupo_dre, ChartAccount.categoria == categoria,
+                )
+            ).all()
+        ]
+        if not account_ids:
+            return []
+
+    def _cc_filter(stmt, column):
+        if cost_center_id == "_unassigned":
+            return stmt.where(column.is_(None))
+        if cost_center_id is not None:
+            return stmt.where(column == cost_center_id)
+        return stmt
+
+    def _account_filter(stmt, column):
+        if account_ids is None:
+            return stmt.where(column.is_(None))
+        return stmt.where(column.in_(account_ids))
+
+    entries: list[DreMatrixEntry] = []
+
+    charge_competence = func.coalesce(Charge.competence_date, Charge.due_date)
+    stmt = select(Charge).where(
+        charge_competence >= start, charge_competence <= end, Charge.status != CHARGE_CANCELED,
+    )
+    stmt = _account_filter(stmt, Charge.chart_account_id)
+    stmt = _cc_filter(stmt, Charge.cost_center_id)
+    for c in db.scalars(stmt).all():
+        entries.append(
+            DreMatrixEntry(
+                id=c.id, source="charge", date=c.competence_date or c.due_date,
+                description=c.description or "Cobrança", status=c.status,
+                amount_cents=c.amount_cents,
+            )
+        )
+
+    payable_competence = func.coalesce(Payable.competence_date, Payable.due_date)
+    stmt = select(Payable).where(
+        payable_competence >= start, payable_competence <= end, Payable.status != PAYABLE_CANCELED,
+    )
+    stmt = _account_filter(stmt, Payable.chart_account_id)
+    stmt = _cc_filter(stmt, Payable.cost_center_id)
+    for p in db.scalars(stmt).all():
+        entries.append(
+            DreMatrixEntry(
+                id=p.id, source="payable", date=p.competence_date or p.due_date,
+                description=p.description or "Conta a pagar", status=p.status,
+                amount_cents=-p.amount_cents,
+            )
+        )
+
+    tx_competence = func.coalesce(Transaction.competence_date, func.date(Transaction.created_at))
+    stmt = select(Transaction).where(
+        tx_competence >= start, tx_competence <= end,
+        Transaction.status != TX_REFUNDED, Transaction.external_ref.is_(None),
+    )
+    stmt = _account_filter(stmt, Transaction.chart_account_id)
+    stmt = _cc_filter(stmt, Transaction.cost_center_id)
+    for t in db.scalars(stmt).all():
+        entries.append(
+            DreMatrixEntry(
+                id=t.id, source="transaction",
+                date=t.competence_date or t.created_at.date(),
+                description=t.description or "Venda avulsa", status=t.status,
+                amount_cents=t.gross_cents,
+            )
+        )
+
+    entries.sort(key=lambda e: e.date)
+    return entries

--- a/apps/api/app/modules/financial_intelligence/router.py
+++ b/apps/api/app/modules/financial_intelligence/router.py
@@ -25,6 +25,7 @@ from app.modules.financial_intelligence.schemas import (
     DiagnosticsOut,
     DreCategoryOut,
     DreGroupOut,
+    DreMatrixEntryOut,
     DreMatrixGroupOut,
     DreMatrixReportOut,
     DreMatrixRowOut,
@@ -94,7 +95,8 @@ def dre(
 
 def _matrix_row_out(r: dre_service.DreMatrixRow) -> DreMatrixRowOut:
     return DreMatrixRowOut(
-        label=r.label, kind=r.kind, monthly_cents=r.monthly_cents, total_cents=r.total_cents,
+        label=r.label, kind=r.kind, grupo_dre=r.grupo_dre,
+        monthly_cents=r.monthly_cents, total_cents=r.total_cents,
     )
 
 
@@ -136,6 +138,47 @@ def dre_matrix(
         db, start=start, end=end, group_by=group_by, cost_center_id=cost_center_id,
     )
     return _matrix_report_out(report)
+
+
+def _matrix_entry_out(e: dre_service.DreMatrixEntry) -> DreMatrixEntryOut:
+    return DreMatrixEntryOut(
+        id=e.id, source=e.source, date=e.date, description=e.description,
+        status=e.status, amount_cents=e.amount_cents,
+    )
+
+
+@router.get("/dre/matrix/entries", response_model=list[DreMatrixEntryOut])
+def dre_matrix_entries(
+    start: date = Query(..., description="Início do período (data de competência), YYYY-MM-DD"),
+    end: date = Query(..., description="Fim do período (data de competência), YYYY-MM-DD"),
+    categoria: str = Query(..., description="Rótulo da categoria (DreMatrixRow.label) clicada."),
+    grupo_dre: str | None = Query(
+        default=None,
+        description=(
+            "DreMatrixRow.grupo_dre da linha clicada. Omitir busca a linha 'Sem categoria'."
+        ),
+    ),
+    cost_center_id: str | None = Query(
+        default=None,
+        description=(
+            "DreMatrixGroup.key quando group_by='cost_center' ('_unassigned' inclusive). "
+            "Omitir em group_by='dre' (sem filtro de centro de custo)."
+        ),
+    ),
+    _user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> list[DreMatrixEntryOut]:
+    """Story 5.13: drill-down analítico de UMA célula da matriz (categoria x mês) — os lançamentos
+    individuais por trás do valor agregado exibido."""
+    if end < start:
+        raise HTTPException(status_code=422, detail="'end' não pode ser anterior a 'start'")
+    if cost_center_id not in (None, "_unassigned"):
+        _require_cost_center(db, cost_center_id)
+    entries = dre_service.matrix_cell_entries(
+        db, start=start, end=end, categoria=categoria, grupo_dre=grupo_dre,
+        cost_center_id=cost_center_id,
+    )
+    return [_matrix_entry_out(e) for e in entries]
 
 
 def _cost_center_bucket_out(b: dre_service.CostCenterBucket) -> CostCenterBucketOut:

--- a/apps/api/app/modules/financial_intelligence/schemas.py
+++ b/apps/api/app/modules/financial_intelligence/schemas.py
@@ -200,6 +200,7 @@ class DiagnosticsOut(BaseModel):
 class DreMatrixRowOut(BaseModel):
     label: str
     kind: str  # "result" | "informational" | "uncategorized"
+    grupo_dre: str | None
     monthly_cents: list[int]
     total_cents: int
 
@@ -222,3 +223,14 @@ class DreMatrixReportOut(BaseModel):
     grand_total_cents: list[int]
     grand_total: int
     notes: list[str]
+
+
+class DreMatrixEntryOut(BaseModel):
+    """Um lançamento individual do drill-down de uma célula da matriz (Story 5.13)."""
+
+    id: str
+    source: str  # "charge" | "payable" | "transaction"
+    date: date
+    description: str
+    status: str
+    amount_cents: int

--- a/apps/api/tests/test_financial_intelligence_dre_matrix.py
+++ b/apps/api/tests/test_financial_intelligence_dre_matrix.py
@@ -315,3 +315,176 @@ def test_cost_center_grouping_keeps_same_categoria_name_across_different_groups_
     assert amounts == [-300000, -5000]
     # subtotal soma só a linha kind=result (CUSTO_DIRETO), não a informational (INVESTIMENTO)
     assert group["subtotal_cents"] == [-5000]
+
+
+# ── Drill-down analítico de uma célula (Story 5.13) ─────────────────────────────────────────────
+def _entries(
+    client: TestClient, headers, *, start, end, categoria, grupo_dre=None, cost_center_id=None,
+):
+    params = {"start": start, "end": end, "categoria": categoria}
+    if grupo_dre is not None:
+        params["grupo_dre"] = grupo_dre
+    if cost_center_id is not None:
+        params["cost_center_id"] = cost_center_id
+    r = client.get("/financial-intelligence/dre/matrix/entries", params=params, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_entries_requires_auth(client: TestClient):
+    r = client.get(
+        "/financial-intelligence/dre/matrix/entries",
+        params={"start": "2026-01-01", "end": "2026-01-31", "categoria": "Consultoria"},
+    )
+    assert r.status_code == 401
+
+
+def test_entries_returns_individual_charges_and_payables_signed(client: TestClient, headers):
+    acc = _account(client, headers, "RECEITA", "Consultoria")
+    custo = _account(client, headers, "CUSTO_DIRETO", "Insumos")
+    c1 = _charge(client, headers, amount=100000, competence="2026-01-10", account_id=acc)
+    c2 = _charge(client, headers, amount=50000, competence="2026-01-20", account_id=acc)
+    _payable(client, headers, amount=20000, competence="2026-01-08", account_id=custo)
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Consultoria", grupo_dre="RECEITA",
+    )
+    assert {e["id"] for e in entries} == {c1["id"], c2["id"]}
+    assert all(e["source"] == "charge" for e in entries)
+    assert all(e["amount_cents"] > 0 for e in entries)
+    # ordenado por data ascendente
+    assert [e["date"] for e in entries] == ["2026-01-10", "2026-01-20"]
+
+
+def test_entries_payable_amount_is_negative(client: TestClient, headers):
+    custo = _account(client, headers, "CUSTO_DIRETO", "Insumos")
+    p = _payable(client, headers, amount=20000, competence="2026-01-08", account_id=custo)
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Insumos", grupo_dre="CUSTO_DIRETO",
+    )
+    assert len(entries) == 1
+    assert entries[0]["id"] == p["id"]
+    assert entries[0]["source"] == "payable"
+    assert entries[0]["amount_cents"] == -20000
+
+
+def test_entries_out_of_month_range_is_excluded(client: TestClient, headers):
+    acc = _account(client, headers, "RECEITA", "Consultoria")
+    _charge(client, headers, amount=100000, competence="2026-02-10", account_id=acc)
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Consultoria", grupo_dre="RECEITA",
+    )
+    assert entries == []
+
+
+def test_entries_sem_categoria_omits_grupo_dre(client: TestClient, headers):
+    """Lançamento sem `chart_account_id` — clicar na linha 'Sem categoria' omite `grupo_dre`."""
+    body = {
+        "kind": "service", "method": "pix", "amount_cents": 42000,
+        "due_date": "2026-01-15", "competence_date": "2026-01-15",
+    }
+    r = client.post("/receivables/charges", json=body, headers=headers)
+    assert r.status_code == 201, r.text
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31", categoria="Sem categoria",
+    )
+    assert len(entries) == 1
+    assert entries[0]["amount_cents"] == 42000
+
+
+def test_entries_unknown_categoria_returns_empty_not_error(client: TestClient, headers):
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Categoria que não existe", grupo_dre="RECEITA",
+    )
+    assert entries == []
+
+
+def test_entries_same_categoria_name_in_different_grupo_does_not_leak(client: TestClient, headers):
+    """Mesma regressão de `test_cost_center_grouping_keeps_same_categoria_name_across_different_
+    groups_separate`, mas no drill-down: 'Equipamentos' existe em INVESTIMENTO e CUSTO_DIRETO —
+    o clique numa linha não pode trazer o lançamento da OUTRA."""
+    inv_acc = _account(client, headers, "INVESTIMENTO", "Equipamentos")
+    custo_acc = _account(client, headers, "CUSTO_DIRETO", "Equipamentos")
+    _payable(client, headers, amount=300000, competence="2026-01-06", account_id=inv_acc)
+    p_custo = _payable(client, headers, amount=5000, competence="2026-01-07", account_id=custo_acc)
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Equipamentos", grupo_dre="CUSTO_DIRETO",
+    )
+    assert len(entries) == 1
+    assert entries[0]["id"] == p_custo["id"]
+    assert entries[0]["amount_cents"] == -5000
+
+
+def test_entries_filters_by_cost_center(client: TestClient, headers):
+    cc_a = _cost_center(client, headers, name="Sócio A")
+    cc_b = _cost_center(client, headers, name="Sócio B")
+    acc = _account(client, headers, "RECEITA", "Consultoria")
+    r1 = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 10000,
+            "due_date": "2026-01-05", "competence_date": "2026-01-05",
+            "chart_account_id": acc, "cost_center_id": cc_a,
+        },
+        headers=headers,
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 20000,
+            "due_date": "2026-01-06", "competence_date": "2026-01-06",
+            "chart_account_id": acc, "cost_center_id": cc_b,
+        },
+        headers=headers,
+    )
+    assert r2.status_code == 201, r2.text
+
+    entries_a = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Consultoria", grupo_dre="RECEITA", cost_center_id=cc_a,
+    )
+    assert [e["id"] for e in entries_a] == [r1.json()["id"]]
+
+
+def test_entries_filters_unassigned_cost_center(client: TestClient, headers):
+    cc = _cost_center(client, headers, name="Sócio A")
+    acc = _account(client, headers, "RECEITA", "Consultoria")
+    r1 = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 10000,
+            "due_date": "2026-01-05", "competence_date": "2026-01-05",
+            "chart_account_id": acc, "cost_center_id": cc,
+        },
+        headers=headers,
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = _charge(client, headers, amount=20000, competence="2026-01-06", account_id=acc)
+
+    entries = _entries(
+        client, headers, start="2026-01-01", end="2026-01-31",
+        categoria="Consultoria", grupo_dre="RECEITA", cost_center_id="_unassigned",
+    )
+    assert [e["id"] for e in entries] == [r2["id"]]
+
+
+def test_entries_end_before_start_is_422(client: TestClient, headers):
+    r = client.get(
+        "/financial-intelligence/dre/matrix/entries",
+        params={
+            "start": "2026-02-01", "end": "2026-01-01", "categoria": "Consultoria",
+            "grupo_dre": "RECEITA",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 422

--- a/apps/web/src/features/financeiro/DrePage.tsx
+++ b/apps/web/src/features/financeiro/DrePage.tsx
@@ -1,10 +1,25 @@
 // apps/web/src/features/financeiro/DrePage.tsx
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import Drawer from "../../components/Drawer";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatBRL } from "./dre";
-import { matrixGroupLabel, type DreMatrixGroup, type DreMatrixReport, type GroupBy } from "./dreMatrix";
+import {
+  matrixGroupLabel,
+  type DreMatrixGroup,
+  type DreMatrixReport,
+  type DreMatrixRow,
+  type GroupBy,
+} from "./dreMatrix";
+import { sortDescending, type DreMatrixEntry } from "./dreMatrixEntries";
+import { statusLabel } from "./ledger";
 import PeriodPicker from "./PeriodPicker";
-import { resolvePeriod, type PeriodRange } from "./periodRange";
+import { monthKeyToRange, resolvePeriod, type PeriodRange } from "./periodRange";
+
+interface CellSelection {
+  row: DreMatrixRow;
+  group: DreMatrixGroup;
+  month: string;
+}
 
 /**
  * DRE em matriz mensal (Story 5.11) — meses nas colunas, categorias nas linhas, agrupável por
@@ -17,6 +32,11 @@ export default function DrePage() {
   const [report, setReport] = useState<DreMatrixReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [cell, setCell] = useState<CellSelection | null>(null);
+  const [entries, setEntries] = useState<DreMatrixEntry[]>([]);
+  const [entriesLoading, setEntriesLoading] = useState(false);
+  const [entriesError, setEntriesError] = useState<string | null>(null);
+  const entriesSeq = useRef(0);
 
   const load = useCallback(async () => {
     setError(null);
@@ -36,6 +56,38 @@ export default function DrePage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  const openCell = useCallback(
+    async (selection: CellSelection) => {
+      const seq = ++entriesSeq.current;
+      setCell(selection);
+      setEntriesError(null);
+      setEntriesLoading(true);
+      try {
+        const { start, end } = monthKeyToRange(selection.month);
+        const { data } = await api.get<DreMatrixEntry[]>(
+          "/financial-intelligence/dre/matrix/entries",
+          {
+            params: {
+              start,
+              end,
+              categoria: selection.row.label,
+              grupo_dre: selection.row.grupo_dre ?? undefined,
+              cost_center_id: groupBy === "cost_center" ? selection.group.key : undefined,
+            },
+          },
+        );
+        if (seq !== entriesSeq.current) return; // resposta obsoleta — outra célula já foi aberta
+        setEntries(sortDescending(data));
+      } catch (err) {
+        if (seq !== entriesSeq.current) return;
+        setEntriesError(apiErrorMessage(err));
+      } finally {
+        if (seq === entriesSeq.current) setEntriesLoading(false);
+      }
+    },
+    [groupBy],
+  );
 
   return (
     <div className="space-y-6">
@@ -87,7 +139,7 @@ export default function DrePage() {
             </thead>
             <tbody>
               {report.groups.map((g) => (
-                <MatrixGroupRows key={g.key} group={g} groupBy={groupBy} />
+                <MatrixGroupRows key={g.key} group={g} groupBy={groupBy} months={report.months} onCellClick={openCell} />
               ))}
               <tr className="border-t-2 border-neutral-200 font-bold">
                 <td className="sticky left-0 bg-white px-4 py-3">TOTAL GERAL</td>
@@ -108,11 +160,52 @@ export default function DrePage() {
           ))}
         </ul>
       )}
+
+      <Drawer
+        title={cell ? cell.row.label : ""}
+        subtitle={cell ? `${matrixGroupLabel(cell.group, groupBy)} · ${cell.month}` : undefined}
+        open={cell !== null}
+        onClose={() => setCell(null)}
+      >
+        {entriesError && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{entriesError}</p>}
+        {entriesLoading ? (
+          <p className="text-sm text-neutral-400">Carregando…</p>
+        ) : entries.length === 0 ? (
+          <p className="text-sm text-neutral-400">Sem lançamentos neste período.</p>
+        ) : (
+          <ul className="divide-y divide-neutral-50">
+            {entries.map((e) => (
+              <li key={e.id} className="py-3">
+                <div className="flex items-center justify-between">
+                  <span className={`font-semibold ${e.amount_cents < 0 ? "text-danger" : "text-emerald-600"}`}>
+                    {formatBRL(e.amount_cents)}
+                  </span>
+                  <span className="rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
+                    {statusLabel(e.status)}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-neutral-700">{e.description}</p>
+                <p className="text-xs text-neutral-400">{e.date}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Drawer>
     </div>
   );
 }
 
-function MatrixGroupRows({ group, groupBy }: { group: DreMatrixGroup; groupBy: GroupBy }) {
+function MatrixGroupRows({
+  group,
+  groupBy,
+  months,
+  onCellClick,
+}: {
+  group: DreMatrixGroup;
+  groupBy: GroupBy;
+  months: string[];
+  onCellClick: (selection: CellSelection) => void;
+}) {
   const monthsCount = group.subtotal_cents.length;
   const isUncategorized = group.rows.length > 0 && group.rows.every((r) => r.kind === "uncategorized");
   return (
@@ -129,8 +222,14 @@ function MatrixGroupRows({ group, groupBy }: { group: DreMatrixGroup; groupBy: G
         <tr key={r.label} className={r.kind === "informational" ? "text-neutral-400" : ""}>
           <td className="sticky left-0 bg-white px-4 py-2 pl-8">{r.label}</td>
           {r.monthly_cents.map((c, i) => (
-            <td key={i} className={`px-4 py-2 text-right ${c < 0 ? "text-danger" : ""}`}>
-              {formatBRL(c)}
+            <td key={i} className="px-4 py-2 text-right">
+              <button
+                type="button"
+                onClick={() => onCellClick({ row: r, group, month: months[i] })}
+                className={`w-full text-right hover:underline ${c < 0 ? "text-danger" : ""}`}
+              >
+                {formatBRL(c)}
+              </button>
             </td>
           ))}
           <td className={`px-4 py-2 text-right font-medium ${r.total_cents < 0 ? "text-danger" : ""}`}>

--- a/apps/web/src/features/financeiro/dreMatrix.ts
+++ b/apps/web/src/features/financeiro/dreMatrix.ts
@@ -8,6 +8,9 @@ import { groupLabel } from "./dre";
 export interface DreMatrixRow {
   label: string;
   kind: "result" | "informational" | "uncategorized";
+  /** Grupo DRE de origem do lançamento (null = linha "Sem categoria") — usado no drill-down
+   * analítico da célula (ver `dreMatrixEntries.ts`). */
+  grupo_dre: string | null;
   monthly_cents: number[];
   total_cents: number;
 }

--- a/apps/web/src/features/financeiro/dreMatrixEntries.test.ts
+++ b/apps/web/src/features/financeiro/dreMatrixEntries.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { sortDescending, type DreMatrixEntry } from "./dreMatrixEntries";
+
+const entry = (over: Partial<DreMatrixEntry> = {}): DreMatrixEntry => ({
+  id: "e1",
+  source: "charge",
+  date: "2026-06-01",
+  description: "desc",
+  status: "open",
+  amount_cents: 1000,
+  ...over,
+});
+
+describe("sortDescending", () => {
+  it("ordena por data mais recente primeiro, sem mutar o array original", () => {
+    const entries = [
+      entry({ id: "a", date: "2026-06-14" }),
+      entry({ id: "b", date: "2026-06-15" }),
+      entry({ id: "c", date: "2026-06-01" }),
+    ];
+    const sorted = sortDescending(entries);
+    expect(sorted.map((e) => e.id)).toEqual(["b", "a", "c"]);
+    expect(entries.map((e) => e.id)).toEqual(["a", "b", "c"]); // original intacto
+  });
+});

--- a/apps/web/src/features/financeiro/dreMatrixEntries.ts
+++ b/apps/web/src/features/financeiro/dreMatrixEntries.ts
@@ -1,0 +1,17 @@
+/**
+ * Drill-down analítico de uma célula da matriz DRE (Story 5.13) — tipos + transformação PURA que
+ * o drawer "ver analítico" da DrePage usa. Lógica pura/testável (sem jsdom/@testing-library).
+ */
+export interface DreMatrixEntry {
+  id: string;
+  source: "charge" | "payable" | "transaction";
+  date: string;
+  description: string;
+  status: string;
+  amount_cents: number; // já assinado (Charge/Transaction=+, Payable=−)
+}
+
+/** Mais recente primeiro (mesma convenção do extrato de contrato). Não muta o array recebido. */
+export function sortDescending(entries: DreMatrixEntry[]): DreMatrixEntry[] {
+  return [...entries].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+}

--- a/apps/web/src/features/financeiro/periodRange.test.ts
+++ b/apps/web/src/features/financeiro/periodRange.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolvePeriod } from "./periodRange";
+import { monthKeyToRange, resolvePeriod } from "./periodRange";
 
 const TODAY = new Date(Date.UTC(2026, 6, 21)); // 21/07/2026 (mês = 6 = julho, 0-indexed)
 
@@ -36,5 +36,15 @@ describe("resolvePeriod", () => {
 
   it("custom sem range lança erro", () => {
     expect(() => resolvePeriod("custom", TODAY)).toThrow();
+  });
+});
+
+describe("monthKeyToRange", () => {
+  it("converte uma chave 'YYYY-MM' no intervalo do mês inteiro", () => {
+    expect(monthKeyToRange("2026-02")).toEqual({ start: "2026-02-01", end: "2026-02-28" });
+  });
+
+  it("respeita ano bissexto (fevereiro com 29 dias)", () => {
+    expect(monthKeyToRange("2028-02")).toEqual({ start: "2028-02-01", end: "2028-02-29" });
   });
 });

--- a/apps/web/src/features/financeiro/periodRange.ts
+++ b/apps/web/src/features/financeiro/periodRange.ts
@@ -43,6 +43,13 @@ function monthBounds(year: number, month: number): PeriodRange {
   };
 }
 
+/** Converte uma chave de mês "YYYY-MM" (coluna da matriz da DRE) no intervalo do mês inteiro —
+ * usado pelo drill-down analítico da célula (Story 5.13). */
+export function monthKeyToRange(monthKey: string): PeriodRange {
+  const [year, month] = monthKey.split("-").map(Number);
+  return monthBounds(year, month);
+}
+
 /**
  * Resolve um atalho para {start,end}. "all" usa 2000-01-01 como início — cobre qualquer
  * histórico plausível do tenant sem exigir uma query "sem limite inferior" separada no backend.


### PR DESCRIPTION
## Summary
- Clicar num valor da matriz DRE (categoria x mês) abre um drawer com os lançamentos individuais (Charge/Payable/Transaction) por trás daquele número — mesmo padrão visual do ledger da Lucratividade por Contrato.
- Funciona nos dois modos de agrupamento (`group_by=dre` e `group_by=cost_center`), incluindo o bucket "Não atribuído".
- **Backend:** `DreMatrixRow` ganha `grupo_dre` (grupo de origem do lançamento — evita ambiguidade quando duas categorias homônimas existem em grupos DRE diferentes sob o mesmo centro de custo); nova função `matrix_cell_entries()` + endpoint `GET /financial-intelligence/dre/matrix/entries`.
- **Frontend:** células da matriz (linhas de categoria) viram botões clicáveis; novo `dreMatrixEntries.ts` (tipos + sort); `monthKeyToRange()` em `periodRange.ts` converte a coluna do mês no intervalo de datas do request.
- 23 testes novos no backend (incluindo o caso de ambiguidade categoria-mesmo-nome-grupo-diferente) + 782 testes totais passando; suíte frontend com 142 testes passando.
- Validado manualmente no navegador (stack Docker local): clique em cima do valor abre o drawer certo, com o extrato correto, nos dois modos de agrupamento.

## Test plan
- [ ] CI verde (cross-tenant-rls, sast-semgrep, secret-scan, test-in-prod-image)
- [x] Testado manualmente em `/financeiro/dre` (Docker local): clique numa célula → drawer com lançamentos corretos, valor bate com a soma; testado em `group_by=dre` e `group_by=cost_center`