### PR TITLE
feat: mídia recebida (imagem/áudio/documento/vídeo) via Evolution

### DIFF
--- a/apps/api/app/core/whatsapp/inbound.py
+++ b/apps/api/app/core/whatsapp/inbound.py
@@ -15,5 +15,12 @@ class InboundMessage:
     from_phone: str | None  # só dígitos, sem "+". None quando o provider não entrega o número
     kind: str  # text | image | audio | document | video
     text_body: str
-    media_ref: str | None  # referência de mídia opaca (meta_media_id, ou base64 da Evolution)
+    media_ref: str | None  # referência de mídia OPACA que exige um fetch depois (meta_media_id
+    # da Meta — resolvida pelo worker via `fetch_media_url`/`download_media`). A Evolution não
+    # entrega media_ref: ela entrega os BYTES já decodificados abaixo (media_bytes), porque não
+    # tem endpoint de resolução separado (ver `providers/evolution.py::fetch_media_url`).
     push_name: str
+    media_bytes: bytes | None = None  # mídia JÁ decodificada (Evolution, quando webhookBase64
+    # está ligado) — ingest cria o Attachment na hora, sem depender do worker.
+    media_mime_type: str | None = None
+    media_filename: str | None = None

--- a/apps/api/app/core/whatsapp/providers/evolution.py
+++ b/apps/api/app/core/whatsapp/providers/evolution.py
@@ -123,13 +123,41 @@ def download_media(**_kwargs: object) -> bytes:
     )
 
 
+# message[key] -> kind normalizado (ver InboundMessage.kind). "documentWithCaptionMessage"
+# embrulha um documentMessage (documento com legenda) num nível extra — tratado à parte abaixo.
+_MEDIA_MESSAGE_KEYS = {
+    "imageMessage": "image",
+    "audioMessage": "audio",
+    "videoMessage": "video",
+    "documentMessage": "document",
+}
+
+
+def _extract_media(message: dict) -> tuple[str | None, dict | None]:
+    """Devolve (kind, objeto da mídia) pro primeiro tipo de mídia reconhecido em `message`, ou
+    (None, None) se for texto puro. `documentWithCaptionMessage` embrulha o documentMessage real
+    um nível a mais (documento enviado com legenda) — desembrulha antes de checar os demais."""
+    wrapped = message.get("documentWithCaptionMessage", {}).get("message", {})
+    if "documentMessage" in wrapped:
+        return "document", wrapped["documentMessage"]
+    for key, kind in _MEDIA_MESSAGE_KEYS.items():
+        if key in message:
+            return kind, message[key]
+    return None, None
+
+
 def parse_inbound(payload: dict) -> list[InboundMessage]:
     """Extrai a mensagem do formato da Evolution API (evento `messages.upsert`). `@lid` no
     lugar do telefone → `from_phone=None` — NUNCA adivinhado por heurística (ver bandeja "Não
     identificados", Onda 3).
 
-    Mídia inbound (imagem/áudio/documento) não é parseada ainda — só texto (dívida registrada
-    na spec §12: o shape exato varia por tipo e exige payload de exemplo real).
+    Mídia (imagem/áudio/documento/vídeo): a Evolution não tem endpoint de resolução separado
+    (ver `fetch_media_url`/`download_media` acima) — os bytes só chegam se o webhook foi
+    configurado com `webhook.base64=true` (ver `whatsapp_session/service.py::connect`), inline
+    em `message.base64` (confirmado contra o código-fonte da Evolution: `whatsapp.baileys.
+    service.ts`, `messageRaw.message.base64 = buffer.toString('base64')`). Se a Evolution não
+    conseguiu baixar (erro dela, ou webhookBase64 desligado), `media_bytes` fica None — a
+    mensagem ainda é registrada (com legenda, se houver), só sem anexo.
     """
     try:
         data = payload.get("data", payload)
@@ -143,12 +171,25 @@ def parse_inbound(payload: dict) -> list[InboundMessage]:
             from_phone = remote_jid.split("@")[0]
         push_name = data.get("pushName", "")
         message = data.get("message", {})
