### PR TITLE
fix: telefone sem código do país fazia a mensagem nunca chegar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,52 @@ e uma tentativa real de conexão avançou mais um passo):
       surgir um 3º transporte, os dois arquivos precisam mudar juntos, e nada no CI reprova o
       esquecimento.
 
+13. **"Mensagem registrada" e nada chegava: o telefone ia sem código do país.** Achado logo após
+    o deploy do item 12 — o funil parou de dar 422, completou a jornada, gravou
+    *"Mensagem registrada para Flavio Kato (whatsapp)"* e **nenhuma mensagem chegou**. A
+    `Notification` ficou `failed` com `last_error` VAZIO (o provider devolve `"failed"` sem
+    levantar, então nada preenchia o campo) e o worker logava só `400 Bad Request`.
+    - **Causa:** o contato estava gravado como `43984074017` — o que o dono digitou, sem o `55`.
+      A sondagem de `/chat/whatsappNumbers` em produção fechou o caso: `43984074017` →
+      `exists:false`; `5543984074017` → `exists:true`. **A forma correta JÁ existia no banco**
+      (`clients.phone_key`, calculado por `normalize_br` na PR #76) — o caminho de envio é que
+      usava `clients.phone`, o cru.
+    - **Por que a resposta no inbox sempre funcionou e isto não:** contato criado pelo webhook
+      nasce com o telefone que veio do WhatsApp, já completo. Contato digitado/importado, não.
+    - **Fix na FRONTEIRA (`whatsapp.__init__._addressable`), não em cada call site:** são **seis**
+      caminhos que resolvem destinatário de campo de telefone cru (funil, alerta pra equipe,
+      convite de funcionário, orçamento, cobrança, contrato) e só `Client` tem gêmeo
+      normalizado — consertar um por um deixaria quatro quebrados. O despachante é por onde todo
+      envio passa (mesma razão de `capabilities` viver lá). O que está GUARDADO não muda:
+      `clients.phone` segue sendo a evidência do que a pessoa digitou.
+    - **Nem todo `to` é telefone** e reescrever os outros trocaria falha visível por entrega no
+      lugar errado: grupo é JID `@g.us`, não identificado é `@lid`, `_owner_recipient` cai em
+      e-mail e o funil cai no NOME do contato. Guarda explícita para `@`; o resto sai intacto
+      porque `normalize_br` devolve `None` fora do formato BR.
+    - ⚠️ **Suposição BR-only, decidida pelo fundador** (coerente com CPF/CNPJ, boleto, Pix): um
+      celular estrangeiro de 10-11 dígitos É reescrito como brasileiro e a mensagem iria para
+      outra pessoa — pior que falhar. Por isso **toda reescrita é logada em INFO**: o caso
+      estrangeiro precisa aparecer. Se um dia houver contato internacional, este é o ponto.
+    - **Dívida (não corrigida):** `crm.update_client` faz `setattr` genérico e **não recalcula
+      `phone_key`** — editar o telefone de um contato deixa a chave velha. Não afeta mais o
+      envio (a fronteira normaliza), mas afeta a deduplicação de lead.
+    - **Lacuna de diagnóstico fechada junto:** `providers/evolution.py` chamava
+      `raise_for_status()` e logava só o código — o CORPO da resposta da Evolution, que já
+      explicava o erro, era descartado. Investigar exigiu sondar a API à mão em produção. Agora
+      `send_text`/`send_media` logam a resposta (truncada em 400 chars). **Regra: ao integrar
+      terceiro, o corpo do erro dele faz parte do log — o status sozinho não diagnostica nada.**
+
+**⚠️ `migrations/env.py` silenciava o logging de TODA a aplicação** (achado no mesmo ciclo, por um
+teste que passava sozinho e falhava na suíte inteira). `fileConfig()` tem
+`disable_existing_loggers=True` por PADRÃO: ele marca `disabled=True` em todo logger já
+existente e não nomeado no `alembic.ini` — `e1p.whatsapp`, `e1p.notifications`, `e1p.worker`.
+Depois disso `logger.info`/`logger.exception` viram no-op silencioso pelo resto do processo.
+Produção escapa **por acidente de topologia** (o compose roda `sh -c "alembic upgrade head &&
+uvicorn ..."`, processos separados); dentro do pytest, um único teste que aplica migrations
+silencia os testes seguintes. Corrigido com `disable_existing_loggers=False`. É a mesma família
+do bug já registrado abaixo ("logs que somem" por falta de `basicConfig`) — **quando um log
+sumir, verifique também quem chamou `fileConfig`/`dictConfig` antes**, não só handler ausente.
+
 **Duas armadilhas operacionais da VPS** (não são bug de código, são do processo de deploy):
 - Depois de mudar a config do webhook via `/webhook/set` numa instância **já conectada**, a mudança pode não valer pro processo em memória (cache do canal Baileys carregado na conexão) — precisou **reiniciar o container `evolution`** (não só recriar) pra pegar a config nova. Sessões reconectam sozinhas (credenciais persistidas no Postgres/Redis), sem precisar de novo QR.
 - `docker compose up -d --build <serviço>` só reconstrói o serviço **nomeado**. Rebuildar só `api` depois de um PR que também mudou frontend deixa o `web` com o build antigo, **em silêncio** (sem erro, só o comportamento antigo persistindo). Depois de qualquer merge, checar QUAIS serviços mudaram no diff antes de escolher o que rebuildar — ou rebuildar todos (`up -d --build` sem nome, como o `reference_e1p_prod_deploy` já recomendava).

--- a/apps/api/app/core/whatsapp/__init__.py
+++ b/apps/api/app/core/whatsapp/__init__.py
@@ -22,14 +22,18 @@ SQLAlchemy já detached — ver nota nesse arquivo).
 """
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
+from app.core.phone import normalize_br
 from app.core.whatsapp import capabilities
 from app.core.whatsapp.providers import evolution, meta
 from app.core.whatsapp.providers.meta import WhatsappApiError
 
 if TYPE_CHECKING:
     from app.modules.settings.models import TenantProfile
+
+logger = logging.getLogger("e1p.whatsapp")
 
 __all__ = [
     "WhatsappApiError",
@@ -55,6 +59,43 @@ def _resolve(profile: TenantProfile | None):
     (por qual API o texto sai) não conseguem divergir. Gate em
     `tests/test_whatsapp_capabilities.py::test_capabilities_e_despachante_nunca_divergem`."""
     return evolution if capabilities.for_profile(profile) is capabilities.EVOLUTION else meta
