### PR TITLE
fix: a suíte parava de valer entre 21h e meia-noite

### DIFF
--- a/apps/api/tests/test_admin_nao_expoe_recebimento_fora_do_trilho.py
+++ b/apps/api/tests/test_admin_nao_expoe_recebimento_fora_do_trilho.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
-from datetime import UTC, date, datetime
+from datetime import date
 
 import pytest
 from fastapi.testclient import TestClient
@@ -40,6 +40,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core.security import hash_password
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.auth.models import Tenant, User
 from app.modules.bank.models import KIND_CHECKING, BankAccount
 from app.modules.crm.models import Client
@@ -311,6 +312,6 @@ def test_a_data_de_hoje_do_cenario_nao_e_futura() -> None:
     snapshots ficariam iguais **por não haver nada**. Um teste que passa por vacuidade é pior do que
     nenhum teste.
     """
-    assert HOJE <= datetime.now(UTC).date(), (
+    assert HOJE <= tenant_today(DEFAULT_TENANT_TIMEZONE), (
         "atualize `HOJE` neste arquivo: a data do cenário precisa estar no passado"
     )

--- a/apps/api/tests/test_ancora_de_hoje.py
+++ b/apps/api/tests/test_ancora_de_hoje.py
@@ -1,0 +1,147 @@
+"""Gate estrutural: nenhum teste define sua âncora de "hoje" em UTC cru.
+
+Depois do PR #78 o sistema inteiro vive no fuso do tenant — `hoje_do_tenant(db)` é a única
+âncora de "hoje" (`CLAUDE.md` §6.0). Doze arquivos de teste ficaram para trás ancorando em
+`datetime.now(UTC).date()`, e **a divergência é invisível 21 horas por dia**: das 21h à
+meia-noite em UTC−3 a data UTC já virou e a do tenant não, então o teste espera amanhã e o
+serviço responde hoje. Resultado medido em 2026-08-05: 20 falhas às 00:28 UTC, zero às 20:33
+UTC do mesmo dia — e um CI reprovado por um defeito que ninguém introduziu naquele PR.
+
+Por que um gate, e não só a correção: quem reintroduzir a âncora em UTC vai ver a suíte verde,
+abrir o PR com a suíte verde, e o custo cai numa madrugada, sobre outra pessoa. É a mesma
+classe de problema que a INSTANCIAÇÃO OBRIGATÓRIA (Epic 8) descreve — sem consumidor mecânico
+que proteste, acertar depende de alguém lembrar.
+
+O gate é ESTREITO de propósito: olha a **definição da âncora** (`def _hoje`, `TODAY = ...`),
+não todo uso de `datetime.now(UTC)`. Datas com margem folgada (`+ timedelta(days=30)` para
+"uma data claramente futura") não viram falha quando o dia desliza, e proibi-las trocaria um
+gate útil por ruído.
+
+O idioma correto já existia no repo (`test_bank_corte_de_data.py`, `test_bank_transfers.py`):
+`tenant_today(DEFAULT_TENANT_TIMEZONE)` — a primitiva pura de `core.tz`, sem `db` e sem um
+segundo relógio, já que os tenants de teste ficam com o fuso padrão.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent
+
+ANCORAS_FUNCAO = {"_hoje", "_today"}
+ANCORAS_CONSTANTE = {"TODAY", "HOJE"}
+
+
+def _usa_utc_cru(no: ast.AST) -> bool:
+    """`datetime.now(UTC).date()` ou `date.today()` dentro deste nó da árvore."""
+    for filho in ast.walk(no):
+        if not isinstance(filho, ast.Call) or not isinstance(filho.func, ast.Attribute):
+            continue
+        # date.today()
+        if filho.func.attr == "today":
+            return True
+        # ....now(UTC).date()
+        if filho.func.attr == "date" and isinstance(filho.func.value, ast.Call):
+            interno = filho.func.value.func
+            if isinstance(interno, ast.Attribute) and interno.attr == "now":
+                return True
+    return False
+
+
+def _violacoes(fonte: str) -> list[str]:
+    """Analisa a ÁRVORE, não o texto: docstring e comentário citam o padrão antigo ao explicá-lo,
+    e uma varredura textual acusaria justamente os arquivos que já foram corrigidos."""
+    achados: list[str] = []
+    arvore = ast.parse(fonte)
+    for no in arvore.body:
+        if isinstance(no, ast.FunctionDef) and no.name in ANCORAS_FUNCAO:
+            corpo = [c for c in no.body if not isinstance(c, ast.Expr)]  # tira a docstring
+            if any(_usa_utc_cru(c) for c in corpo):
+                achados.append(f"linha {no.lineno}: def {no.name}()")
+        elif isinstance(no, ast.Assign):
+            nomes = {a.id for a in no.targets if isinstance(a, ast.Name)}
+            if nomes & ANCORAS_CONSTANTE and _usa_utc_cru(no.value):
+                achados.append(f"linha {no.lineno}: {', '.join(sorted(nomes))} = ...")
+    return achados
+
+
+def _tem_ancora(arvore: ast.Module) -> bool:
+    for no in arvore.body:
+        if isinstance(no, ast.FunctionDef) and no.name in ANCORAS_FUNCAO:
+            return True
+        if isinstance(no, ast.Assign) and any(
+            isinstance(a, ast.Name) and a.id in ANCORAS_CONSTANTE for a in no.targets
+        ):
+            return True
+    return False
+
+
+def _segunda_opiniao(fonte: str) -> list[str]:
+    """Num arquivo que JÁ declara sua âncora, outro cálculo de "hoje" é uma segunda opinião.
+
+    Este é o ponto cego que a primeira versão do gate tinha: `test_receipts.py` teve o helper
+    `_hoje()` corrigido e continuou falhando, porque `_pay()` montava `paid_on` com
+    `datetime.now(UTC).date()` **inline**, sem passar pelo helper. O arquivo tinha duas âncoras
+    discordando entre si.
+
+    Vale só para arquivos COM âncora: quem não declara uma está usando data com margem folgada
+    (`+ timedelta(days=30)`), que não vira falha quando o dia desliza.
+    """
+    arvore = ast.parse(fonte)
+    if not _tem_ancora(arvore):
+        return []
+    achados: list[str] = []
+    for no in ast.walk(arvore):
+        if isinstance(no, ast.FunctionDef) and no.name in ANCORAS_FUNCAO:
+            continue  # a própria âncora já é coberta por `_violacoes`
+        if isinstance(no, ast.Call) and _usa_utc_cru(no):
+            achados.append(f"linha {no.lineno}")
+    return achados
+
+
+def test_nenhuma_ancora_de_hoje_em_utc_cru() -> None:
+    culpados: dict[str, list[str]] = {}
+    for arquivo in sorted(TESTS_DIR.glob("test_*.py")):
+        if arquivo.name == Path(__file__).name:
+            continue
+        achados = _violacoes(arquivo.read_text(encoding="utf-8"))
+        if achados:
+            culpados[arquivo.name] = achados
+
+    assert not culpados, (
+        "Âncora de 'hoje' em UTC cru — o serviço usa o fuso do tenant desde o PR #78. Use "
+        f"`tenant_today(DEFAULT_TENANT_TIMEZONE)`:\n{culpados}"
+    )
+
+
+def test_arquivo_com_ancora_nao_calcula_hoje_por_fora() -> None:
+    culpados: dict[str, list[str]] = {}
+    for arquivo in sorted(TESTS_DIR.glob("test_*.py")):
+        if arquivo.name == Path(__file__).name:
+            continue
+        achados = _segunda_opiniao(arquivo.read_text(encoding="utf-8"))
+        if achados:
+            culpados[arquivo.name] = achados
+
+    assert not culpados, (
+        "Este arquivo já declara sua âncora de 'hoje' — calcular outra por fora faz as duas "
+        f"discordarem 3h por dia. Use o helper do próprio arquivo:\n{culpados}"
+    )
+
+
+def test_o_gate_reconhece_uma_ancora_ruim_e_ignora_a_boa() -> None:
+    """Instanciação obrigatória: um membro E um não-membro. Sem o não-membro o gate poderia
+    estar acusando tudo; sem o membro, poderia não acusar nada."""
+    ruim = "def _hoje():\n    return datetime.now(UTC).date()\n"
+    ruim_constante = "TODAY = date.today()\n"
+    boa = "def _hoje():\n    return tenant_today(DEFAULT_TENANT_TIMEZONE)\n"
+    # O padrão antigo citado numa DOCSTRING é explicação, não âncora — não pode acusar.
+    boa_com_docstring = (
+        'def _hoje():\n    """Nunca `date.today()` solto."""\n'
+        "    return tenant_today(DEFAULT_TENANT_TIMEZONE)\n"
+    )
+
+    assert _violacoes(ruim), "não pegaria a âncora que causou as 20 falhas"
+    assert _violacoes(ruim_constante), "não pegaria a âncora em forma de constante"
+    assert not _violacoes(boa)
+    assert not _violacoes(boa_com_docstring), "acusaria um arquivo já corrigido"