-        text_body = message.get("conversation", "") or message.get(
-            "extendedTextMessage", {}
-        ).get("text", "")
+
+        media_kind, media_obj = _extract_media(message)
+        if media_kind is None:
+            text_body = message.get("conversation", "") or message.get(
+                "extendedTextMessage", {}
+            ).get("text", "")
+            return [InboundMessage(
+                wa_message_id=wa_message_id, from_phone=from_phone, kind="text",
+                text_body=text_body, media_ref=None, push_name=push_name,
+            )]
+
+        raw_b64 = message.get("base64")
+        media_bytes = base64.b64decode(raw_b64) if raw_b64 else None
+        mime_type = (media_obj.get("mimetype") or "application/octet-stream").split(";")[0].strip()
         return [InboundMessage(
-            wa_message_id=wa_message_id, from_phone=from_phone, kind="text",
-            text_body=text_body, media_ref=None, push_name=push_name,
+            wa_message_id=wa_message_id, from_phone=from_phone, kind=media_kind,
+            text_body=media_obj.get("caption", ""), media_ref=None, push_name=push_name,
+            media_bytes=media_bytes, media_mime_type=mime_type,
+            media_filename=media_obj.get("fileName") or media_obj.get("title"),
         )]
-    except (AttributeError, TypeError, KeyError):
+    except (AttributeError, TypeError, KeyError, ValueError):
         return []

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -162,14 +162,48 @@ def ingest_webhook_payload(
                 )
                 client_id = client.id
 
-            db.add(WhatsappMessage(
+            msg_row = WhatsappMessage(
                 tenant_id=tenant_id, client_id=client_id, direction=DIRECTION_IN, kind=msg.kind,
-                text_body=msg.text_body,
-                media_status=MEDIA_STATUS_PENDING if msg.media_ref else MEDIA_STATUS_NONE,
-                wa_message_id=msg.wa_message_id,
-                meta_media_id=msg.media_ref if msg.kind != "text" else None,
-                status="sent",
-            ))
+                text_body=msg.text_body, media_status=MEDIA_STATUS_NONE,
+                wa_message_id=msg.wa_message_id, status="sent",
+            )
+            db.add(msg_row)
+            # `default=_uuid` da coluna só materializa `msg_row.id` no FLUSH (não ao construir o
+            # objeto Python) — precisa disso ANTES de usar como owner_id do Attachment.
+            db.flush()
+
+            if msg.media_bytes:
+                # Evolution: bytes já vieram decodificados no payload (webhookBase64) — cria o
+                # Attachment NA HORA, sem depender do worker (que é Meta-only, ver
+                # `providers/evolution.py::fetch_media_url`, que recusa por design).
+                content_type = (
+                    msg.media_mime_type
+                    if msg.media_mime_type in ALLOWED_TYPES
+                    else "application/octet-stream"
+                )
+                try:
+                    attachment = attachments_service.create_attachment(
+                        db, tenant_id=tenant_id, actor="whatsapp:inbox",
+                        owner_type="whatsapp_message", owner_id=msg_row.id, label="outro",
+                        filename=msg.media_filename or f"{msg.kind}-{msg_row.id}",
+                        content_type=content_type, data=msg.media_bytes,
+                    )
+                    msg_row.media_attachment_id = attachment.id
+                    msg_row.media_status = MEDIA_STATUS_DOWNLOADED
+                except AttachmentError as exc:
+                    # Mensagem ainda é registrada (com legenda, se houver) — só sem anexo. Mesmo
+                    # princípio de isolamento do resto da função: um anexo problemático (tipo/
+                    # tamanho) não pode derrubar o recebimento da mensagem em si.
+                    logger.warning(
+                        "[whatsapp_inbox] falha ao anexar mídia recebida, mensagem fica sem "
+                        "anexo: wa_message_id=%s: %s", msg.wa_message_id, exc,
+                    )
+                    msg_row.media_status = MEDIA_STATUS_FAILED
+            elif msg.media_ref:
+                # Meta: só a referência opaca chegou — o worker resolve depois (assíncrono).
+                msg_row.media_status = MEDIA_STATUS_PENDING
+                msg_row.meta_media_id = msg.media_ref
+
             audit.record(
                 db, tenant_id=tenant_id, actor="whatsapp:inbox",
                 action="whatsapp_inbox.message.received", target=client_id or "unidentified",

--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -104,6 +104,11 @@ def connect(db: Session, *, tenant_id: str) -> dict:
                     ),
                     "byEvents": False,
                     "events": ["MESSAGES_UPSERT"],
+                    # A Evolution baixa e decifra a mídia (tem a mediaKey) e injeta o resultado
+                    # em `message.base64` — sem isto, mídia recebida (foto/áudio/documento)
+                    # chega só com metadado (legenda/mimetype), sem os bytes (ver
+                    # `providers/evolution.py::parse_inbound`, que depende deste campo).
+                    "base64": True,
                 }
             },
             timeout=15,

