### PR TITLE
fix: payload do webhook/set da Evolution estava no formato errado

### DIFF
--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -89,19 +89,29 @@ def connect(db: Session, *, tenant_id: str) -> dict:
     webhook_secret = existing.webhook_secret if existing else secrets.token_urlsafe(32)
 
     try:
-        httpx.post(
+        # v2.3.7 espera o payload ANINHADO sob "webhook" (com "enabled"/"byEvents") — um corpo
+        # solto ({"url":..., "webhook_by_events":...}) é ignorado sem erro visível pra quem
+        # chama (achado ao vivo: webhook/find devolvia null mesmo após esse POST "ter sucesso").
+        resp = httpx.post(
             f"{settings.evolution_api_url}/webhook/set/{instance}",
             headers=_headers(),
             json={
-                "url": (
-                    f"{settings.internal_api_base_url}"
-                    f"/internal/whatsapp/evolution/webhook/{webhook_secret}"
-                ),
-                "webhook_by_events": False,
-                "events": ["MESSAGES_UPSERT"],
+                "webhook": {
+                    "enabled": True,
+                    "url": (
+                        f"{settings.internal_api_base_url}"
+                        f"/internal/whatsapp/evolution/webhook/{webhook_secret}"
+                    ),
+                    "byEvents": False,
+                    "events": ["MESSAGES_UPSERT"],
+                }
             },
             timeout=15,
         )
+        if resp.status_code >= 400:
+            raise WhatsappSessionError(
+                f"Falha ao configurar webhook na Evolution: {resp.text}", 502
+            )
     except httpx.HTTPError as exc:
         raise WhatsappSessionError(f"Falha de rede ao configurar webhook: {exc}", 502) from exc
 

--- a/apps/api/tests/test_whatsapp_session_service.py
+++ b/apps/api/tests/test_whatsapp_session_service.py
@@ -66,8 +66,10 @@ def test_connect_creates_instance_configures_webhook_and_returns_qr(
     assert webhook_call["url"].endswith(
         "/webhook/set/e1p-22222222-2222-2222-2222-222222222222"
     )
-    assert webhook_call["json"]["webhook_by_events"] is False
-    assert webhook_call["json"]["url"].startswith(
+    webhook_payload = webhook_call["json"]["webhook"]
+    assert webhook_payload["enabled"] is True
+    assert webhook_payload["byEvents"] is False
+    assert webhook_payload["url"].startswith(
         "http://api:8000/internal/whatsapp/evolution/webhook/"
     )
 
@@ -79,7 +81,7 @@ def test_connect_creates_instance_configures_webhook_and_returns_qr(
     assert row.last_status == "connecting"
     # o segredo do webhook usado na URL é o mesmo guardado na linha (cifrado em repouso, mas
     # o valor em texto plano lido de volta bate)
-    assert row.webhook_secret in webhook_call["json"]["url"]
+    assert row.webhook_secret in webhook_payload["url"]
 
 
 def test_connect_without_api_key_raises(db) -> None:


### PR DESCRIPTION
## Problema

Usuário conectou o WhatsApp com sucesso (QR escaneado, UI mostrando
"Conectado"), mas mensagens recebidas no celular real nunca aparecem em
Conversas na plataforma.

## Root cause

`connect()` chamava `POST /webhook/set/{instance}` com um corpo solto:
```json
{"url": "...", "webhook_by_events": false, "events": ["MESSAGES_UPSERT"]}
```

Mas a v2.3.7 espera esse payload **aninhado** sob a chave `webhook`, com
nomes de campo diferentes:
```json
{"webhook": {"enabled": true, "url": "...", "byEvents": false, "events": [...]}}
```

(confirmado lendo `webhook.controller.ts` da própria Evolution — o método
`set` acessa `data.webhook?.enabled`/`data.webhook?.url`).

Como o corpo nunca batia com o formato esperado, nenhum webhook era
configurado — confirmado ao vivo: `GET /webhook/find/{instance}` devolvia
`null` para a instância já conectada do usuário. E como nosso código não
conferia o status HTTP dessa chamada (só erro de rede), a falha nunca
apareceu em lugar nenhum — nem log, nem erro pro usuário.

## Fix

- Payload agora no formato real (`webhook: {enabled, url, byEvents, events}`).
- Confere o status code da resposta e levanta `WhatsappSessionError` se a
  Evolution rejeitar (visibilidade pra próxima vez que isso quebrar).

## Test plan

- [ ] CI verde
- [ ] Após merge, rebuild do `api` na VPS
- [ ] Tenant já conectado (`70c1f435-...`) precisa reconectar (clicar em
      Conectar de novo) pra reconfigurar o webhook — a sessão já aberta não
      ganha webhook retroativamente
- [ ] Mandar mensagem real pro WhatsApp conectado e confirmar que aparece em Conversas