### PR TITLE
fix: WhatsApp conectado por QR code não pede mais template aprovado da Meta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,47 @@ e uma tentativa real de conexão avançou mais um passo):
     - **Migration validada contra Postgres REAL** (container descartável, rodando como o papel não-superusuário `e1p_app`, com dados legados semeados): backfill preservou as 7 mensagens de teste, 0 ficaram sem conversa, `last_read_at` migrou, RLS `FORCE` restaurada nas 4 tabelas e isolamento cross-tenant fail-closed conferido (sem GUC → 0 linhas). O backfill **desabilita a RLS na sua janela** — sem isso ele seria um no-op silencioso (armadilha da `0046`, que o SQLite dos testes não pega).
     - **Dívida:** `whatsapp_conversation_states` fica órfã (o estado de leitura mudou de casa); não foi dropada porque `DROP TABLE` é irreversível e vale manter um ciclo para conferência — dropar numa migration posterior.
 
+12. **As regras da Meta seguiam valendo sob a Evolution, porque `capabilities.py` não tinha
+    consumidor nenhum.** Sintoma reportado: o nó de WhatsApp do funil respondia *"Selecione um
+    template de WhatsApp aprovado"* num tenant conectado por QR code — que não tem template
+    nenhum e não consegue criar (a Evolution recusa templates por design). **Template aprovado e
+    janela de 24h são artefatos da Cloud API da Meta**, e o módulo que já codificava exatamente
+    isso (`app/core/whatsapp/capabilities.py`, `EVOLUTION.templates=False`,
+    `session_window=False`) existia desde a Onda 0 com **zero call sites em produção** — só o
+    próprio teste unitário. Sua docstring **afirmava** que 3 consumidores o consultavam; nenhum
+    dos 3 tinha sido escrito.
+    - **A lição de método:** um módulo de capacidades sem consumidor não protege ninguém — ele
+      documenta uma intenção, e a docstring que descreve consumidores inexistentes *impede* que
+      alguém note a lacuna (é a mesma classe de erro da **INSTANCIAÇÃO OBRIGATÓRIA** do Epic 8:
+      conjunto definido por descrição, sem membro escrito, sem consumidor mecânico que proteste).
+      **Regra que fica: capacidade nova nasce com o consumidor no mesmo passo**, e a lista de
+      consumidores na docstring tem que ser verificável por grep.
+    - **Três instâncias do mesmo defeito**, todas corrigidas aqui: (a) o nó do funil exigindo
+      template (`funnels/service.py::run_node` → agora texto livre sob Evolution, com
+      `{{cliente.*}}` resolvido; `engine._params` passou a carregar `config.body` até a ação, sem
+      o que a jornada automática continuaria muda); (b) `is_within_session_window` aplicando a
+      janela de 24h — **beco sem saída**, porque fora da janela a única saída oferecida é
+      template, que ali não existe: a conversa emudeceria 24h após a última mensagem do contato;
+      (c) achado durante a implementação — **os 5 pontos do domínio que resolvem vínculo
+      propósito→template no ENFILEIRAMENTO** (quotes, contracts, receivables, platform,
+      `on_client_moved`) não sabem por qual transporte a mensagem sai, então um tenant que usou a
+      Meta e migrou pro QR mantinha os vínculos e cada notificação chamaria `send_template` →
+      falha garantida + retry com backoff até expirar. Guarda posta no **ponto de entrega**
+      (`process_pending`), onde o transporte é conhecido: cai em `send_text` sem perder conteúdo,
+      porque `notification.message` já é o template renderizado.
+    - **`_resolve` do despachante agora DERIVA de `capabilities.for_profile`** em vez de repetir
+      a comparação `whatsapp_provider == "evolution"`. Se divergissem, um consumidor concluiria
+      "posso mandar texto livre" enquanto o despachante entregaria pela Meta — e a falha
+      apareceria no worker, longe de quem poderia relacionar as duas decisões. Gate em
+      `tests/test_whatsapp_capabilities.py::test_capabilities_e_despachante_nunca_divergem`.
+    - Frontend espelha o mesmo dado em `apps/web/src/lib/whatsappCapabilities.ts` (o builder lê
+      `GET /settings/profile` uma vez e passa o transporte aos dois modais). Conversas **não
+      precisou mudar**: o backend passou a responder `within_session_window: true` e a caixa de
+      texto livre que já existia aparece sozinha.
+    - **Dívida:** o espelho do TS é mantido à mão (mesma dívida geral de `shared-types`) — se
+      surgir um 3º transporte, os dois arquivos precisam mudar juntos, e nada no CI reprova o
+      esquecimento.
+
 **Duas armadilhas operacionais da VPS** (não são bug de código, são do processo de deploy):
 - Depois de mudar a config do webhook via `/webhook/set` numa instância **já conectada**, a mudança pode não valer pro processo em memória (cache do canal Baileys carregado na conexão) — precisou **reiniciar o container `evolution`** (não só recriar) pra pegar a config nova. Sessões reconectam sozinhas (credenciais persistidas no Postgres/Redis), sem precisar de novo QR.
 - `docker compose up -d --build <serviço>` só reconstrói o serviço **nomeado**. Rebuildar só `api` depois de um PR que também mudou frontend deixa o `web` com o build antigo, **em silêncio** (sem erro, só o comportamento antigo persistindo). Depois de qualquer merge, checar QUAIS serviços mudaram no diff antes de escolher o que rebuildar — ou rebuildar todos (`up -d --build` sem nome, como o `reference_e1p_prod_deploy` já recomendava).

--- a/apps/api/app/core/whatsapp/__init__.py
+++ b/apps/api/app/core/whatsapp/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.core.whatsapp import capabilities
 from app.core.whatsapp.providers import evolution, meta
 from app.core.whatsapp.providers.meta import WhatsappApiError
 
