### PR TITLE
fix: Evolution API precisa da rede edge pra sair pra internet

### DIFF
--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -68,11 +68,13 @@ def connect(db: Session, *, tenant_id: str) -> dict:
     settings_service.get_profile(db, tenant_id)  # garante que o profile existe
 
     try:
+        # timeout generoso: a Evolution só responde depois que o Baileys termina o handshake
+        # inicial com o WhatsApp pra gerar o QR — em produção isso já levou mais de 15s.
         resp = httpx.post(
             f"{settings.evolution_api_url}/instance/create",
             headers=_headers(),
             json={"instanceName": instance, "qrcode": True, "integration": "WHATSAPP-BAILEYS"},
-            timeout=15,
+            timeout=45,
         )
         # A Evolution devolve erro se a instância já existir — idempotente: ignoramos esse
         # caso específico (detectado pelo texto da resposta) e seguimos pro resto do fluxo.
@@ -117,7 +119,7 @@ def connect(db: Session, *, tenant_id: str) -> dict:
     try:
         resp = httpx.get(
             f"{settings.evolution_api_url}/instance/connect/{instance}",
-            headers=_headers(), timeout=15,
+            headers=_headers(), timeout=45,
         )
         resp.raise_for_status()
     except httpx.HTTPError as exc:
@@ -188,7 +190,7 @@ def refresh_qr(db: Session, *, tenant_id: str) -> str:
     try:
         resp = httpx.get(
             f"{settings.evolution_api_url}/instance/connect/{instance}",
-            headers=_headers(), timeout=15,
+            headers=_headers(), timeout=45,
         )
         resp.raise_for_status()
     except httpx.HTTPError as exc:

--- a/infra/docker-compose.traefik.yml
+++ b/infra/docker-compose.traefik.yml
@@ -42,9 +42,22 @@ services:
 
   evolution:
     # WhatsApp por Evolution API (Baileys, não-oficial) — transporte alternativo ao Meta Cloud
-    # API. SEM `ports:` e SEM rede `edge` — não é HTTP-facing, não precisa do Traefik
-    # compartilhado. mem_limit RÍGIDO: se uma sessão Baileys inchar, o OOM killer mata a
-    # Evolution, não o Postgres. Versão FIXADA, nunca `:latest`.
+    # API. SEM `ports:` e SEM labels de Traefik — não é HTTP-facing, não é roteado pelo Traefik
+    # compartilhado (só ganha `edge` por causa da saída à internet, ver `networks:` abaixo).
+    # mem_limit RÍGIDO: se uma sessão Baileys inchar, o OOM killer mata a Evolution, não o
+    # Postgres. Versão FIXADA, nunca `:latest`.
+    #
+    # PRECISA da rede `edge` (achado 2026-08-04): `db_internal` é `internal: true` (sem rota
+    # pra internet, de propósito — isola Postgres/Redis). Só com `db_internal` a Evolution
+    # conversa com a API/Postgres/Redis só por Docker DNS interno, mas o Baileys por si só
+    # precisa alcançar os servidores REAIS do WhatsApp (web.whatsapp.com etc.) — sem `edge`,
+    # a resolução DNS externa falhava (`ESERVFAIL` até pra `google.com`, dentro do container)
+    # e a conexão Baileys entrava num loop silencioso de reinício, nunca completando o
+    # handshake pra gerar o QR. Sintoma no produto: "Falha de rede ao criar instância: timed
+    # out" no botão Conectar (nosso httpx com timeout=15 nunca recebia resposta do
+    # `/instance/create`, que trava esperando o Baileys conectar). Mesmo padrão do comentário
+    # do `api` abaixo ("edge... dá saída à internet") — SEM label de Traefik aqui, então
+    # continua inalcançável de fora, só ganha a rota de saída.
     #
     # 512m (não o 1g da spec original — ver docker-compose.prod.yml, cenário de VPS dedicada):
     # esta VPS específica é COMPARTILHADA com vários outros clientes (axisgov/fiscalize,
@@ -72,7 +85,7 @@ services:
         condition: service_started
     volumes:
       - evolution_instances:/evolution/instances
-    networks: [db_internal]
+    networks: [db_internal, edge]
 
   api:
     build: ../apps/api


### PR DESCRIPTION
## Problema

Ao clicar em "Conectar por QR Code" em produção, o usuário via:
`Falha de rede ao criar instância: timed out`

## Root cause

`db_internal` (rede do `docker-compose.traefik.yml`) é `internal: true` — sem
rota para a internet, de propósito (isola Postgres/Redis). O serviço
`evolution` foi colocado só nessa rede (raciocínio original: "não é
HTTP-facing, não precisa do Traefik"), o que é certo para tráfego de entrada
mas errado para saída: o Baileys (WhatsApp não-oficial) precisa alcançar os
servidores reais do WhatsApp pela internet, não só falar com Postgres/Redis
internos.

Confirmado ao vivo na VPS: de dentro do container `evolution`,
`resolve4("google.com")` falhava com `ESERVFAIL` (DNS externo bloqueado pela
rede `internal: true`), enquanto o mesmo teste em `infra-api-1` (que também
está na rede `edge`) resolvia normalmente. Sem alcançar o WhatsApp, o Baileys
entrava num loop silencioso de reinício de conexão (sem nenhum log de
erro/warn visível) e o `/instance/create` nunca respondia dentro do timeout.

## Fix

- `evolution` entra também na rede `edge` (mesmo mecanismo que já dá saída à
  internet para o `api`, ver comentário do próprio arquivo) — **sem** label
  de Traefik, então continua inalcançável de fora (nada muda quanto a
  exposição HTTP).
- Timeout do httpx para `/instance/create` e `/instance/connect` (que
  esperam o Baileys terminar o handshake) sobe de 15s → 45s como reforço,
  já que mesmo com rede OK esse handshake pode legitimamente demorar.

## Test plan

- [ ] CI verde (4 checks obrigatórios)
- [ ] Após merge, aplicar `docker compose -f infra/docker-compose.traefik.yml --env-file .env.prod up -d` na VPS (recria `evolution` + rebuild `api`)
- [ ] Confirmar DNS externo funcionando de dentro do container `evolution` (`google.com`/`web.whatsapp.com`)
- [ ] Clicar em "Conectar por QR Code" na UI e confirmar que o QR aparece sem erro
- [ ] Escanear o QR com um celular real e validar handshake completo