### PR TITLE
feat: a conversa registra o que o produto envia, e o contato deixa de ser dois

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,6 +411,40 @@ silencia os testes seguintes. Corrigido com `disable_existing_loggers=False`. É
 do bug já registrado abaixo ("logs que somem" por falta de `basicConfig`) — **quando um log
 sumir, verifique também quem chamou `fileConfig`/`dictConfig` antes**, não só handler ausente.
 
+14. **A mensagem saiu, chegou no celular e mesmo assim não apareceu em Conversas.** Achado
+    testando a #79 em campo. Duas causas independentes, e a segunda é estrutural:
+    - **O webhook só assinava `MESSAGES_UPSERT`**, que é o que CHEGA (mensagem do contato e a
+      que o dono digita no próprio celular, espelhada pelo Baileys). O que sai pela API da
+      Evolution vem em **`SEND_MESSAGE`** — evento diferente. Sem ele, tudo que o produto dispara
+      sozinho (funil, cobrança, contrato) era entregue de verdade e **não ficava registrado na
+      conversa**: o fio mostrava só um lado. Nomes conferidos por `grep` no dist da imagem que
+      roda em produção, não na documentação. Duplicar não é risco: `ingest_webhook_payload` é
+      idempotente por `wa_message_id`.
+    - **O contato do funil não era o contato da conversa.** Seis cards "Flavio Kato" com o mesmo
+      `phone_key`: o funil inscreveu `8a75cf66` (`source=api`, zero conversas) e a conversa real
+      estava em `4804f5c5` (`source=whatsapp`). `get_timeline` ancora os avisos automáticos em
+      `chat.client_id` — cards diferentes, metade da história em cada.
+    - **`crm/merge.py`** (+ `app.scripts.merge_duplicate_clients`, dry-run por padrão) fecha a
+      dívida que a PR #76 deixou aberta. Descobre as tabelas com `client_id` pelo REGISTRY, não
+      por lista escrita à mão (mesmo motivo da purga dinâmica de tenant: lista esquece o módulo
+      seguinte, e esquecer aqui deixa cobrança apontando para card apagado). Sobrevivente = o
+      mais antigo, **o mesmo critério de `_find_existing`** — se divergisse, `absorb_lead`
+      escolheria um card e a mescla outro, e o próximo lead recriaria a divisão.
+    - ⚠️ **O guarda que impede a mescla errada:** agrupa por telefone **E nome**. `phone_key` não
+      é único de propósito (marido e mulher compartilham telefone) — agrupar só por telefone
+      juntaria duas PESSOAS num card, que é pior que o duplicado.
+    - **O 9º dígito era a segunda forma de o histórico se partir:** o JID real do contato pode
+      não ter o 9 (`554384074017@s.whatsapp.net`, conta pré-2016) enquanto tudo que enviamos
+      passa por `normalize_br`, que o acrescenta. `_get_or_create_chat` ganhou busca secundária
+      por telefone normalizado, só no caminho de miss — mesma classe que o `chat_jid` canônico já
+      resolvera para `@lid` × `@s.whatsapp.net`.
+    - **UX:** "Descrição" do nó virou "Anotação (só no desenho)". Duas caixas multilinha
+      conviviam na mesma tela e só uma era enviada; o fundador escreveu na errada um texto que
+      parecia mensagem e esperou que fosse entregue. Nada na tela dizia o contrário.
+    - **Operacional:** mudar a config do webhook numa instância JÁ conectada exige reaplicar o
+      `/webhook/set` **e reiniciar o container `evolution`** (armadilha já registrada abaixo) —
+      o processo em memória mantém a config carregada na conexão.
+
 **Duas armadilhas operacionais da VPS** (não são bug de código, são do processo de deploy):
 - Depois de mudar a config do webhook via `/webhook/set` numa instância **já conectada**, a mudança pode não valer pro processo em memória (cache do canal Baileys carregado na conexão) — precisou **reiniciar o container `evolution`** (não só recriar) pra pegar a config nova. Sessões reconectam sozinhas (credenciais persistidas no Postgres/Redis), sem precisar de novo QR.
 - `docker compose up -d --build <serviço>` só reconstrói o serviço **nomeado**. Rebuildar só `api` depois de um PR que também mudou frontend deixa o `web` com o build antigo, **em silêncio** (sem erro, só o comportamento antigo persistindo). Depois de qualquer merge, checar QUAIS serviços mudaram no diff antes de escolher o que rebuildar — ou rebuildar todos (`up -d --build` sem nome, como o `reference_e1p_prod_deploy` já recomendava).

