### PR TITLE
feat: linha TOTAL GERAL + INVESTIMENTO na matriz DRE

### DIFF
--- a/apps/web/src/features/financeiro/DrePage.tsx
+++ b/apps/web/src/features/financeiro/DrePage.tsx
@@ -4,7 +4,9 @@ import Drawer from "../../components/Drawer";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatBRL } from "./dre";
 import {
+  investmentTotals,
   matrixGroupLabel,
+  splitGroupsAroundInvestment,
   type DreMatrixGroup,
   type DreMatrixReport,
   type DreMatrixRow,
@@ -138,16 +140,36 @@ export default function DrePage() {
               </tr>
             </thead>
             <tbody>
-              {report.groups.map((g) => (
-                <MatrixGroupRows key={g.key} group={g} groupBy={groupBy} months={report.months} onCellClick={openCell} />
-              ))}
-              <tr className="border-t-2 border-neutral-200 font-bold">
-                <td className="sticky left-0 bg-white px-4 py-3">TOTAL GERAL</td>
-                {report.grand_total_cents.map((c, i) => (
-                  <td key={i} className="px-4 py-3 text-right">{formatBRL(c)}</td>
-                ))}
-                <td className="px-4 py-3 text-right">{formatBRL(report.grand_total)}</td>
-              </tr>
+              {(() => {
+                const { before, after } = splitGroupsAroundInvestment(report.groups, groupBy);
+                const investment = investmentTotals(report);
+                const combinedMonthly = report.grand_total_cents.map((c, i) => c + investment.monthly[i]);
+                const combinedTotal = report.grand_total + investment.total;
+                return (
+                  <>
+                    {before.map((g) => (
+                      <MatrixGroupRows key={g.key} group={g} groupBy={groupBy} months={report.months} onCellClick={openCell} />
+                    ))}
+                    <tr className="border-t-2 border-neutral-200 font-bold">
+                      <td className="sticky left-0 bg-white px-4 py-3">TOTAL GERAL</td>
+                      {report.grand_total_cents.map((c, i) => (
+                        <td key={i} className="px-4 py-3 text-right">{formatBRL(c)}</td>
+                      ))}
+                      <td className="px-4 py-3 text-right">{formatBRL(report.grand_total)}</td>
+                    </tr>
+                    {after.map((g) => (
+                      <MatrixGroupRows key={g.key} group={g} groupBy={groupBy} months={report.months} onCellClick={openCell} />
+                    ))}
+                    <tr className="border-t-2 border-neutral-800 bg-neutral-50 font-bold">
+                      <td className="sticky left-0 bg-neutral-50 px-4 py-3">TOTAL GERAL + INVESTIMENTO</td>
+                      {combinedMonthly.map((c, i) => (
+                        <td key={i} className="px-4 py-3 text-right">{formatBRL(c)}</td>
+                      ))}
+                      <td className="px-4 py-3 text-right">{formatBRL(combinedTotal)}</td>
+                    </tr>
+                  </>
+                );
+              })()}
             </tbody>
           </table>
         </div>

--- a/apps/web/src/features/financeiro/dreMatrix.test.ts
+++ b/apps/web/src/features/financeiro/dreMatrix.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { matrixGroupLabel, type DreMatrixGroup } from "./dreMatrix";
+import {
+  investmentTotals,
+  matrixGroupLabel,
+  splitGroupsAroundInvestment,
+  type DreMatrixGroup,
+  type DreMatrixReport,
+  type DreMatrixRow,
+} from "./dreMatrix";
+
+const row = (over: Partial<DreMatrixRow> = {}): DreMatrixRow => ({
+  label: "Categoria",
+  kind: "result",
+  grupo_dre: "RECEITA",
+  monthly_cents: [0],
+  total_cents: 0,
+  ...over,
+});
 
 const group = (over: Partial<DreMatrixGroup> = {}): DreMatrixGroup => ({
   key: "RECEITA",
@@ -7,6 +23,15 @@ const group = (over: Partial<DreMatrixGroup> = {}): DreMatrixGroup => ({
   rows: [],
   subtotal_cents: [0],
   subtotal_total: 0,
+  ...over,
+});
+
+const report = (over: Partial<DreMatrixReport> = {}): DreMatrixReport => ({
+  months: ["2026-01", "2026-02"],
+  groups: [],
+  grand_total_cents: [0, 0],
+  grand_total: 0,
+  notes: [],
   ...over,
 });
 
@@ -22,5 +47,57 @@ describe("matrixGroupLabel", () => {
 
   it("group_by=cost_center sem label cai no key (defensivo)", () => {
     expect(matrixGroupLabel(group({ key: "_unassigned", label: null }), "cost_center")).toBe("_unassigned");
+  });
+});
+
+describe("investmentTotals", () => {
+  it("soma só as linhas kind=informational, mês a mês e no total", () => {
+    const r = report({
+      groups: [
+        group({
+          key: "INVESTIMENTO",
+          rows: [
+            row({ kind: "informational", monthly_cents: [-300000, 0], total_cents: -300000 }),
+            row({ kind: "result", monthly_cents: [1000, 1000], total_cents: 2000 }), // não conta
+          ],
+        }),
+      ],
+    });
+    expect(investmentTotals(r)).toEqual({ monthly: [-300000, 0], total: -300000 });
+  });
+
+  it("soma linhas informational espalhadas por vários grupos (group_by=cost_center)", () => {
+    const r = report({
+      groups: [
+        group({ key: "cc-a", rows: [row({ kind: "informational", monthly_cents: [-100, 0], total_cents: -100 })] }),
+        group({ key: "cc-b", rows: [row({ kind: "informational", monthly_cents: [0, -50], total_cents: -50 })] }),
+      ],
+    });
+    expect(investmentTotals(r)).toEqual({ monthly: [-100, -50], total: -150 });
+  });
+
+  it("sem linhas informational, retorna zero (nunca quebra)", () => {
+    expect(investmentTotals(report())).toEqual({ monthly: [0, 0], total: 0 });
+  });
+});
+
+describe("splitGroupsAroundInvestment", () => {
+  it("group_by=dre: separa INVESTIMENTO e SEM_CATEGORIA do resto, preservando ordem", () => {
+    const groups = [
+      group({ key: "RECEITA" }),
+      group({ key: "CUSTO_DIRETO" }),
+      group({ key: "INVESTIMENTO" }),
+      group({ key: "SEM_CATEGORIA" }),
+    ];
+    const { before, after } = splitGroupsAroundInvestment(groups, "dre");
+    expect(before.map((g) => g.key)).toEqual(["RECEITA", "CUSTO_DIRETO"]);
+    expect(after.map((g) => g.key)).toEqual(["INVESTIMENTO", "SEM_CATEGORIA"]);
+  });
+
+  it("group_by=cost_center: não reordena nada (investimento fica espalhado por centro)", () => {
+    const groups = [group({ key: "cc-a" }), group({ key: "_unassigned" })];
+    const { before, after } = splitGroupsAroundInvestment(groups, "cost_center");
+    expect(before).toEqual(groups);
+    expect(after).toEqual([]);
   });
 });

--- a/apps/web/src/features/financeiro/dreMatrix.ts
+++ b/apps/web/src/features/financeiro/dreMatrix.ts
@@ -41,3 +41,39 @@ export function matrixGroupLabel(group: DreMatrixGroup, groupBy: GroupBy): strin
   if (groupBy === "cost_center") return group.label ?? group.key;
   return groupLabel(group.key);
 }
+
+/** Soma, mês a mês e no total do período, só as linhas `kind="informational"` (Investimento) de
+ * TODOS os grupos — funciona nos dois modos: em `group_by="dre"` é exatamente o grupo
+ * "INVESTIMENTO"; em `group_by="cost_center"` as linhas de investimento ficam espalhadas por
+ * vários centros, então soma-se por `kind`, não por grupo. Usado pra compor "TOTAL GERAL +
+ * INVESTIMENTO" (o gasto total do período, incluindo o que o resultado operacional exclui). */
+export function investmentTotals(report: DreMatrixReport): { monthly: number[]; total: number } {
+  const monthly = report.months.map(() => 0);
+  let total = 0;
+  for (const group of report.groups) {
+    for (const row of group.rows) {
+      if (row.kind !== "informational") continue;
+      row.monthly_cents.forEach((c, i) => {
+        monthly[i] += c;
+      });
+      total += row.total_cents;
+    }
+  }
+  return { monthly, total };
+}
+
+/** Em `group_by="dre"`, separa o grupo Investimento (e o bucket sintético Sem Categoria, que já
+ * vem depois dele) do resto — pra renderizar TOTAL GERAL logo após Financeiro/antes de
+ * Investimento, e só então o Investimento + o total combinado. Em `group_by="cost_center"` não há
+ * uma seção de investimento separada (fica misturada em cada centro de custo), então `after` fica
+ * vazio e nada é reordenado. */
+export function splitGroupsAroundInvestment(
+  groups: DreMatrixGroup[],
+  groupBy: GroupBy,
+): { before: DreMatrixGroup[]; after: DreMatrixGroup[] } {
+  if (groupBy !== "dre") return { before: groups, after: [] };
+  return {
+    before: groups.filter((g) => g.key !== "INVESTIMENTO" && g.key !== "SEM_CATEGORIA"),
+    after: groups.filter((g) => g.key === "INVESTIMENTO" || g.key === "SEM_CATEGORIA"),
+  };
+}


### PR DESCRIPTION
## Summary
- Na matriz DRE (`group_by=dre`), `TOTAL GERAL` agora aparece logo após "Financeiro" (antes de "Investimento"), e uma nova linha `TOTAL GERAL + INVESTIMENTO` fecha a tabela — soma o resultado operacional + as linhas `kind=informational` (Investimento), dando o gasto/resultado total do período incluindo capex.
- Em `group_by=cost_center` não há reordenação (Investimento fica espalhado por centro de custo, sem seção própria) — as duas linhas de total aparecem em sequência no fim, como já era.
- Cálculo 100% no frontend (`investmentTotals`/`splitGroupsAroundInvestment` em `dreMatrix.ts`) — os campos necessários (kind, monthly_cents, total_cents por linha) já vinham da API da PR #51, sem mudança de backend.

## Test plan
- [ ] CI verde
- [x] Validado manualmente no navegador (Docker local): com 1 lançamento de Investimento (-R$7.833,75) e TOTAL GERAL em -R$561,07, a linha combinada mostrou -R$8.394,82 (soma correta), e a posição TOTAL GERAL → Investimento → TOTAL GERAL + INVESTIMENTO ficou como pedido