### PR TITLE
fix: variável correta pra habilitar cache Redis da Evolution (CACHE_REDIS_*)

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -41,7 +41,9 @@ services:
       AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY:?defina no .env.prod}
       DATABASE_PROVIDER: postgresql
       DATABASE_CONNECTION_URI: postgresql://e1p_evolution:${EVOLUTION_DB_PASSWORD:?defina no .env.prod}@postgres:5432/evolution_db
-      REDIS_URI: redis://redis:6379/0
+      CACHE_REDIS_ENABLED: 'true'
+      CACHE_REDIS_URI: redis://redis:6379/0
+      CACHE_LOCAL_ENABLED: 'false'
       DEL_INSTANCE: 'false'
     depends_on:
       postgres:

--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -61,7 +61,9 @@ services:
       AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY:?defina no .env.prod}
       DATABASE_PROVIDER: postgresql
       DATABASE_CONNECTION_URI: postgresql://e1p_evolution:${EVOLUTION_DB_PASSWORD:?defina no .env.prod}@postgres:5432/evolution_db
-      REDIS_URI: redis://redis:6379/0
+      CACHE_REDIS_ENABLED: 'true'
+      CACHE_REDIS_URI: redis://redis:6379/0
+      CACHE_LOCAL_ENABLED: 'false'
       DEL_INSTANCE: 'false'
     depends_on:
       postgres:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -57,7 +57,9 @@ services:
       #      CREATE DATABASE evolution_db OWNER e1p_evolution;"
       # Validação end-to-end da Evolution (Onda 1) fica para o checklist manual, na VPS.
       DATABASE_CONNECTION_URI: postgresql://e1p_evolution:e1p-evolution-pass@postgres:5432/evolution_db
-      REDIS_URI: redis://redis:6379/0
+      CACHE_REDIS_ENABLED: 'true'
+      CACHE_REDIS_URI: redis://redis:6379/0
+      CACHE_LOCAL_ENABLED: 'false'
       DEL_INSTANCE: 'false'
     depends_on:
       postgres:


### PR DESCRIPTION
## Resumo

Achado no deploy real: `REDIS_URI` (nome usado desde a Onda 1) não é a variável que a Evolution API reconhece para habilitar o cache Redis. Com ela, a Evolution caía em cache local (`fs`) e ainda assim tentava conectar a algum Redis internamente, gerando um loop de erro `redis disconnected` a cada segundo nos logs.

Variável correta confirmada no `.env.example` oficial do projeto: `CACHE_REDIS_ENABLED=true` + `CACHE_REDIS_URI=...` (+ `CACHE_LOCAL_ENABLED=false` pra não manter os dois habilitados à toa). Corrigido nos 3 compose.

## Test plan
- [x] `docker compose config` valida a sintaxe
- [ ] CI (4 checks obrigatórios)
- [ ] Validação final: logs da Evolution sem `redis disconnected` em loop, na VPS

🤖 Gerado com [Claude Code](https://claude.com/claude-code)