### PR TITLE
refactor: /config separado em abas — Empresa, Canais, Integrações, Vendas

### DIFF
--- a/apps/web/src/features/config/CanaisTab.tsx
+++ b/apps/web/src/features/config/CanaisTab.tsx
@@ -1,0 +1,12 @@
+import CelularSection from "./CelularSection";
+import WhatsappSection from "./WhatsappSection";
+
+/** Aba "Canais": por onde a mensagem entra e sai — WhatsApp e o celular do dono. */
+export default function CanaisTab() {
+  return (
+    <div className="space-y-6">
+      <WhatsappSection />
+      <CelularSection />
+    </div>
+  );
+}

--- a/apps/web/src/features/config/ConfiguracoesPage.test.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.test.tsx
@@ -116,6 +116,9 @@ describe("ConfiguracoesPage — Funil de entrada padrão", () => {
     } as never);
     render(<ConfiguracoesPage />);
 
+    // O funil vive na aba "Vendas" desde que /config foi separada em áreas.
+    await user.click(await screen.findByRole("button", { name: /Vendas/ }));
+
     const select = await screen.findByText("Funil Principal");
     expect(select).toBeInTheDocument();
 
@@ -128,6 +131,33 @@ describe("ConfiguracoesPage — Funil de entrada padrão", () => {
         expect.objectContaining({ default_entry_funnel_id: "f-1" }),
       ),
     );