+
+
+def _addressable(to: str) -> str:
+    """Transforma o destinatário GUARDADO num endereço que o WhatsApp entende.
+
+    Bug real de produção (2026-08-05): o funil registrava a mensagem e ela nunca chegava. A
+    Evolution devolvia `400` porque o contato estava gravado como `43984074017` — o que o dono
+    digitou, sem código do país — e esse número simplesmente NÃO existe no WhatsApp
+    (`/chat/whatsappNumbers` confirmou: `exists:false`; com `55` na frente, `exists:true`).
+
+    Por que aqui e não em cada call site: seis caminhos resolvem destinatário de campos de
+    telefone crus (funil, alerta pra equipe, convite de funcionário, orçamento, cobrança,
+    contrato) e só `Client` tem o gêmeo normalizado (`phone_key`, PR #76). Consertar um por um
+    deixaria quatro quebrados. O despachante é por onde TODO envio passa — mesma razão de
+    `capabilities` viver aqui em vez de `if` espalhado.
+
+    Isto NÃO reescreve o que está guardado: `clients.phone` continua sendo a evidência do que a
+    pessoa digitou, no mesmo par `raw_description`/`user_description` de `bank_transactions`.
+
+    **Nem todo `to` é telefone** e reescrever os outros trocaria uma falha visível por uma
+    entrega no lugar errado: grupo é JID (`...@g.us`), contato não identificado é `@lid`, o
+    destinatário do owner cai em e-mail (placeholder histórico de `_owner_recipient`) e o funil
+    cai no NOME do contato quando não há telefone. Tudo que tem `@` sai intacto por guarda
+    explícita; o resto sai intacto porque `normalize_br` devolve `None` quando não é BR.
+
+    ⚠️ **Suposição BR-only** (decisão do fundador, coerente com CPF/CNPJ, boleto e Pix): um
+    celular estrangeiro de 10-11 dígitos é reescrito como se fosse brasileiro, e aí a mensagem
+    vai para outra pessoa — pior que falhar. É por isso que toda reescrita é logada: o caso
+    estrangeiro precisa APARECER, não sumir.
+    """
+    if "@" in to:
+        return to
+    normalized = normalize_br(to)
+    if normalized is None or normalized == to:
+        return to
+    logger.info("[whatsapp] destinatário normalizado: %s -> %s", to, normalized)
+    return normalized
 
 
 def _evolution_instance(profile: TenantProfile | None) -> str:
