### PR TITLE
fix: editar o telefone do contato recalcula phone_key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,9 +382,18 @@ e uma tentativa real de conexão avançou mais um passo):
       celular estrangeiro de 10-11 dígitos É reescrito como brasileiro e a mensagem iria para
       outra pessoa — pior que falhar. Por isso **toda reescrita é logada em INFO**: o caso
       estrangeiro precisa aparecer. Se um dia houver contato internacional, este é o ponto.
-    - **Dívida (não corrigida):** `crm.update_client` faz `setattr` genérico e **não recalcula
-      `phone_key`** — editar o telefone de um contato deixa a chave velha. Não afeta mais o
-      envio (a fronteira normaliza), mas afeta a deduplicação de lead.
+    - **[CORRIGIDO]** `crm.update_client` fazia `setattr` genérico e **não recalculava
+      `phone_key`** — editar o telefone de um contato deixava a chave velha. Não afetava o envio
+      (a fronteira normaliza), mas quebrava a deduplicação: o efeito não aparece na tela de
+      edição e sim no PRÓXIMO lead, como card duplicado. `phone_key` é derivado e não está no
+      `ClientUpdate` (nem deve: derivado não é campo de entrada), então o laço genérico nunca o
+      alcançava. Apagar o telefone agora apaga a chave junto — chave órfã casaria um lead futuro
+      com um contato que já não tem aquele número. **Verificado em produção antes de corrigir:
+      55 contatos, 0 com chave divergente** — nenhum backfill necessário. ⚠️ A primeira sondagem
+      devolveu `contatos=0` e quase virou um "está tudo limpo" falso: `clients` tem RLS e
+      `SessionLocal` sem tenant é fail-closed. **Auditoria de dados em tabela com RLS precisa do
+      papel que faz bypass (`e1p_root`), senão a consulta não vê linha nenhuma e o silêncio
+      parece aprovação.**
     - **Lacuna de diagnóstico fechada junto:** `providers/evolution.py` chamava
       `raise_for_status()` e logava só o código — o CORPO da resposta da Evolution, que já
       explicava o erro, era descartado. Investigar exigiu sondar a API à mão em produção. Agora

--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -400,6 +400,19 @@ def update_client(
         if key == "email" and value is not None:
             value = str(value)
         setattr(client, key, value)
+    if "phone" in fields:
+        # `phone_key` é DERIVADO de `phone`, e derivado que não é recalculado vira mentira.
+        # `create_client` e `absorb_lead` sempre recalcularam; aqui não, porque o laço acima é
+        # genérico sobre o payload e `phone_key` não está no `ClientUpdate` — nem deve estar: é
+        # derivado, não campo de entrada.
+        #
+        # O estrago não aparece na tela de edição, e sim no PRÓXIMO lead: `absorb_lead` procura
+        # pela chave, não acha o contato editado e abre um card novo — a duplicata que a jornada
+        # única existe para impedir. `in fields` (e não `if client.phone`) porque `exclude_unset`
+        # já distingue "mandou telefone" de "não mexeu nele"; apagar o telefone precisa apagar a
+        # chave junto, senão sobra uma chave órfã que casaria um lead futuro com um contato que
+        # já não tem aquele número.
+        client.phone_key = normalize_br(client.phone)
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="crm.client.update", target=client.id
     )

--- a/apps/api/tests/test_lead_absorb.py
+++ b/apps/api/tests/test_lead_absorb.py
@@ -214,3 +214,75 @@ def test_retorno_emite_evento_no_barramento(db, tenant_id):
 
     assert len(recebidos) == 1
     assert recebidos[0]["source"] == "landing"