+  });
+});
+
+describe("ConfiguracoesPage — áreas", () => {
+  it("separa os assuntos em abas em vez de empilhar tudo numa coluna", async () => {
+    render(<ConfiguracoesPage />);
+
+    await screen.findByText("Cor primária"); // espera o profile carregar
+    for (const nome of [/Empresa/, /Canais/, /Integrações/, /Vendas/]) {
+      expect(screen.getByRole("button", { name: nome })).toBeInTheDocument();
+    }
+
+    // A aba Empresa começa ativa; o WhatsApp (aba Canais) não está montado — é o que evita
+    // que abrir /config dispare a rede das quatro áreas de uma vez.
+    expect(screen.queryByText(/WhatsApp por QR Code/i)).not.toBeInTheDocument();
+  });
+
+  it("cada aba mostra só o seu assunto", async () => {
+    const user = userEvent.setup();
+    render(<ConfiguracoesPage />);
+
+    await screen.findByText("Cor primária");
+    expect(screen.queryByText("Funil de entrada padrão")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Vendas/ }));
+    expect(await screen.findByText("Funil de entrada padrão")).toBeInTheDocument();
+    expect(screen.queryByText("Cor primária")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -1,34 +1,30 @@
-import type { FunnelSummary, GoogleCalendarStatus, TenantProfile } from "@e1p/shared-types";
-import { Check, SlidersHorizontal, Video, Workflow } from "lucide-react";
+import type { TenantProfile } from "@e1p/shared-types";
+import { Building2, Check, Filter, MessageCircle, Workflow } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import ImageUploadButton from "../../components/ImageUploadButton";
-import {
-  api,
-  apiErrorMessage,
-  disconnectGoogle,
-  getGoogleConnectUrl,
-  getGoogleStatus,
-} from "../../lib/api";
-import { applyBrandTheme } from "../../lib/theme";
-import CelularSection from "./CelularSection";
-import IntegrationsSection from "./IntegrationsSection";
-import WhatsappSection from "./WhatsappSection";
+import { api, apiErrorMessage } from "../../lib/api";
 import { formatTime } from "../../lib/datetime";
+import { applyBrandTheme } from "../../lib/theme";
 import { useFuso } from "../../store/auth";
+import CanaisTab from "./CanaisTab";
+import EmpresaTab from "./EmpresaTab";
+import IntegracoesTab from "./IntegracoesTab";
+import VendasTab from "./VendasTab";
 
-const FONTS = ["Inter", "Poppins", "Raleway", "Georgia", "Arial"];
-const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
+type Tab = "empresa" | "canais" | "integracoes" | "vendas";
 
-type Tab = "perfil" | "integracoes";
-
-const TABS: { key: Tab; label: string; icon: typeof SlidersHorizontal }[] = [
-  { key: "perfil", label: "Perfil & Marca", icon: SlidersHorizontal },
+const TABS: { key: Tab; label: string; icon: typeof Building2 }[] = [
+  { key: "empresa", label: "Empresa", icon: Building2 },
+  { key: "canais", label: "Canais", icon: MessageCircle },
   { key: "integracoes", label: "Integrações", icon: Workflow },
+  { key: "vendas", label: "Vendas", icon: Filter },
 ];
+
+/** Abas cujo conteúdo edita o perfil do tenant — só nelas o botão Salvar faz sentido. */
+const PERFIL_TABS: Tab[] = ["empresa", "vendas"];
 
 export default function ConfiguracoesPage() {
   const fuso = useFuso();
-  const [tab, setTab] = useState<Tab>("perfil");
+  const [tab, setTab] = useState<Tab>("empresa");
   const [p, setP] = useState<TenantProfile | null>(null);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
@@ -46,6 +42,7 @@ export default function ConfiguracoesPage() {
   if (!p) return <div className="p-8 text-sm text-neutral-400">Carregando...</div>;
 
   const set = (patch: Partial<TenantProfile>) => setP({ ...p, ...patch });
+  const editandoPerfil = PERFIL_TABS.includes(tab);
 
   async function save() {
     setSaving(true);
@@ -62,14 +59,6 @@ export default function ConfiguracoesPage() {
     }
   }
 
-  const colors: [string, keyof TenantProfile][] = [
-    ["Cor primária", "primary_color"],
-    ["Secundária", "secondary_color"],
-    ["Destaque", "accent_color"],
-    ["Texto", "text_color"],
-    ["Fundo", "bg_color"],
-  ];
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between">
@@ -78,22 +67,22 @@ export default function ConfiguracoesPage() {
           <h1 className="text-2xl font-bold text-neutral-800">Configurações</h1>
         </div>
         <div className="flex items-center gap-3">
-          {tab === "perfil" && savedAt && !error && (
+          {editandoPerfil && savedAt && !error && (
             <span className="text-xs text-neutral-400">Salvo {savedAt}</span>
           )}
-          {tab === "perfil" && (
+          {editandoPerfil && (
             <button onClick={save} disabled={saving} className="flex items-center gap-1.5 rounded-pill bg-accent-400 px-5 py-2 text-sm font-semibold text-white hover:bg-accent-500 disabled:opacity-50">
               <Check size={14} /> {saving ? "Salvando..." : "Salvar"}
             </button>
           )}
         </div>
       </div>
-      {tab === "perfil" && error && (
+      {editandoPerfil && error && (
         <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-danger">{error}</div>
       )}
 
-      {/* Abas — uma seção por responsabilidade (menos poluição). */}
-      <div className="flex gap-1 rounded-xl bg-neutral-100 p-1 lg:w-fit">
+      {/* Abas — uma área por assunto (menos poluição). */}
+      <div className="flex gap-1 overflow-x-auto rounded-xl bg-neutral-100 p-1 lg:w-fit">
         {TABS.map((t) => {
           const Icon = t.icon;
           const active = tab === t.key;
@@ -101,7 +90,7 @@ export default function ConfiguracoesPage() {
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className={`flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition ${
+              className={`flex shrink-0 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition ${
                 active ? "bg-white text-primary-600 shadow-sm" : "text-neutral-500 hover:text-neutral-700"
               }`}
             >
@@ -111,260 +100,15 @@ export default function ConfiguracoesPage() {
         })}
       </div>
 
-      {tab === "integracoes" && (
-        <div className="space-y-6">
-          <WhatsappSection />
-          <CelularSection />
-          <IntegrationsSection />
-        </div>
-      )}
-
-      {tab === "perfil" && (
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* Formulário */}
-        <div className="space-y-6 lg:col-span-2">
-          <Card title="Perfil da empresa">
-            <div className="grid grid-cols-2 gap-3">
-              <Inp label="Nome de exibição" value={p.display_name} onChange={(v) => set({ display_name: v })} />
-              <Inp label="CPF/CNPJ" value={p.document} onChange={(v) => set({ document: v })} />
-              <Inp label="E-mail" value={p.email} onChange={(v) => set({ email: v })} />
-              <Inp label="Telefone" value={p.phone} onChange={(v) => set({ phone: v })} />
-              <Inp label="Site" value={p.website} onChange={(v) => set({ website: v })} />
-              <Inp label="Endereço" value={p.address} onChange={(v) => set({ address: v })} />
-            </div>
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs font-medium text-neutral-600">Sobre</span>
-              <textarea value={p.about} onChange={(e) => set({ about: e.target.value })} rows={2} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
-            </label>
-          </Card>
-
-          <Card title="Brand Kit">
-            <p className="mb-3 text-xs text-neutral-400">
-              Usado como padrão em propostas, contratos e carrosséis.
-            </p>
-            <Inp label="Logo (URL)" value={p.logo_url} onChange={(v) => set({ logo_url: v })} placeholder="https://.../logo.png" />
-            <div className="mt-2">
-              <ImageUploadButton label="Enviar logo" onUploaded={(url) => set({ logo_url: url })} />
-            </div>
-            <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3">
-              {colors.map(([label, key]) => (
-                <div key={key}>
-                  <span className="mb-1 block text-xs font-medium text-neutral-600">{label}</span>
-                  <div className="flex items-center gap-2">
-                    <input type="color" value={p[key] as string} onChange={(e) => set({ [key]: e.target.value } as Partial<TenantProfile>)} className="h-9 w-10 cursor-pointer rounded border border-neutral-200" />
-                    <input value={p[key] as string} onChange={(e) => set({ [key]: e.target.value } as Partial<TenantProfile>)} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm uppercase outline-none" />
-                  </div>
-                </div>
-              ))}
-              <label className="block">
-                <span className="mb-1 block text-xs font-medium text-neutral-600">Fonte</span>
-                <select value={p.font} onChange={(e) => set({ font: e.target.value })} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400">
-                  {FONTS.map((f) => <option key={f} value={f}>{f}</option>)}
-                </select>
-              </label>
-            </div>
-          </Card>
-
-          <FunnelEntryCard
-            value={p.default_entry_funnel_id}
-            onChange={(v) => set({ default_entry_funnel_id: v })}
-          />
-
-          <GoogleSection />
-        </div>
-
-        {/* Prévia do Brand Kit */}
-        <div className="lg:col-span-1">
-          <Card title="Prévia">
-            <div className="overflow-hidden rounded-xl" style={{ background: p.bg_color, fontFamily: p.font }}>
-              <div className="px-5 py-6 text-center" style={{ borderTop: `4px solid ${p.primary_color}` }}>
-                {safeSrc(p.logo_url) ? (
-                  <img src={safeSrc(p.logo_url)} alt="logo" className="mx-auto mb-3 max-h-12 object-contain" />
-                ) : (
-                  <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold text-white" style={{ background: p.primary_color }}>
-                    {(p.display_name || "E")[0]}
-                  </div>
-                )}
-                <p className="text-lg font-bold" style={{ color: p.primary_color }}>
-                  {p.display_name || "Sua empresa"}
-                </p>
-                <p className="mt-1 text-sm" style={{ color: p.text_color, opacity: 0.7 }}>
-                  {p.about || "Identidade visual da sua marca"}
-                </p>
-                <div className="mt-4 inline-block rounded-pill px-5 py-2 text-sm font-bold text-white" style={{ background: p.accent_color }}>
-                  Botão de ação
-                </div>
-              </div>
-            </div>
-            <div className="mt-3 flex gap-1.5">
-              {[p.primary_color, p.secondary_color, p.accent_color, p.text_color].map((c, i) => (
-                <span key={i} className="h-6 flex-1 rounded" style={{ background: c }} title={c} />
-              ))}
-            </div>
-          </Card>
-        </div>
-      </div>
+      {tab === "empresa" && <EmpresaTab p={p} set={set} />}
+      {tab === "canais" && <CanaisTab />}
+      {tab === "integracoes" && <IntegracoesTab />}
+      {tab === "vendas" && (
+        <VendasTab
+          value={p.default_entry_funnel_id}
+          onChange={(v) => set({ default_entry_funnel_id: v })}
+        />
       )}
     </div>
-  );
-}
-
-/**
- * Funil de Vendas em que todo lead novo (source=landing/api) é inscrito automaticamente
- * (auto-enroll). Sem seleção = comportamento atual (sem auto-enroll).
- */
-function FunnelEntryCard({
-  value, onChange,
-}: { value: string | null; onChange: (v: string | null) => void }) {
-  const [funnels, setFunnels] = useState<FunnelSummary[]>([]);
-
-  useEffect(() => {
-    api.get<FunnelSummary[]>("/funnels").then(({ data }) => {
-      setFunnels(Array.isArray(data) ? data : []);
-    });
-  }, []);
-
-  return (
-    <Card title="Funil de entrada padrão">
-      <p className="mb-3 text-xs text-neutral-400">
-        Todo lead novo — de uma landing page publicada em Sites ou de um site externo via chave
-        de integração — entra automaticamente neste funil.
-      </p>
-      <select
-        value={value ?? ""}
-        onChange={(e) => onChange(e.target.value || null)}
-        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
-      >
-        <option value="">Nenhum (não inscrever automaticamente)</option>
-        {funnels.map((f) => (
-          <option key={f.id} value={f.id}>{f.name}</option>
-        ))}
-      </select>
-    </Card>
-  );
-}
-
-/**
- * Seção "Google Calendar": conectar/desconectar a conta Google do owner para gerar Meet
- * automaticamente na Agenda (Story 4.1). O botão "Conectar" só aparece se a plataforma tiver o
- * app OAuth configurado (`configured=true`). Trata o retorno do OAuth via `?google=connected|error`.
- */
-function GoogleSection() {
-  const [status, setStatus] = useState<GoogleCalendarStatus | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
-
-  const load = useCallback(async () => {
-    try {
-      setStatus(await getGoogleStatus());
-    } catch {
-      setStatus({ configured: false, connected: false, email: null });
-    }
-  }, []);
-
-  useEffect(() => {
-    // Feedback do retorno do OAuth (?google=connected|error) e limpeza da query string.
-    const params = new URLSearchParams(window.location.search);
-    const g = params.get("google");
-    if (g === "connected") setMsg({ kind: "ok", text: "Conta Google conectada com sucesso." });
-    else if (g === "error") setMsg({ kind: "err", text: "Não foi possível conectar ao Google." });
-    if (g) {
-      params.delete("google");
-      const qs = params.toString();
-      window.history.replaceState({}, "", window.location.pathname + (qs ? `?${qs}` : ""));
-    }
-    load();
-  }, [load]);
-
-  async function connect() {
-    setBusy(true);
-    setMsg(null);
-    try {
-      window.location.href = await getGoogleConnectUrl();
-    } catch (err) {
-      setMsg({ kind: "err", text: apiErrorMessage(err) });
-      setBusy(false);
-    }
-  }
-
-  async function disconnect() {
-    setBusy(true);
-    setMsg(null);
-    try {
-      await disconnectGoogle();
-      await load();
-      setMsg({ kind: "ok", text: "Conta Google desconectada." });
-    } catch (err) {
-      setMsg({ kind: "err", text: apiErrorMessage(err) });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <Card title="Google Calendar">
-      <p className="mb-3 text-xs text-neutral-400">
-        Conecte sua conta Google para gerar links do Meet automaticamente ao criar reuniões na
-        Agenda. Enquanto não conectar, você continua colando o link manualmente.
-      </p>
-      {msg && (
-        <div
-          className={`mb-3 rounded-lg px-3 py-2 text-sm ${
-            msg.kind === "ok" ? "bg-green-50 text-green-700" : "bg-red-50 text-danger"
-          }`}
-        >
-          {msg.text}
-        </div>
-      )}
-      {status === null ? (
-        <p className="text-sm text-neutral-400">Carregando...</p>
-      ) : !status.configured ? (
-        <p className="text-sm text-neutral-500">
-          Integração Google não configurada nesta plataforma.
-        </p>
-      ) : status.connected ? (
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-sm text-neutral-700">
-            <Video size={16} className="text-primary-600" />
-            Conectado{status.email ? ` como ${status.email}` : ""}
-          </div>
-          <button
-            onClick={disconnect}
-            disabled={busy}
-            className="rounded-pill border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
-          >
-            Desconectar
-          </button>
-        </div>
-      ) : (
-        <button
-          onClick={connect}
-          disabled={busy}
-          className="flex items-center gap-1.5 rounded-pill bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
-        >
-          <Video size={14} /> {busy ? "Redirecionando..." : "Conectar Google"}
-        </button>
-      )}
-    </Card>
-  );
-}
-
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-2xl bg-white p-5 shadow-sm">
-      <h2 className="mb-3 font-semibold text-neutral-800">{title}</h2>
-      {children}
-    </div>
-  );
-}
-
-function Inp({ label, value, onChange, placeholder }: {
-  label: string; value: string; onChange: (s: string) => void; placeholder?: string;
-}) {
-  return (
-    <label className="block">
-      <span className="mb-1 block text-xs font-medium text-neutral-600">{label}</span>
-      <input value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
-    </label>
   );
 }

--- a/apps/web/src/features/config/EmpresaTab.tsx
+++ b/apps/web/src/features/config/EmpresaTab.tsx
@@ -1,0 +1,102 @@
+import type { TenantProfile } from "@e1p/shared-types";
+import ImageUploadButton from "../../components/ImageUploadButton";
+import { Card, Inp } from "./ui";
+
+const FONTS = ["Inter", "Poppins", "Raleway", "Georgia", "Arial"];
+const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
+
+const COLORS: [string, keyof TenantProfile][] = [
+  ["Cor primária", "primary_color"],
+  ["Secundária", "secondary_color"],
+  ["Destaque", "accent_color"],
+  ["Texto", "text_color"],
+  ["Fundo", "bg_color"],
+];
+
+/**
+ * Aba "Empresa": quem a empresa é (perfil) e como ela se apresenta (Brand Kit), com a prévia
+ * ao lado. O estado do perfil e o botão Salvar continuam na página — esta aba só edita.
+ */
+export default function EmpresaTab({ p, set }: {
+  p: TenantProfile; set: (patch: Partial<TenantProfile>) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      {/* Formulário */}
+      <div className="space-y-6 lg:col-span-2">
+        <Card title="Perfil da empresa">
+          <div className="grid grid-cols-2 gap-3">
+            <Inp label="Nome de exibição" value={p.display_name} onChange={(v) => set({ display_name: v })} />
+            <Inp label="CPF/CNPJ" value={p.document} onChange={(v) => set({ document: v })} />
+            <Inp label="E-mail" value={p.email} onChange={(v) => set({ email: v })} />
+            <Inp label="Telefone" value={p.phone} onChange={(v) => set({ phone: v })} />
+            <Inp label="Site" value={p.website} onChange={(v) => set({ website: v })} />
+            <Inp label="Endereço" value={p.address} onChange={(v) => set({ address: v })} />
+          </div>
+          <label className="mt-3 block">
+            <span className="mb-1 block text-xs font-medium text-neutral-600">Sobre</span>
+            <textarea value={p.about} onChange={(e) => set({ about: e.target.value })} rows={2} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+          </label>
+        </Card>
+
+        <Card title="Brand Kit">
+          <p className="mb-3 text-xs text-neutral-400">
+            Usado como padrão em propostas, contratos e carrosséis.
+          </p>
+          <Inp label="Logo (URL)" value={p.logo_url} onChange={(v) => set({ logo_url: v })} placeholder="https://.../logo.png" />
+          <div className="mt-2">
+            <ImageUploadButton label="Enviar logo" onUploaded={(url) => set({ logo_url: url })} />
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {COLORS.map(([label, key]) => (
+              <div key={key}>
+                <span className="mb-1 block text-xs font-medium text-neutral-600">{label}</span>
+                <div className="flex items-center gap-2">
+                  <input type="color" value={p[key] as string} onChange={(e) => set({ [key]: e.target.value } as Partial<TenantProfile>)} className="h-9 w-10 cursor-pointer rounded border border-neutral-200" />
+                  <input value={p[key] as string} onChange={(e) => set({ [key]: e.target.value } as Partial<TenantProfile>)} className="w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm uppercase outline-none" />
+                </div>
+              </div>
+            ))}
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-neutral-600">Fonte</span>
+              <select value={p.font} onChange={(e) => set({ font: e.target.value })} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400">
+                {FONTS.map((f) => <option key={f} value={f}>{f}</option>)}
+              </select>
+            </label>
+          </div>
+        </Card>
+      </div>
+
+      {/* Prévia do Brand Kit */}
+      <div className="lg:col-span-1">
+        <Card title="Prévia">
+          <div className="overflow-hidden rounded-xl" style={{ background: p.bg_color, fontFamily: p.font }}>
+            <div className="px-5 py-6 text-center" style={{ borderTop: `4px solid ${p.primary_color}` }}>
+              {safeSrc(p.logo_url) ? (
+                <img src={safeSrc(p.logo_url)} alt="logo" className="mx-auto mb-3 max-h-12 object-contain" />
+              ) : (
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold text-white" style={{ background: p.primary_color }}>
+                  {(p.display_name || "E")[0]}
+                </div>
+              )}
+              <p className="text-lg font-bold" style={{ color: p.primary_color }}>
+                {p.display_name || "Sua empresa"}
+              </p>
+              <p className="mt-1 text-sm" style={{ color: p.text_color, opacity: 0.7 }}>
+                {p.about || "Identidade visual da sua marca"}
+              </p>
+              <div className="mt-4 inline-block rounded-pill px-5 py-2 text-sm font-bold text-white" style={{ background: p.accent_color }}>
+                Botão de ação
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 flex gap-1.5">
+            {[p.primary_color, p.secondary_color, p.accent_color, p.text_color].map((c, i) => (
+              <span key={i} className="h-6 flex-1 rounded" style={{ background: c }} title={c} />
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/config/IntegracoesTab.tsx
+++ b/apps/web/src/features/config/IntegracoesTab.tsx
@@ -1,0 +1,126 @@
+import type { GoogleCalendarStatus } from "@e1p/shared-types";
+import { Video } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  apiErrorMessage,
+  disconnectGoogle,
+  getGoogleConnectUrl,
+  getGoogleStatus,
+} from "../../lib/api";
+import IntegrationsSection from "./IntegrationsSection";
+import { Card } from "./ui";
+
+/** Aba "Integrações": o que o e1p conversa com o mundo fora dele. */
+export default function IntegracoesTab() {
+  return (
+    <div className="space-y-6">
+      <IntegrationsSection />
+      <GoogleSection />
+    </div>
+  );
+}
+
+/**
+ * Seção "Google Calendar": conectar/desconectar a conta Google do owner para gerar Meet
+ * automaticamente na Agenda (Story 4.1). O botão "Conectar" só aparece se a plataforma tiver o
+ * app OAuth configurado (`configured=true`). Trata o retorno do OAuth via `?google=connected|error`.
+ */
+function GoogleSection() {
+  const [status, setStatus] = useState<GoogleCalendarStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setStatus(await getGoogleStatus());
+    } catch {
+      setStatus({ configured: false, connected: false, email: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Feedback do retorno do OAuth (?google=connected|error) e limpeza da query string.
+    const params = new URLSearchParams(window.location.search);
+    const g = params.get("google");
+    if (g === "connected") setMsg({ kind: "ok", text: "Conta Google conectada com sucesso." });
+    else if (g === "error") setMsg({ kind: "err", text: "Não foi possível conectar ao Google." });
+    if (g) {
+      params.delete("google");
+      const qs = params.toString();
+      window.history.replaceState({}, "", window.location.pathname + (qs ? `?${qs}` : ""));
+    }
+    load();
+  }, [load]);
+
+  async function connect() {
+    setBusy(true);
+    setMsg(null);
+    try {
+      window.location.href = await getGoogleConnectUrl();
+    } catch (err) {
+      setMsg({ kind: "err", text: apiErrorMessage(err) });
+      setBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    setBusy(true);
+    setMsg(null);
+    try {
+      await disconnectGoogle();
+      await load();
+      setMsg({ kind: "ok", text: "Conta Google desconectada." });
+    } catch (err) {
+      setMsg({ kind: "err", text: apiErrorMessage(err) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card title="Google Calendar">
+      <p className="mb-3 text-xs text-neutral-400">
+        Conecte sua conta Google para gerar links do Meet automaticamente ao criar reuniões na
+        Agenda. Enquanto não conectar, você continua colando o link manualmente.
+      </p>
+      {msg && (
+        <div
+          className={`mb-3 rounded-lg px-3 py-2 text-sm ${
+            msg.kind === "ok" ? "bg-green-50 text-green-700" : "bg-red-50 text-danger"
+          }`}
+        >
+          {msg.text}
+        </div>
+      )}
+      {status === null ? (
+        <p className="text-sm text-neutral-400">Carregando...</p>
+      ) : !status.configured ? (
+        <p className="text-sm text-neutral-500">
+          Integração Google não configurada nesta plataforma.
+        </p>
+      ) : status.connected ? (
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-neutral-700">
+            <Video size={16} className="text-primary-600" />
+            Conectado{status.email ? ` como ${status.email}` : ""}
+          </div>
+          <button
+            onClick={disconnect}
+            disabled={busy}
+            className="rounded-pill border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
+          >
+            Desconectar
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={connect}
+          disabled={busy}
+          className="flex items-center gap-1.5 rounded-pill bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+        >
+          <Video size={14} /> {busy ? "Redirecionando..." : "Conectar Google"}
+        </button>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/features/config/VendasTab.tsx
+++ b/apps/web/src/features/config/VendasTab.tsx
@@ -1,0 +1,41 @@
+import type { FunnelSummary } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import { Card } from "./ui";
+
+/**
+ * Aba "Vendas". O Funil de Vendas em que todo lead novo (source=landing/api) é inscrito
+ * automaticamente (auto-enroll). Sem seleção = comportamento atual (sem auto-enroll).
+ *
+ * O valor faz parte do perfil do tenant, então quem guarda e salva continua sendo a página.
+ */
+export default function VendasTab({ value, onChange }: {
+  value: string | null; onChange: (v: string | null) => void;
+}) {
+  const [funnels, setFunnels] = useState<FunnelSummary[]>([]);
+
+  useEffect(() => {
+    api.get<FunnelSummary[]>("/funnels").then(({ data }) => {
+      setFunnels(Array.isArray(data) ? data : []);
+    });
+  }, []);
+
+  return (
+    <Card title="Funil de entrada padrão">
+      <p className="mb-3 text-xs text-neutral-400">
+        Todo lead novo — de uma landing page publicada em Sites ou de um site externo via chave
+        de integração — entra automaticamente neste funil.
+      </p>
+      <select
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+      >
+        <option value="">Nenhum (não inscrever automaticamente)</option>
+        {funnels.map((f) => (
+          <option key={f.id} value={f.id}>{f.name}</option>
+        ))}
+      </select>
+    </Card>
+  );
+}

--- a/apps/web/src/features/config/ui.tsx
+++ b/apps/web/src/features/config/ui.tsx
@@ -1,0 +1,23 @@
+/**
+ * Peças visuais compartilhadas pelas abas de `/config`. Vieram inteiras do
+ * `ConfiguracoesPage.tsx`, sem alteração — só saíram de lá porque agora têm mais de um dono.
+ */
+export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm">
+      <h2 className="mb-3 font-semibold text-neutral-800">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+export function Inp({ label, value, onChange, placeholder }: {
+  label: string; value: string; onChange: (s: string) => void; placeholder?: string;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-neutral-600">{label}</span>
+      <input value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+    </label>
+  );
+}


### PR DESCRIPTION
## O problema

`ConfiguracoesPage.tsx` tinha 370 linhas e empilhava sete assuntos sem relação numa coluna só: WhatsApp (o `WhatsappSection.tsx` sozinho tem 711 linhas), Celular, Integrações, Perfil da empresa, Brand Kit, Google Calendar e Funil de entrada padrão.

## O que mudou

Quatro áreas, uma por assunto:

| Aba | Conteúdo |
|---|---|
| **Empresa** | Perfil da empresa + Brand Kit + Prévia |
| **Canais** | `<WhatsappSection />` + `<CelularSection />` |
| **Integrações** | `<IntegrationsSection />` + `<GoogleSection />` |
| **Vendas** | Funil de entrada padrão |

`ConfiguracoesPage.tsx` foi de **370 para 114 linhas** — sobrou o cabeçalho, o estado do perfil e o seletor de abas. `Card` e `Inp` saíram para `ui.tsx` porque passaram a ter mais de um dono.

**Reorganizar, não redesenhar:** nenhum campo novo, nenhuma regra nova, nenhuma mudança de contrato de API. O botão Salvar aparece nas duas abas que editam o perfil (Empresa e Vendas) — é o mesmo `PATCH /settings/profile` de antes.

Efeito colateral bem-vindo do desmonte por aba: abrir `/config` não dispara mais a rede das quatro áreas de uma vez — WhatsApp, Celular e Integrações só buscam quando você abre a aba deles.

## Testes

`pnpm --filter @e1p/web test -- --run` → **55 arquivos, 512 testes, todos verdes** (eram 510; os 2 novos cobrem as quatro abas e o isolamento entre elas).

Um teste existente mudou, em uma linha: `"lista os funis e envia default_entry_funnel_id ao salvar"` procurava o funil sem clicar em aba nenhuma, porque ele ficava na tela inicial. Agora clica em "Vendas" antes. O controle mudou de endereço, não de comportamento — o resto do teste (selectOptions → Salvar → assert do `PATCH`) está intacto. Os 23 de `WhatsappSection.test.tsx` passam sem nenhuma alteração.

`tsc --noEmit` e `eslint --max-warnings 0` limpos.

## Ainda não verificado

Validação visual em ~360px não foi feita (dívida conhecida do projeto, não bloqueia merge). A barra de abas ganhou `overflow-x-auto` + `shrink-0` para as quatro caberem rolando em tela estreita, mas isso não foi conferido num aparelho nem no DevTools.

Referência: Task 20 de `docs/superpowers/plans/2026-08-06-vima-registro-de-fatos-e-briefing.md`. Trabalho independente — não toca em nada da Vima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