--- a/apps/api/tests/test_bank_transactions.py
+++ b/apps/api/tests/test_bank_transactions.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import asdict
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -59,7 +59,7 @@ REGISTER = {
 }
 
 # Toda data usada nos testes é do passado em relação ao "hoje" real: a guarda de data futura
-# (`_validate_posted_at`) ancora em `datetime.now(UTC).date()`, como o resto do projeto.
+# (`_validate_posted_at`) ancora em `_hoje()`, como o resto do projeto.
 OPENING = date(2026, 7, 1)
 OPENING_CENTS = 1_500_00
 
@@ -207,7 +207,7 @@ def test_valor_zero_e_recusado(client: TestClient, headers):
 def test_data_futura_e_recusada(client: TestClient, headers):
     """Extrato é fato passado. Data futura é erro de digitação (ano errado é o caso comum)."""
     acc = _account(client, headers)
-    amanha = datetime.now(UTC).date() + timedelta(days=1)
+    amanha = _hoje() + timedelta(days=1)
     erro = _lancar(client, headers, acc["id"], amount_cents=10_00, posted_at=amanha, expect=422)
     assert "futura" in erro["detail"]
 
@@ -373,7 +373,7 @@ def test_edicao_de_data_e_valor_revalida_as_guardas(client: TestClient, headers)
         ).status_code
         == 422
     )
