### PR TITLE
docs: corrige comando de deploy do runbook Hostinger (compose file + --env-file)

### DIFF
--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -121,11 +121,28 @@ pro IP da VPS (`dig +short app.seudominio.com`) e se a porta 80 está mesmo aces
 > venv↔produção) e valida o isolamento RLS num Postgres real (Story 3.2). O deploy em si
 > continua manual (não há CD automático), mas por processo só suba versões com CI passando.
 
+> **Qual compose file?** Depende de qual proxy a VPS usa (ver nota no topo deste guia) —
+> **não assuma**, confirme antes: `docker inspect infra-api-1 --format
+> '{{index .Config.Labels "com.docker.compose.project.config_files"}}'` na própria VPS mostra
+> o arquivo com que a stack em pé foi criada.
+>
+> - **Caddy próprio** → `docker-compose.prod.yml`.
+> - **Traefik compartilhado** (VPS real, `e1p.doroeventos.com.br`) → `docker-compose.traefik.yml`,
+>   e **precisa de `--env-file .env.prod`** — sem ele o Compose não acha `POSTGRES_ROOT_PASSWORD`
+>   e falha ("required variable ... is missing a value"). O `docker-compose.prod.yml` já resolve
+>   isso via `env_file:` dentro do próprio arquivo, por isso só o `.traefik.yml` exige a flag.
+
 ```bash
 cd /opt/e1p && git pull
-cd infra && docker compose -f docker-compose.prod.yml up -d --build
+cd infra
+# Caddy próprio:
+docker compose -f docker-compose.prod.yml up -d --build
+# Traefik compartilhado (VPS real):
+docker compose --env-file .env.prod -f docker-compose.traefik.yml up -d --build
 ```
 Migrations rodam automaticamente no start do container `api` (mesmo comando do dev).
+Não passe `--remove-orphans` sem checar antes: o mesmo project name do Compose pode ser
+compartilhado com `docker-compose.monitoring.yml` (Uptime Kuma) — a flag mataria o monitoramento.
 
 ## 6. Backup do Postgres (automatizado + offsite + restore testado)
 Sem RDS aqui — backups são responsabilidade sua, mas agora são **automatizados, copiados


### PR DESCRIPTION
## Problema

A secao 5 do `docs/HOSTINGER-DEPLOY.md` so documentava:

```bash
docker compose -f docker-compose.prod.yml up -d --build
```

Mas a VPS real (`e1p.doroeventos.com.br`) roda `docker-compose.traefik.yml` e exige `--env-file .env.prod` — sem a flag o Compose falha por `POSTGRES_ROOT_PASSWORD` ausente. A forma correta so existia enterrada em `RUNBOOK-BACKUP-RESTORE.md:128`, o que custou confusao nos deploys de #55 e #56 (mesmo erro nas duas vezes).

## Mudanca

- Secao 5 agora documenta os **dois** casos explicitamente: Caddy proprio (`docker-compose.prod.yml`) vs Traefik compartilhado (`docker-compose.traefik.yml --env-file .env.prod`).
- Explica *por que* so o `.traefik.yml` precisa da flag (o `.prod.yml` resolve via `env_file:` interno).
- Documenta como confirmar qual compose file a stack em pe usa, via `docker inspect ... com.docker.compose.project.config_files`.
- Alerta para nao passar `--remove-orphans`: o project name do Compose e compartilhado com o Uptime Kuma de `docker-compose.monitoring.yml`, e a flag mataria o monitoramento.

## Escopo

Documentacao apenas — nenhuma mudanca de codigo, config de runtime ou infraestrutura. Nada foi implantado no servidor.