### PR TITLE
fix: sidebar responsiva e telas de comprovante em tela cheia no celular

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../store/useIdleTimeout", () => ({
   useIdleTimeout: () => ({ showWarning: false, stayConnected: vi.fn() }),
 }));
 
-import { LoginRoute, ProtectedLayout } from "./App";
+import { LoginRoute, ProtectedBareLayout, ProtectedLayout } from "./App";
 
 /** Sonda que expõe a rota atual e o `state` carregado pelo history, para asserções sem UI real. */
 function LocationProbe({ label }: { label: string }) {
@@ -100,5 +100,53 @@ describe("Retorno pós-login para a rota de origem (Finding 2 — revisão final
     );
 
     await waitFor(() => screen.getByText("cockpit"));
+  });
+});
+
+// Achado do usuário testando em campo: no celular a sidebar (256px fixos) e a topbar do
+// AppShell espremiam /compartilhar e /comprovante/:id a ponto de o checkbox "marcar como paga"
+// ficar fora da área visível — o usuário tocava Anexar sem conseguir ver/desmarcar o que estava
+// confirmando. `ProtectedBareLayout` aplica a MESMA proteção de `ProtectedLayout` (mesmo
+// `useAuthGate`) sem montar `AppShell` — o teste prova as duas metades: acesso bloqueado
+// deslogado, e nenhum vestígio do shell quando autenticado.
+describe("ProtectedBareLayout — mesma proteção do ProtectedLayout, sem sidebar/topbar", () => {
+  beforeEach(() => {
+    auth.isAuthenticated = false;
+  });
+
+  it("deslogado, redireciona para /login guardando a origem — igual ao ProtectedLayout", async () => {
+    render(
+      <MemoryRouter initialEntries={["/comprovante/r-1"]}>
+        <Routes>
+          <Route path="/login" element={<LoginRoute />} />
+          <Route element={<ProtectedBareLayout />}>
+            <Route path="/comprovante/:id" element={<p>tela do comprovante</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Chegar em <LoginPage> de verdade (não um probe) já prova o redirecionamento; a preservação
+    // da origem via state é coberta, campo a campo, pelos testes de ProtectedLayout acima —
+    // ambos os layouts chamam o MESMO useAuthGate, não duas implementações a manter em sincronia.
+    await waitFor(() => screen.getByRole("button", { name: /^entrar$/i }));
+  });
+
+  it("autenticado, renderiza o conteúdo SEM sidebar nem topbar do AppShell", async () => {
+    auth.isAuthenticated = true;
+
+    render(
+      <MemoryRouter initialEntries={["/comprovante/r-1"]}>
+        <Routes>
+          <Route element={<ProtectedBareLayout />}>
+            <Route path="/comprovante/:id" element={<p>tela do comprovante</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => screen.getByText("tela do comprovante"));
+    // "Sair" só existe na Sidebar do AppShell — sua ausência prova que o shell não montou.
+    expect(screen.queryByText("Sair")).toBeNull();
   });
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import AdminDashboard from "../features/admin/AdminDashboard";
 import AgendaPage from "../features/agenda/AgendaPage";
@@ -72,8 +73,6 @@ export default function App() {
           <Route path="/financeiro/contratos/:id/dre" element={<ContratoDrePage />} />
           <Route path="/cobrancas" element={<CobrancasPage />} />
           <Route path="/pagar" element={<PagarPage />} />
-          <Route path="/compartilhar" element={<CompartilharPage />} />
-          <Route path="/comprovante/:id" element={<ComprovantePage />} />
           <Route path="/produtos" element={<ProdutosPage />} />
           <Route path="/estoque" element={<EstoquePage />} />
           <Route path="/config" element={<ConfiguracoesPage />} />
@@ -96,6 +95,11 @@ export default function App() {
           <Route path="/funis/:id" element={<FunnelBuilderPage />} />
           <Route path="/admin" element={<AdminOnly />} />
           <Route path="*" element={<ComingSoon />} />
+        </Route>
+        {/* Telas de tarefa única vindas do share sheet do celular: mesma proteção, sem shell. */}
+        <Route element={<ProtectedBareLayout />}>
+          <Route path="/compartilhar" element={<CompartilharPage />} />
+          <Route path="/comprovante/:id" element={<ComprovantePage />} />
         </Route>
       </Routes>
     </AuthProvider>
@@ -123,11 +127,16 @@ export function LoginRoute() {
   return isAuthenticated ? <Navigate to={loginReturnTo(location.state)} replace /> : <LoginPage />;
 }
 
-export function ProtectedLayout() {
+/**
+ * Portão de autenticação, sem nenhuma decisão visual: devolve `null` quando pode seguir, ou o
+ * elemento que deve ser renderizado no lugar do conteúdo (redirect para login / troca de senha).
+ *
+ * Extraído para que `ProtectedLayout` (com shell) e `ProtectedBareLayout` (tela cheia) apliquem
+ * exatamente a MESMA regra de acesso — duplicar isso seria criar duas portas para o mesmo prédio.
+ */
+function useAuthGate(): ReactElement | null {
   const { isAuthenticated, user } = useAuth();
   const location = useLocation();
-  // Idle timeout LGPD (Story 1.3): hook sempre chamado (regra dos hooks); no-op quando deslogado.
-  const { showWarning, stayConnected } = useIdleTimeout();
   if (!isAuthenticated) {
     // Guarda a rota de origem para o LoginRoute retomar após autenticar — genérico para
     // qualquer rota protegida, não só `/compartilhar`/`/comprovante/:id`.
@@ -135,6 +144,14 @@ export function ProtectedLayout() {
   }
   // 1º acesso: bloqueia o app até o usuário trocar a senha temporária.
   if (user?.must_reset_password) return <FirstAccessPage />;
+  return null;
+}
+
+export function ProtectedLayout() {
+  // Idle timeout LGPD (Story 1.3): hook sempre chamado (regra dos hooks); no-op quando deslogado.
+  const { showWarning, stayConnected } = useIdleTimeout();
+  const blocked = useAuthGate();
+  if (blocked) return blocked;
   return (
     <PageActionsProvider>
       <AppShell>
@@ -142,6 +159,27 @@ export function ProtectedLayout() {
       </AppShell>
       <IdleWarningModal open={showWarning} onStay={stayConnected} />
     </PageActionsProvider>
+  );
+}
+
+/**
+ * Mesma proteção do `ProtectedLayout`, SEM sidebar e SEM topbar.
+ *
+ * Para telas de tarefa única que chegam pelo compartilhamento do celular: ali o menu não é
+ * navegação, é ruído competindo por uma largura que o polegar já disputa. A saída fica na
+ * própria tela (o "Cancelar" do cabeçalho), não no shell.
+ */
+export function ProtectedBareLayout() {
+  const { showWarning, stayConnected } = useIdleTimeout();
+  const blocked = useAuthGate();
+  if (blocked) return blocked;
+  return (
+    <>
+      <div className="min-h-screen bg-neutral-50 p-4">
+        <Outlet />
+      </div>
+      <IdleWarningModal open={showWarning} onStay={stayConnected} />
+    </>
   );
 }
 

--- a/apps/web/src/app/AppShell.test.tsx
+++ b/apps/web/src/app/AppShell.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Achado do usuário testando em campo (screenshot em Android): a sidebar tem 256px FIXOS
+// (`w-64 shrink-0`, sem breakpoint algum) e sempre empurrou o conteúdo — num aparelho de 360px
+// sobravam ~100px, títulos viravam "Desp", cartões espremidos, e o checkbox "marcar como paga"
+// da tela de comprovante ficava fora da área visível. Esta suíte cobre o comportamento
+// responsivo novo: a gaveta nasce fechada abaixo do breakpoint desktop e fecha sozinha ao
+// navegar; no desktop ela nasce aberta e permanece.
+vi.mock("../lib/api", () => ({
+  api: { get: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+vi.mock("../store/auth", () => ({
+  useAuth: () => ({ logout: vi.fn(), user: null, tenant: null }),
+}));
+vi.mock("../store/pageActions", () => ({
+  usePageActions: () => ({ action: null }),
+}));
+
+import AppShell from "./AppShell";
+
+/** Simula a largura do viewport ANTES do primeiro render — o estado inicial da gaveta lê
+ * `window.innerWidth` no `useState(isDesktopWidth)`, então precisa estar certo de antemão. */
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+}
+
+describe("AppShell — sidebar responsiva (achado de campo: layout quebrado no celular)", () => {
+  afterEach(() => {
+    setViewportWidth(1024); // não vaza a largura de um teste para o próximo
+  });
+
+  it("no celular, a gaveta nasce FECHADA — não mais os 256px fixos espremendo o conteúdo", async () => {
+    setViewportWidth(375); // largura comum de Android/iPhone, abaixo do breakpoint
+
+    render(
+      <MemoryRouter>
+        <AppShell>
+          <p>conteúdo da página</p>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => screen.getByText("conteúdo da página"));
+    // "Sair" só existe dentro da <Sidebar> — sua ausência prova que ela não montou.
+    expect(screen.queryByText("Sair")).toBeNull();
+  });
+
+  it("no desktop, a gaveta nasce ABERTA — preserva o comportamento de sempre", async () => {
+    setViewportWidth(1280);
+
+    render(
+      <MemoryRouter>
+        <AppShell>
+          <p>conteúdo da página</p>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => screen.getByText("Sair"));
+  });
+
+  it("no celular, abrir a gaveta e navegar para outra rota a fecha sozinha", async () => {
+    setViewportWidth(375);
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AppShell>
+          <p>conteúdo da página</p>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByLabelText("Abrir menu"));
+    const agendaLink = await screen.findByRole("link", { name: /agenda/i });
+    await user.click(agendaLink);
+
+    // A gaveta cobre a tela inteira no celular: sair sem fechá-la deixaria o usuário olhando
+    // para o menu em vez da página que acabou de escolher.
+    await waitFor(() => expect(screen.queryByText("Sair")).toBeNull());
+  });
+});

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -9,12 +9,25 @@ import { useAuth } from "../store/auth";
 import { usePageActions } from "../store/pageActions";
 import { navSections } from "./navigation";
 
+/** Largura a partir da qual a sidebar cabe ao lado do conteúdo (= breakpoint `md` do Tailwind). */
+const DESKTOP_MIN_WIDTH = 768;
+
+/** `true` quando há largura para a sidebar conviver com o conteúdo. Fora do browser, assume desktop. */
+function isDesktopWidth(): boolean {
+  return typeof window === "undefined" || window.innerWidth >= DESKTOP_MIN_WIDTH;
+}
+
 /**
  * Shell visual do e1p — sidebar violeta (#5D44F8) + topbar, conforme o design Figma "Portal".
- * Sidebar colapsável pelo botão X. Item ativo é um pill branco que "vaza" para a direita.
+ * Item ativo é um pill branco que "vaza" para a direita.
+ *
+ * **Responsivo:** a sidebar tem 256px FIXOS (`w-64 shrink-0`). Num aparelho de 360px isso deixava
+ * ~100px de conteúdo — títulos viravam "Desp", cartões espremidos. Por isso, abaixo de
+ * `DESKTOP_MIN_WIDTH` ela nasce fechada e abre SOBREPOSTA (`fixed`, fora do fluxo), com fundo
+ * escurecido; no desktop segue no fluxo (`md:sticky`) como sempre foi.
  */
 export default function AppShell({ children }: { children: ReactNode }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(isDesktopWidth);
 
   // Aplica o Brand Kit do tenant como tema do app (sidebar/botões) uma vez por sessão — as
   // classes Tailwind já apontam pra CSS vars com fallback estático, então sem tema custom nada
@@ -30,7 +43,19 @@ export default function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex min-h-screen bg-neutral-50">
-      {open && <Sidebar onClose={() => setOpen(false)} />}
+      {open && (
+        <>
+          {/* Fundo escurecido: só existe no celular, onde a sidebar cobre o conteúdo. Tocar
+              fora fecha — sem isso a gaveta engoliria a tela sem saída óbvia no polegar. */}
+          <button
+            type="button"
+            aria-label="Fechar menu"
+            onClick={() => setOpen(false)}
+            className="fixed inset-0 z-30 bg-black/40 md:hidden"
+          />
+          <Sidebar onClose={() => setOpen(false)} />
+        </>
+      )}
       {/* min-w-0 impede o flex-child de estourar e empurrar a sidebar quando o Kanban
           rola na horizontal — o scroll fica contido no conteúdo. */}
       <div className="flex min-w-0 flex-1 flex-col">
@@ -43,8 +68,15 @@ export default function AppShell({ children }: { children: ReactNode }) {
 
 function Sidebar({ onClose }: { onClose: () => void }) {
   const { logout, user } = useAuth();
+  // No celular a gaveta cobre a tela: navegar sem fechá-la deixaria o usuário olhando para o
+  // menu em vez da página que acabou de escolher. No desktop ela é parte do layout, então fica.
+  const closeIfMobile = () => {
+    if (!isDesktopWidth()) onClose();
+  };
   return (
-    <aside className="sticky top-0 flex h-screen w-64 shrink-0 flex-col self-start bg-primary-500 py-6 pl-4 text-white">
+    <aside
+      className="fixed inset-y-0 left-0 z-40 flex h-screen w-64 shrink-0 flex-col overflow-y-auto bg-primary-500 py-6 pl-4 text-white md:sticky md:top-0 md:z-auto md:self-start"
+    >
       {/* Botão de fechar/colapsar (como no anexo) */}
       <button
         onClick={onClose}
@@ -69,6 +101,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
                   <NavLink
                     to={item.to}
                     end={item.to === "/" || item.exact === true}
+                    onClick={closeIfMobile}
                     className={({ isActive }) =>
                       clsx(
                         "flex min-w-0 items-center gap-3 py-3 pl-4 text-[15px] font-medium transition",
@@ -99,6 +132,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
             <div className="mb-5 mr-4 border-t border-dashed border-white/35" />
             <NavLink
               to="/admin"
+              onClick={closeIfMobile}
               className={({ isActive }) =>
                 clsx(
                   "flex items-center gap-3 py-3 pl-4 text-[15px] font-medium transition",

--- a/apps/web/src/features/pagar/ComprovantePage.test.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.test.tsx
@@ -57,6 +57,29 @@ describe("ComprovantePage", () => {
     expect(screen.getByText("Pago")).toBeTruthy();
   });
 
+  // Achado da revisão final (item deferido, agora corrigido): o cabeçalho mostrava o texto
+  // estático "Comprovante recebido" sem identificar QUAL arquivo — com a bandeja tendo vários,
+  // o usuário não sabia o que estava prestes a anexar. `GET /payables/receipts` (já usado pela
+  // bandeja/PagarPage) é filtrado pelo `id` da rota, sem endpoint novo.
+  it("mostra o nome do arquivo do comprovante no cabeçalho, não um texto genérico", async () => {
+    mockApi();
+    renderPage();
+    await waitFor(() => screen.getByText("comp.pdf"));
+    expect(screen.getByText(/1 KB/i)).toBeTruthy();
+  });
+
+  it("o botão Cancelar volta para Contas a Pagar sem descartar o comprovante", async () => {
+    mockApi();
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => screen.getByText("Energia"));
+
+    await user.click(screen.getByRole("button", { name: /^cancelar$/i }));
+
+    await waitFor(() => screen.getByText("contas a pagar"));
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+
   it("mostra o checkbox de baixa apenas para conta em aberto", async () => {
     mockApi();
     renderPage();

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -1,10 +1,19 @@
 import type { Payable } from "@e1p/shared-types";
-import { FileText, Trash2 } from "lucide-react";
+import { ChevronLeft, FileText, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
 
+/** O que a bandeja devolve por comprovante (`GET /payables/receipts`). */
+interface ReceiptInfo {
+  id: string;
+  filename: string;
+  size: number;
+}
+
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const kb = (n: number) =>
+  n < 1024 * 1024 ? `${Math.round(n / 1024)} KB` : `${(n / 1024 / 1024).toFixed(1)} MB`;
 const dia = (iso: string) => new Date(`${iso}T00:00:00Z`).toLocaleDateString("pt-BR", { timeZone: "UTC" });
 
 /**
@@ -47,6 +56,25 @@ export default function ComprovantePage() {
   const [showNew, setShowNew] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<ReceiptInfo | null>(null);
+
+  // Identifica QUAL comprovante está na tela. Não existe `GET /payables/receipts/{id}`, mas a
+  // bandeja é curta por construção (teto de 30), então filtrar a lista basta e evita rota nova.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get<ReceiptInfo[]>("/payables/receipts")
+      .then(({ data }) => {
+        if (cancelled) return;
+        setReceipt(data.find((r) => r.id === id) ?? null);
+      })
+      .catch(() => {
+        /* o nome do arquivo é contexto, não função — sem ele a tela opera igual */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
 
   const load = useCallback(async () => {
     const { data } = await api.get<Payable[]>(
@@ -134,19 +162,37 @@ export default function ComprovantePage() {
 
   return (
     <div className="mx-auto max-w-lg space-y-4 pb-28">
-      <header className="flex items-center gap-3 rounded-2xl bg-white p-4 shadow-sm">
-        <FileText size={22} className="shrink-0 text-neutral-400" />
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold text-neutral-700">Comprovante recebido</p>
-          <p className="text-xs text-neutral-500">Escolha a conta a que ele pertence</p>
+      <header className="space-y-3 rounded-2xl bg-white p-4 shadow-sm">
+        {/* Esta tela roda FORA do shell (sem sidebar/topbar), então a saída mora aqui. "Cancelar"
+            só sai — o comprovante continua na bandeja e o aviso em Contas a Pagar aponta pra ele.
+            Quem quer se livrar do arquivo usa "Descartar", que é destrutivo e fica separado. */}
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={() => navigate("/pagar")}
+            className="flex shrink-0 items-center gap-1 text-sm font-medium text-neutral-500 hover:text-neutral-800"
+          >
+            <ChevronLeft size={16} /> Cancelar
+          </button>
+          <button
+            onClick={discard}
+            disabled={busy}
+            className="flex shrink-0 items-center gap-1 text-xs text-neutral-400 hover:text-danger disabled:opacity-50"
+          >
+            <Trash2 size={14} /> Descartar
+          </button>
         </div>
-        <button
-          onClick={discard}
-          disabled={busy}
-          className="flex shrink-0 items-center gap-1 text-xs text-neutral-400 hover:text-danger"
-        >
-          <Trash2 size={14} /> Descartar
-        </button>
+        <div className="flex items-center gap-3 border-t border-neutral-100 pt-3">
+          <FileText size={22} className="shrink-0 text-neutral-400" />
+          <div className="min-w-0 flex-1">
+            {/* Mostrar QUAL arquivo está sendo arquivado importa quando a bandeja tem vários. */}
+            <p className="truncate text-sm font-semibold text-neutral-700">
+              {receipt?.filename ?? "Comprovante recebido"}
+            </p>
+            <p className="text-xs text-neutral-500">
+              {receipt ? `${kb(receipt.size)} — escolha a conta` : "Escolha a conta a que ele pertence"}
+            </p>
+          </div>
+        </div>
       </header>
 
       <input


### PR DESCRIPTION
## Contexto

Achado testando em campo, num Android real de ~360px de largura, logo após o deploy do #55.

O `AppShell` nunca teve breakpoint responsivo: a sidebar de 256px fixos ocupava ~85% da tela, espremendo o conteúdo a ponto dos títulos truncarem ("Desp...") e os cards ficarem ilegíveis.

A consequência prática foi pior que o layout: o checkbox **"marcar como paga"** ficava fora da área visível, e o usuário tocava em **Anexar** sem conseguir ver nem desmarcar o que estava confirmando — uma conta foi marcada como paga sem confirmação consciente.

## Mudanças

- **`AppShell`**: abaixo do breakpoint `md` a gaveta nasce fechada e abre sobreposta (`fixed` + backdrop), fechando sozinha ao navegar. Desktop inalterado.
- **`/compartilhar` e `/comprovante/:id`**: passam a rodar em `ProtectedBareLayout`, sem sidebar/topbar — cabeçalho mínimo com "Cancelar" no lugar do menu. Mantêm a mesma proteção do `ProtectedLayout`, via `useAuthGate` compartilhado.
- **`ComprovantePage`**: mostra o nome/tamanho real do arquivo no cabeçalho em vez de texto genérico (item já deferido na revisão final do #55).

## Escopo

Frontend apenas — 6 arquivos, todos sob `apps/web`. Nenhuma alteração de backend e **nenhuma migration**.

## Testes

- `pnpm --filter @e1p/web test`: 184 passando, incluindo 3 testes novos em `AppShell.test.tsx` e 2 em `ComprovantePage.test.tsx` cobrindo exatamente esta correção.
- `pnpm --filter @e1p/web typecheck`: limpo.
- `pnpm --filter @e1p/web lint`: limpo, exceto o warning pré-existente em `ChartAccountSelect.tsx` já conhecido do #55 (não relacionado, não tocado).
