### PR TITLE
fix: o WhatsApp para de falhar em silêncio no convite de usuário

### DIFF
--- a/apps/api/app/core/whatsapp/__init__.py
+++ b/apps/api/app/core/whatsapp/__init__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from app.config import settings
 from app.core.phone import normalize_br
 from app.core.whatsapp import capabilities
 from app.core.whatsapp.providers import evolution, meta
@@ -37,6 +38,7 @@ logger = logging.getLogger("e1p.whatsapp")
 
 __all__ = [
     "WhatsappApiError",
+    "is_deliverable",
     "fetch_group_subject",
     "send_text",
     "send_template",
@@ -59,6 +61,29 @@ def _resolve(profile: TenantProfile | None):
     (por qual API o texto sai) não conseguem divergir. Gate em
     `tests/test_whatsapp_capabilities.py::test_capabilities_e_despachante_nunca_divergem`."""
     return evolution if capabilities.for_profile(profile) is capabilities.EVOLUTION else meta
+
+
+def is_deliverable(profile: TenantProfile | None) -> bool:
+    """Existe, AGORA, transporte capaz de entregar para este tenant?
+
+    Sem isso, quem enfileira não distingue "vai sair" de "vai morrer": os providers devolvem
+    `"logged"` quando não têm credencial — um status de sucesso aparente, TERMINAL (o worker não
+    reprocessa `logged`). Foi assim que um convite de funcionário sumiu em produção
+    (2026-08-05): a sessão Evolution tinha caído, o envio caiu no stub da Meta e a tela do Master
+    disse que estava tudo certo.
+
+    Mora no despachante, e não em cada call site, pela mesma razão de `_addressable` e
+    `capabilities`: é a fronteira por onde TODO envio passa, e são seis os caminhos que enfileiram
+    WhatsApp. Responde sobre a POSSIBILIDADE de entregar — não promete que o WhatsApp do
+    destinatário existe, nem que a sessão não vai cair no minuto seguinte.
+    """
+    if _resolve(profile) is evolution:
+        # Credencial da Evolution é GLOBAL; o vínculo com o tenant é o `whatsapp_provider`, que
+        # `_resolve` já conferiu e que só `confirm()`/`promote_pending_connections` escrevem.
+        return bool(settings.evolution_api_key)
+    if profile is not None:
+        return bool(profile.whatsapp_token and profile.whatsapp_phone_id)
+    return bool(settings.whatsapp_token and settings.whatsapp_phone_id)
 
 
 def _addressable(to: str) -> str:

--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -26,6 +26,7 @@ from app.modules.settings import service as settings_service
 from app.modules.whatsapp_session.models import PublicWhatsappInstance
 from app.modules.whatsapp_templates.models import (
     PURPOSE_CLIENT_MOVED,
+    PURPOSE_STAFF_INVITE,
     STATUS_APPROVED,
     WhatsappTemplate,
 )
@@ -347,6 +348,63 @@ def on_client_moved(*, tenant_id: str, client_id: str, to_stage: str, **_: objec
                 "notificação NÃO enfileirada",
                 tenant_id,
             )
+
+
+# Quanto tempo a senha de um convite NÃO entregue continua recuperável do registro. É a janela
+# em que ela ainda serve ao Master (o funcionário não conseguiu entrar, e alguém vai reclamar);
+# depois dela, recriar o usuário é a resposta, e o texto puro vira só passivo.
+INVITE_SECRET_GRACE = timedelta(days=7)
+# `message` é NOT NULL — a marca substitui o corpo em vez de esvaziá-lo, e diz o que houve.
+INVITE_BODY_REDACTED = "[convite entregue — senha removida do registro]"
+
+
+def purge_invite_secrets(db: Session, *, tenant_id: str, now: datetime) -> int:
+    """Apaga a senha temporária do registro dos convites, mantendo o metadado. Devolve quantos.
+
+    `notifications.message` guarda o corpo INTEIRO do convite, com a linha `Senha temporária:`,
+    e `whatsapp_template_variables` guarda a mesma senha como último elemento. Sem expurgo, toda
+    senha temporária já emitida fica legível em texto puro para sempre — enquanto a mesma senha,
+    em `users`, está protegida por bcrypt. Achado ao investigar o incidente de 2026-08-05.
+
+    Três estados, três tratamentos (decisão do fundador):
+      - **entregue** (`sent`): a senha já está com o destinatário; o registro não tem mais o que
+        acrescentar. Expurga na primeira passada.
+      - **terminal sem entrega** (`logged`/`failed`/`expired`): a senha ainda pode ser a única
+        cópia útil ao Master. Expurga só depois de `INVITE_SECRET_GRACE`.
+      - **`pending`**: NUNCA — o worker ainda precisa do corpo para enviar.
+
+    `tenant_id` é parâmetro por simetria com as demais funções do módulo (o isolamento real vem
+    da RLS da sessão), e `now` é injetável pelo mesmo motivo de `process_pending`: uma janela de
+    carência presa ao relógio da máquina não é testável.
+    """
+    alvos = list(
+        db.scalars(
+            select(Notification).where(
+                Notification.purpose == PURPOSE_STAFF_INVITE,
+                Notification.status != "pending",
+                Notification.message != INVITE_BODY_REDACTED,  # idempotência
+            )
+        ).all()
+    )
+    purgados = 0
+    for n in alvos:
+        if n.status != "sent":
+            criada = n.created_at
+            if criada is not None:
+                if criada.tzinfo is None:  # SQLite devolve naive; Postgres, aware
+                    criada = criada.replace(tzinfo=UTC)
+                if now - criada < INVITE_SECRET_GRACE:
+                    continue
+        n.message = INVITE_BODY_REDACTED
+        n.whatsapp_template_variables = None
+        purgados += 1
+    if purgados:
+        db.commit()
+        logger.info(
+            "[notifications:purge_invite_secrets] senhas removidas do registro tenant=%s n=%s",
+            tenant_id, purgados,
+        )
+    return purgados
 
 
 def list_notifications(db: Session, limit: int = 50) -> list[Notification]:

--- a/apps/api/app/modules/platform/router.py
+++ b/apps/api/app/modules/platform/router.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.config import settings
 from app.core.tenancy import CurrentUser, require_platform_admin
 from app.db.session import get_db
 from app.modules.auth.schemas import TenantOut, UserOut
@@ -54,8 +53,9 @@ def create_account(
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return AccountInviteOut(
         tenant=TenantOut.model_validate(tenant), owner=UserOut.model_validate(owner),
-        # Em produção a senha temporária NÃO volta no corpo (vai por e-mail/WhatsApp — AC3).
-        temp_password=None if settings.is_production else temp,
+        # Em produção a senha só volta quando NÃO houve entrega — sem isso o dono da conta nova
+        # nasce inacessível (não existe reenvio de convite). Ver `reveals_temp_password`.
+        temp_password=temp if service.reveals_temp_password(status) else None,
         delivery=data.delivery, delivery_status=status,
     )
 
@@ -118,8 +118,8 @@ def create_staff(
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return StaffInviteOut(
         user=UserOut.model_validate(user),
-        # Em produção a senha temporária NÃO volta no corpo (vai por e-mail/WhatsApp — AC3).
-        temp_password=None if settings.is_production else temp,
+        # Em produção a senha só volta quando NÃO houve entrega — ver `reveals_temp_password`.
+        temp_password=temp if service.reveals_temp_password(status) else None,
         delivery=data.delivery, delivery_status=status,
     )
 

--- a/apps/api/app/modules/platform/service.py
+++ b/apps/api/app/modules/platform/service.py
@@ -6,11 +6,13 @@ as linhas globais.
 """
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.core import audit
+from app.core import audit, whatsapp
 from app.core.security import hash_password
 from app.core.tenancy import CurrentUser
 from app.db.base import TenantMixin
@@ -24,6 +26,8 @@ from app.modules.platform.schemas import (
     UpdateAccountRequest,
     UpdateUserRequest,
 )
+
+logger = logging.getLogger("e1p.platform")
 
 
 def _business_table_names() -> set[str]:
@@ -263,7 +267,15 @@ def _send_invite(
     *, name: str, email: str, phone: str, temp: str, delivery: str, company: str, tenant_id: str
 ) -> str:
     """Entrega a senha temporária por e-mail ou WhatsApp. Devolve o status do envio ("queued"
-    para WhatsApp desde a Onda 3 — a entrega real é do worker).
+    para WhatsApp desde a Onda 3 — a entrega real é do worker; "unconfigured" quando não há
+    transporte por onde entregar).
+
+    ⚠️ **"queued" só é dito quando existe transporte utilizável** (`whatsapp.is_deliverable`).
+    Sem essa guarda, um tenant com a sessão Evolution caída recebia "queued", a notificação ia
+    para o stub da Meta e morria como `logged` — status TERMINAL, que o worker não reprocessa.
+    Bug real de produção (2026-08-05): a senha de um funcionário nunca chegou e a tela do Master
+    afirmou que o envio tinha sido feito. Não enfileiramos o que já se sabe que vai morrer:
+    a `Notification` órfã só serviria para dar aparência de trabalho feito.
 
     O convite é enviado em nome do TENANT sendo criado/atendido (`tenant_id`), nunca da
     plataforma: por WhatsApp, usamos o vínculo de template daquele escritório (Configurações).
@@ -296,6 +308,12 @@ def _send_invite(
 
         with tenant_session(tenant_id) as tdb:
             profile = settings_service.get_profile(tdb, tenant_id)
+            if not whatsapp.is_deliverable(profile):
+                logger.warning(
+                    "[platform] convite por whatsapp sem transporte tenant=%s — não enfileirado",
+                    tenant_id,
+                )
+                return "unconfigured"
             template_id = (profile.whatsapp_template_bindings or {}).get(PURPOSE_STAFF_INVITE)
             template = tdb.get(WhatsappTemplate, template_id) if template_id else None
             if template is not None and template.status == STATUS_APPROVED:

--- a/apps/api/app/modules/platform/service.py
+++ b/apps/api/app/modules/platform/service.py
@@ -12,6 +12,7 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.core import audit, whatsapp
 from app.core.security import hash_password
 from app.core.tenancy import CurrentUser
@@ -261,6 +262,28 @@ def _temp_password() -> str:
     import secrets
 
     return secrets.token_urlsafe(9)
+
+
+# Status em que a senha chegou (ou vai chegar) ao destinatário por um canal de verdade.
+# `queued` entra aqui porque a entrega é do worker, não porque já aconteceu.
+_ENTREGUE = frozenset({"sent", "queued"})
+
+
+def reveals_temp_password(delivery_status: str) -> bool:
+    """Se a senha temporária pode voltar no corpo da resposta ao Master.
+
+    O AC3 da Story 2.1 esconde a senha em produção porque ela vai pelo canal de entrega — o
+    Master não precisa vê-la. **Quando não há entrega, essa premissa cai:** não existe sigilo a
+    preservar (a senha não saiu por lugar nenhum) e o usuário recém-criado fica inacessível para
+    sempre, já que não existe reenvio de convite. Aconteceu em produção (2026-08-05).
+
+    A exceção é ESTREITA de propósito: só vale para os status que dizem que NÃO foi entregue
+    (`unconfigured`, `failed`, `logged`). `sent` e `queued` seguem escondendo — decisão do
+    fundador ao autorizar esta abertura.
+    """
+    if not settings.is_production:
+        return True
+    return delivery_status not in _ENTREGUE
 
 
 def _send_invite(

--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -7,6 +7,7 @@ com credencial GLOBAL igual, mas endpoints e ciclo de vida próprios.
 """
 from __future__ import annotations
 
+import logging
 import secrets
 
 import httpx
@@ -21,6 +22,8 @@ from app.modules.whatsapp_session.models import (
     STATUS_DISCONNECTED,
     PublicWhatsappInstance,
 )
+
+logger = logging.getLogger("e1p.whatsapp")
 
 
 class WhatsappSessionError(Exception):
@@ -197,8 +200,8 @@ def get_status(db: Session, *, tenant_id: str) -> str:
 def confirm(db: Session, *, tenant_id: str) -> str:
     """Reverifica com a Evolution (nunca confia no client) e, se realmente 'open', É QUEM
     seta `whatsapp_provider='evolution'` — a única escrita de transição-pra-conectado deste
-    módulo. Chamado pelo frontend ao ver 'connected' pela primeira vez; o worker (Onda 2,
-    4ª etapa) é a rede de segurança caso a aba feche antes disso."""
+    módulo. Chamado pelo frontend ao ver 'connected' pela primeira vez; se a aba fechar antes
+    disso, `promote_pending_connections` (worker) faz a mesma transição."""
     instance = _instance_name(tenant_id)
     row = db.get(PublicWhatsappInstance, instance)
     if row is None:
@@ -211,6 +214,41 @@ def confirm(db: Session, *, tenant_id: str) -> str:
     row.last_status = STATUS_CONNECTED
     db.commit()
     return STATUS_CONNECTED
+
+
+def promote_pending_connections(db: Session, *, tenant_id: str) -> int:
+    """A rede de segurança que `confirm()` sempre prometeu e nunca teve. Devolve 1 se promoveu.
+
+    Quem escreve `whatsapp_provider='evolution'` é `confirm()`, disparado PELO FRONTEND ao ver
+    'connected'. Se a aba fechar antes, a Evolution segue conectada e o campo segue nulo — e o
+    despachante, que DERIVA o transporte desse campo (`core/whatsapp._resolve`), manda todo
+    envio pela Meta, que sem credencial devolve "logged". Nada protesta em lugar nenhum: o
+    recebimento continua funcionando (o webhook não consulta o provider), então o tenant parece
+    saudável enquanto nenhuma mensagem sai. Bug real de produção (2026-08-05, Doro Eventos): um
+    convite de funcionário ficou `logged` e a senha nunca chegou ao destinatário.
+
+    `check_connections` NÃO cobria isso: ele retorna cedo justamente quando o provider ainda não
+    é "evolution", que é a condição do defeito.
+
+    Só promove quem está em `connecting`. Uma instância em `disconnected` pode continuar "open"
+    do lado da Evolution — `disconnect()` engole falha de rede do logout —, e promovê-la
+    desfaria em silêncio um pedido explícito do dono.
+    """
+    row = db.get(PublicWhatsappInstance, _instance_name(tenant_id))
+    if row is None or row.last_status != STATUS_CONNECTING:
+        return 0
+    profile = settings_service.get_profile(db, tenant_id)
+    if profile.whatsapp_provider == "evolution":
+        return 0
+    if _fetch_evolution_status(row.instance_name) != "open":
+        return 0
+    profile.whatsapp_provider = "evolution"
+    row.last_status = STATUS_CONNECTED
+    db.commit()
+    logger.info(
+        "[whatsapp.session] conexão confirmada pelo worker (aba fechou antes) tenant=%s", tenant_id
+    )
+    return 1
 
 
 def refresh_qr(db: Session, *, tenant_id: str) -> str:

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -88,6 +88,10 @@ def run_sweep(
         # que é o lugar onde a granularidade tem consumidor real.
         "scheduled_promoted": 0,
         "whatsapp_connections_dropped": 0,
+        # Contador PRÓPRIO, e não uma partição de `dropped`: são eventos OPOSTOS do ciclo de
+        # vida da sessão (uma subiu × uma caiu), não dois recortes de um mesmo número. Somá-los
+        # produziria um total sem significado. Ver `test_o_sweep_NAO_ganhou_contador_novo`.
+        "whatsapp_connections_promoted": 0,
         "errors": [],
     }
 
@@ -165,8 +169,18 @@ def run_sweep(
                 {"tenant_id": tenant_id, "stage": "scheduled_promote", "error": str(exc)}
             )
 
-        # Etapa 5 — monitora quedas de sessão Evolution (sessão SEPARADA das outras quatro).
+        # Etapa 5 — reconcilia a sessão Evolution nas DUAS direções (sessão SEPARADA das outras
+        # quatro). Promover vem antes de checar queda: é a ordem do ciclo de vida, e um tenant
+        # promovido agora já entra saudável na checagem seguinte.
+        #
+        # As duas chamadas dividem o MESMO try porque dependem da mesma API externa — se a
+        # Evolution está fora do ar, separá-las só produziria dois registros do mesmo erro.
         try:
+            with tenant_session_factory(tenant_id) as db:
+                promoted = whatsapp_session_service.promote_pending_connections(
+                    db, tenant_id=tenant_id
+                )
+            result["whatsapp_connections_promoted"] += promoted
             with tenant_session_factory(tenant_id) as db:
                 dropped = whatsapp_session_service.check_connections(db, tenant_id=tenant_id)
             result["whatsapp_connections_dropped"] += dropped
@@ -178,12 +192,14 @@ def run_sweep(
 
     logger.info(
         "[worker] sweep: tenants=%s funil_resumido=%s notificacoes=%s midia_whatsapp=%s "
-        "agendadas_promovidas=%s conexoes_whatsapp_caidas=%s erros=%s",
+        "agendadas_promovidas=%s conexoes_whatsapp_promovidas=%s conexoes_whatsapp_caidas=%s "
+        "erros=%s",
         result["tenants_checked"],
         result["funnel_resumed"],
         result["notifications_processed"],
         result["whatsapp_media_processed"],
         result["scheduled_promoted"],
+        result["whatsapp_connections_promoted"],
         result["whatsapp_connections_dropped"],
         len(result["errors"]),
     )

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import argparse
 import logging
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -121,6 +121,20 @@ def run_sweep(
             logger.exception("[worker] fila falhou tenant=%s", tenant_id)
             result["errors"].append(
                 {"tenant_id": tenant_id, "stage": "notifications", "error": str(exc)}
+            )
+
+        # Etapa 2b — expurga a senha temporária do registro dos convites já resolvidos. Sem
+        # contador próprio: é faxina, não trabalho de negócio, e o volume tende a zero. Roda
+        # DEPOIS da fila (etapa 2) para nunca disputar o corpo de uma notificação ainda pendente.
+        try:
+            with tenant_session_factory(tenant_id) as db:
+                notifications_service.purge_invite_secrets(
+                    db, tenant_id=tenant_id, now=now or datetime.now(UTC)
+                )
+        except Exception as exc:  # noqa: BLE001 — idem: isola a falha por tenant (IV2)
+            logger.exception("[worker] expurgo de senha de convite falhou tenant=%s", tenant_id)
+            result["errors"].append(
+                {"tenant_id": tenant_id, "stage": "invite_secrets", "error": str(exc)}
             )
 
         # Etapa 3 — mídia pendente do inbox de WhatsApp (sessão SEPARADA das outras duas).

--- a/apps/api/tests/test_notifications_secret_purge.py
+++ b/apps/api/tests/test_notifications_secret_purge.py
@@ -1,0 +1,100 @@
+"""A senha temporária não fica para sempre em texto puro na fila.
+
+Achado ao investigar o incidente de 2026-08-05: `notifications.message` guarda o corpo do
+convite INTEIRO, incluindo a linha `Senha temporária: ...`, sem expiração — e
+`whatsapp_template_variables` guarda a mesma senha como último elemento. Foi o que permitiu
+recuperar a senha de um funcionário quando a entrega falhou, e é exatamente por isso que
+incomoda: o hash bcrypt em `users` protege muito bem uma senha que está em claro na mesa ao
+lado.
+
+Regra (decisão do fundador): entregue → expurga já; terminal sem entrega → expurga depois da
+carência (a senha ainda pode ser útil ao Master nesse intervalo); `pending` → nunca (o worker
+ainda precisa do corpo para enviar).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.modules.notifications import service
+from app.modules.notifications.models import Notification
+from app.modules.whatsapp_templates.models import PURPOSE_STAFF_INVITE
+
+TENANT_ID = "44444444-4444-4444-4444-444444444444"
+AGORA = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+SENHA = "lJQ2ooc8HPpj"
+CORPO = f"Olá! Login: a@b.com\nSenha temporária: {SENHA}\n"
+
+
+def _convite(db, *, status: str, criada_em: datetime, purpose: str = PURPOSE_STAFF_INVITE):
+    n = Notification(
+        tenant_id=TENANT_ID, channel="whatsapp", recipient="5511999999999",
+        message=CORPO, status=status, purpose=purpose,
+        whatsapp_template_variables=["Fulano", "Empresa", "a@b.com", SENHA],
+    )
+    db.add(n)
+    db.flush()
+    # `created_at` tem server_default; sobrescrevemos para posicionar a notificação no tempo.
+    n.created_at = criada_em
+    db.commit()
+    return n
+
+
+def test_convite_entregue_perde_a_senha_do_registro(db) -> None:
+    n = _convite(db, status="sent", criada_em=AGORA)
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 1
+
+    db.refresh(n)
+    assert SENHA not in n.message
+    assert n.whatsapp_template_variables is None
+    # O metadado permanece: o rastro de QUE houve um convite não pode sumir junto com o segredo.
+    assert n.status == "sent" and n.purpose == PURPOSE_STAFF_INVITE
+    assert n.recipient == "5511999999999"
+
+
+def test_convite_pendente_mantem_o_corpo(db) -> None:
+    """O worker ainda vai enviar essa mensagem — expurgar aqui entregaria um texto sem senha."""
+    n = _convite(db, status="pending", criada_em=AGORA)
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 0
+
+    db.refresh(n)
+    assert SENHA in n.message
+
+
+def test_convite_nao_entregue_sobrevive_a_carencia(db) -> None:
+    """`logged`/`failed` é o caso em que o Master pode precisar da senha — expurgar no ato
+    destruiria a única cópia recuperável dentro da janela em que ela ainda serve."""
+    n = _convite(db, status="logged", criada_em=AGORA - timedelta(days=3))
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 0
+
+    db.refresh(n)
+    assert SENHA in n.message
+
+
+def test_convite_nao_entregue_e_velho_e_expurgado(db) -> None:
+    n = _convite(db, status="logged", criada_em=AGORA - timedelta(days=8))
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 1
+
+    db.refresh(n)
+    assert SENHA not in n.message
+
+
+def test_nao_toca_em_notificacao_de_outro_proposito(db) -> None:
+    """Só o convite carrega senha. Cobrança/contrato têm corpo que o dono pode querer reler."""
+    n = _convite(db, status="sent", criada_em=AGORA, purpose="charge_reminder")
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 0
+
+    db.refresh(n)
+    assert n.message == CORPO
+
+
+def test_e_idempotente(db) -> None:
+    """Roda a cada sweep: a segunda passada não pode recontar o que já limpou."""
+    _convite(db, status="sent", criada_em=AGORA)
+
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 1
+    assert service.purge_invite_secrets(db, tenant_id=TENANT_ID, now=AGORA) == 0

--- a/apps/api/tests/test_platform.py
+++ b/apps/api/tests/test_platform.py
@@ -491,9 +491,20 @@ def test_users_requires_admin(client: TestClient):
 
 # ── Gating de temp_password em produção (Story 2.1 AC3) ──────────────────────
 def test_temp_password_hidden_in_production_account(client: TestClient, admin_headers, monkeypatch):
-    """Em produção, POST /admin/accounts NÃO retorna a senha no corpo (vai por e-mail)."""
-    from app.config import settings
+    """Em produção, POST /admin/accounts NÃO retorna a senha no corpo quando o e-mail SAIU.
 
+    ⚠️ **Este teste mudou em 2026-08-05.** Antes ele exercia entrega `logged` (sem SMTP no
+    ambiente de teste) e ainda assim exigia senha oculta — travando a regra AMPLA "produção
+    esconde sempre". Essa regra deixava o usuário inacessível quando a entrega não acontecia,
+    e foi ESTREITADA por decisão do fundador: esconde-se quando a senha chegou (ou vai chegar)
+    ao destinatário, não sempre. Por isso o envio agora é forçado a "sent" — é essa a condição
+    que o AC3 realmente protege. O outro lado tem cobertura própria em
+    `test_producao_devolve_a_senha_quando_nao_houve_como_entregar`.
+    """
+    from app.config import settings
+    from app.core import email as email_module
+
+    monkeypatch.setattr(email_module, "send_email", lambda **kw: "sent")
     monkeypatch.setattr(settings, "environment", "production")
     resp = client.post(
         "/admin/accounts",
@@ -502,17 +513,21 @@ def test_temp_password_hidden_in_production_account(client: TestClient, admin_he
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["temp_password"] is None  # AC3: não vaza no corpo em produção
-    # o envio continua acontecendo (delivery_status) e a conta é criada normalmente
-    assert body["delivery_status"] in ("sent", "logged", "failed")
+    assert body["temp_password"] is None  # AC3: não vaza no corpo quando a entrega aconteceu
+    assert body["delivery_status"] == "sent"
     assert body["owner"]["must_reset_password"] is True
 
 
 def test_temp_password_hidden_in_production_staff(client: TestClient, admin_headers, monkeypatch):
-    """Em produção, POST /admin/accounts/{tid}/users NÃO retorna a senha temporária no corpo."""
+    """Em produção, POST /admin/accounts/{tid}/users NÃO retorna a senha quando o e-mail SAIU.
+
+    Mesma mudança de 2026-08-05 explicada no teste irmão acima (regra estreitada de "produção
+    esconde sempre" para "produção esconde quando a senha chegou ao destinatário")."""
     from app.config import settings
+    from app.core import email as email_module
 
     tid = _tenant_id(client, admin_headers, slug="prodstaff", email="prodstaff@example.com")
+    monkeypatch.setattr(email_module, "send_email", lambda **kw: "sent")
     monkeypatch.setattr(settings, "environment", "production")
     resp = client.post(
         f"/admin/accounts/{tid}/users",
@@ -521,8 +536,8 @@ def test_temp_password_hidden_in_production_staff(client: TestClient, admin_head
     )
     assert resp.status_code == 201, resp.text
     body = resp.json()
-    assert body["temp_password"] is None  # AC3: não vaza no corpo em produção
-    assert body["delivery_status"] in ("sent", "logged", "failed")
+    assert body["temp_password"] is None  # AC3: não vaza no corpo quando a entrega aconteceu
+    assert body["delivery_status"] == "sent"
 
 
 # ── Exclusão de conta: purga atômica + log de plataforma sobrevivente (Story 1.2) ────
@@ -683,3 +698,66 @@ def test_delete_account_404_for_unknown_tenant(
     resp = client.delete("/admin/accounts/tenant-inexistente-1234", headers=admin_headers)
     assert resp.status_code == 404
     assert db.query(PlatformAuditEntry).count() == 0
+
+
+# ── A senha volta ao Master QUANDO a entrega não aconteceu (decisão do fundador, 2026-08-05) ──
+#
+# O AC3 da Story 2.1 esconde `temp_password` em produção porque a senha vai pelo canal de
+# entrega. Quando NÃO há entrega, essa premissa cai: não existe sigilo a preservar (a senha não
+# saiu por lugar nenhum) e o usuário recém-criado fica inacessível para sempre. A exceção é
+# ESTREITA — só quando o status diz que não foi entregue; `sent` e `queued` seguem escondendo.
+
+@pytest.fixture()
+def _producao(monkeypatch: pytest.MonkeyPatch):
+    from app.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "environment", "production")
+
+
+def test_producao_devolve_a_senha_quando_nao_houve_como_entregar(
+    client: TestClient, admin_headers, _producao, _tenant_session_to_test_db
+):
+    tid = _tenant_id(client, admin_headers, slug="escprod", email="escprod@example.com")
+    invite = client.post(
+        f"/admin/accounts/{tid}/users",
+        json=_staff_body(email="prodzap@escprod.com", delivery="whatsapp"),
+        headers=admin_headers,
+    ).json()
+
+    assert invite["delivery_status"] == "unconfigured"
+    assert invite["temp_password"], "sem entrega e sem senha, o usuário nasce inacessível"
+
+
+def test_producao_continua_escondendo_a_senha_quando_a_entrega_esta_a_caminho(
+    client: TestClient, admin_headers, db: Session, _producao, _tenant_session_to_test_db
+):
+    tid = _tenant_id(client, admin_headers, slug="escprodok", email="escprodok@example.com")
+    db.add(TenantProfile(tenant_id=tid, whatsapp_token="tok-p", whatsapp_phone_id="phone-p"))
+    db.commit()
+
+    invite = client.post(
+        f"/admin/accounts/{tid}/users",
+        json=_staff_body(email="prodok@escprodok.com", delivery="whatsapp"),
+        headers=admin_headers,
+    ).json()
+
+    assert invite["delivery_status"] == "queued"
+    assert invite["temp_password"] is None
+
+
+def test_producao_devolve_a_senha_da_CONTA_nova_quando_a_entrega_falha(
+    client: TestClient, admin_headers, _producao, _tenant_session_to_test_db
+):
+    """Mesma regra nos dois convites — dono de conta e funcionário."""
+    body = client.post(
+        "/admin/accounts",
+        json={
+            "legal_name": "Conta Sem Zap", "slug": "semzapconta", "document": "12345678909",
+            "name": "Dona Sem Zap", "email": "dona@semzapconta.com",
+            "address": "Rua X, 1", "phone": "27988887777", "delivery": "whatsapp",
+        },
+        headers=admin_headers,
+    ).json()
+
+    assert body["delivery_status"] == "unconfigured"
+    assert body["temp_password"]

--- a/apps/api/tests/test_platform.py
+++ b/apps/api/tests/test_platform.py
@@ -205,16 +205,71 @@ def test_create_edit_delete_staff(client: TestClient, admin_headers):
     assert node["staff_count"] == 0
 
 
-def test_staff_whatsapp_delivery(client: TestClient, admin_headers, _tenant_session_to_test_db):
+def test_staff_whatsapp_delivery(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    """Tenant COM transporte utilizável: o request enfileira e a entrega real fica pro worker
+    (Onda 3 — fila com validade/freio)."""
     tid = _tenant_id(client, admin_headers, slug="escw", email="escw@example.com")
+    db.add(TenantProfile(tenant_id=tid, whatsapp_token="tok-w", whatsapp_phone_id="phone-w"))
+    db.commit()
+
     invite = client.post(
         f"/admin/accounts/{tid}/users",
         json=_staff_body(email="zap@escw.com", delivery="whatsapp"),
         headers=admin_headers,
     ).json()
-    # entrega real fica pro worker desde a Onda 3 (fila com validade/freio) — o request só
-    # enfileira.
     assert invite["delivery"] == "whatsapp" and invite["delivery_status"] == "queued"
+
+
+# ── O convite não finge que enviou (fix do transporte silencioso, 2026-08-05) ────────────────
+#
+# Bug real de produção: o Master cadastrou um funcionário por WhatsApp num tenant cuja sessão
+# Evolution tinha sido desconectada 46min antes. `_send_invite` devolveu "queued" assim mesmo, a
+# notificação foi entregue ao stub da Meta (sem credencial) e morreu como `logged` — status
+# TERMINAL, que o worker não reprocessa. A senha nunca chegou, e a tela não tinha como saber.
+
+def test_convite_por_whatsapp_sem_transporte_nao_finge_que_enfileirou(
+    client: TestClient, admin_headers, db: Session, _tenant_session_to_test_db
+):
+    """Sem Evolution conectada e sem credencial da Meta, não há por onde entregar: o status diz
+    isso, e nada vai pra fila — enfileirar o que já se sabe que morrerá é a própria mentira."""
+    tid = _tenant_id(client, admin_headers, slug="escsem", email="escsem@example.com")
+
+    invite = client.post(
+        f"/admin/accounts/{tid}/users",
+        json=_staff_body(email="semzap@escsem.com", delivery="whatsapp"),
+        headers=admin_headers,
+    ).json()
+
+    assert invite["delivery_status"] == "unconfigured"
+    assert db.scalar(
+        select(Notification).where(
+            Notification.tenant_id == tid, Notification.channel == "whatsapp"
+        )
+    ) is None
+
+
+def test_convite_por_whatsapp_com_evolution_conectada_enfileira(
+    client: TestClient, admin_headers, db: Session, monkeypatch: pytest.MonkeyPatch,
+    _tenant_session_to_test_db,
+):
+    """Evolution confirmada (`whatsapp_provider='evolution'`) dispensa credencial da Meta — a
+    credencial dela é global."""
+    from app.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "evolution_api_key", "global-key")
+    tid = _tenant_id(client, admin_headers, slug="escevo", email="escevo@example.com")
+    db.add(TenantProfile(tenant_id=tid, whatsapp_provider="evolution"))
+    db.commit()
+
+    invite = client.post(
+        f"/admin/accounts/{tid}/users",
+        json=_staff_body(email="evozap@escevo.com", delivery="whatsapp"),
+        headers=admin_headers,
+    ).json()
+
+    assert invite["delivery_status"] == "queued"
 
 
 # ── WhatsApp por template (staff_invite) — Story convite via template ───────────────────────

--- a/apps/api/tests/test_whatsapp_session_service.py
+++ b/apps/api/tests/test_whatsapp_session_service.py
@@ -336,3 +336,91 @@ def test_check_connections_noop_when_still_connected(db, monkeypatch: pytest.Mon
 def test_check_connections_ignores_tenants_not_on_evolution(db) -> None:
     # profile.whatsapp_provider != "evolution" (nunca conectou) — nada a checar.
     assert session_service.check_connections(db, tenant_id=TENANT_ID) == 0
+
+
+# ── Rede de segurança: promover connecting->connected sem depender da aba aberta ──────────
+#
+# Bug real de produção (2026-08-05, tenant Doro Eventos): quem escreve
+# `whatsapp_provider='evolution'` é `confirm()`, disparado PELO FRONTEND ao ver "connected". O
+# docstring de `check_connections` afirmava que o worker era a rede de segurança caso a aba
+# fechasse antes — mas ele retorna cedo justamente quando o provider ainda não é "evolution".
+# A rede não existia. Consequência: a Evolution fica conectada, mensagens RECEBIDAS funcionam
+# (o webhook não consulta o provider) e todo ENVIO cai no stub da Meta virando `logged`, sem
+# erro em lugar nenhum.
+
+
+def _evolution_respondendo(status: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Faz `/instance/fetchInstances` devolver `status` para qualquer instância consultada."""
+
+    def _fake_get(url: str, **kwargs: object) -> object:
+        params = kwargs.get("params") or {}
+
+        class _R:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> list:
+                return [{"name": params.get("instanceName"), "connectionStatus": status}]
+
+        return _R()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+
+def test_promove_conexao_que_a_aba_fechada_deixou_pela_metade(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db.add(PublicWhatsappInstance(
+        instance_name="e1p-" + TENANT_ID, tenant_id=TENANT_ID, webhook_secret="s",
+        last_status=session_service.STATUS_CONNECTING,
+    ))
+    db.commit()
+    _evolution_respondendo("open", monkeypatch)
+
+    assert session_service.promote_pending_connections(db, tenant_id=TENANT_ID) == 1
+
+    db.expire_all()
+    assert settings_service.get_profile(db, TENANT_ID).whatsapp_provider == "evolution"
+    row = db.get(PublicWhatsappInstance, "e1p-" + TENANT_ID)
+    assert row.last_status == session_service.STATUS_CONNECTED
+
+
+def test_nao_promove_enquanto_a_evolution_nao_confirma(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db.add(PublicWhatsappInstance(
+        instance_name="e1p-" + TENANT_ID, tenant_id=TENANT_ID, webhook_secret="s",
+        last_status=session_service.STATUS_CONNECTING,
+    ))
+    db.commit()
+    _evolution_respondendo("connecting", monkeypatch)
+
+    assert session_service.promote_pending_connections(db, tenant_id=TENANT_ID) == 0
+
+    db.expire_all()
+    assert settings_service.get_profile(db, TENANT_ID).whatsapp_provider is None
+
+
+def test_nao_ressuscita_sessao_que_o_dono_desconectou(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`disconnect()` engole falha de rede do logout — a instância pode seguir "open" na
+    Evolution enquanto o dono já pediu para desconectar. Promover aqui desfaria, em silêncio,
+    uma decisão explícita dele. Só `connecting` é promovível; `disconnected` nunca."""
+    db.add(PublicWhatsappInstance(
+        instance_name="e1p-" + TENANT_ID, tenant_id=TENANT_ID, webhook_secret="s",
+        last_status=session_service.STATUS_DISCONNECTED,
+    ))
+    db.commit()
+    _evolution_respondendo("open", monkeypatch)
+
+    assert session_service.promote_pending_connections(db, tenant_id=TENANT_ID) == 0
+
+    db.expire_all()
+    assert settings_service.get_profile(db, TENANT_ID).whatsapp_provider is None
+
+
+def test_nao_promove_tenant_sem_instancia(db) -> None:
+    assert session_service.promote_pending_connections(db, tenant_id=TENANT_ID) == 0

--- a/apps/api/tests/test_worker.py
+++ b/apps/api/tests/test_worker.py
@@ -494,6 +494,12 @@ def test_o_sweep_NAO_ganhou_contador_novo(client: TestClient, db):
     ⚠️ **[Merge com `main`]** `whatsapp_connections_dropped` entrou na lista — é a 5ª etapa (monitor
     de sessão Evolution), independente da promoção de agendadas e trazida por outra frente de
     trabalho (PRs #62–#69). As duas etapas coexistem: nenhuma substitui a outra.
+
+    ⚠️ **`whatsapp_connections_promoted` entrou depois (fix do transporte silencioso, 2026-08-05)
+    e NÃO viola a regra acima.** A regra proíbe dar três números para uma informação — o caso da
+    promoção de agendadas, onde os dois lados somam. Aqui os dois contadores são eventos
+    OPOSTOS do ciclo de vida da sessão (uma conexão subiu × uma caiu); a soma deles não
+    responde pergunta nenhuma, e cada um sozinho responde a sua.
     """
     client.post("/auth/register", json=REGISTER)
     cm = _cm_factory(db)
@@ -505,6 +511,7 @@ def test_o_sweep_NAO_ganhou_contador_novo(client: TestClient, db):
         "whatsapp_media_processed",
         "scheduled_promoted",
         "whatsapp_connections_dropped",
+        "whatsapp_connections_promoted",
         "errors",
     }
 
@@ -552,3 +559,49 @@ def test_run_sweep_isolates_whatsapp_stage_failure(db, monkeypatch):
     assert len(result["errors"]) == 1
     assert result["errors"][0]["stage"] == "whatsapp_connections"
     assert result["errors"][0]["tenant_id"] == tenant.id
+
+
+# --- Etapa 5 (cont.): promover a conexão que a aba fechada deixou pela metade ----------------
+#
+# Bug real de produção (2026-08-05): `confirm()` só roda se o FRONTEND vir "connected". Aba
+# fechada antes = Evolution conectada, `whatsapp_provider` nulo, todo envio caindo no stub da
+# Meta como `logged`, sem erro nenhum. `check_connections` não cobre: ele retorna cedo quando o
+# provider ainda não é "evolution", que é exatamente a condição do defeito.
+
+def test_run_sweep_promove_conexao_que_ficou_pela_metade(db, monkeypatch):
+    tenant = _make_tenant(db, slug="wa-promove")
+    db.commit()
+
+    promovidos: list[str] = []
+    monkeypatch.setattr(
+        worker.whatsapp_session_service, "promote_pending_connections",
+        lambda db, *, tenant_id: promovidos.append(tenant_id) or 1,
+    )
+    monkeypatch.setattr(
+        worker.whatsapp_session_service, "check_connections",
+        lambda db, *, tenant_id: 0,
+    )
+
+    cm = _cm_factory(db)
+    result = run_sweep(session_factory=cm, tenant_session_factory=cm)
+
+    assert promovidos == [tenant.id]
+    assert result["whatsapp_connections_promoted"] == 1
+    assert result["errors"] == []
+
+
+def test_falha_ao_promover_nao_derruba_o_sweep(db, monkeypatch):
+    """Mesmo isolamento por etapa (IV2) das outras: o erro é acumulado, o sweep segue."""
+    _make_tenant(db, slug="wa-promove-falha")
+    db.commit()
+
+    def _boom(db, *, tenant_id):
+        raise RuntimeError("evolution fora do ar")
+
+    monkeypatch.setattr(worker.whatsapp_session_service, "promote_pending_connections", _boom)
+
+    cm = _cm_factory(db)
+    result = run_sweep(session_factory=cm, tenant_session_factory=cm)
+
+    assert [e["stage"] for e in result["errors"]] == ["whatsapp_connections"]
+    assert result["tenants_checked"] == 1

--- a/apps/api/tests/test_worker.py
+++ b/apps/api/tests/test_worker.py
@@ -605,3 +605,44 @@ def test_falha_ao_promover_nao_derruba_o_sweep(db, monkeypatch):
 
     assert [e["stage"] for e in result["errors"]] == ["whatsapp_connections"]
     assert result["tenants_checked"] == 1
+
+
+# --- Etapa 6: a senha do convite não fica em texto puro para sempre -------------------------
+
+def test_sweep_expurga_a_senha_de_convite_ja_entregue(db):
+    from app.modules.notifications.models import Notification
+    from app.modules.notifications.service import INVITE_BODY_REDACTED
+    from app.modules.whatsapp_templates.models import PURPOSE_STAFF_INVITE
+
+    tenant = _make_tenant(db, slug="wa-purga")
+    n = Notification(
+        tenant_id=tenant.id, channel="whatsapp", recipient="5511999999999",
+        message="Senha temporária: segredo-123", status="sent", purpose=PURPOSE_STAFF_INVITE,
+        whatsapp_template_variables=["a", "b", "c", "segredo-123"],
+    )
+    db.add(n)
+    db.commit()
+
+    cm = _cm_factory(db)
+    result = run_sweep(session_factory=cm, tenant_session_factory=cm)
+
+    db.refresh(n)
+    assert n.message == INVITE_BODY_REDACTED
+    assert n.whatsapp_template_variables is None
+    assert result["errors"] == []
+
+
+def test_falha_no_expurgo_nao_derruba_o_sweep(db, monkeypatch):
+    _make_tenant(db, slug="wa-purga-falha")
+    db.commit()
+
+    def _boom(db, *, tenant_id, now):
+        raise RuntimeError("expurgo explodiu")
+
+    monkeypatch.setattr(worker.notifications_service, "purge_invite_secrets", _boom)
+
+    cm = _cm_factory(db)
+    result = run_sweep(session_factory=cm, tenant_session_factory=cm)
+
+    assert [e["stage"] for e in result["errors"]] == ["invite_secrets"]
+    assert result["tenants_checked"] == 1

--- a/apps/web/src/features/admin/PlatformUsers.test.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.test.tsx
@@ -197,3 +197,82 @@ describe("PlatformUsers/OfficeCard — suspender/excluir usuário: tratamento de
     expect(vi.mocked(api.delete)).toHaveBeenCalledWith("/admin/users/user-staff");
   });
 });
+
+// ── A tela de confirmação não pode mentir sobre o envio (fix de 2026-08-05) ──────────────────
+//
+// Bug real de produção: o Master cadastrou um funcionário por WhatsApp e a tela disse
+// "modo de teste (não saiu de verdade) — repasse a senha abaixo", com a caixa de senha VAZIA.
+// Duas causas somadas: (a) `queued` (o status normal do WhatsApp desde a Onda 3) era tratado
+// como falha, porque o código só aceitava `sent`; (b) em produção a API não devolve a senha
+// (Story 2.1 AC3), e o JSX renderizava `{invite.temp_password}` cru — rótulo órfão sobre o nada.
+
+async function cadastrarConta(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole("button", { name: "Nova conta" }));
+  await user.type(screen.getByLabelText("Nome da empresa"), "Empresa Teste Ltda");
+  await user.type(screen.getByLabelText("Subdomínio"), "empresa-teste");
+  await user.type(screen.getByLabelText("Nome completo"), "Fulano de Tal");
+  await user.type(screen.getByLabelText("CPF/CNPJ"), "12345678901");
+  await user.type(screen.getByLabelText("WhatsApp"), "27999990000");
+  await user.type(screen.getByLabelText("E-mail"), "fulano-teste@example.com");
+  await user.type(screen.getByLabelText("Endereço"), "Rua Teste, 100");
+  await user.click(screen.getByRole("button", { name: "Cadastrar e enviar senha" }));
+  await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+}
+
+describe("PlatformUsers — a confirmação do convite diz a verdade sobre a entrega", () => {
+  it("'queued' é sucesso, não modo de teste", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        temp_password: "senha-fake-123",
+        delivery_status: "queued",
+        delivery: "whatsapp",
+        owner: { name: "Fulano de Tal" },
+        tenant: { legal_name: "Empresa Teste Ltda" },
+      },
+    } as never);
+    renderPage();
+    await cadastrarConta(user);
+
+    expect(await screen.findByRole("heading", { name: "Conta criada" })).toBeInTheDocument();
+    expect(screen.queryByText(/modo de teste/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/enviada por WhatsApp/i)).toBeInTheDocument();
+  });
+
+  it("sem transporte: avisa que NÃO foi enviada", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        temp_password: "senha-fake-123",
+        delivery_status: "unconfigured",
+        delivery: "whatsapp",
+        owner: { name: "Fulano de Tal" },
+        tenant: { legal_name: "Empresa Teste Ltda" },
+      },
+    } as never);
+    renderPage();
+    await cadastrarConta(user);
+
+    expect(await screen.findByText(/não foi enviada/i)).toBeInTheDocument();
+    // A senha veio no corpo (dev): continua à mão para o Master repassar.
+    expect(screen.getByText("senha-fake-123")).toBeInTheDocument();
+  });
+
+  it("sem senha no corpo (produção): nenhuma caixa de senha vazia", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        temp_password: null,
+        delivery_status: "queued",
+        delivery: "whatsapp",
+        owner: { name: "Fulano de Tal" },
+        tenant: { legal_name: "Empresa Teste Ltda" },
+      },
+    } as never);
+    renderPage();
+    await cadastrarConta(user);
+
+    expect(await screen.findByRole("heading", { name: "Conta criada" })).toBeInTheDocument();
+    expect(screen.queryByText("Senha temporária")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/admin/PlatformUsers.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.tsx
@@ -13,6 +13,89 @@ import { usePrimaryAction } from "../../store/pageActions";
 // ROOT_DOMAIN configurado no Traefik/backend. Fallback "e1p.com" só pra dev local sem o build arg.
 const ROOT_DOMAIN = import.meta.env.VITE_ROOT_DOMAIN ?? "e1p.com";
 
+// ── Resultado do convite: a única voz sobre o que aconteceu com a senha ──────────────────────
+//
+// Os dois modais (funcionário e conta nova) tinham cópias divergentes desta tela, e ambas
+// erravam do mesmo jeito. Bug real de produção (2026-08-05): o Master leu
+// "modo de teste (não saiu de verdade) — repasse a senha abaixo" sobre uma caixa de senha
+// VAZIA. Eram dois defeitos somados:
+//   (a) só `sent` contava como sucesso, mas o WhatsApp devolve `queued` desde a Onda 3 (a
+//       entrega real é do worker) — o caminho normal era relatado como falha;
+//   (b) em produção a API não devolve a senha (Story 2.1 AC3) e o JSX renderizava
+//       `{invite.temp_password}` cru, deixando o rótulo órfão sobre o nada.
+// Daí a caixa da senha só existir quando há senha, e a frase derivar do status inteiro.
+
+const CANAL: Record<string, string> = { whatsapp: "WhatsApp", email: "e-mail" };
+
+/** Frase + se a entrega aconteceu. `entregue: false` é o que autoriza o tom de alerta. */
+function mensagemDeEntrega(status: string, canal: string): { texto: string; entregue: boolean } {
+  switch (status) {
+    case "sent":
+      return { texto: `A senha foi enviada por ${canal}.`, entregue: true };
+    case "queued":
+      // A fila é o caminho normal, não uma degradação: o worker entrega fora do request.
+      return { texto: `A senha foi enviada por ${canal} e chega em instantes.`, entregue: true };
+    case "unconfigured":
+      return {
+        texto: `A senha NÃO foi enviada: o ${canal} desta conta não está conectado.`,
+        entregue: false,
+      };
+    case "failed":
+      return { texto: `A senha NÃO foi enviada: o envio por ${canal} falhou.`, entregue: false };
+    default:
+      // "logged" — provedor sem credencial devolve isso; é o modo de teste de verdade.
+      return {
+        texto: `O envio por ${canal} está em modo de teste (não saiu de verdade).`,
+        entregue: false,
+      };
+  }
+}
+
+function InviteResult({
+  quem, delivery, deliveryStatus, tempPassword, rodape, onConcluir,
+}: {
+  quem: string;
+  delivery: string;
+  deliveryStatus: string;
+  tempPassword?: string | null;
+  rodape: string;
+  onConcluir: () => void;
+}) {
+  const canal = CANAL[delivery] ?? delivery;
+  const { texto, entregue } = mensagemDeEntrega(deliveryStatus, canal);
+  return (
+    <div className="space-y-3 text-sm">
+      <p className="text-neutral-600">
+        <strong>{quem}</strong> foi cadastrado. {texto}
+        {!entregue && tempPassword ? " Repasse a senha abaixo." : ""}
+      </p>
+      {tempPassword ? (
+        <div className="rounded-xl bg-neutral-50 p-3">
+          <p className="text-xs text-neutral-400">Senha temporária</p>
+          <p className="select-all font-mono text-base font-semibold text-neutral-800">
+            {tempPassword}
+          </p>
+        </div>
+      ) : null}
+      {!entregue && !tempPassword ? (
+        // Sem entrega E sem senha à mão, dizer "repasse abaixo" seria mandar o Master fazer o
+        // impossível. O caminho honesto é conectar o transporte e cadastrar de novo.
+        <p className="rounded-xl bg-amber-50 p-3 text-xs text-amber-800">
+          A senha não aparece aqui por segurança e o envio não aconteceu, então este usuário
+          ainda não tem como entrar. Conecte o {canal} em Configurações e cadastre novamente.
+        </p>
+      ) : null}
+      <p className="text-xs text-neutral-500">{rodape}</p>
+      <button
+        onClick={onConcluir}
+        className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500"
+      >
+        Concluir
+      </button>
+    </div>
+  );
+}
+
 // Módulos que um funcionário pode receber (vazio = acesso a tudo).
 const MODULES: { key: string; label: string }[] = [
   { key: "crm", label: "CRM" },
@@ -317,30 +400,16 @@ function AddStaffModal({ tenantId, onClose, onCreated }: { tenantId: string; onC
 
   // Tela de confirmação: usuário criado, senha temporária enviada.
   if (invite) {
-    const sent = invite.delivery_status === "sent";
-    const channel = invite.delivery === "whatsapp" ? "WhatsApp" : "e-mail";
     return (
       <Modal title="Usuário cadastrado" open onClose={() => { onClose(); onCreated(); }}>
-        <div className="space-y-3 text-sm">
-          <p className="text-neutral-600">
-            <strong>{invite.user.name}</strong> foi cadastrado. {sent
-              ? `A senha foi enviada por ${channel}.`
-              : `O envio por ${channel} está em modo de teste (não saiu de verdade) — repasse a senha abaixo.`}
-          </p>
-          <div className="rounded-xl bg-neutral-50 p-3">
-            <p className="text-xs text-neutral-400">Senha temporária</p>
-            <p className="select-all font-mono text-base font-semibold text-neutral-800">{invite.temp_password}</p>
-          </div>
-          <p className="text-xs text-neutral-500">
-            No primeiro acesso o usuário entra com essa senha e define uma nova.
-          </p>
-          <button
-            onClick={() => { onClose(); onCreated(); }}
-            className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500"
-          >
-            Concluir
-          </button>
-        </div>
+        <InviteResult
+          quem={invite.user.name}
+          delivery={invite.delivery}
+          deliveryStatus={invite.delivery_status}
+          tempPassword={invite.temp_password}
+          rodape="No primeiro acesso o usuário entra com essa senha e define uma nova."
+          onConcluir={() => { onClose(); onCreated(); }}
+        />
       </Modal>
     );
   }
@@ -448,24 +517,16 @@ function NewAccountModal({ open, onClose, onCreated }: { open: boolean; onClose:
   if (!open) return null;
 
   if (invite) {
-    const sent = invite.delivery_status === "sent";
-    const channel = invite.delivery === "whatsapp" ? "WhatsApp" : "e-mail";
     return (
       <Modal title="Conta criada" open onClose={finish}>
-        <div className="space-y-3 text-sm">
-          <p className="text-neutral-600">
-            <strong>{invite.owner.name}</strong> ({invite.tenant.legal_name}) foi cadastrado.{" "}
-            {sent ? `A senha foi enviada por ${channel}.` : `Envio por ${channel} em modo de teste — repasse a senha abaixo.`}
-          </p>
-          <div className="rounded-xl bg-neutral-50 p-3">
-            <p className="text-xs text-neutral-400">Senha temporária</p>
-            <p className="select-all font-mono text-base font-semibold text-neutral-800">{invite.temp_password}</p>
-          </div>
-          <p className="text-xs text-neutral-500">No primeiro acesso o dono define uma nova senha.</p>
-          <button onClick={finish} className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white hover:bg-accent-500">
-            Concluir
-          </button>
-        </div>
+        <InviteResult
+          quem={`${invite.owner.name} (${invite.tenant.legal_name})`}
+          delivery={invite.delivery}
+          deliveryStatus={invite.delivery_status}
+          tempPassword={invite.temp_password}
+          rodape="No primeiro acesso o dono define uma nova senha."
+          onConcluir={finish}
+        />
       </Modal>
     );
   }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -56,7 +56,7 @@ export interface StaffInvite {
   user: User;
   temp_password: string;
   delivery: "email" | "whatsapp";
-  delivery_status: "sent" | "logged" | "failed";
+  delivery_status: "sent" | "queued" | "logged" | "failed" | "unconfigured";
 }
 
 /** Conta gerenciada pelo Super Admin: tenant + seu owner. */
@@ -84,7 +84,7 @@ export interface AccountInvite {
   owner: User;
   temp_password: string;
   delivery: "email" | "whatsapp";
-  delivery_status: "sent" | "logged" | "failed";
+  delivery_status: "sent" | "queued" | "logged" | "failed" | "unconfigured";
 }
 
 /** Nó da hierarquia que o Super Admin vê: escritório → Admin → funcionários + clientes. */


### PR DESCRIPTION
## O incidente

Um funcionário foi cadastrado por WhatsApp em produção (tenant Doro Eventos, 05/08 19:26). A tela disse **"modo de teste — repasse a senha abaixo"** sobre uma caixa de senha **vazia**, e a senha nunca chegou a ninguém.

A investigação achou a origem: a sessão Evolution tinha sido desconectada às **18:40:36** — 46 minutos antes. A Evolution confirma ao vivo (`connectionStatus: close`, `reasonCode: 401`), e a linha em `public_whatsapp_instances` foi atualizada 22ms depois, ordem que corresponde a `disconnect()` chamado explicitamente. Confirmado com o fundador: foi ele quem encerrou.

Daí em diante tudo foi consequência mecânica — e **nenhuma etapa protestou**.

## Os defeitos

**1. A rede de segurança do worker não existia.** `confirm()` é o único escritor de `whatsapp_provider='evolution'` e quem o dispara é o frontend ao ver "connected". Seu docstring afirmava que o worker cobria o caso de a aba fechar antes; mas `check_connections` retorna cedo justamente quando o provider ainda não é `evolution` — a condição do defeito. Agora existe `promote_pending_connections`, e ela **só promove quem está em `connecting`**: `disconnect()` engole falha de rede do logout, então promover algo em `disconnected` desfaria em silêncio um pedido explícito do dono.

**2. O convite dizia "queued" sem ter para onde entregar.** A notificação ia ao stub da Meta e morria como `logged` — status **terminal**, que o worker não reprocessa. Agora `whatsapp.is_deliverable(profile)` decide antes de enfileirar, e o status vira `unconfigured`. Não enfileiramos o que já se sabe que vai morrer.

**3. O modal mentia de duas formas.** Só `sent` contava como sucesso, mas o WhatsApp devolve `queued` desde a Onda 3 — o caminho normal era relatado como falha. E renderizava `{invite.temp_password}` cru, deixando rótulo órfão quando a API não devolve a senha (AC3, produção). As duas cópias divergentes da tela viraram um `InviteResult` só.

**4. A senha era inalcançável quando a entrega falhava.** Sem entrega e sem senha no corpo, o usuário criado ficava inacessível para sempre (não há reenvio de convite). O AC3 foi **estreitado** por decisão do fundador: esconde quando a senha chegou ou vai chegar ao destinatário; revela quando não houve entrega.

**5. A senha morava em texto puro na fila, sem expiração.** `notifications.message` e `whatsapp_template_variables` guardavam a senha de todo convite já emitido. Foi o que permitiu recuperar a do funcionário — e é exatamente por isso que incomoda. `purge_invite_secrets` (etapa 2b do worker): entregue expurga já, terminal-sem-entrega expurga após 7 dias, `pending` nunca.

## Onde as decisões moram

`is_deliverable` fica no **despachante**, pela mesma razão de `_addressable` e `capabilities`: é a fronteira por onde todo envio passa, e são seis os caminhos que enfileiram WhatsApp. Corrigir call site por call site deixaria cinco quebrados.

## Não incluído

O item "normalizar telefone" que eu havia diagnosticado **já estava resolvido em `main`** (PR #79, `normalize_br` na fronteira) — o diagnóstico inicial leu uma branch atrasada. Nada a fazer.

## Verificação

- `pytest`: 1727 passed, 1 skipped, **20 falhas pré-existentes**
- `vitest`: 507 passed · `ruff`, `tsc`, `eslint --max-warnings 0`: limpos

⚠️ **As 20 falhas não vêm deste PR.** `test_receivables_off_rail`, `test_payables*`, `test_receipts`, `test_projection_saldo_misto` e `test_invariante_do_trilho` ancoram "hoje" em `datetime.now(UTC).date()` enquanto o serviço usa `hoje_do_tenant` (PR #78) — quebram **todo dia entre 21h e meia-noite de Brasília**. Verificado num worktree limpo em `origin/main`: mesmas 20, conjunto idêntico. Vale um PR próprio.

## Depois do merge

O WhatsApp do tenant continua desconectado — é preciso reescanear o QR em Configurações, **mantendo a aba aberta até aparecer "conectado"** (ou, agora, esperar o worker promover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)