@@ -84,6 +125,7 @@ def send_text(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    to = _addressable(to)
     if provider is evolution:
         # Evolution não usa token/phone_id por tenant (credencial GLOBAL) — identifica a
         # instância pelo tenant_id, não por essas duas credenciais da Meta.
@@ -105,6 +147,7 @@ def send_template(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    to = _addressable(to)
     if profile is not None:
         token = profile.whatsapp_token or ""
         phone_id = profile.whatsapp_phone_id or ""
@@ -129,6 +172,7 @@ def send_media(
     phone_id: str | None = None,
 ) -> str:
     provider = _resolve(profile)
+    to = _addressable(to)
     if provider is evolution:
         return provider.send_media(
             to=to, instance=_evolution_instance(profile), kind=kind, media_id=media_id,

--- a/apps/api/app/core/whatsapp/providers/evolution.py
+++ b/apps/api/app/core/whatsapp/providers/evolution.py
@@ -20,6 +20,24 @@ from app.core.whatsapp.inbound import InboundMessage
 logger = logging.getLogger("e1p.whatsapp.evolution")
 
 
+def _response_body(exc: Exception) -> str:
+    """O CORPO da resposta que a Evolution devolveu junto com o erro.
+
+    `raise_for_status()` só carrega o código no texto da exceção. Um `400 Bad Request` sozinho
+    não diz nada — foi exatamente isso que aconteceu na investigação de 2026-08-05: o traceback
+    dizia "400" e o motivo real (número sem código do país, inexistente no WhatsApp) só apareceu
+    sondando `/chat/whatsappNumbers` à mão, em produção. O corpo da própria resposta já dizia.
+
+    Truncado: mensagem de erro de log não é lugar para payload inteiro."""
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return "(sem resposta HTTP)"
+    try:
+        return resp.text[:400]
+    except Exception:  # noqa: BLE001 — diagnóstico nunca pode virar a causa de outra falha
+        return "(corpo ilegível)"
+
+
 class EvolutionUnsupportedError(Exception):
     """Levantado por operações que a Evolution API não suporta (ver `capabilities.EVOLUTION`:
     templates=False). Um consumidor real só chega aqui se ignorou `capabilities.py` — é bug de
@@ -41,8 +59,11 @@ def send_text(*, to: str, text: str, instance: str) -> str:
         )
         resp.raise_for_status()
         return "sent"
-    except Exception:
-        logger.exception("[whatsapp.evolution:failed] instancia=%s para=%s", instance, to)
+    except Exception as exc:
+        logger.exception(
+            "[whatsapp.evolution:failed] instancia=%s para=%s resposta=%s",
+            instance, to, _response_body(exc),
+        )
         return "failed"
 
 
@@ -79,8 +100,11 @@ def send_media(
         )
         resp.raise_for_status()
         return "sent"
-    except Exception:
-        logger.exception("[whatsapp.evolution:failed] mídia instancia=%s para=%s", instance, to)
+    except Exception as exc:
+        logger.exception(
+            "[whatsapp.evolution:failed] mídia instancia=%s para=%s resposta=%s",
+            instance, to, _response_body(exc),
+        )
         return "failed"
 
 

--- a/apps/api/migrations/env.py
+++ b/apps/api/migrations/env.py
@@ -10,7 +10,18 @@ config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # `disable_existing_loggers=False` é obrigatório: o PADRÃO do `fileConfig` é `True`, e aí
+    # ele marca `disabled=True` em TODO logger que já existe e não está nomeado no alembic.ini
+    # — `e1p.whatsapp`, `e1p.notifications`, `e1p.worker`... Depois disso, `logger.info` e
+    # `logger.exception` viram no-op silencioso para o resto do processo.
+    #
+    # Produção escapa por acidente de topologia (o compose roda `sh -c "alembic upgrade head &&
+    # uvicorn ..."`, processos separados), mas dentro do pytest um único teste que aplica
+    # migrations silencia o logging da aplicação para todos os testes seguintes — foi assim que
+    # `test_reescrita_e_logada` passava sozinho e falhava na suíte inteira. Qualquer código
+    # futuro que migre no MESMO processo em que a app loga herdaria o silêncio em produção, que
+    # é a mesma classe do bug já registrado no CLAUDE.md (logs que "somem").
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/apps/api/tests/test_whatsapp_recipient_normalization.py
+++ b/apps/api/tests/test_whatsapp_recipient_normalization.py
@@ -1,0 +1,160 @@
+"""O destinatário é normalizado na FRONTEIRA (despachante), não em cada call site.
+
+Bug real de produção (2026-08-05): o nó de WhatsApp do funil registrava a mensagem e ela nunca
+chegava. A Evolution devolvia `400`, e a sondagem do endpoint `/chat/whatsappNumbers` provou o
+motivo — o contato estava gravado como `43984074017` (o que o dono digitou, sem código do país)
+e esse número **não existe** no WhatsApp; `5543984074017` existe.
+
+A forma normalizada já era calculada em `clients.phone_key` (PR #76), mas os 6 caminhos que
+enviam WhatsApp (funil, alerta pra equipe, convite de funcionário, orçamento, cobrança,
+contrato) resolvem o destinatário de campos de telefone CRUS, e só `Client` tem gêmeo
+normalizado. Corrigir call site por call site deixaria 4 deles quebrados — por isso a
+normalização vive no despachante, que é por onde TODO envio passa.
+
+Decisão de produto do fundador: o produto é BR-only (CPF/CNPJ, boleto, Pix), então assume-se
+número brasileiro. Um celular estrangeiro de 10-11 dígitos seria reescrito como BR — daí toda
+reescrita ser logada em nível INFO, para que o caso apareça em vez de sumir.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from app.core import whatsapp
+from app.core.whatsapp.providers import evolution, meta
+from app.modules.settings.models import TenantProfile
+
+TENANT_ID = "99999999-9999-9999-9999-999999999999"
+
+
+@pytest.fixture()
+def enviados(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Captura o `to` que chegou NO PROVIDER — o que de fato vai pra rede."""
+    destinos: list[str] = []
+
+    def _fake(**kwargs: object) -> str:
+        destinos.append(str(kwargs["to"]))
+        return "sent"
+
+    monkeypatch.setattr(evolution, "send_text", _fake)
+    monkeypatch.setattr(meta, "send_text", _fake)
+    return destinos
+
+
+def _evolution() -> TenantProfile:
+    return TenantProfile(tenant_id=TENANT_ID, whatsapp_provider="evolution")
+
+
+def test_numero_sem_codigo_do_pais_ganha_o_55(enviados: list[str]) -> None:
+    """O bug reportado, na forma mínima."""
+    whatsapp.send_text(to="43984074017", text="oi", profile=_evolution())
+    assert enviados == ["5543984074017"]
+
+
+def test_numero_como_a_pessoa_digitou(enviados: list[str]) -> None:
+    """`clients.phone` guarda o que foi digitado, com máscara e tudo — é evidência, não
+    endereço. Quem transforma em endereço é o despachante."""
+    whatsapp.send_text(to="(43) 98407-4017", text="oi", profile=_evolution())
+    assert enviados == ["5543984074017"]
+
+
+def test_numero_ja_normalizado_passa_igual(enviados: list[str]) -> None:
+    whatsapp.send_text(to="5543984074017", text="oi", profile=_evolution())
+    assert enviados == ["5543984074017"]
+
+
+def test_vale_tambem_para_a_meta(enviados: list[str]) -> None:
+    """A Cloud API também exige o número internacional — a normalização é do transporte
+    WhatsApp, não de um provider específico."""
+    whatsapp.send_text(to="43984074017", text="oi", profile=None)
+    assert enviados == ["5543984074017"]
+
+
+# ── O que NÃO pode ser tocado ────────────────────────────────────────────────
+# Nem todo `to` é telefone: grupo é JID, contato não identificado é `@lid`, e o destinatário do
+# owner cai em e-mail (placeholder histórico) ou no NOME do contato quando não há telefone.
+# Reescrever qualquer um desses seria trocar um envio que falha visível por um que vai pro
+# lugar errado.
+
+
+@pytest.mark.parametrize(
+    "destino",
+    [
+        "120363123456789012@g.us",   # grupo
+        "123456789012345@lid",       # contato não identificado
+        "dono@example.com",          # fallback histórico de _owner_recipient
+        "Flavio Kato",               # fallback do funil quando o contato não tem telefone
+        "legacy:unidentified",       # JID sintético do backfill da 0066
+        "",                          # nunca vira "55" + lixo
+    ],
+)
+def test_destino_que_nao_e_telefone_passa_intacto(
+    enviados: list[str], destino: str
+) -> None:
+    whatsapp.send_text(to=destino, text="oi", profile=_evolution())
+    assert enviados == [destino]
+
+
+@pytest.fixture()
+def logs() -> Iterator[list[str]]:
+    """Handler PRÓPRIO, preso ao logger `e1p.whatsapp`.
+
+    Não usa `caplog`: ele captura por um handler na raiz, e o nível efetivo da raiz depende do
+    que os ~1700 outros testes da suíte deixaram para trás (`app/main.py` e `app/worker.py`
+    chamam `logging.basicConfig` na importação). Este teste passava sozinho e falhava na suíte
+    inteira — a asserção estava medindo o estado global de logging, não o comportamento do
+    despachante."""
+    logger = logging.getLogger("e1p.whatsapp")
+    capturado: list[str] = []
+
+    class _Coletor(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            capturado.append(record.getMessage())
+
+    handler = _Coletor(level=logging.INFO)
+    nivel_anterior, propaga_anterior = logger.level, logger.propagate
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False  # não suja a saída dos outros testes
+    try:
+        yield capturado
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(nivel_anterior)
+        logger.propagate = propaga_anterior
+
+
+def test_reescrita_e_logada(enviados: list[str], logs: list[str]) -> None:
+    """A reescrita precisa ser observável: é ela que carrega a suposição BR-only, e o caso
+    estrangeiro só aparece se a gente registrar quando mexemos no número."""
+    whatsapp.send_text(to="43984074017", text="oi", profile=_evolution())
+    assert any("43984074017" in m and "5543984074017" in m for m in logs)
+
+
+def test_numero_intacto_nao_polui_o_log(enviados: list[str], logs: list[str]) -> None:
+    whatsapp.send_text(to="5543984074017", text="oi", profile=_evolution())
+    assert logs == []
+
+
+def test_send_media_normaliza_igual(monkeypatch: pytest.MonkeyPatch) -> None:
+    destinos: list[str] = []
+    monkeypatch.setattr(
+        evolution, "send_media", lambda **kw: (destinos.append(str(kw["to"])), "sent")[1]
+    )
+    whatsapp.send_media(
+        to="43984074017", kind="image", media_id="x", profile=_evolution()
+    )
+    assert destinos == ["5543984074017"]
+
+
+def test_send_template_normaliza_igual(monkeypatch: pytest.MonkeyPatch) -> None:
+    destinos: list[str] = []
+    monkeypatch.setattr(
+        meta, "send_template", lambda **kw: (destinos.append(str(kw["to"])), "sent")[1]
+    )
+    whatsapp.send_template(
+        to="43984074017", template_name="t", language="pt_BR", variables=[], profile=None
+    )
+    assert destinos == ["5543984074017"]


### PR DESCRIPTION
## O sintoma

Depois do deploy da #77 o funil parou de dar 422 e completou a jornada — gravou **"Mensagem registrada para Flavio Kato (whatsapp)"** e **nenhuma mensagem chegou**.

O rastro era quase mudo: `Notification` em `failed` com `last_error` **vazio** (o provider devolve `"failed"` sem levantar exceção, então nada preenchia o campo) e o worker logando só `400 Bad Request`.

## A causa

O contato estava gravado como `43984074017` — o que o dono digitou, **sem o `55`**. Sondando a própria Evolution em produção:

| Número | `exists` |
|---|---|
| `43984074017` (o que enviávamos, de `clients.phone`) | ❌ `false` |
| `5543984074017` (de `clients.phone_key`) | ✅ `true` |

**A forma correta já estava no banco.** `phone_key` é calculado por `normalize_br` desde a PR #76; o caminho de envio é que usava `phone`, o cru.

Isso também explica por que **responder no inbox sempre funcionou e isto não**: contato criado pelo webhook nasce com o número que veio do WhatsApp, já completo. Contato digitado ou importado, não.

## O fix, e por que na fronteira

São **seis** caminhos que resolvem destinatário a partir de campo de telefone cru — funil, alerta para a equipe, convite de funcionário, orçamento, cobrança, contrato — e só `Client` tem gêmeo normalizado. Consertar call site por call site deixaria quatro quebrados.

A normalização vive em `whatsapp.__init__._addressable`, por onde **todo** envio passa (mesma razão de `capabilities` viver ali). O que está guardado não muda: `clients.phone` segue sendo a evidência do que a pessoa digitou, no par `raw_description`/`user_description` de `bank_transactions`.

**Nem todo `to` é telefone**, e reescrever os outros trocaria uma falha visível por uma entrega no lugar errado:

```
"43984074017"          -> 5543984074017   ✅ o bug
"(43) 98407-4017"      -> 5543984074017   ✅ máscara
"5543984074017"        -> inalterado      ✅
"120363...@g.us"       -> inalterado      ✅ grupo
"123456789012345@lid"  -> inalterado      ✅ não identificado
"dono@example.com"     -> inalterado      ✅ fallback de _owner_recipient
"Flavio Kato"          -> inalterado      ✅ fallback do funil sem telefone
```

Guarda explícita para `@`; o resto sai intacto porque `normalize_br` devolve `None` fora do formato BR.

## ⚠️ Suposição BR-only — decisão consciente

Um celular **estrangeiro** de 10-11 dígitos **é** reescrito como brasileiro, e aí a mensagem vai para outra pessoa — pior que falhar. Decisão do fundador, coerente com CPF/CNPJ, boleto e Pix em todo o resto do produto.

Por isso **toda reescrita é logada em INFO**: o caso estrangeiro precisa aparecer em vez de sumir. Se um dia houver contato internacional, este é o ponto único a revisitar.

## Dois achados corrigidos junto

**A resposta de erro da Evolution era descartada.** `raise_for_status()` carrega só o status; o corpo — que já explicava o problema — nunca era logado. Diagnosticar exigiu sondar a API à mão em produção. `send_text`/`send_media` agora logam o corpo (truncado em 400 chars).

> Regra que fica: ao integrar terceiro, **o corpo do erro dele faz parte do log**. O status sozinho não diagnostica nada.

**`migrations/env.py` silenciava o logging de toda a aplicação.** `fileConfig()` tem `disable_existing_loggers=True` por padrão — marca `disabled=True` em todo logger já existente e não nomeado no `alembic.ini` (`e1p.whatsapp`, `e1p.notifications`, `e1p.worker`), e a partir daí `logger.info` é no-op pelo resto do processo.

Produção escapa **por acidente de topologia** (o compose roda `sh -c "alembic upgrade head && uvicorn ..."`, processos separados). Dentro do pytest, um único teste que aplica migrations silencia os seguintes — foi exatamente assim que o teste do log passava sozinho e falhava na suíte inteira. **Não foi contornado no teste: era defeito real.**

## Testes

`1709 passed, 1 skipped` · ruff limpo. Frontend não foi tocado.

Os casos que **não** podem ser reescritos (grupo, `@lid`, e-mail, nome, string vazia) estão parametrizados — são eles que impedem que uma futura "melhoria" na normalização vire entrega no destinatário errado.

## Dívida registrada, não corrigida

`crm.update_client` faz `setattr` genérico e **não recalcula `phone_key`** ao editar o telefone de um contato. Não afeta mais o envio (a fronteira normaliza), mas deixa a chave velha para deduplicação de lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