@@ -47,12 +48,13 @@ __all__ = [
 
 
 def _resolve(profile: TenantProfile | None):
-    """Escolhe o provider pelo transporte do tenant. `None` (perfil ausente) ou qualquer valor
-    diferente de "evolution" cai em `meta` — inclusive `None`/"meta" (estado de hoje, ou tenant
-    que nunca conectou por QR)."""
-    if profile is not None and profile.whatsapp_provider == "evolution":
-        return evolution
-    return meta
+    """Escolhe o provider pelo transporte do tenant.
+
+    DERIVA de `capabilities.for_profile` em vez de repetir a comparação: assim o que os
+    consumidores de domínio checam (posso mandar texto livre?) e o que este módulo faz de fato
+    (por qual API o texto sai) não conseguem divergir. Gate em
+    `tests/test_whatsapp_capabilities.py::test_capabilities_e_despachante_nunca_divergem`."""
+    return evolution if capabilities.for_profile(profile) is capabilities.EVOLUTION else meta
 
 
 def _evolution_instance(profile: TenantProfile | None) -> str:

--- a/apps/api/app/core/whatsapp/capabilities.py
+++ b/apps/api/app/core/whatsapp/capabilities.py
@@ -2,21 +2,37 @@
 
 A Meta Cloud API exige template aprovado fora da janela de 24h; a Evolution (Baileys) não
 conhece nenhum dos dois conceitos. Em vez de cada consumidor checar
-`profile.whatsapp_provider == "meta"` (fácil de esquecer num consumidor novo), os 3 pontos que
-precisam saber disso (fila de notificações ao resolver vínculo propósito→template, caixa de
-resposta do inbox ao decidir entre texto livre e seletor de template, tela de Configurações ao
-mostrar/esconder os cards de Templates e Vínculos) consultam este objeto — um transporte novo
-sem entrada aqui quebra explicitamente em vez de falhar em silêncio.
+`profile.whatsapp_provider == "meta"` (fácil de esquecer num consumidor novo), quem precisa
+saber disso chama `for_profile(profile)`.
 
 Ver docs/superpowers/specs/2026-07-30-whatsapp-evolution-multi-tenant-design.md §4.
 
-Nesta onda (Onda 0), `EVOLUTION` é dado sem provider atrás — `providers/evolution.py` chega na
-Onda 1, e nenhum consumidor consegue alcançar `EVOLUTION` de fato até `TenantProfile
-.whatsapp_provider` existir (Onda 2).
+⚠️ **Este módulo nasceu (Onda 0) descrevendo 3 consumidores que nunca foram escritos** — ficou
+com zero call sites em produção e só o próprio teste unitário, enquanto as regras da Meta
+seguiam rodando incondicionalmente sob a Evolution. Isso custou dois bugs reais, achados usando
+o produto conectado por QR code: o nó de WhatsApp do funil exigindo template aprovado, e a
+janela de 24h emudecendo a conversa no inbox. **A docstring afirmava que os consumidores
+existiam, e nada contradizia a afirmação** — um módulo de capacidades sem consumidor não
+protege ninguém; ele só documenta uma intenção. Antes de adicionar uma capacidade aqui,
+escreva o consumidor no mesmo passo.
+
+Consumidores REAIS hoje (verificáveis por grep de `capabilities.for_profile` /
+`whatsapp_capabilities`):
+- `app/core/whatsapp/__init__.py::_resolve` — escolhe o provider (a resolução é DERIVADA daqui,
+  então capacidade e provider não conseguem divergir; gate em tests/test_whatsapp_capabilities).
+- `app/modules/funnels/service.py::run_node` (`send_message`) — template aprovado × texto livre.
+- `app/modules/whatsapp_inbox/service.py::is_within_session_window` — janela de 24h.
+- `app/modules/notifications/service.py::process_pending` — guarda de ENTREGA: os 5 pontos do
+  domínio que resolvem vínculo propósito→template no enfileiramento não sabem por qual
+  transporte a mensagem sai; a decisão final é tomada aqui, onde o transporte é conhecido.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.modules.settings.models import TenantProfile
 
 
 @dataclass(frozen=True)
@@ -31,3 +47,17 @@ META = Capabilities(templates=True, session_window=True, media=True, provisionin
 EVOLUTION = Capabilities(
     templates=False, session_window=False, media=True, provisioning="qrcode"
 )
+
+
+def for_profile(profile: TenantProfile | None) -> Capabilities:
+    """O que o transporte DESTE tenant sabe fazer.
+
+    `None` (perfil ausente) ou qualquer valor diferente de "evolution" é Meta — inclusive
+    `None`/"meta" (tenant que nunca conectou por QR). É deliberadamente a MESMA regra de
+    `whatsapp.__init__._resolve`, que a deriva desta função em vez de repetir a comparação:
+    capacidade e provider divergirem produziria um envio que passa na validação aqui e falha
+    lá no worker, longe de quem poderia relacionar as duas decisões.
+    """
+    if profile is not None and profile.whatsapp_provider == "evolution":
+        return EVOLUTION
+    return META

--- a/apps/api/app/modules/funnels/engine.py
+++ b/apps/api/app/modules/funnels/engine.py
@@ -100,7 +100,12 @@ def _params(data: dict) -> dict:
                 "message": cfg.get("body") or cfg.get("message", ""),
                 "recipient": cfg.get("recipient", "client")}
     if action == "send_message":
+        # `message` (texto livre, transporte Evolution) e `template_id`/`variables` (Meta) andam
+        # JUNTOS: o nó pode ter sido configurado num transporte e executado noutro, e quem decide
+        # qual dos dois vale é o service, consultando as capabilities do tenant — não este
+        # dicionário, que só entrega o que o nó guardou.
         return {"template_id": cfg.get("template_id"), "variables": cfg.get("variables") or [],
+                "message": cfg.get("body") or cfg.get("message", ""),
                 "recipient": cfg.get("recipient", "client")}
     if action == "create_client":
         return {"name": cfg.get("name", "")}

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -335,6 +335,7 @@ def run_node(
     from datetime import UTC, datetime, timedelta
 
     from app.core import email
+    from app.core.whatsapp import capabilities as whatsapp_capabilities
     from app.modules.auth.models import User
     from app.modules.crm import service as crm_service
     from app.modules.crm.models import Client
@@ -446,25 +447,43 @@ def run_node(
 
     if action == "send_message":
         c = _client()
-        template_id = params.get("template_id")
-        if not template_id:
-            raise FunnelError("Selecione um template de WhatsApp aprovado", 422)
-        tpl = db.get(WhatsappTemplate, template_id)
-        if tpl is None or tpl.status != STATUS_APPROVED:
-            raise FunnelError("Template não encontrado ou ainda não aprovado pela Meta", 422)
         to_team = params.get("recipient") == "team"
         to_phone = _team_phone() if to_team else (c.phone or "")
         recipient = to_phone or c.name
-        resolved_vars = [_resolve_template_variable(v, c) for v in (params.get("variables") or [])]
-        rendered = _render_template_preview(tpl.body_text, resolved_vars)
-        notifications_service.enqueue(
-            db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient, client_id=c.id,
-            message=rendered, purpose=PURPOSE_FUNNEL_NODE, whatsapp_template_name=tpl.name,
-            whatsapp_template_language=tpl.language, whatsapp_template_variables=resolved_vars,
-        )
+        who = "equipe" if to_team else c.name
+        profile = settings_service.get_profile(db, tenant_id)
+
+        if not whatsapp_capabilities.for_profile(profile).templates:
+            # Evolution (Baileys): template aprovado não existe nesse transporte — a mensagem é
+            # texto livre, escrito no nó. Um `template_id` guardado de quando o tenant ainda era
+            # Meta é IGNORADO de propósito: reaproveitá-lo faria o worker chamar send_template,
+            # que a Evolution recusa por design (providers/evolution.py).
+            body = (params.get("message") or "").strip()
+            if not body:
+                raise FunnelError("Escreva a mensagem do WhatsApp no nó antes de executar", 422)
+            notifications_service.enqueue(
+                db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient, client_id=c.id,
+                message=_render_client_placeholders(body, c), purpose=PURPOSE_FUNNEL_NODE,
+            )
+        else:
+            template_id = params.get("template_id")
+            if not template_id:
+                raise FunnelError("Selecione um template de WhatsApp aprovado", 422)
+            tpl = db.get(WhatsappTemplate, template_id)
+            if tpl is None or tpl.status != STATUS_APPROVED:
+                raise FunnelError("Template não encontrado ou ainda não aprovado pela Meta", 422)
+            resolved_vars = [
+                _resolve_template_variable(v, c) for v in (params.get("variables") or [])
+            ]
+            notifications_service.enqueue(
+                db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient, client_id=c.id,
+                message=_render_template_preview(tpl.body_text, resolved_vars),
+                purpose=PURPOSE_FUNNEL_NODE, whatsapp_template_name=tpl.name,
+                whatsapp_template_language=tpl.language, whatsapp_template_variables=resolved_vars,
+            )
+
         audit.record(db, tenant_id=tenant_id, actor=actor, action="funnel.run.message", target=c.id)
         db.commit()
-        who = "equipe" if to_team else c.name
         return {"message": f"Mensagem registrada para {who} (whatsapp)", "kind": "message",
                 "ref_id": c.id}
 

--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import email, events, whatsapp
+from app.core.whatsapp import capabilities as whatsapp_capabilities
 from app.db.session import tenant_session
 from app.modules.auth.models import User
 from app.modules.crm.models import Client, PipelineStage
@@ -230,6 +231,15 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
     )
     # `profile` já foi carregado acima (mesmo lote, mesmo tenant) — reaproveitado aqui pro
     # send_text/send_template de cada notificação.
+    #
+    # Guarda de transporte: 5 lugares do domínio (quotes, contracts, receivables, platform,
+    # on_client_moved) resolvem o vínculo propósito→template no ENFILEIRAMENTO, e nenhum deles
+    # sabe por qual transporte a mensagem vai sair. Um tenant que usou a Meta e depois migrou
+    # pro QR code mantém os vínculos salvos — sem esta guarda, cada notificação dessas chamaria
+    # `send_template`, que a Evolution recusa por design, e o retry com backoff repetiria a
+    # falha até expirar. Cair em `send_text` não perde nada: `notification.message` JÁ é o
+    # template renderizado (quem enfileirou substituiu os `{{n}}` antes de gravar).
+    _usa_template = whatsapp_capabilities.for_profile(profile).templates
     processed = 0
     for notification in pending:
         if notification.expires_at is not None and notification.expires_at < now:
@@ -244,7 +254,7 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
                     subject="Notificação e1p",
                     body=notification.message,
                 )
-            elif notification.whatsapp_template_name:
+            elif notification.whatsapp_template_name and _usa_template:
                 status = whatsapp.send_template(
                     to=notification.recipient,
                     profile=profile,

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.core import audit, whatsapp
 from app.core.phone import normalize_br
+from app.core.whatsapp import capabilities as whatsapp_capabilities
 from app.core.whatsapp.inbound import InboundMessage
 from app.modules.attachments import service as attachments_service
 from app.modules.attachments.models import ALLOWED_TYPES, MAX_BYTES
@@ -530,10 +531,20 @@ def is_within_session_window(db: Session, *, chat_id: str) -> bool:
     """A janela de 24h é uma regra da Meta (Cloud API): fora dela só template aprovado passa.
 
     **Não se aplica a grupo** — a API oficial da Meta nem tem grupos, então a regra não existe
-    para eles; exigi-la ali só tornaria o grupo mudo por engano. Grupo responde sempre."""
+    para eles; exigi-la ali só tornaria o grupo mudo por engano. Grupo responde sempre.
+
+    **Nem ao transporte Evolution** (Baileys), que não tem janela nenhuma. Aqui não é só rigor
+    desnecessário: fora da janela a ÚNICA saída que o produto oferece é template aprovado, e um
+    tenant conectado por QR code não tem nenhum e não consegue criar (a Evolution recusa
+    templates por design). A conversa ficaria muda para sempre 24h depois da última mensagem do
+    contato. Ver app/core/whatsapp/capabilities.py."""
     chat = db.get(WhatsappChat, chat_id)
     if chat is not None and chat.kind == CHAT_KIND_GROUP:
         return True
+    if chat is not None:
+        profile = settings_service.get_profile(db, chat.tenant_id)
+        if not whatsapp_capabilities.for_profile(profile).session_window:
+            return True
     last_inbound = db.scalar(
         select(WhatsappMessage)
         .where(WhatsappMessage.chat_id == chat_id, WhatsappMessage.direction == DIRECTION_IN)

--- a/apps/api/tests/test_funnel_automation.py
+++ b/apps/api/tests/test_funnel_automation.py
@@ -93,6 +93,34 @@ def test_enroll_runs_until_wait_then_tick_resumes(
     assert any(n["channel"] == "whatsapp" for n in notifs)
 
 
+def test_jornada_completa_no_transporte_evolution(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    """O motor tem que levar o texto livre do nó (`config.body`) até a ação.
+
+    Antes o `_params` de `send_message` só repassava `template_id`/`variables`, então mesmo
+    depois de o service aceitar texto livre a jornada automática continuaria falhando — o texto
+    nunca sairia do nó. É o caminho que o usuário realmente usa (a jornada roda sozinha; o botão
+    "Executar agora" é só o teste manual)."""
+    from app.modules.settings import service as settings_service
+
+    settings_service.get_profile(db, tenant_id).whatsapp_provider = "evolution"
+    db.commit()
+
+    cid = _client_id(client, headers, "Ana Evolution")
+    nodes = [_node("n1", "whatsapp", "send_message",
+                   config={"body": "Oi {{cliente.nome}}, vamos conversar?"})]
+    fid = _funnel(client, headers, nodes, [])
+
+    run = client.post(f"/funnels/{fid}/enroll", json={"client_id": cid}, headers=headers).json()
+    assert run["status"] == "done", run["steps"]
+    assert any(s["action"] == "send_message" and s["status"] == "ok" for s in run["steps"])
+
+    notifs = client.get("/notifications", headers=headers).json()
+    msg = next(n for n in notifs if n["channel"] == "whatsapp")
+    assert msg["message"] == "Oi Ana Evolution, vamos conversar?"
+
+
 def test_conditional_branches_by_tag(client: TestClient, headers):
     cid = _client_id(client, headers, "VIP")
     r = client.patch(f"/crm/clients/{cid}", json={"tags": ["vip"]}, headers=headers)

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -212,6 +212,93 @@ def test_run_send_message_missing_template_is_422(client: TestClient, headers):
     assert resp.status_code == 422
 
 
+# ── Transporte Evolution: template aprovado não existe lá ────────────────────
+# Template aprovado e janela de 24h são regras da Cloud API da Meta. A Evolution (Baileys) não
+# conhece nenhuma das duas, então exigir template do nó de WhatsApp deixava o funil INTEIRO
+# mudo para quem conectou por QR code. Ver app/core/whatsapp/capabilities.py.
+
+
+def _evolution(db: Session, tenant_id: str) -> None:
+    from app.modules.settings import service as settings_service
+
+    settings_service.get_profile(db, tenant_id).whatsapp_provider = "evolution"
+    db.commit()
+
+
+def test_run_send_message_evolution_usa_texto_livre(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    from sqlalchemy import select
+
+    from app.modules.notifications.models import Notification
+
+    _evolution(db, tenant_id)
+    cl = client.post(
+        "/crm/clients", json={"name": "Maria Cliente", "phone": "5511988887777"}, headers=headers
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"],
+              "params": {"message": "Oi {{cliente.nome}}, tudo bem?"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    notif = db.scalar(select(Notification).where(Notification.channel == "whatsapp"))
+    assert notif is not None
+    assert notif.purpose == "funnel_node"
+    assert notif.message == "Oi Maria Cliente, tudo bem?"  # {{cliente.*}} resolvido
+    # Sem template: o worker precisa cair em send_text, não em send_template.
+    assert notif.whatsapp_template_name is None
+    assert notif.whatsapp_template_language is None
+    assert notif.whatsapp_template_variables is None
+
+
+def test_run_send_message_evolution_sem_texto_is_422(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    """Continua havendo uma exigência — só deixou de ser a errada. Mensagem vazia é entrada
+    inválida em QUALQUER transporte."""
+    _evolution(db, tenant_id)
+    cl = client.post("/crm/clients", json={"name": "Contato"}, headers=headers).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"], "params": {"message": "   "}},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "template" not in resp.json()["detail"].lower()  # nunca pede template na Evolution
+
+
+def test_run_send_message_evolution_ignora_template_configurado(
+    client: TestClient, headers, db: Session, tenant_id: str
+):
+    """Nó configurado quando o tenant ainda era Meta, migrado depois para Evolution: o
+    `template_id` guardado no nó não pode ressuscitar o caminho de template — a Evolution
+    recusaria o envio lá no worker (`providers/evolution.send_template` levanta)."""
+    from sqlalchemy import select
+
+    from app.modules.notifications.models import Notification
+
+    tpl = _template(db, tenant_id)
+    _evolution(db, tenant_id)
+    cl = client.post(
+        "/crm/clients", json={"name": "Contato", "phone": "5511988887777"}, headers=headers
+    ).json()
+    resp = client.post(
+        "/funnels/run-node",
+        json={"action": "send_message", "client_id": cl["id"],
+              "params": {"template_id": tpl.id, "variables": ["Maria", "#123"],
+                         "message": "Oi, tudo bem?"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    notif = db.scalar(select(Notification).where(Notification.channel == "whatsapp"))
+    assert notif is not None
+    assert notif.whatsapp_template_name is None
+    assert notif.message == "Oi, tudo bem?"
+
+
 def test_run_send_message_template_not_approved_is_422(
     client: TestClient, headers, db: Session, tenant_id: str
 ):

--- a/apps/api/tests/test_notifications_throttle.py
+++ b/apps/api/tests/test_notifications_throttle.py
@@ -50,6 +50,61 @@ def test_evolution_tenant_respects_max_per_sweep(db, monkeypatch: pytest.MonkeyP
     assert processed <= 5  # teto por sweep, spec §7
 
 
+def test_vinculo_de_template_da_meta_nao_vaza_para_a_evolution(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Notificação enfileirada COM template, entregue por um tenant no transporte Evolution.
+
+    Acontece de verdade com quem usou a Meta e depois migrou pro QR code: os vínculos
+    propósito→template ficam salvos no perfil, e os 5 pontos do domínio que os resolvem no
+    enfileiramento não sabem por qual transporte a mensagem vai sair. Chamar `send_template`
+    aqui seria falha garantida (a Evolution recusa templates por design) e o retry repetiria
+    até expirar. Cai em `send_text` com a mensagem JÁ renderizada."""
+    _evolution_tenant(db)
+    service.enqueue(
+        db, tenant_id=TENANT_ID, channel="whatsapp", recipient="5511999998888",
+        message="Olá Maria, seu pedido #123 foi confirmado!",  # template já renderizado
+        whatsapp_template_name="confirmacao_pedido", whatsapp_template_language="pt_BR",
+        whatsapp_template_variables=["Maria", "#123"],
+    )
+    db.commit()
+
+    enviados: list[str] = []
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda *, to, text, profile=None, token=None, phone_id=None: (
+            enviados.append(text), "sent")[1],
+    )
+    monkeypatch.setattr(
+        whatsapp, "send_template",
+        lambda **kw: pytest.fail("send_template não pode ser chamado no transporte Evolution"),
+    )
+
+    assert service.process_pending(db, tenant_id=TENANT_ID) == 1
+    assert enviados == ["Olá Maria, seu pedido #123 foi confirmado!"]  # conteúdo preservado
+
+
+def test_vinculo_de_template_continua_valendo_na_meta(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contraprova: no transporte da Meta o template continua sendo usado (sem regressão)."""
+    service.enqueue(
+        db, tenant_id=TENANT_ID, channel="whatsapp", recipient="5511999998888",
+        message="Olá Maria, seu pedido #123 foi confirmado!",
+        whatsapp_template_name="confirmacao_pedido", whatsapp_template_language="pt_BR",
+        whatsapp_template_variables=["Maria", "#123"],
+    )
+    db.commit()
+
+    usados: list[str] = []
+    monkeypatch.setattr(
+        whatsapp, "send_template",
+        lambda **kw: (usados.append(kw["template_name"]), "sent")[1],
+    )
+    assert service.process_pending(db, tenant_id=TENANT_ID) == 1
+    assert usados == ["confirmacao_pedido"]
+
+
 def test_meta_tenant_is_not_throttled(db, monkeypatch: pytest.MonkeyPatch) -> None:
     # Sem instância Evolution — profile.whatsapp_provider permanece None/"meta". Sem freio.
     _enqueue_n(db, 8)

--- a/apps/api/tests/test_whatsapp_capabilities.py
+++ b/apps/api/tests/test_whatsapp_capabilities.py
@@ -6,7 +6,18 @@ import dataclasses
 
 import pytest
 
-from app.core.whatsapp.capabilities import EVOLUTION, META, Capabilities
+from app.core import whatsapp
+from app.core.whatsapp.capabilities import EVOLUTION, META, Capabilities, for_profile
+from app.core.whatsapp.providers import evolution as evolution_provider
+from app.core.whatsapp.providers import meta as meta_provider
+
+
+class _Profile:
+    """Dublê mínimo — `for_profile` só lê `whatsapp_provider` (mesmo padrão do dublê de
+    tests/test_whatsapp_dispatcher.py)."""
+
+    def __init__(self, provider: str | None) -> None:
+        self.whatsapp_provider = provider
 
 
 def test_meta_capabilities() -> None:
@@ -24,3 +35,31 @@ def test_evolution_capabilities() -> None:
 def test_capabilities_is_frozen() -> None:
     with pytest.raises(dataclasses.FrozenInstanceError):
         META.templates = False  # type: ignore[misc]
+
+
+def test_for_profile_evolution() -> None:
+    assert for_profile(_Profile("evolution")) is EVOLUTION
+
+
+@pytest.mark.parametrize("provider", ["meta", None, "", "transporte-que-nao-existe"])
+def test_for_profile_cai_em_meta(provider: str | None) -> None:
+    """Qualquer valor diferente de "evolution" (inclusive `None` = nunca conectou) é Meta —
+    MESMA regra do despachante, por construção (ver o teste de acordo abaixo)."""
+    assert for_profile(_Profile(provider)) is META
+
+
+def test_for_profile_sem_perfil_e_meta() -> None:
+    assert for_profile(None) is META
+
+
+@pytest.mark.parametrize("provider", ["evolution", "meta", None, "transporte-que-nao-existe"])
+def test_capabilities_e_despachante_nunca_divergem(provider: str | None) -> None:
+    """Gate estrutural: capability e provider REAL têm que concordar sempre.
+
+    Se divergissem, um consumidor consultaria `capabilities` (e concluiria "posso mandar texto
+    livre") enquanto o despachante entregaria pela Meta (que exige template fora da janela) — o
+    envio falharia longe daqui, no worker, sem ninguém para relacionar as duas decisões. Por isso
+    `_resolve` deriva de `for_profile`, e este teste prova que continua derivando."""
+    profile = _Profile(provider)
+    esperado = evolution_provider if for_profile(profile) is EVOLUTION else meta_provider
+    assert whatsapp._resolve(profile) is esperado

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -504,6 +504,40 @@ def test_is_within_session_window_false_when_never_messaged(db):
     assert inbox_service.is_within_session_window(db, chat_id=chat.id) is False
 
 
+def test_janela_de_24h_nao_se_aplica_ao_transporte_evolution(db):
+    """A janela de 24h é regra da Cloud API da Meta — a Evolution (Baileys) não a tem.
+
+    Aplicá-la ali é um beco sem saída, não um inconveniente: fora da janela a única saída
+    oferecida é template aprovado, e a Evolution não tem nenhum e nem consegue criar. A conversa
+    ficaria muda para sempre 24h depois da última mensagem do contato."""
+    profile = _configure_credentials(db)
+    profile.whatsapp_provider = "evolution"
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900007777", source="manual")
+    db.add(client)
+    db.flush()
+    chat = _chat_for(db, client)
+    db.commit()  # nenhuma mensagem recebida — na Meta isso seria "fora da janela"
+
+    assert inbox_service.is_within_session_window(db, chat_id=chat.id) is True
+
+
+def test_resposta_livre_passa_no_transporte_evolution(db, monkeypatch: pytest.MonkeyPatch):
+    profile = _configure_credentials(db)
+    profile.whatsapp_provider = "evolution"
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900008888", source="manual")
+    db.add(client)
+    db.flush()
+    chat = _chat_for(db, client)
+    db.commit()
+
+    monkeypatch.setattr(whatsapp, "send_text", lambda **kw: "sent")
+    msg = inbox_service.send_reply_text(
+        db, tenant_id=TENANT_ID, actor="user-1", chat_id=chat.id, text="Oi, tudo certo?",
+    )
+    assert msg.direction == DIRECTION_OUT
+    assert msg.status == "sent"
+
+
 def test_get_timeline_merges_conversation_and_automated(db):
     _configure_credentials(db)
     client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900003333", source="manual")

--- a/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -37,9 +37,17 @@ const catalog = [
     color: "#F59E0B",
     items: [
       { key: "novo_lead", label: "Novo Lead", description: "Entrada de um novo lead", shape: "node" },
+      // `whatsapp` é a chave que `contentKind` mapeia para o editor de mensagem.
+      { key: "whatsapp", label: "WhatsApp", description: "Envia mensagem", shape: "node",
+        action: "send_message" },
     ],
   },
 ];
+
+/** Perfil do tenant — só o transporte de WhatsApp importa aqui. */
+function profile(provider: "meta" | "evolution" | null) {
+  return { whatsapp_provider: provider };
+}
 
 // FunnelBuilderPage usa useParams/useNavigate → rota /funis/novo (isNew=true, sem GET /funnels/{id}).
 // O default export já inclui <ReactFlowProvider> (não precisa adicionar outro).
@@ -53,11 +61,17 @@ function renderNew() {
   );
 }
 
-beforeEach(() => {
+function mockApi(provider: "meta" | "evolution" | null = null, templates: unknown[] = []) {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/funnels/components") return Promise.resolve({ data: catalog } as never);
+    if (url === "/settings/profile") return Promise.resolve({ data: profile(provider) } as never);
+    if (url === "/whatsapp-templates") return Promise.resolve({ data: templates } as never);
     return Promise.resolve({ data: [] } as never);
   });
+}
+
+beforeEach(() => {
+  mockApi();
   vi.mocked(api.post).mockReset();
   vi.mocked(api.patch).mockReset();
 });
@@ -102,5 +116,50 @@ describe("FunnelBuilderPage — criar nó e salvar funil (Story 7.16, Task 3)", 
     expect(toast).toHaveClass("bg-danger");
     // O canvas permanece montado: o botão "Salvar" segue presente (a tela não quebrou).
     expect(screen.getByRole("button", { name: "Salvar" })).toBeInTheDocument();
+  });
+});
+
+describe("nó de WhatsApp — template (Meta) × texto livre (Evolution)", () => {
+  /** Adiciona o nó de WhatsApp, seleciona-o e abre o editor de conteúdo.
+   *
+   * O nó do canvas é selecionado com `fireEvent.click` (e não `userEvent`) de propósito: o
+   * `userEvent` emite `mousedown`, o React Flow entrega ao `d3-drag`, e o `d3-drag` estoura no
+   * jsdom (`nodrag.js` acessa `document` de uma view nula). Aqui interessa só o `onNodeClick`. */
+  async function abrirEditorDeMensagem(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(await screen.findByText("WhatsApp")); // item da paleta → cria o nó
+    // O nó recém-criado aparece no canvas com o mesmo rótulo — o último "WhatsApp" é o nó.
+    fireEvent.click(screen.getAllByText("WhatsApp").at(-1)!);
+    await user.click(await screen.findByRole("button", { name: /Escrever mensagem/ }));
+  }
+
+  it("Evolution (QR code): oferece texto livre, não pede template aprovado", async () => {
+    const user = userEvent.setup();
+    mockApi("evolution");
+    renderNew();
+
+    await abrirEditorDeMensagem(user);
+
+    // O seletor de template da Meta não existe neste transporte...
+    expect(screen.queryByText("Template aprovado (Meta)")).not.toBeInTheDocument();
+    // ...e a lista de templates nem chega a ser buscada.
+    expect(vi.mocked(api.get)).not.toHaveBeenCalledWith("/whatsapp-templates", expect.anything());
+
+    // O que aparece é a caixa de mensagem livre, e ela destrava o "Salvar no nó".
+    expect(screen.getByText("Mensagem")).toBeInTheDocument();
+    const salvar = screen.getByRole("button", { name: "Salvar no nó" });
+    expect(salvar).toBeDisabled(); // vazio ainda é entrada inválida
+    await user.type(screen.getByPlaceholderText("Escreva mensagem..."), "Oi, tudo bem?");
+    expect(salvar).toBeEnabled();
+  });
+
+  it("Meta: continua exigindo template aprovado (sem regressão)", async () => {
+    const user = userEvent.setup();
+    mockApi("meta");
+    renderNew();
+
+    await abrirEditorDeMensagem(user);
+
+    expect(await screen.findByText("Template aprovado (Meta)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Salvar no nó" })).toBeDisabled();
   });
 });

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -1,4 +1,9 @@
-import type { Client, FunnelComponentCategory, WhatsappTemplate } from "@e1p/shared-types";
+import type {
+  Client,
+  FunnelComponentCategory,
+  TenantProfile,
+  WhatsappTemplate,
+} from "@e1p/shared-types";
 import html2canvas from "html2canvas";
 import {
   ArrowLeft, Download, GitBranch, type LucideIcon, Maximize2, MessageCircle, MousePointerClick,
@@ -24,6 +29,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { api, apiErrorMessage } from "../../lib/api";
+import { capabilitiesFor } from "../../lib/whatsappCapabilities";
 
 type NodeConfig = {
   subject?: string; body?: string; model?: string;
@@ -64,6 +70,18 @@ const KIND_VERB: Record<string, string> = {
   email: "Criar e-mail", whatsapp: "Escrever mensagem", sms: "Escrever SMS",
   generic: "Configurar conteúdo",
 };
+
+/** O nó já tem conteúdo (ponto verde no canvas / "✓" no painel)?
+ *
+ * Para WhatsApp vale template aprovado (Meta) **ou** texto escrito (Evolution). Checar só o
+ * template marcaria como vazio todo nó de quem conectou por QR code — que é justamente quem
+ * nunca vai ter um. */
+function hasNodeContent(data: NodeData): boolean {
+  if (contentKind(data.key) === "whatsapp") {
+    return !!(data.config?.template_id || data.config?.body?.trim());
+  }
+  return !!(data.config?.body || data.config?.model);
+}
 
 /** Mockup de página que muda conforme o "Modelo de página" escolhido. */
 function PageMockup({ model, color }: { model?: string; color: string }) {
@@ -111,9 +129,7 @@ function PageMockup({ model, color }: { model?: string; color: string }) {
 }
 
 function FunnelNode({ data, selected }: NodeProps<NodeData>) {
-  const configured = contentKind(data.key) === "whatsapp"
-    ? !!data.config?.template_id
-    : !!(data.config?.body || data.config?.model);
+  const configured = hasNodeContent(data);
   const handleStyle = { background: "#fff", border: `2px solid ${data.color}`, width: 10, height: 10 };
 
   // PÁGINA → card quadrado com mockup colorido.
@@ -180,6 +196,10 @@ function Builder() {
   const [running, setRunning] = useState<string | null>(null);
   const [showRuns, setShowRuns] = useState(false);
   const [toast, setToast] = useState<{ msg: string; type: "ok" | "err" } | null>(null);
+  // Transporte de WhatsApp do tenant — decide se o nó de mensagem pede template aprovado (Meta)
+  // ou texto livre (Evolution/QR code). `null` até carregar, e `null` já significa Meta.
+  const [whatsappProvider, setWhatsappProvider] =
+    useState<TenantProfile["whatsapp_provider"]>(null);
 
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -194,6 +214,10 @@ function Builder() {
 
   useEffect(() => {
     api.get<FunnelComponentCategory[]>("/funnels/components").then(({ data }) => setCatalog(data));
+    api
+      .get<TenantProfile>("/settings/profile")
+      .then(({ data }) => setWhatsappProvider(data.whatsapp_provider))
+      .catch(() => setWhatsappProvider(null)); // falha ao ler o perfil não derruba o builder
   }, []);
 
   useEffect(() => {
@@ -448,9 +472,7 @@ function Builder() {
                 {selectedNode.data.shape === "page"
                   ? "Editar página"
                   : KIND_VERB[contentKind(selectedNode.data.key)]}
-                {contentKind(selectedNode.data.key) === "whatsapp"
-                  ? (selectedNode.data.config?.template_id ? " ✓" : "")
-                  : (selectedNode.data.config?.body || selectedNode.data.config?.model ? " ✓" : "")}
+                {hasNodeContent(selectedNode.data) ? " ✓" : ""}
               </button>
               {selectedNode.data.action && (
                 <button
@@ -476,6 +498,7 @@ function Builder() {
             return (
               <NodeContentEditor
                 node={node}
+                whatsappProvider={whatsappProvider}
                 onClose={() => setEditing(null)}
                 onSave={(config) => {
                   setNodes((nds) =>
@@ -495,6 +518,7 @@ function Builder() {
             return (
               <RunNodeModal
                 node={node}
+                whatsappProvider={whatsappProvider}
                 onClose={() => setRunning(null)}
                 onDone={(msg) => { setRunning(null); notify(msg); }}
                 onError={(msg) => notify(msg, "err")}
@@ -536,11 +560,13 @@ const ACTION_TITLE: Record<string, string> = {
 
 function RunNodeModal({
   node,
+  whatsappProvider,
   onClose,
   onDone,
   onError,
 }: {
   node: Node<NodeData>;
+  whatsappProvider: TenantProfile["whatsapp_provider"];
   onClose: () => void;
   onDone: (msg: string) => void;
   onError: (msg: string) => void;
@@ -583,8 +609,10 @@ function RunNodeModal({
       params.recipient = node.data.config?.recipient ?? "client";
     }
     if (action === "send_message") {
+      // Manda os dois: quem decide qual vale é o backend, pelas capabilities do transporte.
       params.template_id = node.data.config?.template_id;
       params.variables = node.data.config?.variables ?? [];
+      params.message = node.data.config?.body ?? "";
       params.recipient = node.data.config?.recipient ?? "client";
     }
     try {
@@ -600,7 +628,12 @@ function RunNodeModal({
   }
 
   const money = action === "create_quote" || action === "create_charge";
-  const hasTemplate = !!node.data.config?.template_id;
+  // O que o nó precisa ter configurado para poder rodar depende do transporte: template
+  // aprovado (Meta) ou texto escrito (Evolution/QR code).
+  const usaTemplate = capabilitiesFor(whatsappProvider).templates;
+  const msgPronta = usaTemplate
+    ? !!node.data.config?.template_id
+    : !!node.data.config?.body?.trim();
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/30 p-4" onClick={onClose}>
@@ -653,10 +686,14 @@ function RunNodeModal({
             </label>
           )}
           {action === "send_message" && (
-            <p className={`rounded-lg p-2 text-xs ${hasTemplate ? "bg-neutral-50 text-neutral-500" : "bg-amber-50 text-amber-700"}`}>
-              {hasTemplate
-                ? "Usa o template de WhatsApp configurado no nó (botão “Escrever mensagem”)."
-                : "Configure um template de WhatsApp aprovado no nó (botão “Escrever mensagem”) antes de executar."}
+            <p className={`rounded-lg p-2 text-xs ${msgPronta ? "bg-neutral-50 text-neutral-500" : "bg-amber-50 text-amber-700"}`}>
+              {msgPronta
+                ? usaTemplate
+                  ? "Usa o template de WhatsApp configurado no nó (botão “Escrever mensagem”)."
+                  : "Usa a mensagem escrita no nó (botão “Escrever mensagem”)."
+                : usaTemplate
+                  ? "Configure um template de WhatsApp aprovado no nó (botão “Escrever mensagem”) antes de executar."
+                  : "Escreva a mensagem no nó (botão “Escrever mensagem”) antes de executar."}
             </p>
           )}
         </div>
@@ -665,7 +702,7 @@ function RunNodeModal({
           <button onClick={onClose} className="flex-1 rounded-pill bg-neutral-100 py-2.5 font-semibold text-neutral-600 hover:bg-neutral-200">Cancelar</button>
           <button
             onClick={run}
-            disabled={busy || (action === "send_message" && !hasTemplate)}
+            disabled={busy || (action === "send_message" && !msgPronta)}
             className="flex flex-1 items-center justify-center gap-1.5 rounded-pill bg-accent-500 py-2.5 font-semibold text-white hover:bg-accent-600 disabled:opacity-60"
           >
             <Play size={14} /> {busy ? "Executando..." : "Executar agora"}
@@ -694,10 +731,12 @@ const EMAIL_KEYWORDS = [...TEMPLATE_KEYWORDS, "cliente.notas"] as const;
 
 function NodeContentEditor({
   node,
+  whatsappProvider,
   onClose,
   onSave,
 }: {
   node: Node<NodeData>;
+  whatsappProvider: TenantProfile["whatsapp_provider"];
   onClose: () => void;
   onSave: (config: NodeConfig) => void;
 }) {
@@ -716,13 +755,18 @@ function NodeContentEditor({
   const [templateId, setTemplateId] = useState(node.data.config?.template_id ?? "");
   const [variables, setVariables] = useState<string[]>(node.data.config?.variables ?? []);
   const [recipient, setRecipient] = useState<"client" | "team">(node.data.config?.recipient ?? "client");
+  // Só o transporte da Meta tem template aprovado. Quem conectou por QR (Evolution) escreve
+  // texto livre, como no e-mail — pedir template ali travava o nó sem saída.
+  const usaTemplate = capabilitiesFor(whatsappProvider).templates;
+  const isWhatsappTemplate = isWhatsapp && usaTemplate;
+  const isWhatsappLivre = isWhatsapp && !usaTemplate;
 
   useEffect(() => {
-    if (!isWhatsapp) return;
+    if (!isWhatsappTemplate) return;
     api
       .get<WhatsappTemplate[]>("/whatsapp-templates", { params: { status: "APPROVED" } })
       .then(({ data }) => setTemplates(data));
-  }, [isWhatsapp]);
+  }, [isWhatsappTemplate]);
 
   const selectedTemplate = templates.find((t) => t.id === templateId);
 
@@ -798,7 +842,7 @@ function NodeContentEditor({
           </label>
         )}
 
-        {isWhatsapp ? (
+        {isWhatsappTemplate ? (
           <>
             <label className="mb-3 block">
               <span className="mb-1 block text-xs font-medium text-neutral-600">Template aprovado (Meta)</span>
@@ -852,6 +896,12 @@ function NodeContentEditor({
           </>
         ) : (
           <>
+            {isWhatsappLivre && (
+              <p className="mb-3 rounded-lg bg-neutral-50 p-2 text-[11px] text-neutral-500">
+                Seu WhatsApp está conectado por QR code, que envia mensagem livre — não precisa de
+                template aprovado pela Meta.
+              </p>
+            )}
             <div className="mb-3 rounded-lg bg-primary-50 p-2">
               <span className="mb-1 block text-xs font-medium text-primary-700">Gerar com IA</span>
               <div className="flex gap-2">
@@ -871,7 +921,7 @@ function NodeContentEditor({
             <label className="mb-4 block">
               <span className="mb-1 block text-xs font-medium text-neutral-600">{bodyLabel}</span>
               <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={isEmail ? 8 : 5} placeholder={`Escreva ${bodyLabel.toLowerCase()}...`} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
-              {isEmail && (
+              {(isEmail || isWhatsappLivre) && (
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
                   <span className="text-[11px] text-neutral-400">Inserir dado do lead:</span>
                   {EMAIL_KEYWORDS.map((kw) => (
@@ -896,15 +946,15 @@ function NodeContentEditor({
           <button
             onClick={() =>
               onSave(
-                isWhatsapp
+                isWhatsappTemplate
                   ? { template_id: templateId, variables, recipient }
                   : {
                       subject: isEmail ? subject : "", body, model: isPage ? model : undefined,
-                      recipient: isEmail ? recipient : undefined,
+                      recipient: isEmail || isWhatsappLivre ? recipient : undefined,
                     },
               )
             }
-            disabled={isWhatsapp && !templateId}
+            disabled={isWhatsappTemplate ? !templateId : isWhatsappLivre && !body.trim()}
             className="flex-1 rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500 disabled:opacity-50"
           >
             Salvar no nó

--- a/apps/web/src/lib/whatsappCapabilities.ts
+++ b/apps/web/src/lib/whatsappCapabilities.ts
@@ -1,0 +1,29 @@
+/**
+ * O que cada transporte de WhatsApp sabe fazer — espelho de
+ * `apps/api/app/core/whatsapp/capabilities.py`.
+ *
+ * Template aprovado e janela de 24h são regras da Cloud API da Meta; a Evolution (Baileys) não
+ * conhece nenhuma das duas. A tela precisa saber disso para não oferecer um seletor de template
+ * a quem conectou por QR code — não existe template nenhum para escolher, e a lista viria vazia
+ * com o botão de salvar travado (foi exatamente esse o bug no nó de WhatsApp do funil).
+ *
+ * Mesma regra de resolução do backend: qualquer valor diferente de "evolution" — inclusive
+ * `null` (nunca conectou) — é Meta.
+ */
+import type { TenantProfile } from "@e1p/shared-types";
+
+export type WhatsappCapabilities = {
+  /** Exige template aprovado pela Meta fora da janela de 24h. */
+  templates: boolean;
+  /** Tem janela de 24h (só responde livre depois que o contato escreve). */
+  sessionWindow: boolean;
+};
+
+export const META: WhatsappCapabilities = { templates: true, sessionWindow: true };
+export const EVOLUTION: WhatsappCapabilities = { templates: false, sessionWindow: false };
+
+export function capabilitiesFor(
+  provider: TenantProfile["whatsapp_provider"] | undefined,
+): WhatsappCapabilities {
+  return provider === "evolution" ? EVOLUTION : META;
+}


### PR DESCRIPTION
## O problema

O nó de WhatsApp do funil respondia **"Selecione um template de WhatsApp aprovado"** para um tenant conectado por QR code — que não tem template nenhum e não consegue criar (a Evolution recusa templates por design). O funil inteiro ficava mudo.

## Causa raiz

Template aprovado e janela de 24h são regras da **Cloud API da Meta**. A Evolution (Baileys) não conhece nenhuma das duas.

`app/core/whatsapp/capabilities.py` já codificava exatamente essa diferença desde a Onda 0 (`EVOLUTION.templates=False`, `session_window=False`) — mas tinha **zero call sites em produção**, só o próprio teste unitário, enquanto sua docstring **afirmava** que 3 consumidores o consultavam. Nenhum dos 3 tinha sido escrito.

> **A lição de método:** um módulo de capacidades sem consumidor não protege ninguém — ele documenta uma intenção, e a docstring que descreve consumidores inexistentes *impede* que alguém note a lacuna. É a mesma classe de erro da **INSTANCIAÇÃO OBRIGATÓRIA** do Epic 8: conjunto definido por descrição, sem membro escrito, sem consumidor mecânico que proteste. **Capacidade nova nasce com o consumidor no mesmo passo**, e a lista de consumidores na docstring tem que ser verificável por grep.

## Três instâncias do mesmo defeito

| # | Onde | Sintoma sob Evolution |
|---|---|---|
| 1 | `funnels/service.py::run_node` | 422 exigindo template — **o bug reportado** |
| 2 | `whatsapp_inbox::is_within_session_window` | Janela de 24h aplicada: **beco sem saída** — fora dela a única saída oferecida é template, que ali não existe. A conversa emudeceria 24h após a última mensagem do contato. |
| 3 | `notifications::process_pending` | **Achado durante a implementação.** Os 5 pontos do domínio que resolvem vínculo propósito→template no *enfileiramento* (quotes, contracts, receivables, platform, `on_client_moved`) não sabem por qual transporte a mensagem sai. Um tenant que usou a Meta e migrou pro QR mantém os vínculos → cada notificação chamaria `send_template` → falha garantida + retry com backoff até expirar. |

## O que mudou

- **Funil** — sob Evolution usa o texto livre do nó, com `{{cliente.*}}` resolvido. Um `template_id` guardado de quando o tenant era Meta é **ignorado de propósito** (reaproveitá-lo faria o worker chamar `send_template`, que a Evolution recusa).
- **`engine._params`** passou a carregar `config.body` até a ação. Sem isso o botão "Executar agora" funcionaria e a **jornada automática continuaria muda** — que é o caminho que o usuário realmente usa.
- **Inbox** — a janela de 24h não se aplica ao transporte, pelo mesmo mecanismo que já isentava grupo.
- **Entrega** — guarda no ponto onde o transporte é conhecido; cai em `send_text` **sem perder conteúdo**, porque `notification.message` já é o template renderizado.
- **`whatsapp._resolve` agora DERIVA de `capabilities.for_profile`** em vez de repetir a comparação `whatsapp_provider == "evolution"`. Se divergissem, um consumidor concluiria "posso mandar texto livre" enquanto o despachante entregaria pela Meta — e a falha apareceria no worker, longe de quem poderia relacionar as duas decisões. Gate: `test_capabilities_e_despachante_nunca_divergem`.
- **Frontend** — espelho em `apps/web/src/lib/whatsappCapabilities.ts`; o builder lê `GET /settings/profile` uma vez e passa o transporte aos dois modais. **Conversas não precisou mudar**: o backend passou a responder `within_session_window: true` e a caixa de texto livre que já existia aparece sozinha.

Sem migration. Contrato HTTP inalterado (`params.message` é aditivo em `/funnels/run-node`).

## Testes

Escritos **antes** da correção, e falharam pelo motivo certo. Cada instância tem par + contraprova de que o caminho da Meta não regrediu.

- `1682 passed, 1 skipped` (backend) · ruff limpo
- `493 passed` em 54 arquivos (frontend) · eslint e `tsc --noEmit` limpos

## Ao fazer deploy

**`api` e `web` mudaram** — rebuildar só um deixa o outro com o comportamento antigo em silêncio (armadilha já registrada no CLAUDE.md).

Vale validar em produção o caminho completo: inscrever um contato num funil com nó de WhatsApp e ver a mensagem chegar. Foi exatamente isso que revelou os 11 bugs anteriores da Evolution — cada um só apareceu com infraestrutura viva.

## Dívida

O espelho TS das capabilities é mantido à mão (mesma dívida geral de `shared-types`): se surgir um 3º transporte, os dois arquivos precisam mudar juntos e nada no CI reprova o esquecimento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