--- a/apps/api/tests/test_whatsapp_inbound_parsing.py
+++ b/apps/api/tests/test_whatsapp_inbound_parsing.py
@@ -2,6 +2,8 @@
 Payloads de exemplo reais/realistas de cada provider."""
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from app.core.whatsapp.inbound import InboundMessage
@@ -66,6 +68,112 @@ def test_evolution_parse_inbound_lid_has_no_phone() -> None:
 def test_evolution_parse_inbound_malformed_payload_returns_empty() -> None:
     assert evolution.parse_inbound({"unexpected": "shape"}) == []
     assert evolution.parse_inbound({}) == []
+
+
+# --- Evolution: mídia (imagem/áudio/documento) — shape real confirmado ao vivo contra a v2.3.7
+# (payload de produção capturado 2026-08-04: imageMessage com url/mimetype/caption direto no
+# objeto, e message.base64 como irmão de imageMessage quando webhookBase64 está ligado — ver
+# whatsapp.baileys.service.ts, messageRaw.message.base64 = buffer.toString('base64')) ------------
+
+def test_evolution_parse_inbound_image_with_base64() -> None:
+    payload = {
+        "data": {
+            "key": {"id": "3EB0IMG1", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {
+                "imageMessage": {
+                    "url": "https://mmg.whatsapp.net/o1/v/t24/...",
+                    "mimetype": "image/jpeg",
+                    "caption": "olha essa foto",
+                },
+                "base64": base64.b64encode(b"fake-jpeg-bytes").decode(),
+            },
+        }
+    }
+    messages = evolution.parse_inbound(payload)
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg.kind == "image"
+    assert msg.from_phone == "5511988887777"
+    assert msg.text_body == "olha essa foto"
+    assert msg.media_bytes == b"fake-jpeg-bytes"
+    assert msg.media_mime_type == "image/jpeg"
+
+
+def test_evolution_parse_inbound_image_without_base64_has_no_bytes() -> None:
+    # Evolution não conseguiu baixar (erro dela) ou webhookBase64 desligado — a mensagem ainda é
+    # registrada (com legenda), só sem os bytes.
+    payload = {
+        "data": {
+            "key": {"id": "3EB0IMG2", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {"imageMessage": {"mimetype": "image/jpeg", "caption": "sem bytes"}},
+        }
+    }
+    messages = evolution.parse_inbound(payload)
+    assert messages[0].kind == "image"
+    assert messages[0].media_bytes is None
+    assert messages[0].text_body == "sem bytes"
+
+
+def test_evolution_parse_inbound_document_with_caption_wrapper() -> None:
+    # Documento com legenda vem embrulhado em documentWithCaptionMessage.message.documentMessage
+    # (um nível a mais que um documento simples).
+    payload = {
+        "data": {
+            "key": {"id": "3EB0DOC1", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {
+                "documentWithCaptionMessage": {
+                    "message": {
+                        "documentMessage": {
+                            "mimetype": "text/markdown",
+                            "fileName": "learnings.md",
+                            "caption": "segue o arquivo",
+                        }
+                    }
+                },
+                "base64": base64.b64encode(b"# markdown").decode(),
+            },
+        }
+    }
+    messages = evolution.parse_inbound(payload)
+    msg = messages[0]
+    assert msg.kind == "document"
+    assert msg.media_filename == "learnings.md"
+    assert msg.text_body == "segue o arquivo"
+    assert msg.media_bytes == b"# markdown"
+
+
+def test_evolution_parse_inbound_audio_strips_codec_suffix_from_mimetype() -> None:
+    payload = {
+        "data": {
+            "key": {"id": "3EB0AUD1", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {
+                "audioMessage": {"mimetype": "audio/ogg; codecs=opus"},
+                "base64": base64.b64encode(b"fake-audio").decode(),
+            },
+        }
+    }
+    messages = evolution.parse_inbound(payload)
+    assert messages[0].kind == "audio"
+    assert messages[0].media_mime_type == "audio/ogg"
+    assert messages[0].text_body == ""
+
+
+def test_evolution_parse_inbound_invalid_base64_returns_empty() -> None:
+    payload = {
+        "data": {
+            "key": {"id": "3EB0BAD1", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {
+                "imageMessage": {"mimetype": "image/jpeg", "caption": ""},
+                "base64": "not-valid-base64!!!",
+            },
+        }
+    }
+    assert evolution.parse_inbound(payload) == []
 
 
 # --- Meta: shape do LOTE quebrado levanta ValueError (movido de test_whatsapp_inbox_service.py,

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.core import whatsapp
 from app.core.audit import AuditEntry
+from app.core.whatsapp.inbound import InboundMessage
 from app.core.whatsapp.providers import meta
 from app.modules.attachments.models import Attachment
 from app.modules.crm.models import Client
@@ -17,6 +18,8 @@ from app.modules.whatsapp_inbox import service as inbox_service
 from app.modules.whatsapp_inbox.models import (
     DIRECTION_IN,
     DIRECTION_OUT,
+    MEDIA_STATUS_DOWNLOADED,
+    MEDIA_STATUS_FAILED,
     MEDIA_STATUS_PENDING,
     PublicWhatsappAccount,
     WhatsappConversationState,
@@ -217,6 +220,69 @@ def test_ingest_image_message_marks_media_pending(db):
     msg = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "wamid.img"))
     assert msg.kind == "image"
     assert msg.media_status == MEDIA_STATUS_PENDING
+
+
+def test_ingest_evolution_media_creates_attachment_synchronously(db):
+    # Evolution entrega bytes já decodificados (webhookBase64) — diferente do fluxo Meta acima
+    # (media_ref opaco + worker assíncrono), o Attachment é criado NA HORA, dentro do próprio
+    # ingest_webhook_payload.
+    _configure_credentials(db)
+    msg = InboundMessage(
+        wa_message_id="3EB0IMG1", from_phone="5511922223333", kind="image",
+        text_body="olha essa foto", media_ref=None, push_name="Cliente Evolution",
+        media_bytes=b"fake-jpeg-bytes", media_mime_type="image/jpeg",
+        media_filename=None,
+    )
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, messages=[msg])
+
+    row = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "3EB0IMG1"))
+    assert row is not None
+    assert row.media_status == MEDIA_STATUS_DOWNLOADED
+    assert row.media_attachment_id is not None
+    assert row.text_body == "olha essa foto"
+
+    attachment = db.get(Attachment, row.media_attachment_id)
+    assert attachment is not None
+    assert attachment.content_type == "image/jpeg"
+    assert attachment.owner_type == "whatsapp_message"
+    assert attachment.owner_id == row.id
+
+
+def test_ingest_evolution_media_unknown_mime_falls_back_to_octet_stream(db):
+    # .md e outros tipos exóticos não estão em ALLOWED_TYPES — cai pro genérico em vez de
+    # rejeitar o anexo (mesmo padrão já usado no envio de resposta com mídia).
+    _configure_credentials(db)
+    msg = InboundMessage(
+        wa_message_id="3EB0DOC1", from_phone="5511922224444", kind="document",
+        text_body="segue o arquivo", media_ref=None, push_name="Cliente Evolution",
+        media_bytes=b"# markdown", media_mime_type="text/markdown",
+        media_filename="learnings.md",
+    )
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, messages=[msg])
+
+    row = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "3EB0DOC1"))
+    attachment = db.get(Attachment, row.media_attachment_id)
+    assert attachment.content_type == "application/octet-stream"
+    assert attachment.filename == "learnings.md"
+
+
+def test_ingest_evolution_media_over_size_limit_fails_gracefully(db):
+    # Anexo grande demais: a mensagem AINDA é registrada (com legenda), só sem o anexo — mesmo
+    # princípio de isolamento por mensagem do resto da função.
+    _configure_credentials(db)
+    msg = InboundMessage(
+        wa_message_id="3EB0BIG1", from_phone="5511922225555", kind="image",
+        text_body="foto gigante", media_ref=None, push_name="Cliente Evolution",
+        media_bytes=b"x" * (11 * 1024 * 1024), media_mime_type="image/jpeg",
+        media_filename=None,
+    )
+    inbox_service.ingest_webhook_payload(db, tenant_id=TENANT_ID, messages=[msg])
+
+    row = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "3EB0BIG1"))
+    assert row is not None
+    assert row.text_body == "foto gigante"
+    assert row.media_status == MEDIA_STATUS_FAILED
+    assert row.media_attachment_id is None
 
 
 # NOTA (Onda 3): os testes de shape do LOTE malformado (`value` não-dict, `messages` não é uma

--- a/apps/api/tests/test_whatsapp_session_service.py
+++ b/apps/api/tests/test_whatsapp_session_service.py
@@ -69,6 +69,7 @@ def test_connect_creates_instance_configures_webhook_and_returns_qr(
     webhook_payload = webhook_call["json"]["webhook"]
     assert webhook_payload["enabled"] is True
     assert webhook_payload["byEvents"] is False
+    assert webhook_payload["base64"] is True  # mídia recebida vem decodificada no payload
     assert webhook_payload["url"].startswith(
         "http://api:8000/internal/whatsapp/evolution/webhook/"
     )

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -108,6 +108,13 @@ function ConversationThread({
     }
   }
 
+  async function openAttachment(attachmentId: string) {
+    const { data } = await api.get(`/attachments/${attachmentId}/download`, {
+      responseType: "blob",
+    });
+    window.open(URL.createObjectURL(data as Blob), "_blank");
+  }
+
   async function sendMedia(file: File) {
     setError(null);
     const form = new FormData();
@@ -140,7 +147,22 @@ function ConversationThread({
             {entry.source === "automated" && (
               <p className="mb-0.5 text-xs font-semibold">🤖 {entry.purpose_label}</p>
             )}
-            <p>{entry.text_body || `[${entry.kind}]`}</p>
+            {entry.media_attachment_id && (
+              <button
+                onClick={() => openAttachment(entry.media_attachment_id!)}
+                className={`mb-1 flex items-center gap-1 text-xs font-semibold underline ${
+                  entry.direction === "out" ? "text-white" : "text-primary-600"
+                }`}
+              >
+                <Paperclip size={12} />
+                {entry.kind === "image" ? "Ver imagem" : "Baixar anexo"}
+              </button>
+            )}
+            {(entry.text_body || !entry.media_attachment_id) && (
+              <p className="whitespace-pre-wrap">
+                {entry.text_body || `[${entry.kind}]`}
+              </p>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Problema

Mensagens de mídia (foto, documento, áudio) recebidas pelo WhatsApp
conectado via Evolution apareciam em Conversas como `[text]` — sem
conteúdo nenhum. `parse_inbound` da Evolution nunca tinha suporte a mídia
(só texto), gap documentado desde a implementação original.

## Investigação

Capturei ao vivo (log temporário, revertido) o payload real de uma mensagem
de imagem e de um documento (.md) enviados de verdade pelo WhatsApp
conectado em produção. Confirmei contra o código-fonte da Evolution
(`whatsapp.baileys.service.ts`) o mecanismo de entrega de mídia: com
`webhook.base64=true` na configuração do webhook, a Evolution baixa e
decifra a mídia (ela já tem a `mediaKey`) e injeta o resultado em
`message.base64` — evitando reimplementar a criptografia de mídia do
WhatsApp na mão.

## Mudanças

- `connect()` liga `"base64": true` na config do webhook.
- `evolution.py::parse_inbound` detecta `imageMessage`/`audioMessage`/
  `documentMessage`/`documentWithCaptionMessage` (documento com legenda
  vem embrulhado um nível a mais), decodifica `message.base64` e extrai
  mimetype/legenda/nome do arquivo.
- `InboundMessage` ganha `media_bytes`/`media_mime_type`/`media_filename`
  (default `None` — não quebra o contrato existente do Meta).
- `ingest_webhook_payload` cria o `Attachment` **sincronamente** quando
  `media_bytes` vem preenchido (a Evolution não tem endpoint de resolução
  separado como a Meta — o worker assíncrono existente é Meta-only).
  Mimetype fora de `ALLOWED_TYPES` cai pra `application/octet-stream` em
  vez de rejeitar; falha ao anexar (ex.: acima do limite de 10MB) não
  derruba a mensagem, só fica sem anexo.
- Frontend (`ConversasPage.tsx`): bolha de mensagem ganha link "Ver
  imagem"/"Baixar anexo" quando há `media_attachment_id`; `whitespace-pre-wrap`
  na legenda/texto (achado incidental: mensagem com quebra de linha real
  ficava tudo numa linha só).

## Achado incidental (documentado, não corrigido nesta mudança)

O comentário em `attachments/service.py` sobre `default=_uuid` materializar
o `id` "ao construir o objeto Python" está incorreto — só materializa no
`flush()`. Só afetou este código novo (corrigido com `db.add()`+`db.flush()`
antes de usar `msg_row.id`); não é regressão em código existente.

## Test plan

- [x] Suíte completa local: 1129 passed
- [ ] CI verde
- [ ] Após merge, rebuild do `api` + reconectar (reconfigurar webhook) do
      tenant já conectado
- [ ] Reenviar foto/documento reais e confirmar que aparecem com conteúdo
      (não `[image]`/`[document]`) e o link "Ver imagem"/"Baixar anexo" funciona