--- a/apps/api/app/modules/crm/merge.py
+++ b/apps/api/app/modules/crm/merge.py
@@ -1,0 +1,151 @@
+"""Mescla de contatos duplicados — o card absorvido some, o histórico não.
+
+A PR #76 (`absorb_lead`) parou de CRIAR duplicados: as três portas de entrada passaram a
+convergir por telefone normalizado. Os que já existiam ficaram, por decisão explícita do
+fundador na época ("a correção vale daqui para frente"). Este módulo é a ferramenta que faltava.
+
+**Por que a mescla precisa existir, e não só a prevenção:** o duplicado não é feio, é
+funcional. No tenant do fundador havia SEIS "Flavio Kato" com o mesmo `phone_key`; o funil
+inscreveu um deles (`source=api`, sem nenhuma conversa) enquanto a conversa real do WhatsApp
+estava pendurada em outro (`source=whatsapp`). A mensagem foi enviada e entregue, e mesmo assim
+não apareceu no fio — porque `get_timeline` mostra os avisos automáticos do
+`chat.client_id`, e eram cards diferentes. Enquanto houver dois cards, qualquer coisa
+ancorada em `client_id` conta metade da história.
+
+**A regra que impede a mescla errada:** `phone_key` NÃO é único de propósito — marido e mulher
+compartilham telefone (ver `crm/service._find_existing`). Agrupar só por telefone juntaria duas
+PESSOAS num card só, que é pior que o problema. Por isso `find_duplicate_groups` exige também
+nome equivalente, e nunca decide sozinha: propõe, e quem executa é uma chamada explícita.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+
+from sqlalchemy import bindparam, select, text
+from sqlalchemy.orm import Session
+
+from app.core import audit
+from app.db.registry import Base
+from app.modules.crm.models import Client
+
+# Campos que o sobrevivente COMPLEMENTA a partir do absorvido quando estiver vazio. Mesma regra
+# de `absorb_lead`: preenche buraco, nunca sobrescreve o que já tem valor.
+_CAMPOS_COMPLEMENTAVEIS = ("email", "phone", "document", "gender", "birthdate")
+
+
+def _chave_de_nome(nome: str | None) -> str:
+    """Forma comparável do nome: sem acento, sem caixa, sem espaço repetido.
+
+    Não é dedup por nome — é só o guarda que impede "Flavio Kato" e "Maria Kato" (mesmo
+    telefone da casa) de virarem um contato só."""
+    bruto = unicodedata.normalize("NFKD", nome or "")
+    sem_acento = "".join(c for c in bruto if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", sem_acento).strip().casefold()
+
+
+def tabelas_que_apontam_para_cliente() -> list[str]:
+    """Toda tabela com coluna `client_id`, DESCOBERTA e não listada à mão.
+
+    Mesmo motivo da purga dinâmica em `platform/service._business_table_names`: uma lista
+    escrita à mão esquece o módulo seguinte, e aqui esquecer significa deixar cobrança, contrato
+    ou conversa apontando para um card que acabou de ser apagado."""
+    tabelas = {
+        mapper.class_.__tablename__
+        for mapper in Base.registry.mappers
+        if "client_id" in mapper.columns
+    }
+    return sorted(tabelas)
+
+
+@dataclass
+class GrupoDuplicado:
+    phone_key: str
+    nome: str
+    sobrevivente: Client
+    absorvidos: list[Client] = field(default_factory=list)
+
+
+def find_duplicate_groups(db: Session) -> list[GrupoDuplicado]:
+    """Grupos de cards que são a MESMA pessoa: mesmo telefone normalizado E mesmo nome.
+
+    O sobrevivente é o MAIS ANTIGO (`created_at`, desempatando por `id`) — exatamente o critério
+    de `crm/service._find_existing`. Tem que ser o mesmo: se divergisse, `absorb_lead` passaria a
+    escolher um card e a mescla outro, e o próximo lead recriaria a divisão que esta função
+    acabou de desfazer."""
+    por_chave: dict[tuple[str, str], list[Client]] = {}
+    for cliente in db.scalars(
+        select(Client).where(Client.phone_key.is_not(None)).order_by(
+            Client.created_at, Client.id
+        )
+    ).all():
+        por_chave.setdefault((cliente.phone_key or "", _chave_de_nome(cliente.name)), []).append(
+            cliente
+        )
+    return [
+        GrupoDuplicado(
+            phone_key=chave, nome=cards[0].name, sobrevivente=cards[0], absorvidos=cards[1:]
+        )
+        for (chave, _nome), cards in sorted(por_chave.items())
+        if len(cards) > 1
+    ]
+
+
+def merge_clients(
+    db: Session, *, tenant_id: str, actor: str, survivor_id: str, absorbed_ids: list[str]
+) -> dict:
+    """Repõe tudo que apontava para os absorvidos no sobrevivente e apaga os absorvidos.
+
+    NÃO commita — quem chama decide, mesmo padrão de `receivables.build_charge`. Devolve o que
+    foi movido, por tabela, para que o chamador possa relatar em vez de afirmar sucesso mudo.
+
+    Ordem importa: repontar ANTES de apagar. O inverso deixaria órfãos por um instante e, se a
+    transação falhasse no meio, o histórico apontaria para um card inexistente."""
+    sobrevivente = db.get(Client, survivor_id)
+    if sobrevivente is None:
+        raise ValueError(f"contato sobrevivente {survivor_id} não encontrado")
+    absorvidos = [c for c in (db.get(Client, cid) for cid in absorbed_ids) if c is not None]
+    if not absorvidos:
+        return {"movidos": {}, "absorvidos": 0}
+
+    antigos = [c.id for c in absorvidos]
+    movidos: dict[str, int] = {}
+    for tabela in tabelas_que_apontam_para_cliente():
+        resultado = db.execute(
+            text(
+                f"UPDATE {tabela} SET client_id = :novo "  # noqa: S608 — nome vem do registry
+                "WHERE client_id IN :antigos"
+            ).bindparams(
+                # `expanding=True` é obrigatório num `IN` com lista: sem ele o SQLAlchemy manda a
+                # tupla como UM parâmetro só e o banco recusa a query.
+                bindparam("antigos", expanding=True),
+            ),
+            {"novo": survivor_id, "antigos": antigos},
+        )
+        if resultado.rowcount:
+            movidos[tabela] = resultado.rowcount
+
+    # Complementa buracos do sobrevivente (nunca sobrescreve) e junta as tags.
+    for absorvido in absorvidos:
+        for campo in _CAMPOS_COMPLEMENTAVEIS:
+            if not getattr(sobrevivente, campo, None):
+                valor = getattr(absorvido, campo, None)
+                if valor:
+                    setattr(sobrevivente, campo, valor)
+        if absorvido.tags:
+            sobrevivente.tags = sorted({*(sobrevivente.tags or []), *absorvido.tags})
+        # Observação do dono é texto escrito à mão: perder seria pior que duplicar. Só entra o
+        # que ainda não está lá, e sempre ANEXADO — nunca por cima.
+        nota = (absorvido.notes or "").strip()
+        if nota and nota not in (sobrevivente.notes or ""):
+            atual = (sobrevivente.notes or "").rstrip()
+            sobrevivente.notes = f"{atual}\n{nota}".strip() if atual else nota
+
+    for absorvido in absorvidos:
+        db.delete(absorvido)
+
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="crm.client.merge", target=survivor_id
+    )
+    return {"movidos": movidos, "absorvidos": len(absorvidos)}

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -159,6 +159,30 @@ def _resolve_group_title(profile, chat: WhatsappChat) -> None:
         chat.title = subject
 
 
+def _find_direct_chat_by_phone(db: Session, *, chat_jid: str) -> WhatsappChat | None:
+    """A conversa direta cujo telefone NORMALIZA para o mesmo valor deste JID.
+
+    A comparação é feita em Python, e não em SQL, porque a forma comparável do telefone não é
+    coluna em `whatsapp_chats` (é em `clients.phone_key`) — e criar a coluna aqui exigiria
+    migration num momento de frentes paralelas. O custo é aceitável porque só roda no MISS: o
+    caminho normal (JID idêntico) resolve na primeira consulta, e este só varre as conversas
+    diretas do tenant quando uma grafia nova aparece, que é raro por definição.
+
+    Devolve `None` quando o JID não carrega telefone (`@lid`, sintéticos do backfill): sem
+    telefone não há o que comparar, e adivinhar seria pior que abrir conversa nova."""
+    alvo = normalize_br(chat_jid.split("@", 1)[0]) if "@" in chat_jid else None
+    if alvo is None:
+        return None
+    for candidata in db.scalars(
+        select(WhatsappChat).where(WhatsappChat.kind != CHAT_KIND_GROUP)
+    ).all():
+        if "@" not in candidata.chat_jid:
+            continue  # `legacy:`/`client:` do backfill da 0066 — não são endereço de ninguém
+        if normalize_br(candidata.chat_jid.split("@", 1)[0]) == alvo:
+            return candidata
+    return None
+
+
 def _get_or_create_chat(
     db: Session, *, tenant_id: str, chat_jid: str, kind: str, client: Client | None, profile,
 ) -> WhatsappChat:
@@ -166,8 +190,21 @@ def _get_or_create_chat(
 
     `client` é ENRIQUECIMENTO, não chave: uma conversa direta cujo contato só foi identificado
     depois (`@lid` que passou a vir com `remoteJidAlt`) ganha o vínculo aqui, sem trocar de
-    identidade nem partir o histórico."""
+    identidade nem partir o histórico.
+
+    **O 9º dígito é a segunda forma de o histórico se partir.** O JID que o WhatsApp usa para um
+    celular pré-2016 pode não ter o 9 (`554384074017@s.whatsapp.net` — caso real do tenant do
+    fundador), enquanto tudo que o produto envia passa por `normalize_br`, que o ACRESCENTA
+    (`5543984074017`). Duas grafias do mesmo telefone, e a busca por igualdade de string cria
+    duas conversas para a mesma pessoa — a mesma classe de bug que `chat_jid` canônico resolveu
+    para `@lid` × `@s.whatsapp.net`.
+
+    Por isso a conversa direta tem um segundo critério de busca: telefone NORMALIZADO. Só entra
+    no caminho de miss (quando não há JID idêntico), então não custa nada no fluxo normal, e
+    nunca se aplica a grupo (JID de grupo não é telefone)."""
     chat = db.scalar(select(WhatsappChat).where(WhatsappChat.chat_jid == chat_jid))
+    if chat is None and kind != CHAT_KIND_GROUP:
+        chat = _find_direct_chat_by_phone(db, chat_jid=chat_jid)
     if chat is None:
         chat = WhatsappChat(
             tenant_id=tenant_id, chat_jid=chat_jid, kind=kind,

--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -103,7 +103,19 @@ def connect(db: Session, *, tenant_id: str) -> dict:
                         f"/internal/whatsapp/evolution/webhook/{webhook_secret}"
                     ),
                     "byEvents": False,
-                    "events": ["MESSAGES_UPSERT"],
+                    # `MESSAGES_UPSERT` é o que CHEGA — mensagem do contato e também a que o
+                    # dono digita no celular dele (o Baileys espelha as duas no mesmo evento;
+                    # ver `from_me` em `parse_inbound`). O que sai pela API da PRÓPRIA Evolution
+                    # (`/message/sendText`, usado pelo worker de notificações) vem em
+                    # `SEND_MESSAGE` — evento diferente. Sem ele, tudo que o produto dispara
+                    # sozinho (funil, cobrança, contrato) saía de verdade e NÃO ficava registrado
+                    # na conversa: o fio mostrava só um lado. Nomes conferidos na imagem que roda
+                    # em produção (`grep` no dist da v2.3.7), não na documentação.
+                    #
+                    # Duplicar não é risco: `ingest_webhook_payload` é idempotente por
+                    # `wa_message_id`, então a mesma mensagem chegando pelos dois eventos vira
+                    # uma linha só.
+                    "events": ["MESSAGES_UPSERT", "SEND_MESSAGE"],
                     # A Evolution baixa e decifra a mídia (tem a mediaKey) e injeta o resultado
                     # em `message.base64` — sem isto, mídia recebida (foto/áudio/documento)
                     # chega só com metadado (legenda/mimetype), sem os bytes (ver

--- a/apps/api/app/scripts/merge_duplicate_clients.py
+++ b/apps/api/app/scripts/merge_duplicate_clients.py
@@ -1,0 +1,92 @@
+"""Mescla os contatos duplicados que já existiam antes da PR #76 (`absorb_lead`).
+
+    docker compose exec api python -m app.scripts.merge_duplicate_clients            # dry-run
+    docker compose exec api python -m app.scripts.merge_duplicate_clients --apply    # executa
+
+**Dry-run é o padrão, de propósito.** A mescla apaga linhas e não tem desfazer: `--apply` só
+depois de ler a lista. O mesmo comando roda quantas vezes for preciso — na segunda passada não
+há mais grupo e ele termina em silêncio.
+
+Só agrupa cards com **mesmo telefone normalizado E mesmo nome**. `phone_key` sozinho não serve
+como critério: ele não é único de propósito (marido e mulher compartilham telefone, ver
+`crm/service._find_existing`), e juntar duas pessoas num card é pior que o duplicado.
+
+Isolamento de tenant: itera a tabela GLOBAL `tenants` e abre `tenant_session` por tenant (RLS
+fixada), mesmo padrão de `migrate_attachments_to_s3`. Nunca cruza dados entre tenants.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+
+from sqlalchemy import select
+
+from app.db.session import get_db, tenant_session
+from app.modules.auth.models import Tenant
+from app.modules.crm import merge
+
+logger = logging.getLogger("e1p.merge_duplicate_clients")
+
+
+def _list_tenant_ids() -> list[str]:
+    gen = get_db()
+    db = next(gen)
+    try:
+        return [t.id for t in db.scalars(select(Tenant)).all()]
+    finally:
+        gen.close()
+
+
+def main(apply: bool) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    modo = "APLICANDO" if apply else "DRY-RUN (nada será alterado)"
+    logger.info("=== Mescla de contatos duplicados — %s ===", modo)
+
+    total_grupos = total_absorvidos = 0
+    for tenant_id in _list_tenant_ids():
+        with tenant_session(tenant_id) as db:
+            grupos = merge.find_duplicate_groups(db)
+            if not grupos:
+                continue
+            logger.info("\ntenant %s — %d grupo(s):", tenant_id, len(grupos))
+            for grupo in grupos:
+                total_grupos += 1
+                total_absorvidos += len(grupo.absorvidos)
+                logger.info(
+                    "  %s (%s) — fica %s [%s, criado %s], absorve %d:",
+                    grupo.nome, grupo.phone_key, grupo.sobrevivente.id[:8],
+                    grupo.sobrevivente.source, grupo.sobrevivente.created_at,
+                    len(grupo.absorvidos),
+                )
+                for absorvido in grupo.absorvidos:
+                    logger.info(
+                        "      %s [%s, criado %s]",
+                        absorvido.id[:8], absorvido.source, absorvido.created_at,
+                    )
+                if apply:
+                    resultado = merge.merge_clients(
+                        db, tenant_id=tenant_id, actor="script:merge_duplicate_clients",
+                        survivor_id=grupo.sobrevivente.id,
+                        absorbed_ids=[c.id for c in grupo.absorvidos],
+                    )
+                    db.commit()
+                    movidos = resultado["movidos"]
+                    logger.info(
+                        "      -> movido: %s",
+                        ", ".join(f"{t}={n}" for t, n in sorted(movidos.items())) or "nada",
+                    )
+
+    if total_grupos == 0:
+        logger.info("\nNenhum duplicado encontrado.")
+    elif apply:
+        logger.info("\n%d grupo(s), %d card(s) absorvido(s).", total_grupos, total_absorvidos)
+    else:
+        logger.info(
+            "\n%d grupo(s), %d card(s) seriam absorvidos. Rode com --apply para executar.",
+            total_grupos, total_absorvidos,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(apply="--apply" in sys.argv))