+
+
+# ── Editar o telefone na ficha do CRM ────────────────────────────────────────
+# `phone_key` é derivado de `phone`, e derivado que não é recalculado vira mentira. `create_client`
+# e `absorb_lead` sempre recalcularam; `update_client` não — ele faz `setattr` genérico sobre o
+# payload, e `phone_key` não está no `ClientUpdate` (nem deve estar: é derivado, não é campo de
+# entrada). O efeito não aparece na tela de edição: aparece no PRÓXIMO lead, como um card
+# duplicado — exatamente o que a jornada única do contato existe para impedir.
+
+
+def _edita(db, tenant_id: str, client_id: str, **campos):
+    from app.modules.crm.schemas import ClientUpdate
+
+    return service.update_client(
+        db, client_id=client_id, tenant_id=tenant_id, actor="dono",
+        data=ClientUpdate(**campos),
+    )
+
+
+def test_editar_telefone_recalcula_a_chave(db, tenant_id):
+    contato, _ = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="(11) 99999-8888", source="landing"
+    )
+    editado = _edita(db, tenant_id, contato.id, phone="(43) 98407-4017")
+    assert editado.phone_key == "5543984074017"
+
+
+def test_lead_com_o_telefone_corrigido_cai_no_mesmo_card(db, tenant_id):
+    """A consequência que importa: sem recálculo, o lead seguinte não encontra o contato pela
+    chave velha e abre um card novo."""
+    contato, _ = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="(11) 99999-8888", source="landing"
+    )
+    _edita(db, tenant_id, contato.id, phone="(43) 98407-4017")
+
+    de_volta, novo = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="5543984074017", source="landing"
+    )
+    assert novo is False
+    assert de_volta.id == contato.id
+    assert db.scalar(select(Client).where(Client.id != contato.id)) is None
+
+
+def test_editar_outro_campo_nao_mexe_na_chave(db, tenant_id):
+    """`exclude_unset=True`: quem não mandou telefone não teve telefone alterado, e a chave
+    derivada dele não pode se mover sozinha."""
+    contato, _ = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="(11) 99999-8888", source="landing"
+    )
+    antes = contato.phone_key
+    editado = _edita(db, tenant_id, contato.id, name="Flávio Kato")
+    assert editado.phone_key == antes == "5511999998888"
+
+
+def test_apagar_o_telefone_apaga_a_chave(db, tenant_id):
+    """Chave órfã seria pior que chave ausente: casaria um lead futuro com um contato que já não
+    tem aquele telefone."""
+    contato, _ = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="(11) 99999-8888", source="landing"
+    )
+    editado = _edita(db, tenant_id, contato.id, phone=None)
+    assert editado.phone_key is None
+
+
+def test_telefone_invalido_nao_deixa_chave_velha_para_tras(db, tenant_id):
+    """`normalize_br` devolve `None` para o que não é telefone BR. O contato fica sem chave — e
+    sem chave é honesto; com a chave ANTIGA seria um casamento errado."""
+    contato, _ = _absorve(
+        db, tenant_id, name="Flavio Kato", phone="(11) 99999-8888", source="landing"
+    )
+    editado = _edita(db, tenant_id, contato.id, phone="não é telefone")
+    assert editado.phone_key is None


### PR DESCRIPTION
Fecha a dívida registrada na #79.

## O problema

`phone_key` é **derivado** de `phone`, e derivado que não é recalculado vira mentira.

`create_client` e `absorb_lead` sempre recalcularam. `update_client` não: ele faz `setattr` genérico sobre o payload, e `phone_key` não está no `ClientUpdate` — **nem deve estar**, é derivado, não campo de entrada. Então o laço nunca o alcançava.

**O estrago não aparece na tela de edição.** Aparece no *próximo* lead: `absorb_lead` procura pela chave, não encontra o contato editado e abre um card novo — exatamente a duplicata que a jornada única do contato (#76) existe para impedir.

## Comportamento

| Ação | `phone_key` |
|---|---|
| Editar telefone | recalculado |
| Editar só o nome (telefone não veio no payload) | intacto |
| Apagar o telefone | apagado junto |
| Telefone que `normalize_br` não reconhece | fica `None` |

As duas últimas linhas são o cuidado que importa: **chave órfã é pior que chave ausente**, porque casaria um lead futuro com um contato que já não tem aquele número. Sem chave é honesto; com a chave antiga é um casamento errado.

O guard é `if "phone" in fields` e não `if client.phone` — `exclude_unset=True` já distingue "mandou telefone" de "não mexeu nele", e é essa distinção que preserva a linha 2 da tabela.

## Verificado em produção antes de corrigir

55 contatos, **0 com chave divergente**. Nenhum backfill necessário; a correção é preventiva.

⚠️ A primeira sondagem devolveu `contatos=0` e quase virou um "está tudo limpo" falso: `clients` tem RLS e `SessionLocal` sem tenant é **fail-closed**. Auditoria de dados em tabela com RLS precisa do papel que faz bypass (`e1p_root`) — senão a consulta não vê linha nenhuma e o silêncio parece aprovação. Ficou registrado no CLAUDE.md.

## Testes

`1714 passed, 1 skipped` · ruff limpo. Cinco testes novos em `test_lead_absorb.py`; quatro falhavam antes.

O que carrega o valor é `test_lead_com_o_telefone_corrigido_cai_no_mesmo_card` — ele afirma a **consequência** (não duplicar o card), não o mecanismo. Os outros fixam as bordas que uma futura "simplificação" tenderia a quebrar.

Sem migration. Nada no frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
