### PR TITLE
fix: status da Evolution nunca batia (campos errados na resposta)

### DIFF
--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -143,9 +143,12 @@ def _fetch_evolution_status(instance: str) -> str | None:
     data = resp.json()
     items = data if isinstance(data, list) else []
     for item in items:
-        inst = item.get("instance", item)
-        if inst.get("instanceName") == instance:
-            return inst.get("status")
+        # v2.3.7 devolve os campos direto no item (sem wrapper "instance"), com "name" (não
+        # "instanceName") e "connectionStatus" (não "status") — confirmado ao vivo contra a
+        # API real; achado porque a versão anterior deste código nunca batia, então
+        # get_status()/confirm() sempre viam a sessão como desconectada mesmo já conectada.
+        if item.get("name") == instance:
+            return item.get("connectionStatus")
     return None
 
 

--- a/apps/api/tests/test_whatsapp_session_router.py
+++ b/apps/api/tests/test_whatsapp_session_router.py
@@ -101,7 +101,7 @@ def test_confirm_then_profile_reflects_provider(client: TestClient, headers, mon
 
             def json(self) -> list:
                 return [{
-                    "instance": {"instanceName": params.get("instanceName"), "status": "open"}
+                    "name": params.get("instanceName"), "connectionStatus": "open"
                 }]
 
         return _R()

--- a/apps/api/tests/test_whatsapp_session_service.py
+++ b/apps/api/tests/test_whatsapp_session_service.py
@@ -112,7 +112,7 @@ def test_get_status_connecting_when_evolution_reports_non_open(
                 return None
 
             def json(self) -> list:
-                return [{"instance": {"instanceName": "e1p-" + TENANT_ID, "status": "connecting"}}]
+                return [{"name": "e1p-" + TENANT_ID, "connectionStatus": "connecting"}]
 
         return _Resp()
 
@@ -136,7 +136,7 @@ def test_get_status_does_not_write_to_db(db, monkeypatch: pytest.MonkeyPatch) ->
                 return None
 
             def json(self) -> list:
-                return [{"instance": {"instanceName": "e1p-" + TENANT_ID, "status": "open"}}]
+                return [{"name": "e1p-" + TENANT_ID, "connectionStatus": "open"}]
 
         return _Resp()
 
@@ -166,7 +166,7 @@ def test_confirm_sets_provider_when_evolution_reports_open(
                 return None
 
             def json(self) -> list:
-                return [{"instance": {"instanceName": "e1p-" + TENANT_ID, "status": "open"}}]
+                return [{"name": "e1p-" + TENANT_ID, "connectionStatus": "open"}]
 
         return _Resp()
 
@@ -197,7 +197,7 @@ def test_confirm_does_not_set_provider_when_not_open(
                 return None
 
             def json(self) -> list:
-                return [{"instance": {"instanceName": "e1p-" + TENANT_ID, "status": "connecting"}}]
+                return [{"name": "e1p-" + TENANT_ID, "connectionStatus": "connecting"}]
 
         return _Resp()
 
@@ -277,7 +277,7 @@ def test_check_connections_emails_owner_on_drop(db, monkeypatch: pytest.MonkeyPa
 
             def json(self) -> list:
                 return [{
-                    "instance": {"instanceName": params.get("instanceName"), "status": "close"}
+                    "name": params.get("instanceName"), "connectionStatus": "close"
                 }]
 
         return _R()
@@ -316,7 +316,7 @@ def test_check_connections_noop_when_still_connected(db, monkeypatch: pytest.Mon
 
             def json(self) -> list:
                 return [{
-                    "instance": {"instanceName": params.get("instanceName"), "status": "open"}
+                    "name": params.get("instanceName"), "connectionStatus": "open"
                 }]
 
         return _R()


### PR DESCRIPTION
## Problema

Usuário escaneou o QR Code, o WhatsApp confirmou a conexão no celular (real,
com histórico sincronizado), mas a tela de Configurações continuou mostrando
"Conectar por QR Code" (nunca virou "Conectado").

## Root cause

`_fetch_evolution_status` esperava a resposta de `/instance/fetchInstances`
no formato `{"instance": {"instanceName": ..., "status": ...}}`, mas a
Evolution v2.3.7 devolve os campos direto no item, com nomes diferentes:
`{"name": ..., "connectionStatus": ...}` (sem wrapper `instance`).

Como os nomes nunca batiam, a função sempre devolvia `None` — `get_status()`
e `confirm()` viam toda sessão como desconectada, mesmo já conectada de
verdade. É por isso que o polling do frontend (a cada 3s, `EvolutionQrCard`)
nunca via `status === "connected"` pra chamar `/whatsapp-session/confirm`.

Confirmado ao vivo: `fetchInstances` devolveu
`{"name": "e1p-...", "connectionStatus": "open", ...}` pra uma instância já
com 29613 mensagens e 1967 contatos sincronizados do celular real.

## Fix

`_fetch_evolution_status` agora lê `name`/`connectionStatus` (schema real
confirmado da v2.3.7), sem o wrapper/nomes antigos que nunca existiram
nessa versão.

## Test plan

- [ ] CI verde
- [ ] Após merge, rebuild do `api` na VPS
- [ ] Reabrir a tela de Configurações e confirmar que mostra "Conectado" pro tenant que já escaneou o QR (instância `e1p-5d975889-8ab3-4fec-a70e-b62862a03044`, já com `connectionStatus: open` na Evolution)
- [ ] Enviar/receber uma mensagem de teste de verdade pelo WhatsApp conectado