### PR TITLE
fix: imagem correta da Evolution API (evoapicloud, não atendai) — v2.3.7

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -34,7 +34,7 @@ services:
     # WhatsApp por Evolution API (Baileys, não-oficial) — transporte alternativo ao Meta Cloud
     # API. SEM `ports:` — nada publicado, nada no Caddy/Traefik. mem_limit RÍGIDO: se uma sessão
     # Baileys inchar, o OOM killer mata a Evolution, não o Postgres. Versão FIXADA, nunca `:latest`.
-    image: atendai/evolution-api:v2.2.3
+    image: evoapicloud/evolution-api:v2.3.7
     restart: always
     mem_limit: 1g
     environment:

--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -54,7 +54,7 @@ services:
     # baixo) e subir depois com dado real de consumo por sessão, em vez de reservar 1g numa
     # caixa já densa e arriscar o OOM killer escolher vítima fora do nosso controle sob
     # pressão global de memória.
-    image: atendai/evolution-api:v2.2.3
+    image: evoapicloud/evolution-api:v2.3.7
     restart: always
     mem_limit: 512m
     environment:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # API. SEM `ports:` — nada publicado, nada no Traefik (o manager web da Evolution não existe
     # pra fora). mem_limit RÍGIDO: se uma sessão Baileys inchar, o OOM killer mata a Evolution,
     # não o Postgres (o WhatsApp cai, o produto continua de pé). Versão FIXADA, nunca `:latest`.
-    image: atendai/evolution-api:v2.2.3
+    image: evoapicloud/evolution-api:v2.3.7
     restart: unless-stopped
     mem_limit: 1g
     environment:


### PR DESCRIPTION
## Resumo

Achado durante o deploy real na VPS: `atendai/evolution-api` (usado nos 3 docker-compose desde a Onda 1) devolve `401 insufficient_scope` ao tentar pull — o projeto migrou o Docker Hub org para `evoapicloud` (confirmado via README oficial do projeto e pull real bem-sucedido na VPS). `v2.2.3` não existe mais nesse namespace; `v2.3.7` é a versão estável mais recente da linha 2.x.

Corrigido nos 3 compose (dev/prod/traefik).

## Test plan
- [x] `docker compose config` valida a sintaxe dos 3 arquivos
- [x] `docker pull evoapicloud/evolution-api:v2.3.7` bem-sucedido na VPS de produção
- [ ] CI (4 checks obrigatórios)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)