--- a/apps/api/tests/test_crm_merge.py
+++ b/apps/api/tests/test_crm_merge.py
@@ -1,0 +1,215 @@
+"""Mescla de contatos duplicados: o card some, o histórico não.
+
+Contexto real (tenant do fundador, 2026-08-05): SEIS cards "Flavio Kato" com o mesmo
+`phone_key`. O funil inscreveu um (`source=api`, zero conversas) enquanto a conversa do WhatsApp
+estava pendurada em outro (`source=whatsapp`) — a mensagem foi entregue e mesmo assim não
+apareceu no fio, porque `get_timeline` ancora os avisos automáticos em `chat.client_id`.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.modules.crm import merge, service
+from app.modules.crm.models import Client, ClientEvent
+from app.modules.crm.schemas import ClientCreate
+from app.modules.receivables.models import Charge
+
+REGISTER = {
+    "legal_name": "Doro Eventos",
+    "document": "11222333000181",
+    "slug": "doro",
+    "email": "doro@example.com",
+    "name": "Doro",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient) -> str:
+    return client.post("/auth/register", json=REGISTER).json()["tenant"]["id"]
+
+
+def _cria(db, tenant_id: str, **campos) -> Client:
+    return service.create_client(
+        db, tenant_id=tenant_id, actor="dono", data=ClientCreate(**campos)
+    )
+
+
+# ── Descoberta das tabelas ───────────────────────────────────────────────────
+
+
+def test_descobre_as_tabelas_em_vez_de_listar():
+    """Lista escrita à mão esquece o módulo seguinte — e esquecer aqui significa deixar cobrança
+    ou conversa apontando para um card recém-apagado."""
+    tabelas = merge.tabelas_que_apontam_para_cliente()
+    # Uma amostra de módulos independentes entre si: se a descoberta quebrar, alguma some.
+    assert {"charges", "quotes", "contracts", "notifications", "whatsapp_chats",
+            "whatsapp_messages", "client_events"} <= set(tabelas)
+    assert "clients" not in tabelas  # a própria tabela não tem `client_id`
+
+
+# ── O guarda que impede a mescla errada ──────────────────────────────────────
+
+
+def test_mesmo_telefone_nomes_diferentes_nao_e_duplicado(db, tenant_id):
+    """`phone_key` não é único DE PROPÓSITO: marido e mulher compartilham telefone. Juntar duas
+    pessoas num card é pior que o duplicado que a mescla existe para resolver."""
+    _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017", source="manual")
+    _cria(db, tenant_id, name="Maria Kato", phone="(43) 98407-4017", source="manual")
+    assert merge.find_duplicate_groups(db) == []
+
+
+def test_nome_com_acento_e_caixa_diferentes_ainda_e_a_mesma_pessoa(db, tenant_id):
+    _cria(db, tenant_id, name="Flávio Kato", phone="(43) 98407-4017", source="manual")
+    _cria(db, tenant_id, name="flavio  kato", phone="5543984074017", source="manual")
+    grupos = merge.find_duplicate_groups(db)
+    assert len(grupos) == 1
+    assert len(grupos[0].absorvidos) == 1
+
+
+def test_contato_sem_telefone_nunca_entra_num_grupo(db, tenant_id):
+    _cria(db, tenant_id, name="Sem Telefone", email="a@x.com", source="manual")
+    _cria(db, tenant_id, name="Sem Telefone", email="b@x.com", source="manual")
+    assert merge.find_duplicate_groups(db) == []
+
+
+def test_sobrevivente_e_o_mais_antigo(db, tenant_id):
+    """Tem que ser o MESMO critério de `_find_existing`. Se divergisse, `absorb_lead` escolheria
+    um card e a mescla outro, e o próximo lead recriaria a divisão.
+
+    `created_at` explícito pela mesma razão de `test_multiplos_candidatos_escolhe_o_mais_antigo`:
+    `server_default=func.now()` dá timestamp IDÊNTICO a duas linhas do mesmo segundo (SQLite) ou
+    da mesma transação (Postgres), e aí "o mais antigo" deixa de ser observável — o desempate cai
+    no uuid e o teste vira moeda."""
+    antigo = Client(
+        tenant_id=tenant_id, name="Flavio Kato", phone="4384074017",
+        phone_key="5543984074017", source="manual",
+        created_at=datetime(2026, 7, 1, 10, 0, tzinfo=UTC),
+    )
+    novo = Client(
+        tenant_id=tenant_id, name="Flavio Kato", phone="43984074017",
+        phone_key="5543984074017", source="api",
+        created_at=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    db.add_all([antigo, novo])
+    db.commit()
+
+    grupo = merge.find_duplicate_groups(db)[0]
+    assert grupo.sobrevivente.id == antigo.id
+    assert [c.id for c in grupo.absorvidos] == [novo.id]
+
+
+# ── A mescla em si ───────────────────────────────────────────────────────────
+
+
+def test_historico_do_absorvido_migra_para_o_sobrevivente(db, tenant_id):
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         source="manual")
+    absorvido = _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017", source="api")
+    db.add(Charge(
+        tenant_id=tenant_id, client_id=absorvido.id, description="Sinal do evento",
+        kind="service", method="pix", amount_cents=50_000,
+        due_date=date(2026, 9, 1),
+    ))
+    db.commit()
+
+    resultado = merge.merge_clients(
+        db, tenant_id=tenant_id, actor="dono",
+        survivor_id=sobrevivente.id, absorbed_ids=[absorvido.id],
+    )
+    db.commit()
+
+    assert resultado["absorvidos"] == 1
+    assert resultado["movidos"]["charges"] == 1
+    cobranca = db.scalar(select(Charge))
+    assert cobranca.client_id == sobrevivente.id       # a cobrança seguiu o contato...
+    assert db.get(Client, absorvido.id) is None        # ...e o card duplicado sumiu
+
+
+def test_eventos_dos_dois_cards_ficam_na_mesma_linha_do_tempo(db, tenant_id):
+    """É a razão de existir da mescla: uma pessoa, uma história."""
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         source="manual")
+    absorvido = _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017", source="landing")
+
+    merge.merge_clients(db, tenant_id=tenant_id, actor="dono",
+                        survivor_id=sobrevivente.id, absorbed_ids=[absorvido.id])
+    db.commit()
+
+    eventos = db.scalars(
+        select(ClientEvent).where(ClientEvent.client_id == sobrevivente.id)
+    ).all()
+    assert len(eventos) == 2  # o "lead_created" de cada card, agora no mesmo fio
+
+
+def test_complementa_buraco_mas_nunca_sobrescreve(db, tenant_id):
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         email="antigo@x.com", source="manual")
+    absorvido = _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017",
+                      email="novo@x.com", document="52998224725", source="api")
+
+    merge.merge_clients(db, tenant_id=tenant_id, actor="dono",
+                        survivor_id=sobrevivente.id, absorbed_ids=[absorvido.id])
+    db.commit()
+    db.refresh(sobrevivente)
+
+    assert sobrevivente.email == "antigo@x.com"   # tinha valor: intocado
+    assert sobrevivente.document == "52998224725"  # estava vazio: complementado
+
+
+def test_nao_perde_a_observacao_escrita_pelo_dono(db, tenant_id):
+    """Texto escrito à mão é o dado mais caro da ficha. Some no card absorvido = some de vez."""
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         notes="Prefere contato de manhã", source="manual")
+    absorvido = _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017",
+                      notes="Indicado pelo Rogério", source="api")
+
+    merge.merge_clients(db, tenant_id=tenant_id, actor="dono",
+                        survivor_id=sobrevivente.id, absorbed_ids=[absorvido.id])
+    db.commit()
+    db.refresh(sobrevivente)
+
+    assert "Prefere contato de manhã" in sobrevivente.notes
+    assert "Indicado pelo Rogério" in sobrevivente.notes
+
+
+def test_junta_as_tags_dos_dois(db, tenant_id):
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         tags=["vip"], source="manual")
+    absorvido = _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017",
+                      tags=["vindo-do-site", "vip"], source="landing")
+
+    merge.merge_clients(db, tenant_id=tenant_id, actor="dono",
+                        survivor_id=sobrevivente.id, absorbed_ids=[absorvido.id])
+    db.commit()
+    db.refresh(sobrevivente)
+
+    assert sobrevivente.tags == ["vindo-do-site", "vip"]  # união, sem repetir
+
+
+def test_mescla_de_varios_de_uma_vez(db, tenant_id):
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         source="manual")
+    outros = [
+        _cria(db, tenant_id, name="Flavio Kato", phone="5543984074017", source=s)
+        for s in ("api", "landing", "whatsapp")
+    ]
+    merge.merge_clients(db, tenant_id=tenant_id, actor="dono", survivor_id=sobrevivente.id,
+                        absorbed_ids=[c.id for c in outros])
+    db.commit()
+    assert db.scalars(select(Client)).all() == [sobrevivente]
+
+
+def test_absorbed_ids_vazio_nao_faz_nada(db, tenant_id):
+    """Rodar o mesmo comando duas vezes não pode explodir: a segunda passada não acha mais
+    duplicado e precisa terminar em silêncio."""
+    sobrevivente = _cria(db, tenant_id, name="Flavio Kato", phone="(43) 98407-4017",
+                         source="manual")
+    resultado = merge.merge_clients(db, tenant_id=tenant_id, actor="dono",
+                                    survivor_id=sobrevivente.id, absorbed_ids=[])
+    assert resultado == {"movidos": {}, "absorvidos": 0}
+    assert db.get(Client, sobrevivente.id) is not None

--- a/apps/api/tests/test_whatsapp_inbox_groups.py
+++ b/apps/api/tests/test_whatsapp_inbox_groups.py
@@ -299,3 +299,53 @@ def test_group_rejects_template_reply(db) -> None:
         assert "Grupo não usa template" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("deveria ter recusado")
+
+
+# ── O 9º dígito não pode partir a conversa em duas ───────────────────────────
+# Caso real do tenant do fundador: o JID que o WhatsApp usa para o celular dele é
+# `554384074017@s.whatsapp.net` (SEM o 9, conta pré-2016), mas tudo que o produto ENVIA passa
+# por `normalize_br`, que acrescenta o 9. Se a conversa fosse resolvida só por igualdade de
+# string, a mensagem que o funil dispara abriria um segundo fio para a mesma pessoa.
+
+
+def test_jid_com_e_sem_o_nono_digito_caem_na_mesma_conversa(db) -> None:
+    from app.core.whatsapp.inbound import InboundMessage
+    from app.modules.whatsapp_inbox import service as inbox_service
+    from app.modules.whatsapp_inbox.models import WhatsappChat
+
+    def _ingesta(jid: str, texto: str, from_me: bool) -> None:
+        inbox_service.ingest_webhook_payload(
+            db, tenant_id=TENANT_ID,
+            messages=[InboundMessage(
+                wa_message_id=f"wa-{texto}", from_phone=jid.split("@", 1)[0],
+                push_name="Flavio Kato", kind="text", text_body=texto, media_ref=None,
+                from_me=from_me, chat_jid=jid, chat_kind="direct",
+            )],
+        )
+
+    _ingesta("554384074017@s.whatsapp.net", "oi, chegou?", from_me=False)   # o contato escreveu
+    _ingesta("5543984074017@s.whatsapp.net", "aqui e a Doro", from_me=True)  # o funil respondeu
+
+    conversas = db.scalars(select(WhatsappChat).where(WhatsappChat.kind == "direct")).all()
+    assert len(conversas) == 1, [c.chat_jid for c in conversas]
+    fio = inbox_service.get_timeline(db, chat_id=conversas[0].id)
+    assert [e["direction"] for e in fio] == ["in", "out"]
+
+
+def test_grupo_nao_entra_na_reconciliacao_por_telefone(db) -> None:
+    """JID de grupo não é telefone. Dois grupos distintos jamais podem colapsar num só."""
+    from app.core.whatsapp.inbound import InboundMessage
+    from app.modules.whatsapp_inbox import service as inbox_service
+    from app.modules.whatsapp_inbox.models import WhatsappChat
+
+    for jid in ("554384074017-1503532407@g.us", "554384074017-9999999999@g.us"):
+        inbox_service.ingest_webhook_payload(
+            db, tenant_id=TENANT_ID,
+            messages=[InboundMessage(
+                wa_message_id=f"wa-{jid}", from_phone=None, push_name="Alguem",
+                kind="text", text_body="oi", media_ref=None, from_me=False,
+                chat_jid=jid, chat_kind="group",
+            )],
+        )
+    grupos = db.scalars(select(WhatsappChat).where(WhatsappChat.kind == "group")).all()
+    assert len(grupos) == 2

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -457,9 +457,21 @@ function Builder() {
                 <span className="mb-1 block text-xs font-medium text-neutral-600">Rótulo / Título</span>
                 <input value={selectedNode.data.label} onChange={(e) => updateSelected({ label: e.target.value })} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-primary-400" />
               </label>
+              {/* Duas caixas de texto multilinha convivem nesta tela e SÓ UMA é enviada. Esta
+                  é anotação do desenho; a que sai é a de "Escrever mensagem". Um usuário real
+                  escreveu aqui um texto que parecia mensagem ("Olá, aqui é a Doro...") e
+                  esperou que fosse entregue — nada na tela dizia o contrário. */}
               <label className="mb-2 block">
-                <span className="mb-1 block text-xs font-medium text-neutral-600">Descrição</span>
-                <textarea value={selectedNode.data.description} onChange={(e) => updateSelected({ description: e.target.value })} rows={3} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-primary-400" />
+                <span className="mb-1 block text-xs font-medium text-neutral-600">
+                  Anotação <span className="font-normal text-neutral-400">(só no desenho)</span>
+                </span>
+                <textarea value={selectedNode.data.description} onChange={(e) => updateSelected({ description: e.target.value })} rows={3} placeholder="Lembrete para você — não é enviado a ninguém" className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-primary-400" />
+                {contentKind(selectedNode.data.key) === "whatsapp" && (
+                  <span className="mt-1 block text-[11px] text-neutral-400">
+                    A mensagem que o contato recebe é a de <strong>“Escrever mensagem”</strong>,
+                    abaixo.
+                  </span>
+                )}
               </label>
 
               <AutomationFields data={selectedNode.data} onChange={updateSelectedConfig} />


### PR DESCRIPTION
A mensagem do funil saiu, chegou no celular e **não apareceu em Conversas**. Duas causas independentes — e a segunda é estrutural.

## 1. O webhook não ouvia o que nós mandamos

Assinávamos só `MESSAGES_UPSERT`, que é o que **chega**: mensagem do contato, e também a que o dono digita no próprio celular (o Baileys espelha, foi o que a #74 tratou).

O que sai pela API da Evolution vem em **`SEND_MESSAGE`** — evento diferente. Sem ele, tudo que o produto dispara sozinho (funil, cobrança, contrato) era entregue de verdade e **não ficava registrado na conversa**: o fio mostrava só um lado.

Nomes conferidos por `grep` no dist da imagem que roda em produção (`MESSAGES_UPSERT`, `SEND_MESSAGE`, `SEND_MESSAGE_UPDATE`), não na documentação — a lição que este repo já pagou seis vezes. Duplicar não é risco: `ingest_webhook_payload` é idempotente por `wa_message_id`.

## 2. O contato do funil não era o contato da conversa

Seis cards "Flavio Kato" com o mesmo `phone_key`. O funil inscreveu `8a75cf66` (`source=api`, **zero conversas**); a conversa real estava em `4804f5c5` (`source=whatsapp`). `get_timeline` ancora os avisos automáticos em `chat.client_id` — cards diferentes, metade da história em cada.

`crm/merge.py` + `app.scripts.merge_duplicate_clients` fecham a dívida que a #76 deixou aberta explicitamente.

**As tabelas com `client_id` são DESCOBERTAS pelo registry**, não listadas à mão — mesmo motivo da purga dinâmica de tenant: lista escrita à mão esquece o módulo seguinte, e esquecer aqui deixa cobrança apontando para um card apagado.

**Sobrevivente = o mais antigo, o mesmo critério de `_find_existing`.** Não é detalhe: se divergisse, `absorb_lead` escolheria um card e a mescla outro, e o próximo lead recriaria a divisão que a mescla acabou de desfazer.

### ⚠️ O guarda que impede a mescla errada

Agrupa por telefone **E nome**. `phone_key` não é único de propósito — marido e mulher compartilham telefone (está escrito em `_find_existing`). Agrupar só por telefone juntaria **duas pessoas** num card, que é pior que o duplicado que a ferramenta existe para resolver.

**Dry-run é o padrão.** A mescla apaga linhas e não tem desfazer; `--apply` é explícito. Idempotente: a segunda passada não acha grupo e termina em silêncio.

Prévia contra os dados reais de produção (leitura apenas): 57 contatos, **1 grupo**, 5 cards a absorver, **0 telefones compartilhados por nomes diferentes**.

## Junto, duas correções que sairiam caras depois

**O 9º dígito era a segunda forma de o histórico se partir.** O JID real do contato pode não ter o 9 (`554384074017@s.whatsapp.net`, conta pré-2016) enquanto tudo que enviamos passa por `normalize_br`, que o **acrescenta**. Busca por igualdade de string abriria uma segunda conversa para a mesma pessoa. `_get_or_create_chat` ganhou busca secundária por telefone normalizado, só no caminho de miss — mesma classe que o `chat_jid` canônico já resolvera para `@lid` × `@s.whatsapp.net`.

**UX:** "Descrição" do nó virou **"Anotação (só no desenho)"**, com aviso de que a mensagem enviada é a de "Escrever mensagem". Duas caixas multilinha conviviam na mesma tela e só uma era enviada; o fundador escreveu na errada um texto que parecia mensagem e esperou que fosse entregue. Nada na tela dizia o contrário.

## Testes

`1728 passed, 1 skipped` · ruff, eslint e `tsc --noEmit` limpos.

Os que carregam o valor afirmam consequência, não mecanismo: as duas grafias do telefone caem na mesma conversa; dois grupos distintos **não** colapsam; nome diferente com o mesmo telefone **não** é duplicado; a observação escrita pelo dono não se perde na mescla.

Sem migration.

## Ao fazer deploy — passo operacional

A instância do fundador **já está conectada**, e mudar a config do webhook numa instância viva exige reaplicar o `/webhook/set` **e reiniciar o container `evolution`** (armadilha já registrada no CLAUDE.md: o processo mantém em memória a config carregada na conexão). Sessão reconecta sozinha, sem novo QR.

Depois disso, a mescla roda sob confirmação:

```bash
docker compose exec api python -m app.scripts.merge_duplicate_clients          # confere
docker compose exec api python -m app.scripts.merge_duplicate_clients --apply  # executa
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