-    amanha = (datetime.now(UTC).date() + timedelta(days=1)).isoformat()
+    amanha = (_hoje() + timedelta(days=1)).isoformat()
     assert (
         client.patch(
             f"/bank/transactions/{tx['id']}", json={"posted_at": amanha}, headers=headers
@@ -808,7 +808,7 @@ def test_AC4_manual_continua_recusando_data_futura(client: TestClient, headers):
 
     assert SOURCE_MANUAL in SOURCES_EXTERNA
     acc = _account(client, headers)
-    amanha = datetime.now(UTC).date() + timedelta(days=1)
+    amanha = _hoje() + timedelta(days=1)
     erro = _lancar(client, headers, acc["id"], amount_cents=10_00, posted_at=amanha, expect=422)
     assert "futura" in erro["detail"]
 
@@ -826,7 +826,7 @@ def test_AC4_toda_origem_de_SISTEMA_aceita_data_futura(client: TestClient, heade
     por outro motivo (a A-3 de lá). São guardas diferentes, em camadas diferentes.
     """
     acc = _account(client, headers)
-    amanha = datetime.now(UTC).date() + timedelta(days=1)
+    amanha = _hoje() + timedelta(days=1)
     assert (
         service._validate_posted_at(
             amanha, service.get_account(db, acc["id"]), _hoje(), source=source
@@ -841,7 +841,7 @@ def test_AC4_toda_origem_EXTERNA_recusa_data_futura(client: TestClient, headers,
     caminho de escrita (Onda 4), e é justamente por isso que a regra é fixada agora: quando o
     parser chegar, ele herda a recusa em vez de a redescobrir."""
     acc = _account(client, headers)
-    amanha = datetime.now(UTC).date() + timedelta(days=1)
+    amanha = _hoje() + timedelta(days=1)
     with pytest.raises(service.BankError) as exc:
         service._validate_posted_at(
             amanha, service.get_account(db, acc["id"]), _hoje(), source=source
@@ -859,7 +859,7 @@ def test_AC4_source_desconhecido_e_422_e_nao_ganha_a_isencao(client: TestClient,
     caro, porque cria movimento futuro que só aparece semanas depois.
     """
     acc = _account(client, headers)
-    amanha = datetime.now(UTC).date() + timedelta(days=1)
+    amanha = _hoje() + timedelta(days=1)
     with pytest.raises(service.BankError) as exc:
         service._validate_posted_at(
             amanha, service.get_account(db, acc["id"]), _hoje(), source="origem_inventada"

--- a/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
+++ b/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
@@ -23,6 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.financial_intelligence import ai_narrator, diagnostics, engine
 from app.modules.payables import service as payables_service
 from app.modules.payables.models import Payable
@@ -40,7 +41,7 @@ REGISTER = {
 # Datas ancoradas em HOJE (e não em constantes fixas) porque o endpoint não injeta `today`: as
 # guardas de "data futura" de conta/checkpoint/movimento ancoram no relógio real, e um período fixo
 # no passado deixaria de conter os dados conforme o tempo passa.
-TODAY = datetime.now(UTC).date()
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
 START = TODAY - timedelta(days=20)
 END = TODAY
 REF = TODAY - timedelta(days=2)

--- a/apps/api/tests/test_financial_intelligence_projection.py
+++ b/apps/api/tests/test_financial_intelligence_projection.py
@@ -26,7 +26,7 @@ RLS não é exercida (ver conftest).
 """
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -34,6 +34,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.money_planes import ORIGEM_PLATAFORMA, ORIGENS
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.financial_intelligence import diagnostics as diagnostics_service
 from app.modules.financial_intelligence import projection as projection_service
 from app.modules.payables.models import Payable
@@ -49,7 +50,7 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-TODAY = datetime.now(UTC).date()
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 def _d(days: int) -> str:

--- a/apps/api/tests/test_financial_intelligence_projection_rls.py
+++ b/apps/api/tests/test_financial_intelligence_projection_rls.py
@@ -18,7 +18,7 @@ no `pytest -q`/`scripts/check.sh` (suíte SQLite), só no job dedicado do CI ou 
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from pathlib import Path
 from uuid import uuid4
 
@@ -31,6 +31,8 @@ from sqlalchemy.orm import Session  # noqa: E402
 from sqlalchemy.pool import NullPool  # noqa: E402
 from testcontainers.postgres import PostgresContainer  # noqa: E402
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today  # noqa: E402
+
 pytestmark = pytest.mark.rls_e2e
 
 _ROOT_USER = "e1p_root"
@@ -40,7 +42,7 @@ _DB_NAME = "e1pdb"
 
 _API_DIR = Path(__file__).resolve().parents[1]
 
-TODAY = date.today()
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 def _bootstrap_rls_role(super_url: str) -> None:

--- a/apps/api/tests/test_invariante_do_trilho.py
+++ b/apps/api/tests/test_invariante_do_trilho.py
@@ -26,13 +26,14 @@ cópias divergem, e o parecer da ratificação é a prova de que já divergiram 
 """
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank.models import BankTransaction
 from app.modules.receivables.models import (
     STATUS_CANCELED,
@@ -60,8 +61,9 @@ LIQUIDADAS = (STATUS_PAID, STATUS_SCHEDULED)
 
 
 def _hoje() -> date:
-    """A MESMA âncora do service (UTC), nunca `date.today()` local — `CLAUDE.md` §6.0."""
-    return datetime.now(UTC).date()
+    """A MESMA âncora do service, que desde o PR #78 é o FUSO DO TENANT — nunca UTC cru
+    nem `date.today()` local. O tenant de teste fica com o fuso padrão."""
+    return tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 ABERTURA = _hoje() - timedelta(days=60)

--- a/apps/api/tests/test_payables.py
+++ b/apps/api/tests/test_payables.py
@@ -6,10 +6,12 @@ hoje. Os testes que davam baixa ganharam a fixture `conta` e o helper `_pay`; **
 comportamento antigo foi enfraquecida ou apagada**. O que a 8.12 acrescenta de novo vive em
 `test_payables_bank_origin.py`.
 """
-from datetime import UTC, date, datetime
+from datetime import date
 
 import pytest
 from fastapi.testclient import TestClient
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 
 REGISTER = {
     "legal_name": "Pag Co",
@@ -49,7 +51,7 @@ def conta(client: TestClient, headers) -> str:
 
 
 def _hoje() -> str:
-    return datetime.now(UTC).date().isoformat()
+    return tenant_today(DEFAULT_TENANT_TIMEZONE).isoformat()
 
 
 def _pay(client: TestClient, headers, bill_id: str, conta: str, paid_on: str | None = None):

--- a/apps/api/tests/test_payables_bank_origin.py
+++ b/apps/api/tests/test_payables_bank_origin.py
@@ -32,13 +32,14 @@ do AC13 vive em `test_bank_rls.py` (`rls_e2e`, Postgres real com o papel `e1p_ap
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank.models import (
     SOURCE_OFX,
     SOURCE_PAYABLE,
@@ -81,7 +82,7 @@ def tenant_id(client: TestClient, headers) -> str:
 
 
 def _hoje() -> date:
-    return datetime.now(UTC).date()
+    return tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 def _conta(client: TestClient, headers, *, name: str = "Itaú PJ", **over) -> dict:

--- a/apps/api/tests/test_payables_scheduled.py
+++ b/apps/api/tests/test_payables_scheduled.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,6 +35,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.scheduling import status_por_data
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank import service as bank_service
 from app.modules.bank.models import BankTransaction
 from app.modules.payables import receipts as receipts_service
@@ -66,8 +67,9 @@ PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 64
 
 
 def _hoje() -> date:
-    """A MESMA âncora do service (UTC), nunca `date.today()` local — `CLAUDE.md` §6.0."""
-    return datetime.now(UTC).date()
+    """A MESMA âncora do service, que desde o PR #78 é o FUSO DO TENANT — nunca UTC cru
+    nem `date.today()` local. O tenant de teste fica com o fuso padrão."""
+    return tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 # Abertura dois meses atrás: o piso fica longe o bastante para não interferir nos testes de data

--- a/apps/api/tests/test_payment_queue_rls.py
+++ b/apps/api/tests/test_payment_queue_rls.py
@@ -12,7 +12,7 @@ com Docker (`pytest -m rls_e2e`).
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from pathlib import Path
 from uuid import uuid4
 
@@ -25,6 +25,8 @@ from sqlalchemy.orm import Session  # noqa: E402
 from sqlalchemy.pool import NullPool  # noqa: E402
 from testcontainers.postgres import PostgresContainer  # noqa: E402
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today  # noqa: E402
+
 pytestmark = pytest.mark.rls_e2e
 
 _ROOT_USER = "e1p_root"
@@ -34,7 +36,7 @@ _DB_NAME = "e1pdb"
 
 _API_DIR = Path(__file__).resolve().parents[1]
 
-TODAY = date.today()
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 def _bootstrap_rls_role(super_url: str) -> None:

--- a/apps/api/tests/test_projection_saldo_misto.py
+++ b/apps/api/tests/test_projection_saldo_misto.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -38,6 +38,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.money_planes import ORIGEM_MISTO, ORIGEM_PLATAFORMA, ORIGENS
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank import service as bank_service
 from app.modules.bank.models import (
     KIND_CHECKING,
@@ -65,7 +66,7 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-TODAY = datetime.now(UTC).date()
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
 # Abertura bem no passado: dá espaço para lançar movimento em qualquer data recente sem esbarrar na
 # guarda `posted_at > opening_date` do service (Story 8.3).
 OPENING = (TODAY - timedelta(days=60)).isoformat()

--- a/apps/api/tests/test_receipts.py
+++ b/apps/api/tests/test_receipts.py
@@ -15,6 +15,8 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
+
 REGISTER = {
     "legal_name": "Recibo Co",
     "document": "12345678000195",
@@ -65,13 +67,14 @@ def conta_primaria(client: TestClient, headers) -> str:
 
 
 def _hoje() -> str:
-    """Hoje em UTC — a mesma âncora do teto de `payables.service._valida_data_de_baixa`."""
-    return datetime.now(UTC).date().isoformat()
+    """Hoje NO FUSO DO TENANT — a mesma âncora do teto de
+    `payables.service._valida_data_de_baixa` desde o PR #78."""
+    return tenant_today(DEFAULT_TENANT_TIMEZONE).isoformat()
 
 
 def _pay(client: TestClient, headers, bill_id: str, conta: str, paid_on: str | None = None):
     """`POST /bills/{id}/pay` com o corpo obrigatório da Story 8.12 (AC11)."""
-    body = {"bank_account_id": conta, "paid_on": paid_on or datetime.now(UTC).date().isoformat()}
+    body = {"bank_account_id": conta, "paid_on": paid_on or _hoje()}
     return client.post(f"/payables/bills/{bill_id}/pay", json=body, headers=headers)
 
 
@@ -415,7 +418,7 @@ def test_link_grava_a_data_que_veio_no_payload(client: TestClient, headers, cont
     Este é o teste que reprova o retorno do `TODO(8.13)`: se o backend voltar a cravar `hoje`
     (como fazia na 8.12), `paid_at` deixa de ser a data enviada.
     """
-    ontem = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+    ontem = (tenant_today(DEFAULT_TENANT_TIMEZONE) - timedelta(days=1)).isoformat()
     # Vencimento HOJE e pagamento ONTEM: as duas datas plausíveis são diferentes, então a que for
     # gravada identifica sem ambiguidade quem mandou nela.
     b = _bill(client, headers, due_date=_hoje())
@@ -434,7 +437,7 @@ def test_link_sem_data_cai_no_default_due_date_do_apply_paid(
     """`paid_on` ausente ⇒ `due_date` (fundador F10) — o default vive em `apply_paid`, e a bandeja
     apenas **repassa** o `None`. Antes da 8.13 a bandeja cravava `hoje` aqui e este teste falharia.
     """
-    ontem = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+    ontem = (tenant_today(DEFAULT_TENANT_TIMEZONE) - timedelta(days=1)).isoformat()
     b = _bill(client, headers, due_date=ontem)
     rid = _upload(client, headers).json()["id"]
 

--- a/apps/api/tests/test_receivables_off_rail.py
+++ b/apps/api/tests/test_receivables_off_rail.py
@@ -30,13 +30,14 @@ from __future__ import annotations
 
 import ast
 import pathlib
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank.models import BankTransaction
 from app.modules.payables import service as payables_service
 from app.modules.receivables import service as receivables_service
@@ -69,8 +70,9 @@ OUTRO_TENANT = {
 
 
 def _hoje() -> date:
-    """A MESMA âncora do service (UTC), nunca `date.today()` local — `CLAUDE.md` §6.0."""
-    return datetime.now(UTC).date()
+    """A MESMA âncora do service, que desde o PR #78 é o FUSO DO TENANT — nunca UTC cru
+    nem `date.today()` local. O tenant de teste fica com o fuso padrão."""
+    return tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 # Ancorada em "hoje", nunca num dia fixo: data fixa envelheceria junto com o repositório sem nunca

--- a/apps/api/tests/test_transferencia_nao_altera_dre.py
+++ b/apps/api/tests/test_transferencia_nao_altera_dre.py
@@ -31,12 +31,13 @@ investimento, e não é).
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.bank.models import (
     KIND_CHECKING,
     KIND_INVESTMENT,
@@ -58,7 +59,7 @@ REGISTER = {
 
 
 def _hoje() -> date:
-    return datetime.now(UTC).date()
+    return tenant_today(DEFAULT_TENANT_TIMEZONE)
 
 
 ABERTURA = _hoje() - timedelta(days=90)


### PR DESCRIPTION
## O sintoma

A suíte de `main` falha **20 testes toda noite**, das 21h à meia-noite (horário de Brasília), e passa o resto do dia. Medido em 2026-08-05 num worktree limpo em `origin/main`: **20 falhas às 00:28 UTC, zero às 20:33 UTC do mesmo dia.**

Isso reprovou o CI do #83 por um defeito que aquele PR não introduziu — foi assim que apareceu.

## A causa

O PR #78 moveu o sistema inteiro para o fuso do tenant: `hoje_do_tenant(db)` virou a única âncora de "hoje". Doze arquivos de teste ficaram para trás ancorando em `datetime.now(UTC).date()`.

Das 21h à meia-noite em UTC−3 a data UTC já virou e a do tenant não. O teste espera amanhã, o serviço responde hoje. Nas outras 21 horas as duas coincidem e nada denuncia.

O idioma correto **já existia no repo** — `test_bank_corte_de_data.py` e `test_bank_transfers.py` usam `tenant_today(DEFAULT_TENANT_TIMEZONE)`, a primitiva pura de `core.tz`, sem `db` e sem um segundo relógio. Os doze passaram a usá-lo.

## O gate

`tests/test_ancora_de_hoje.py`, com duas asserções:

**1. Nenhuma definição de âncora em UTC cru** (`def _hoje`, `TODAY = ...`). Analisa a **árvore**, não o texto: uma varredura textual acusaria justamente os dois arquivos já corrigidos, que citam o padrão antigo na docstring ao explicá-lo.

**2. Num arquivo que já declara sua âncora, nada calcula "hoje" por fora.** Esta nasceu de um ponto cego real durante o próprio trabalho: `test_receipts.py` teve o `_hoje()` corrigido e **continuou falhando**, porque `_pay()` montava `paid_on` inline. O arquivo tinha duas âncoras discordando entre si. Depois de escrita, ela pegou mais dois arquivos (`test_bank_transactions.py`, 7 ocorrências, e `test_admin_nao_expoe_recebimento_fora_do_trilho.py`).

O gate é **estreito de propósito**: data com margem folgada (`+ timedelta(days=30)` para "uma data claramente futura") não vira falha quando o dia desliza, e proibi-la trocaria um gate útil por ruído.

## Por que gate, e não só a correção

O defeito é invisível 21 horas por dia. Quem reintroduzir a âncora em UTC vai ver a suíte verde, abrir o PR com a suíte verde, e o custo cai numa madrugada, sobre outra pessoa. É a mesma classe que a **INSTANCIAÇÃO OBRIGATÓRIA** do Epic 8 descreve — sem consumidor mecânico que proteste, acertar depende de alguém lembrar. Por isso o gate também tem o teste que prova que ele **reconhece uma âncora ruim e ignora a boa**: um gate sempre-verde é pior que nenhum.

## Escopo

**Nenhum arquivo de `app/` foi tocado** — é correção de teste. O comportamento de produção já estava certo desde o #78; eram os testes que mediam com a régua errada.

## Verificação

Rodado **às 01:09 UTC, dentro da janela que quebrava**: `1745 passed, 1 skipped`, `ruff` limpo. Antes: 20 falhas no mesmo horário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)