### PR TITLE
fix: checkbox de baixa colado no Anexar; tabela de contas rolável

### DIFF
--- a/apps/web/src/features/pagar/ComprovantePage.test.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -91,6 +91,29 @@ describe("ComprovantePage", () => {
 
     await userEvent.click(screen.getByText("Internet"));
     expect(screen.queryByRole("checkbox", { name: /marcar como paga/i })).toBeNull();
+  });
+
+  // Achado de campo (produção): o checkbox vivia num bloco separado, mais acima na página. Quem
+  // selecionava uma conta e tocava direto em "Anexar" sem rolar NUNCA via o checkbox — a baixa
+  // saía com o padrão (marcado) sem confirmação visível. Este teste prova a correção
+  // estruturalmente: o checkbox e o botão "Anexar" precisam estar no MESMO contêiner (a barra
+  // fixa do rodapé), não apenas ambos presentes em algum lugar da página — dois nós no mesmo pai
+  // não podem ficar em posições de rolagem diferentes.
+  it("o checkbox de baixa fica DENTRO da mesma barra fixa do botão Anexar, não numa seção à parte", async () => {
+    mockApi();
+    renderPage();
+    await waitFor(() => screen.getByText("Energia"));
+
+    await userEvent.click(screen.getByText("Energia"));
+    const check = screen.getByRole("checkbox", { name: /marcar como paga/i });
+    const anexar = screen.getByRole("button", { name: /^anexar$/i });
+    const footer = anexar.parentElement as HTMLElement;
+    expect(check.closest("div")?.parentElement).toBe(footer);
+
+    // O resumo, dentro da MESMA barra, também identifica QUAL conta será afetada — não só
+    // que "alguma" será. O valor também aparece no cartão da lista (por isso a busca é
+    // escopada ao rodapé, não à página inteira).
+    expect(within(footer).getByText("R$ 300,00")).toBeTruthy();
   });
 
   it("vincula chamando link com o payload correto", async () => {
@@ -252,11 +275,15 @@ describe("ComprovantePage", () => {
     renderPage();
     await waitFor(() => screen.getByText("Energia"));
 
-    await userEvent.click(screen.getByText("Energia"));
+    // O resumo da conta escolhida (rodapé fixo) também mostra "Energia" depois da 1ª seleção —
+    // por isso o cartão sempre é a PRIMEIRA ocorrência (ele vem antes no DOM).
+    const card = () => screen.getAllByText("Energia")[0];
+
+    await userEvent.click(card());
     expect(screen.getByRole("button", { name: /^anexar$/i })).not.toBeDisabled();
     expect(screen.queryByRole("button", { name: /criar conta nova/i })).toBeNull();
 
-    await userEvent.click(screen.getByText("Energia"));
+    await userEvent.click(card());
 
     expect(screen.getByRole("button", { name: /^anexar$/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /criar conta nova/i })).toBeTruthy();

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -244,18 +244,6 @@ export default function ComprovantePage() {
         )}
       </ul>
 
-      {chosen?.status === "open" && (
-        <label className="flex items-center gap-2 rounded-2xl bg-white p-4 text-sm text-neutral-700 shadow-sm">
-          <input
-            type="checkbox"
-            checked={markPaid}
-            onChange={(e) => setMarkPaid(e.target.checked)}
-            className="h-4 w-4"
-          />
-          Marcar como paga
-        </label>
-      )}
-
       {/* Vincular a uma conta existente e criar uma conta nova são caminhos de mutação
           concorrentes para o mesmo comprovante — mantidos mutuamente exclusivos NAS DUAS
           direções por `selectCandidate`/`openNewBillForm` (acima), que resetam o outro fluxo
@@ -275,7 +263,33 @@ export default function ComprovantePage() {
       )}
 
       {!showNew && (
-        <div className="fixed inset-x-0 bottom-0 border-t border-neutral-100 bg-white p-4">
+        <div className="fixed inset-x-0 bottom-0 space-y-3 border-t border-neutral-100 bg-white p-4">
+          {/* Achado de campo: com a conta escolhida e o checkbox num bloco separado, mais acima
+              na página, quem tocava numa conta e ia direto no Anexar (sem rolar) NUNCA via o
+              checkbox — a baixa acontecia com o padrão (marcado) sem confirmação visível. Fica
+              aqui dentro, colado no botão que comete a ação: fisicamente não dá pra tocar em
+              Anexar sem ver o que está sendo confirmado. */}
+          {chosen && (
+            <div className="mx-auto flex max-w-lg items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-neutral-700">
+                  {chosen.description || chosen.supplier || "Conta"}
+                </p>
+                <p className="text-xs text-neutral-500">{brl(chosen.amount_cents)}</p>
+              </div>
+              {chosen.status === "open" && (
+                <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-neutral-600">
+                  <input
+                    type="checkbox"
+                    checked={markPaid}
+                    onChange={(e) => setMarkPaid(e.target.checked)}
+                    className="h-4 w-4"
+                  />
+                  Marcar como paga
+                </label>
+              )}
+            </div>
+          )}
           <button
             onClick={link}
             disabled={!chosen || busy}

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -134,6 +134,33 @@ describe("PagarPage — bandeja de comprovantes (Task 11)", () => {
     await waitFor(() => screen.getByText(/2 comprovantes aguardando/i));
   });
 
+  // Achado de campo (produção): o contêiner da tabela usava `overflow-hidden`, que CORTA em vez
+  // de rolar — em tela estreita a coluna Status e os botões de ação (Editar/Marcar paga/
+  // Estornar) ficavam invisíveis, sem nenhum jeito de alcançá-los. `overflow-x-auto` (mesmo
+  // padrão de DrePage/LucratividadePage) torna a tabela rolável em vez de clipada.
+  it("a tabela de contas é rolável horizontalmente, não cortada (overflow-x-auto)", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({
+          data: [{
+            id: "b-1", description: "Aluguel", category: "Estrutura", supplier: "Imobiliária",
+            amount_cents: 250000, due_date: "2099-08-05", status: "open", is_overdue: false,
+            paid_at: null, recurrence: "none", recurrence_count: 1, recurrence_group: null,
+            payment_code: "", attachment_url: "", created_at: "2026-01-01T00:00:00Z",
+            tenant_id: "t-1", competence_date: null, chart_account_id: null, contract_id: null,
+            cost_center_id: null,
+          }],
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+
+    const table = await screen.findByRole("table");
+    expect(table.parentElement?.className).toContain("overflow-x-auto");
+    expect(table.parentElement?.className).not.toContain("overflow-hidden");
+  });
+
   it("não mostra o aviso com a bandeja vazia", async () => {
     // beforeEach já mocka /payables/receipts (via fallback) devolvendo [].
     renderPage();

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -155,7 +155,10 @@ export default function PagarPage() {
         <Stat label="Pago no mês" value={brl(summary.paid_month_cents)} tone="text-accent-700" />
       </div>
 
-      <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+      {/* overflow-x-auto (não overflow-hidden): achado de campo — em tela estreita a tabela tem
+          7 colunas e ficava CORTADA em vez de rolável, escondendo Status e as ações (Editar/
+          Marcar paga/Estornar). Mesmo padrão de DrePage/LucratividadePage. */}
+      <div className="overflow-x-auto rounded-2xl bg-white shadow-sm">
         {bills.length === 0 ? (
           <p className="p-8 text-center text-sm text-neutral-400">
             Nenhuma conta. Clique em "Nova conta".


### PR DESCRIPTION
## Contexto

Terceira rodada de teste em produção no celular real, depois do fix de layout (#56).

Ao selecionar uma conta em `/comprovante/:id` e tocar **Anexar**, a conta era
baixada sem que o usuário jamais visse o checkbox "marcar como paga" para
confirmar ou desmarcar — o checkbox vivia num bloco separado, mais acima na
página, e tocar Anexar sem rolar a tela passava direto por ele.

Depois disso o usuário também não conseguia conferir o que tinha acontecido na
tabela de Contas a Pagar: o contêiner usava `overflow-hidden` em vez de
`overflow-x-auto`, então em tela estreita a coluna Status e os botões de ação
(Editar / Marcar paga / Estornar) ficavam cortados, sem nenhuma forma de
alcançá-los.

## Mudanças

- **`ComprovantePage.tsx`** — checkbox de "marcar como paga" + resumo da conta
  escolhida (nome, valor) movidos para DENTRO da mesma barra fixa do rodapé que
  contém o botão Anexar. Agora são estruturalmente inseparáveis da ação que os
  torna efetivos: não há como acionar o Anexar sem o checkbox na tela.
- **`PagarPage.tsx`** — `overflow-hidden` → `overflow-x-auto` no contêiner da
  tabela, seguindo a convenção já usada em `DrePage.tsx` / `LucratividadePage.tsx`.

## Testes

- `pnpm --filter @e1p/web test` — **186 passed** (44 arquivos), incluindo testes
  novos que provam que o checkbox e o botão Anexar compartilham o mesmo elemento
  pai no DOM, e que o contêiner da tabela usa `overflow-x-auto` e não
  `overflow-hidden`.
- `pnpm --filter @e1p/web typecheck` — limpo.
- `pnpm --filter @e1p/web lint` — limpo, exceto o warning pré-existente em
  `ChartAccountSelect.tsx` (o mesmo dos PRs #55/#56/#57; não é novo e não foi tocado).

## Escopo

Somente frontend: 4 arquivos sob `apps/web`. Nenhum arquivo de backend, nenhuma
migration.
