### PR TITLE
fix: despachante de WhatsApp quebrava ao responder via Evolution (500)

### DIFF
--- a/apps/api/app/core/whatsapp/__init__.py
+++ b/apps/api/app/core/whatsapp/__init__.py
@@ -54,6 +54,13 @@ def _resolve(profile: TenantProfile | None):
     return meta
 
 
+def _evolution_instance(profile: TenantProfile | None) -> str:
+    """Mesmo formato de `whatsapp_session/service.py::_instance_name` — só chamada quando
+    `_resolve` já confirmou `profile.whatsapp_provider == "evolution"`, então `profile` nunca é
+    None aqui (garantia do chamador, não repetida em runtime)."""
+    return f"e1p-{profile.tenant_id}"  # type: ignore[union-attr]
+
+
 def send_text(
     *,
     to: str,
@@ -63,6 +70,10 @@ def send_text(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    if provider is evolution:
+        # Evolution não usa token/phone_id por tenant (credencial GLOBAL) — identifica a
+        # instância pelo tenant_id, não por essas duas credenciais da Meta.
+        return provider.send_text(to=to, text=text, instance=_evolution_instance(profile))
     if profile is not None:
         token = profile.whatsapp_token
         phone_id = profile.whatsapp_phone_id
@@ -104,6 +115,11 @@ def send_media(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    if provider is evolution:
+        return provider.send_media(
+            to=to, instance=_evolution_instance(profile), kind=kind, media_id=media_id,
+            caption=caption,
+        )
     if profile is not None:
         token = profile.whatsapp_token or ""
         phone_id = profile.whatsapp_phone_id or ""
@@ -127,6 +143,12 @@ def upload_media(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    if provider is evolution:
+        # Evolution não tem endpoint de upload separado (ver docstring de
+        # providers/evolution.py::upload_media) — não usa token/phone_id.
+        return provider.upload_media(
+            file_bytes=file_bytes, filename=filename, mime_type=mime_type,
+        )
     if profile is not None:
         token = profile.whatsapp_token or ""
         phone_id = profile.whatsapp_phone_id or ""

--- a/apps/api/tests/test_whatsapp_dispatcher_evolution.py
+++ b/apps/api/tests/test_whatsapp_dispatcher_evolution.py
@@ -1,0 +1,80 @@
+"""Testes do despachante (core/whatsapp/__init__.py) pro ramo Evolution — cobre um bug real
+achado em produção: send_text/send_media/upload_media chamavam SEMPRE o provider com
+token=/phone_id= (parâmetros da Meta), mesmo quando `_resolve` escolhia `evolution`, cujas
+funções não aceitam esses kwargs (`TypeError`). Nunca foi pego porque, até essa mensagem real
+em produção, nenhuma resposta tinha sido enviada de fato por um tenant conectado via Evolution
+— toda a suíte anterior (test_whatsapp.py) só cobre o provider Meta."""
+from __future__ import annotations
+
+from app.core import whatsapp
+from app.core.whatsapp.providers import evolution
+from app.modules.settings.models import TenantProfile
+
+TENANT_ID = "99999999-9999-9999-9999-999999999999"
+
+
+def _evolution_profile() -> TenantProfile:
+    return TenantProfile(tenant_id=TENANT_ID, whatsapp_provider="evolution")
+
+
+def test_send_text_dispatches_to_evolution_with_instance_not_token(
+    monkeypatch,
+) -> None:
+    calls: list[dict] = []
+
+    def _fake_send_text(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return "sent"
+
+    monkeypatch.setattr(evolution, "send_text", _fake_send_text)
+    status = whatsapp.send_text(to="5511999999999", text="oi", profile=_evolution_profile())
+    assert status == "sent"
+    assert calls == [{
+        "to": "5511999999999", "text": "oi", "instance": f"e1p-{TENANT_ID}",
+    }]
+
+
+def test_send_media_dispatches_to_evolution_with_instance_not_token(
+    monkeypatch,
+) -> None:
+    calls: list[dict] = []
+
+    def _fake_send_media(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return "sent"
+
+    monkeypatch.setattr(evolution, "send_media", _fake_send_media)
+    status = whatsapp.send_media(
+        to="5511999999999", kind="image", media_id="base64ref", caption="legenda",
+        profile=_evolution_profile(),
+    )
+    assert status == "sent"
+    assert calls == [{
+        "to": "5511999999999", "instance": f"e1p-{TENANT_ID}", "kind": "image",
+        "media_id": "base64ref", "caption": "legenda",
+    }]
+
+
+def test_upload_media_dispatches_to_evolution_without_token_or_phone_id(
+    monkeypatch,
+) -> None:
+    calls: list[dict] = []
+
+    def _fake_upload_media(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return "base64-ref"
+
+    monkeypatch.setattr(evolution, "upload_media", _fake_upload_media)
+    media_id = whatsapp.upload_media(
+        file_bytes=b"bytes", filename="foto.jpg", mime_type="image/jpeg",
+        profile=_evolution_profile(),
+    )
+    assert media_id == "base64-ref"
+    assert calls == [{
+        "file_bytes": b"bytes", "filename": "foto.jpg", "mime_type": "image/jpeg",
+    }]
+
+
+def test_send_text_without_profile_still_dispatches_to_meta() -> None:
+    # Retrocompatibilidade preservada: sem profile, cai sempre em Meta (token=/phone_id= diretos).
+    assert whatsapp._resolve(None) is whatsapp.meta


### PR DESCRIPTION
## Problema (produção, cliente real esperando resposta)

Ao tentar responder uma conversa de WhatsApp recebida via Evolution, a UI
mostrou "Request failed with status code 500".

## Root cause

`core/whatsapp/__init__.py` (o despachante Meta/Evolution) resolve o
provider certo via `_resolve(profile)`, mas `send_text`/`send_media`/
`upload_media` sempre chamavam esse provider passando `token=`/`phone_id=`
(parâmetros específicos da Meta) — mesmo quando o provider resolvido era
`evolution`, cujas funções (`send_text(*, to, text, instance)`) não aceitam
esses kwargs:

```
TypeError: send_text() got an unexpected keyword argument 'token'
```

Log real da VPS confirma o traceback batendo exatamente nisso.

Nunca foi pego antes porque esta foi a PRIMEIRA resposta real enviada por
um tenant conectado via Evolution — toda a suíte de testes existente
(`test_whatsapp.py`) só exercita o provider Meta.

## Fix

Quando `_resolve` escolhe `evolution`, o despachante monta
`instance=f"e1p-{profile.tenant_id}"` e chama com a assinatura certa da
Evolution, em vez de token/phone_id. `fetch_media_url`/`download_media` não
precisaram de fix (usam `**kwargs` do lado da Evolution e já levantavam
`EvolutionUnsupportedError` corretamente).

Teste novo (`test_whatsapp_dispatcher_evolution.py`) cobre os 3 pontos
afetados — gap real na suíte que nunca exercitava o roteamento pra Evolution
com um profile de verdade.

## Test plan

- [x] Suíte completa local: 1133 passed
- [ ] CI verde
- [ ] Após merge, rebuild do `api` na VPS e responder a conversa real que
      está esperando