### PR TITLE
feat: contabilidade de uso de IA e roteamento de modelo por tarefa

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ DATABASE_URL=postgresql://e1puser:e1ppass@localhost:5432/e1pdb
 
 # ── IA (Anthropic) ─────────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_MODEL=claude-opus-4-8
+# ANTHROPIC_MODEL saiu: o modelo é escolhido por tarefa em core/ai.MODELO_POR_TAREFA.
 
 # ── Auth ───────────────────────────────────────────────
 JWT_SECRET=gere-uma-string-aleatoria-longa-aqui

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -15,7 +15,9 @@ class Settings(BaseSettings):
 
     # IA
     anthropic_api_key: str = ""
-    anthropic_model: str = "claude-opus-4-8"
+    # O MODELO não mora mais aqui: ele é escolhido por tarefa em `core/ai.MODELO_POR_TAREFA`.
+    # Um valor global fazia narrar um briefing já calculado custar o mesmo que redigir peça
+    # jurídica — dívida registrada na spec da Vima e fechada aqui.
 
     # Auth
     jwt_secret: str = _DEV_SECRET

--- a/apps/api/app/core/ai.py
+++ b/apps/api/app/core/ai.py
@@ -2,15 +2,67 @@
 
 REGRA: todo texto que entra aqui DEVE já estar anonimizado (ver anonymizer.py).
 Esta camada não conhece dados reais — ela só fala com a Anthropic e devolve tokens + texto.
+
+Duas responsabilidades além de chamar a API, e as duas existem porque o ponto único de
+passagem é o único lugar onde elas são *garantidas*:
+
+1. **Contabilidade.** `db` e `tenant_id` são OBRIGATÓRIOS. Não é rigor decorativo: é a mesma
+   disciplina de `payables.is_overdue`, que exige `today` como parâmetro justamente para que
+   ninguém esqueça. Com eles obrigatórios, é impossível chamar a IA sem contabilizar — o
+   esquecimento vira `TypeError` no import, não uma linha faltando na conta seis meses depois.
+2. **Roteamento por tarefa.** O modelo sai de `MODELO_POR_TAREFA`, não de uma configuração
+   global. Narrar um briefing já calculado e redigir peça jurídica são trabalhos diferentes e
+   não deviam custar o mesmo.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
 
+from sqlalchemy.orm import Session
+
 from app.config import settings
+from app.core import ai_usage
 
 _client: Any | None = None
+
+# ── Roteamento de modelo por tarefa ────────────────────────────────────────────────────────
+#
+# Preços (USD por milhão de tokens, entrada/saída) no momento desta escolha:
+#   claude-haiku-4-5  →  $1 / $5
+#   claude-sonnet-5   →  $3 / $15
+#   claude-opus-5     →  $5 / $25
+#
+# O critério é o custo do ERRO, não o tamanho do texto. Onde a IA só reescreve um payload que
+# um motor determinístico já calculou, ela não origina número nenhum e o modelo mais barato
+# basta. Onde ela redige — proposta, criativo, peça — a qualidade do texto É o produto. E onde
+# alucinar tem consequência jurídica, o modelo mais capaz é o único aceitável.
+#
+# ⚠️ `claude-opus-5` custa exatamente o mesmo que o `claude-opus-4-8` que estava configurado
+# globalmente ($5/$25): trocar é ganho de capacidade sem centavo a mais.
+MODELO_POR_TAREFA: dict[str, str] = {
+    # Só narram o que já foi calculado — não originam número.
+    "vima.briefing": "claude-haiku-4-5",
+    "financeiro.diagnostico": "claude-haiku-4-5",
+    "receivables.cobranca": "claude-haiku-4-5",
+    # Redação: o texto é o produto.
+    "quotes.escopo": "claude-sonnet-5",
+    "funnels.compose": "claude-sonnet-5",
+    "marketing.carrossel": "claude-sonnet-5",
+    # Anti-alucinação é crítico e o dado é sensível (segredo de justiça).
+    "juridico.documento": "claude-opus-5",
+}
+
+# Tarefa desconhecida cai aqui em vez de estourar. O default é o modelo mais CAPAZ, não o mais
+# barato, por assimetria de custo: uma tarefa nova roteada para Haiku por engano degrada em
+# silêncio (texto pior, ninguém percebe), enquanto roteada para Opus só custa mais — e o
+# excesso aparece no ledger, que é exatamente o instrumento que este PR instala.
+MODELO_PADRAO = "claude-opus-5"
+
+
+def modelo_da_tarefa(task: str) -> str:
+    """Qual modelo roda esta tarefa. Tarefa desconhecida → `MODELO_PADRAO`."""
+    return MODELO_POR_TAREFA.get(task, MODELO_PADRAO)
 
 
 def _get_client() -> Any:
@@ -28,24 +80,66 @@ class AIResult:
     text: str
     input_tokens: int
     output_tokens: int
+    # Cache tem preço próprio e a Anthropic os devolve separados; achatá-los em `input_tokens`
+    # produziria uma conta errada. Default 0 para não quebrar quem constrói o resultado à mão
+    # (os testes dos narradores fazem isso).
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
 
 
 def complete(
     *,
+    db: Session,
+    tenant_id: str,
+    task: str,
     system: str,
     user_message: str,
     max_tokens: int = 4096,
     model: str | None = None,
+    user_id: str | None = None,
 ) -> AIResult:
-    """Chamada simples de completude. `user_message` deve estar anonimizado."""
+    """Chamada simples de completude. `user_message` deve estar anonimizado.
+
+    `db`, `tenant_id` e `task` são obrigatórios — ver o item 1 do docstring do módulo. `model`
+    continua aceito para sobrepor o roteamento em um caso específico, mas o normal é deixar a
+    `task` decidir.
+
+    Tudo é keyword-only, `db` inclusive — diferente de `facts.record(db, *, ...)` e
+    `audit.record(db, *, ...)`, que tomam a sessão posicionalmente. A divergência é deliberada:
+    esta função é substituída por mock em vários testes de narrador (`lambda **kw`), e um
+    parâmetro posicional os quebraria todos sem que nenhum deles tenha relação com contabilidade
+    de IA. Obrigatório e keyword-only são independentes — sem default, esquecer ainda é
+    `TypeError`.
+
+    O registro no ledger acontece DEPOIS da resposta e é best-effort: se ele falhar, esta
+    função devolve o resultado do mesmo jeito (ver `ai_usage.record`).
+    """
+    modelo = model or modelo_da_tarefa(task)
     resp = _get_client().messages.create(
-        model=model or settings.anthropic_model,
+        model=modelo,
         max_tokens=max_tokens,
         system=system,
         messages=[{"role": "user", "content": user_message}],
     )
-    return AIResult(
+    resultado = AIResult(
         text=resp.content[0].text,
         input_tokens=resp.usage.input_tokens,
         output_tokens=resp.usage.output_tokens,
+        # `getattr` porque nem toda resposta traz os campos de cache (e os mocks dos testes de
+        # narrador, que constroem um objeto de usage mínimo, nunca trazem).
+        cache_read_tokens=getattr(resp.usage, "cache_read_input_tokens", 0) or 0,
+        cache_creation_tokens=getattr(resp.usage, "cache_creation_input_tokens", 0) or 0,
     )
+
+    ai_usage.record(
+        db,
+        tenant_id=tenant_id,
+        task=task,
+        model=modelo,
+        input_tokens=resultado.input_tokens,
+        output_tokens=resultado.output_tokens,
+        cache_read_tokens=resultado.cache_read_tokens,
+        cache_creation_tokens=resultado.cache_creation_tokens,
+        user_id=user_id,
+    )
+    return resultado

--- a/apps/api/app/core/ai_usage.py
+++ b/apps/api/app/core/ai_usage.py
@@ -1,0 +1,111 @@
+"""O ledger de uso de IA — quanto se gastou, por quem, em qual tarefa.
+
+Antes disto o e1p já gastava IA em produção e não sabia quanto: seis módulos chamavam
+`ai.complete` e cinco descartavam os tokens que a Anthropic devolvia. Só o `juridico` guardava,
+e na própria linha do documento (`LegalDocument.input_tokens`), o que não agrega por tenant nem
+por período. A descoberta do custo vinha pela fatura.
+
+**Isto é medição, não cobrança.** Não há teto de gasto, tela ou preço aqui — medir é
+reversível, decisão de preço não é, e ela ainda não foi tomada.
+
+⚠️ **A regra de gravação é o OPOSTO da de `core/facts.py`, e é o ponto mais fácil de errar
+lendo por analogia.** `facts.record` grava na mesma transação e falha junto de propósito: um
+fato que existe sem o negócio é pior que nenhum fato. Aqui não — quando o ledger vai gravar,
+a chamada à Anthropic **já aconteceu e já custou dinheiro**. Derrubar a transação por causa do
+registro perderia o documento jurídico que o usuário esperou 40 segundos para receber, e o
+dinheiro teria sido gasto do mesmo jeito. Então: best-effort, `logger.exception` em falha,
+nunca derrubando quem chamou.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import BigInteger, DateTime, String, func
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+logger = logging.getLogger("e1p.ai")
+
+
+class AIUsage(Base, TenantMixin, TimestampMixin):
+    """Uma chamada à Anthropic, com o que ela custou em tokens."""
+
+    __tablename__ = "ai_usage"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    # NULL quando não há usuário: worker, cron, webhook de gateway. É por isso que a coluna é
+    # nullable — não porque o campo seja opcional para quem tem usuário.
+    user_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
+    # `vima.briefing`, `juridico.documento`, `receivables.cobranca`… É o eixo de agregação que
+    # responde "qual funcionalidade custa caro", e o mesmo eixo que escolhe o modelo em
+    # `core/ai.py`. Um só vocabulário para as duas perguntas.
+    task: Mapped[str] = mapped_column(String(48), nullable=False, index=True)
+    # O modelo que REALMENTE rodou, não o configurado. Divergem quando o roteamento muda, e é a
+    # linha gravada que precisa valer para reconstruir a conta.
+    model: Mapped[str] = mapped_column(String(64), nullable=False)
+    input_tokens: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
+    # Cache tem preço próprio (leitura ~0,1× do input; escrita ~1,25×), então somar tudo em
+    # `input_tokens` produziria uma conta errada — para mais ou para menos, dependendo do mix.
+    cache_read_tokens: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
+    cache_creation_tokens: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
+
+    # Default do lado do PYTHON: no Postgres `now()` é o instante da TRANSAÇÃO, e duas chamadas
+    # de IA no mesmo commit sairiam com timestamp idêntico. Mesma lição de `Fact.created_at`.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+
+def record(
+    db: Session,
+    *,
+    tenant_id: str,
+    task: str,
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    user_id: str | None = None,
+) -> AIUsage | None:
+    """Registra uma chamada de IA. **Nunca levanta** — devolve `None` se não conseguiu gravar.
+
+    O `begin_nested()` é o que torna a promessa acima verdadeira em vez de aspiracional. Um
+    `db.add()` seguido de `flush()` que falha deixa a Session em estado de rollback pendente:
+    o `except` engoliria a exceção e o **commit do chamador** morreria depois, longe daqui,
+    com uma mensagem que não menciona IA nenhuma. O SAVEPOINT delimita a falha — desfaz só o
+    que esta função tentou escrever e devolve a transação de fora intacta.
+
+    Preço assumido: a linha vive na transação do chamador, então um rollback do NEGÓCIO leva o
+    registro junto e o gasto some da conta. É raro comparado a "o insert do ledger falhou", e a
+    alternativa (conexão própria, commit independente) paga uma conexão a mais em toda chamada
+    de IA para cobrir o caso raro.
+    """
+    try:
+        with db.begin_nested():
+            uso = AIUsage(
+                tenant_id=tenant_id,
+                user_id=user_id,
+                task=task,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_creation_tokens=cache_creation_tokens,
+            )
+            db.add(uso)
+            db.flush()
+        return uso
+    except Exception:  # noqa: BLE001 — a contabilidade nunca derruba quem já pagou pela chamada.
+        logger.exception(
+            "Falha ao registrar uso de IA (task=%s, model=%s, tenant=%s) — "
+            "a chamada à Anthropic já aconteceu e já custou; seguindo sem o registro.",
+            task, model, tenant_id,
+        )
+        return None

--- a/apps/api/app/db/registry.py
+++ b/apps/api/app/db/registry.py
@@ -4,6 +4,7 @@ Usado pelo Alembic (autogenerate) e pelos testes (create_all). Sempre que criar 
 garanta que ele seja importado aqui (direta ou indiretamente).
 """
 # noqa: F401 — imports existem só para registrar as tabelas no metadata.
+from app.core.ai_usage import AIUsage  # noqa: F401
 from app.core.audit import AuditEntry, PlatformAuditEntry  # noqa: F401
 from app.core.facts import Fact  # noqa: F401
 from app.db.base import Base

--- a/apps/api/app/modules/financial_intelligence/ai_narrator.py
+++ b/apps/api/app/modules/financial_intelligence/ai_narrator.py
@@ -77,7 +77,8 @@ def narrate_with_source(
 ) -> tuple[str, str]:
     """Como `narrate_signals`, mas devolve `(texto, origem)` onde origem ∈ {"ai", "template"} —
     usado pela rota para informar a UI qual caminho gerou a narrativa. Nunca levanta:
-    - sem sinais / sem `ANTHROPIC_API_KEY` / erro da IA → (template, "template"), SEM rastro;
+    - sem sinais / sem `ANTHROPIC_API_KEY` / sem `db`+`tenant_id` / erro da IA →
+      (template, "template"), SEM rastro;
     - com IA → (texto anonimizado→narrado→desanonimizado, "ai") + `audit.record(is_ai=True)`
       + commit quando `db`+`tenant_id` vierem (Regra de Ouro nº 3).
     """
@@ -88,23 +89,33 @@ def narrate_with_source(
     if not settings.anthropic_api_key:
         return fallback_narrative(signals), "template"
 
+    # Sem onde contabilizar, não se chama a IA. `db`/`tenant_id` são opcionais nesta assinatura
+    # (narração pura em teste), e `ai.complete` passou a exigi-los — em vez de furar a regra com
+    # um tenant fictício, esta borda cai no template, que é o mesmo caminho já usado quando não
+    # há chave. Toda chamada que de fato acontece fica registrada no ledger.
+    if db is None or tenant_id is None:
+        return fallback_narrative(signals), "template"
+
     source = _source_text(signals)
     # Regra de Ouro nº 2: anonimiza ANTES de chamar a IA; desanonimiza LOCALMENTE na volta.
     safe_text, mapping = anonymizer.mask(source)
     try:
-        result = ai.complete(system=_SYSTEM, user_message=safe_text, max_tokens=800)
+        result = ai.complete(
+            db=db, tenant_id=tenant_id, task="financeiro.diagnostico",
+            system=_SYSTEM, user_message=safe_text, max_tokens=800,
+        )
     except Exception:  # noqa: BLE001 — IA nunca pode derrubar o diagnóstico (IV3): cai no template.
         return fallback_narrative(signals), "template"
 
     final = anonymizer.unmask(result.text.strip(), mapping)
 
     # Regra de Ouro nº 3: houve ação REAL de IA → grava o rastro "Ação executada pela IA".
-    if db is not None and tenant_id is not None:
-        audit.record(
-            db, tenant_id=tenant_id, actor=actor,
-            action="financial_diagnostics.narrated", target=target, is_ai=True,
-        )
-        db.commit()
+    # A guarda de `None` que existia aqui saiu: a borda acima já garantiu que ambos existem.
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor,
+        action="financial_diagnostics.narrated", target=target, is_ai=True,
+    )
+    db.commit()
 
     return final, "ai"
 

--- a/apps/api/app/modules/funnels/router.py
+++ b/apps/api/app/modules/funnels/router.py
@@ -48,10 +48,12 @@ def components(_u: CurrentUser = Depends(_guard)) -> list[ComponentCategory]:
 @router.post("/ai-compose", response_model=ComposeResult)
 def ai_compose(
     data: ComposeRequest,
-    _u: CurrentUser = Depends(_guard),
-    _db: Session = Depends(get_tenant_db),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
 ) -> ComposeResult:
-    return ComposeResult(**service.ai_compose(data.kind, data.prompt))
+    return ComposeResult(
+        **service.ai_compose(db, tenant_id=user.tenant_id, kind=data.kind, prompt=data.prompt)
+    )
 
 
 @router.post("/run-node", response_model=RunNodeResult)

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -252,13 +252,20 @@ def _compose_fallback(kind: str, prompt: str) -> dict:
     return {"subject": "", "body": f"Sobre {prompt}."}
 
 
-def ai_compose(kind: str, prompt: str) -> dict:
-    """Gera o conteúdo do nó com IA; cai para um rascunho simples sem chave/parsing."""
+def ai_compose(db: Session, *, tenant_id: str, kind: str, prompt: str) -> dict:
+    """Gera o conteúdo do nó com IA; cai para um rascunho simples sem chave/parsing.
+
+    `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
+    não lê nem escreve nada de negócio.
+    """
     system = _COMPOSE_SYSTEM.get(kind, _COMPOSE_SYSTEM["generic"])
     if not settings.anthropic_api_key:
         return _compose_fallback(kind, prompt)
     try:
-        text = ai.complete(system=system, user_message=prompt, max_tokens=800).text
+        text = ai.complete(
+            db=db, tenant_id=tenant_id, task="funnels.compose",
+            system=system, user_message=prompt, max_tokens=800,
+        ).text
         cleaned = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.MULTILINE).strip()
         data = json.loads(cleaned)
         return {

--- a/apps/api/app/modules/juridico/service.py
+++ b/apps/api/app/modules/juridico/service.py
@@ -136,7 +136,10 @@ def generate(db: Session, *, tenant_id: str, actor: str, data: DocumentCreate) -
         return doc
 
     try:
-        result = complete(system=system_prompt, user_message=safe_message, max_tokens=8192)
+        result = complete(
+            db=db, tenant_id=tenant_id, task="juridico.documento",
+            system=system_prompt, user_message=safe_message, max_tokens=8192,
+        )
     except Exception as e:  # noqa: BLE001
         raise JuridicoError(f"Falha na geração por IA: {e}", 502) from e
 

--- a/apps/api/app/modules/marketing/router.py
+++ b/apps/api/app/modules/marketing/router.py
@@ -54,10 +54,14 @@ def list_templates(_u: CurrentUser = Depends(_guard)) -> list[TemplatePreset]:
 @router.post("/generate", response_model=GenerateResult)
 def generate(
     data: GenerateRequest,
-    _u: CurrentUser = Depends(_guard),
-    _db: Session = Depends(get_tenant_db),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
 ) -> GenerateResult:
-    return GenerateResult(**service.generate_content(data.topic, data.slides, data.tone))
+    return GenerateResult(
+        **service.generate_content(
+            db, tenant_id=user.tenant_id, topic=data.topic, n=data.slides, tone=data.tone
+        )
+    )
 
 
 @router.get("", response_model=list[CarouselOut])

--- a/apps/api/app/modules/marketing/service.py
+++ b/apps/api/app/modules/marketing/service.py
@@ -105,13 +105,20 @@ def _parse(text: str, topic: str, n: int) -> dict:
     }
 
 
-def generate_content(topic: str, n: int, tone: str) -> dict:
-    """IA escreve slides + legenda + hashtags; cai para um esqueleto editorial em caso de erro."""
+def generate_content(db: Session, *, tenant_id: str, topic: str, n: int, tone: str) -> dict:
+    """IA escreve slides + legenda + hashtags; cai para um esqueleto editorial em caso de erro.
+
+    `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
+    não lê nem escreve nada de negócio.
+    """
     if not settings.anthropic_api_key:
         return _fallback(topic, n)
     user = f"Tema: {topic}\nNúmero de slides: {n}\nTom: {tone}"
     try:
-        text = ai.complete(system=_EDITORIAL_SYSTEM, user_message=user, max_tokens=2000).text
+        text = ai.complete(
+            db=db, tenant_id=tenant_id, task="marketing.carrossel",
+            system=_EDITORIAL_SYSTEM, user_message=user, max_tokens=2000,
+        ).text
         return _parse(text, topic, n)
     except Exception:
         return _fallback(topic, n)

--- a/apps/api/app/modules/quotes/router.py
+++ b/apps/api/app/modules/quotes/router.py
@@ -73,10 +73,12 @@ def summary(
 @router.post("/scope", response_model=ScopeResult)
 def scope(
     data: ScopeRequest,
-    _u: CurrentUser = Depends(_guard),
-    _db: Session = Depends(get_tenant_db),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
 ) -> ScopeResult:
-    return ScopeResult(description=service.generate_scope(data.brief))
+    return ScopeResult(
+        description=service.generate_scope(db, tenant_id=user.tenant_id, brief=data.brief)
+    )
 
 
 @router.get("", response_model=list[QuoteOut])

--- a/apps/api/app/modules/quotes/service.py
+++ b/apps/api/app/modules/quotes/service.py
@@ -333,8 +333,12 @@ def summary(db: Session) -> dict:
     }
 
 
-def generate_scope(brief: str) -> str:
-    """IA redige a descrição comercial do escopo (fallback p/ o próprio briefing)."""
+def generate_scope(db: Session, *, tenant_id: str, brief: str) -> str:
+    """IA redige a descrição comercial do escopo (fallback p/ o próprio briefing).
+
+    `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
+    não lê nem escreve nada de negócio.
+    """
     if not settings.anthropic_api_key:
         return brief.strip()
     system = (
@@ -342,7 +346,10 @@ def generate_scope(brief: str) -> str:
         "de escopo profissional e enxuta (1-2 frases) para um orçamento. Responda só com o texto."
     )
     try:
-        return ai.complete(system=system, user_message=brief, max_tokens=300).text.strip()
+        return ai.complete(
+            db=db, tenant_id=tenant_id, task="quotes.escopo",
+            system=system, user_message=brief, max_tokens=300,
+        ).text.strip()
     except Exception:
         return brief.strip()
 

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -1172,7 +1172,10 @@ def _money(cents: int) -> str:
     return f"R$ {cents / 100:.2f}".replace(".", ",")
 
 
-def _compose_dunning(name: str, amount_cents: int, due: date, description: str) -> str:
+def _compose_dunning(
+    db: Session, *, tenant_id: str,
+    name: str, amount_cents: int, due: date, description: str,
+) -> str:
     """Mensagem de cobrança amigável. Usa a IA (Claude) se houver chave; senão, template.
 
     PII: enviamos o placeholder [NOME] ao Claude e reinserimos o nome real localmente.
@@ -1193,7 +1196,10 @@ def _compose_dunning(name: str, amount_cents: int, due: date, description: str) 
     )
     user = f"Valor: {valor}\nVencimento: {venc}\nDescrição: {desc}\nNome do cliente: [NOME]"
     try:
-        result = ai.complete(system=system, user_message=user, max_tokens=300)
+        result = ai.complete(
+            db=db, tenant_id=tenant_id, task="receivables.cobranca",
+            system=system, user_message=user, max_tokens=300,
+        )
         return result.text.strip().replace("[NOME]", name)
     except Exception:
         return (
@@ -1202,7 +1208,10 @@ def _compose_dunning(name: str, amount_cents: int, due: date, description: str) 
         )
 
 
-def _compose_dunning_phrase(name: str, amount_cents: int, due: date, description: str) -> str:
+def _compose_dunning_phrase(
+    db: Session, *, tenant_id: str,
+    name: str, amount_cents: int, due: date, description: str,
+) -> str:
     """Só a FRASE de cobrança (variável 2 do template `charge_reminder`) — não a mensagem inteira.
 
     Usa a IA (Claude) se houver chave; senão, frase padrão. Mesma técnica de anonimização de PII
@@ -1223,7 +1232,10 @@ def _compose_dunning_phrase(name: str, amount_cents: int, due: date, description
     )
     user = f"Valor: {valor}\nVencimento: {venc}\nDescrição: {desc}\nNome do cliente: [NOME]"
     try:
-        result = ai.complete(system=system, user_message=user, max_tokens=100)
+        result = ai.complete(
+            db=db, tenant_id=tenant_id, task="receivables.cobranca",
+            system=system, user_message=user, max_tokens=100,
+        )
         return result.text.strip().replace("[NOME]", name)
     except Exception:
         return "Notamos que sua cobrança está em aberto."
@@ -1269,7 +1281,9 @@ def collect_with_ai(db: Session, *, charge_id: str, tenant_id: str, actor: str) 
         valor = _money(charge.amount_cents)
         venc = charge.due_date.strftime("%d/%m/%Y")
         phrase = _compose_dunning_phrase(
-            name, charge.amount_cents, charge.due_date, charge.description
+            db, tenant_id=tenant_id,
+            name=name, amount_cents=charge.amount_cents, due=charge.due_date,
+            description=charge.description,
         )
         variables = [name, phrase, valor, venc]
         message = _render_template_preview(template.body_text, variables)
@@ -1280,7 +1294,11 @@ def collect_with_ai(db: Session, *, charge_id: str, tenant_id: str, actor: str) 
             whatsapp_template_variables=variables,
         )
     else:
-        message = _compose_dunning(name, charge.amount_cents, charge.due_date, charge.description)
+        message = _compose_dunning(
+            db, tenant_id=tenant_id,
+            name=name, amount_cents=charge.amount_cents, due=charge.due_date,
+            description=charge.description,
+        )
         notifications_service.enqueue(
             db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient,
             client_id=charge.client_id, message=message, purpose=PURPOSE_CHARGE_REMINDER,

--- a/apps/api/app/modules/vima/narrator.py
+++ b/apps/api/app/modules/vima/narrator.py
@@ -70,7 +70,10 @@ def narrar(
 
     seguro, mapa = anonymizer.mask(fonte)
     try:
-        resposta = ai.complete(system=_SYSTEM, user_message=seguro, max_tokens=1500)
+        resposta = ai.complete(
+            db=db, tenant_id=tenant_id, task="vima.briefing",
+            system=_SYSTEM, user_message=seguro, max_tokens=1500,
+        )
     except Exception:  # noqa: BLE001 — a IA nunca derruba o briefing: cai no template.
         logger.exception("Narração da Vima falhou; caindo no template")
         return Narracao(texto=fonte, por_ia=False)

--- a/apps/api/migrations/versions/0071_ai_usage.py
+++ b/apps/api/migrations/versions/0071_ai_usage.py
@@ -1,0 +1,61 @@
+"""Ledger de uso de IA
+
+Revision ID: 0071
+Revises: 0070
+Create Date: 2026-08-06
+
+Sem backfill — o consumo passado não foi guardado por ninguém (cinco dos seis módulos
+descartavam os tokens) e não tem como ser reconstruído. A conta vale a partir daqui.
+
+Só DDL, então a armadilha de RLS no backfill (ver 0046/0066/0067/0068/0069) não se aplica.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0071"
+down_revision: str | None = "0070"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_usage",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("tenant_id", sa.String(length=36), nullable=False, index=True),
+        sa.Column("user_id", sa.String(length=36), nullable=True),
+        sa.Column("task", sa.String(length=48), nullable=False),
+        sa.Column("model", sa.String(length=64), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("cache_read_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("cache_creation_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+    )
+    op.create_index("ix_ai_usage_user_id", "ai_usage", ["user_id"])
+    op.create_index("ix_ai_usage_task", "ai_usage", ["task"])
+    # A pergunta que este ledger existe para responder é "quanto este tenant gastou no período".
+    # Sem o índice composto ela vira varredura assim que a tabela crescer — e ela cresce a cada
+    # chamada de IA, não a cada operação de negócio.
+    op.create_index("ix_ai_usage_tenant_created", "ai_usage", ["tenant_id", "created_at"])
+
+    op.execute("ALTER TABLE ai_usage ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE ai_usage FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON ai_usage
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ai_usage")

--- a/apps/api/tests/test_ai.py
+++ b/apps/api/tests/test_ai.py
@@ -1,16 +1,20 @@
 """Testes unitários diretos da camada de IA (`core/ai.py`).
 
-Cobrem, isoladamente (sem tocar a API real do Claude), a montagem do prompt,
-o parsing de `AIResult` e a propagação de erro — pré-condição dos fallbacks
-implementados em cada caller (marketing, juridico, funnels, quotes,
-financial_intelligence, receivables).
+Cobrem, isoladamente (sem tocar a API real do Claude), a montagem do prompt, o parsing de
+`AIResult`, a propagação de erro — pré-condição dos fallbacks implementados em cada caller
+(marketing, juridico, funnels, quotes, financial_intelligence, receivables, vima) — e as duas
+garantias novas: **toda chamada bem-sucedida é contabilizada** e **o roteamento escolhe o
+modelo pela tarefa**.
 """
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy.orm import Session
 
-from app.config import settings
 from app.core import ai
+from app.core.ai_usage import AIUsage
+
+TENANT = "t1"
 
 
 class _FakeMessages:
@@ -33,10 +37,12 @@ class _FakeClient:
         self.messages = messages
 
 
-def _ok_response(text="ok", input_tokens=1, output_tokens=1):
+def _ok_response(text="ok", input_tokens=1, output_tokens=1, **usage_extra):
     return SimpleNamespace(
         content=[SimpleNamespace(text=text)],
-        usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+        usage=SimpleNamespace(
+            input_tokens=input_tokens, output_tokens=output_tokens, **usage_extra
+        ),
     )
 
 
@@ -47,42 +53,186 @@ def _install_fake(monkeypatch, *, response=None, error=None) -> _FakeMessages:
     return messages
 
 
-def test_complete_builds_prompt_with_system_and_user_message(monkeypatch):
+def _complete(db, **over):
+    """Chamada mínima válida — `db`, `tenant_id` e `task` são obrigatórios."""
+    kwargs = {
+        "db": db, "tenant_id": TENANT, "task": "vima.briefing",
+        "system": "S", "user_message": "U",
+    }
+    kwargs.update(over)
+    return ai.complete(**kwargs)
+
+
+# ── Montagem do prompt e parsing ────────────────────────────────────────────────────────────
+
+
+def test_complete_builds_prompt_with_system_and_user_message(db: Session, monkeypatch):
     messages = _install_fake(monkeypatch, response=_ok_response())
-    ai.complete(system="SYS", user_message="MSG", max_tokens=123)
+    _complete(db, system="SYS", user_message="MSG", max_tokens=123)
     kwargs = messages.captured
     assert kwargs["system"] == "SYS"
     assert kwargs["messages"] == [{"role": "user", "content": "MSG"}]
     assert kwargs["max_tokens"] == 123
-    assert kwargs["model"] == settings.anthropic_model  # default
 
 
-def test_complete_uses_explicit_model_override(monkeypatch):
+def test_complete_uses_explicit_model_override(db: Session, monkeypatch):
     messages = _install_fake(monkeypatch, response=_ok_response())
-    ai.complete(system="S", user_message="U", model="modelo-x")
+    _complete(db, model="modelo-x")
     assert messages.captured["model"] == "modelo-x"
 
 
-def test_complete_uses_default_max_tokens(monkeypatch):
+def test_complete_uses_default_max_tokens(db: Session, monkeypatch):
     messages = _install_fake(monkeypatch, response=_ok_response())
-    ai.complete(system="S", user_message="U")
+    _complete(db)
     assert messages.captured["max_tokens"] == 4096
 
 
-def test_complete_parses_ai_result_from_response(monkeypatch):
+def test_complete_parses_ai_result_from_response(db: Session, monkeypatch):
     _install_fake(
         monkeypatch,
         response=_ok_response(text="resposta da IA", input_tokens=10, output_tokens=20),
     )
-    result = ai.complete(system="S", user_message="U")
+    result = _complete(db)
     assert isinstance(result, ai.AIResult)
     assert result.text == "resposta da IA"
     assert result.input_tokens == 10
     assert result.output_tokens == 20
 
 
-def test_complete_propagates_client_error(monkeypatch):
+def test_complete_propagates_client_error(db: Session, monkeypatch):
     _install_fake(monkeypatch, error=RuntimeError("api indisponível"))
     # A exceção sobe crua — é isso que permite o try/except de fallback dos callers.
     with pytest.raises(RuntimeError, match="api indisponível"):
-        ai.complete(system="S", user_message="U")
+        _complete(db)
+
+
+# ── Roteamento de modelo por tarefa ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("task", "modelo"),
+    [
+        ("vima.briefing", "claude-haiku-4-5"),
+        ("financeiro.diagnostico", "claude-haiku-4-5"),
+        ("receivables.cobranca", "claude-haiku-4-5"),
+        ("quotes.escopo", "claude-sonnet-5"),
+        ("funnels.compose", "claude-sonnet-5"),
+        ("marketing.carrossel", "claude-sonnet-5"),
+        ("juridico.documento", "claude-opus-5"),
+    ],
+)
+def test_roteamento_escolhe_o_modelo_da_tarefa(db: Session, monkeypatch, task, modelo):
+    messages = _install_fake(monkeypatch, response=_ok_response())
+    _complete(db, task=task)
+    assert messages.captured["model"] == modelo
+
+
+def test_tarefa_desconhecida_cai_no_default_em_vez_de_explodir(db: Session, monkeypatch):
+    """Uma tarefa nova não pode derrubar a chamada — e o default é o modelo mais CAPAZ.
+
+    Roteada por engano para o mais barato, ela degradaria em silêncio; roteada para o mais caro,
+    só custa mais — e o excedente aparece no ledger, que é o instrumento instalado aqui.
+    """
+    messages = _install_fake(monkeypatch, response=_ok_response())
+    _complete(db, task="modulo.que.ainda.nao.existe")
+    assert messages.captured["model"] == ai.MODELO_PADRAO == "claude-opus-5"
+
+
+def test_toda_tarefa_roteada_usa_um_modelo_conhecido():
+    """Instanciação obrigatória do mapa: um typo no ID vira 404 só em produção, na primeira
+    chamada real daquela tarefa — nenhum teste de comportamento pega isso."""
+    conhecidos = {"claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"}
+    assert set(ai.MODELO_POR_TAREFA.values()) <= conhecidos
+    assert ai.MODELO_PADRAO in conhecidos
+    # O não-membro que torna a asserção acima não-trivial.
+    assert ai.modelo_da_tarefa("tarefa.inexistente") == ai.MODELO_PADRAO
+
+
+# ── Contabilidade ───────────────────────────────────────────────────────────────────────────
+
+
+def test_toda_chamada_bem_sucedida_grava_uma_linha_no_ledger(db: Session, monkeypatch):
+    _install_fake(
+        monkeypatch,
+        response=_ok_response(
+            input_tokens=100, output_tokens=250,
+            cache_read_input_tokens=40, cache_creation_input_tokens=7,
+        ),
+    )
+    _complete(db, task="juridico.documento", user_id="u1")
+    db.commit()
+
+    linhas = db.query(AIUsage).all()
+    assert len(linhas) == 1
+    uso = linhas[0]
+    assert uso.tenant_id == TENANT
+    assert uso.user_id == "u1"
+    assert uso.task == "juridico.documento"
+    # O modelo gravado é o que RODOU, não o configurado.
+    assert uso.model == "claude-opus-5"
+    assert (uso.input_tokens, uso.output_tokens) == (100, 250)
+    assert (uso.cache_read_tokens, uso.cache_creation_tokens) == (40, 7)
+
+
+def test_resposta_sem_campos_de_cache_grava_zero(db: Session, monkeypatch):
+    """Nem toda resposta traz os campos de cache; a ausência deles não pode virar erro."""
+    _install_fake(monkeypatch, response=_ok_response(input_tokens=5, output_tokens=6))
+    _complete(db)
+    db.commit()
+
+    uso = db.query(AIUsage).one()
+    assert (uso.cache_read_tokens, uso.cache_creation_tokens) == (0, 0)
+
+
+def test_sem_usuario_a_linha_ainda_e_gravada(db: Session, monkeypatch):
+    """Worker e cron não têm usuário — `user_id` nulo é o caso normal, não uma falha."""
+    _install_fake(monkeypatch, response=_ok_response())
+    _complete(db)
+    db.commit()
+
+    assert db.query(AIUsage).one().user_id is None
+
+
+def test_falha_ao_gravar_o_ledger_nao_derruba_a_chamada(db: Session, monkeypatch):
+    """A regra que separa este ledger de `facts.record`.
+
+    Quando o ledger vai gravar, a chamada à Anthropic JÁ aconteceu e JÁ custou dinheiro.
+    Derrubar a transação aqui perderia o documento que o usuário esperou 40 segundos para
+    receber — e o dinheiro teria sido gasto do mesmo jeito.
+    """
+    _install_fake(monkeypatch, response=_ok_response(text="entregue mesmo assim"))
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("banco caiu na hora de gravar o ledger")
+
+    monkeypatch.setattr(ai.ai_usage, "AIUsage", _explode)
+
+    resultado = _complete(db)
+
+    assert resultado.text == "entregue mesmo assim"
+    assert db.query(AIUsage).count() == 0
+
+
+def test_transacao_do_chamador_sobrevive_a_falha_do_ledger(db: Session, monkeypatch):
+    """O `except` sozinho não bastaria: um flush que falha deixa a Session em rollback
+    pendente, e o commit do CHAMADOR morreria depois, longe daqui. O SAVEPOINT é o que
+    delimita a falha."""
+    from app.core.audit import AuditEntry
+    from app.core.facts import Fact
+
+    _install_fake(monkeypatch, response=_ok_response())
+
+    # Trabalho de negócio pendente ANTES da chamada de IA, como no juridico.
+    db.add(AuditEntry(tenant_id=TENANT, actor="u1", action="legal.generate", target="doc1"))
+
+    def _flush_quebrado(*_a, **_kw):
+        # Uma linha inválida: `module` é NOT NULL. Estoura no flush, dentro do savepoint.
+        return Fact(tenant_id=TENANT, kind="x", title="y", actor="s")
+
+    monkeypatch.setattr(ai.ai_usage, "AIUsage", _flush_quebrado)
+
+    _complete(db)
+    db.commit()  # o que importa: isto não pode levantar
+
+    assert db.query(AuditEntry).count() == 1
+    assert db.query(AIUsage).count() == 0

--- a/apps/api/tests/test_ai_usage_rls.py
+++ b/apps/api/tests/test_ai_usage_rls.py
@@ -1,0 +1,168 @@
+"""Isolamento cross-tenant do ledger de uso de IA no Postgres REAL (Regra de Ouro nº 1).
+
+O ledger é uma tabela de custo: se ela vazasse entre tenants, um cliente veria quanto outro
+gasta com IA e em quais funcionalidades — perfil de uso do negócio alheio. Vale a mesma RLS
+`FORCE` de qualquer tabela de negócio, e este teste é o que a prova sob o papel NÃO-superusuário
+`e1p_app` (que não faz bypass).
+
+Cobre:
+- `ai_usage.record` grava sob a ótica de cada tenant e **nenhum enxerga a linha do outro**;
+- a mesma leitura vista pelo tenant DONO devolve a linha — o controle positivo que prova que a
+  asserção negativa falha pelo motivo certo, e não por dado ausente/id errado;
+- sem a GUC de tenant a tabela é **fail-closed** (zero linhas), não aberta.
+
+Mesmo bootstrap dos demais `*_rls.py`: engine SQLAlchemy cru da URL do container, migrations
+aplicadas com `alembic upgrade head` como `e1p_app` — o que também exercita a migration 0071 de
+fato. Módulo marcado `rls_e2e`: NÃO roda no `pytest -q` (suíte SQLite), só no job dedicado do CI
+(`cross-tenant-rls`) ou manualmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, select, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+
+_API_DIR = Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original_url
+
+
+@contextmanager
+def _tenant_session(app_url: str, tenant_id: str | None):
+    """Sessão com a GUC de tenant fixada antes de qualquer query. `tenant_id=None` abre a sessão
+    SEM a GUC — é assim que se testa o fail-closed."""
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            if tenant_id is not None:
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                    {"tid": tenant_id},
+                )
+                conn.commit()
+            session = Session(bind=conn)
+            try:
+                yield session
+            finally:
+                session.close()
+    finally:
+        engine.dispose()
+
+
+def _record(app_url: str, *, tenant_id: str, task: str, model: str) -> str:
+    """Grava um uso de IA pelo caminho REAL (`ai_usage.record`), sob a ótica do tenant dono."""
+    from app.core import ai_usage
+
+    with _tenant_session(app_url, tenant_id) as session:
+        uso = ai_usage.record(
+            session, tenant_id=tenant_id, task=task, model=model,
+            input_tokens=100, output_tokens=200,
+        )
+        assert uso is not None, "record() devolveu None — falhou ao gravar sob o tenant dono"
+        session.commit()
+        return uso.id
+
+
+def _tasks_visiveis(app_url: str, tenant_id: str | None) -> list[str]:
+    from app.core.ai_usage import AIUsage
+
+    with _tenant_session(app_url, tenant_id) as session:
+        return list(session.scalars(select(AIUsage.task).order_by(AIUsage.task)).all())
+
+
+def _consegue_ler_por_id(app_url: str, *, viewer_tenant_id: str, usage_id: str) -> bool:
+    from app.core.ai_usage import AIUsage
+
+    with _tenant_session(app_url, viewer_tenant_id) as session:
+        return session.get(AIUsage, usage_id) is not None
+
+
+def test_ai_usage_cross_tenant_isolation() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+
+        uso_a = _record(app_url, tenant_id=tenant_a, task="juridico.documento",
+                        model="claude-opus-5")
+        uso_b = _record(app_url, tenant_id=tenant_b, task="vima.briefing",
+                        model="claude-haiku-4-5")
+
+        # ── Caso 1: cada tenant vê só o próprio consumo ───────────────────────────────────────
+        assert _tasks_visiveis(app_url, tenant_a) == ["juridico.documento"], (
+            "RLS falhou: A enxergou consumo de IA que não é dele"
+        )
+        assert _tasks_visiveis(app_url, tenant_b) == ["vima.briefing"], (
+            "RLS falhou: B enxergou consumo de IA que não é dele"
+        )
+
+        # ── Caso 2: leitura direta por id também é barrada ────────────────────────────────────
+        # O controle POSITIVO (o dono lê o próprio) é o que prova que a asserção negativa não
+        # está passando por id errado ou linha inexistente.
+        assert _consegue_ler_por_id(app_url, viewer_tenant_id=tenant_a, usage_id=uso_a) is True
+        assert _consegue_ler_por_id(app_url, viewer_tenant_id=tenant_b, usage_id=uso_b) is True
+        assert _consegue_ler_por_id(app_url, viewer_tenant_id=tenant_a, usage_id=uso_b) is False, (
+            "RLS falhou: A leu por id a linha de consumo de B"
+        )
+        assert _consegue_ler_por_id(app_url, viewer_tenant_id=tenant_b, usage_id=uso_a) is False, (
+            "RLS falhou: B leu por id a linha de consumo de A"
+        )
+
+        # ── Caso 3: sem GUC de tenant, fail-closed (zero linhas, não a tabela toda) ───────────
+        assert _tasks_visiveis(app_url, None) == [], (
+            "RLS não é fail-closed: sessão sem tenant enxergou o ledger"
+        )

--- a/apps/api/tests/test_financial_intelligence_narrator.py
+++ b/apps/api/tests/test_financial_intelligence_narrator.py
@@ -74,7 +74,10 @@ def test_payload_sent_to_ai_is_anonymized_and_unmasked_on_return(db: Session, mo
     monkeypatch.setattr(ai_narrator.settings, "anthropic_api_key", "sk-ant-x", raising=False)
     captured: dict[str, str] = {}
 
-    def _fake_complete(*, system: str, user_message: str, max_tokens: int = 800, model=None):
+    def _fake_complete(
+        *, system: str, user_message: str, max_tokens: int = 800, model=None,
+        **_contabilidade,  # db/tenant_id/task — cobertos em tests/test_ai.py
+    ):
         captured["system"] = system
         captured["user_message"] = user_message
         # A IA "responde" ecoando o texto seguro (com placeholders) — força o teste de unmask.

--- a/apps/api/tests/test_juridico.py
+++ b/apps/api/tests/test_juridico.py
@@ -30,7 +30,10 @@ def fake_ai(monkeypatch):
     """Captura o que vai para a IA e devolve um documento com a seção de METADADOS."""
     seen = {}
 
-    def _fake(*, system, user_message, max_tokens=8192, model=None):
+    def _fake(
+        *, system, user_message, max_tokens=8192, model=None,
+        **_contabilidade,  # db/tenant_id/task — cobertos em tests/test_ai.py
+    ):
         seen["system"] = system
         seen["user"] = user_message
         body = (


### PR DESCRIPTION
Adendo ortogonal à Vima: o e1p passa a saber quanto gasta de IA, e a escolher o modelo por tarefa.

> **Base:** este PR sai de `feat/vima-registro-de-fatos-e-briefing` (#85), não de `main`. O motivo é dependência real: `vima/narrator.py` é um dos oito call sites de `ai.complete`, e ele só existe naquela branch. Saindo de `main`, o call site da Vima ficaria chamando `ai.complete` sem os parâmetros novos e quebraria no merge de #85. Revisar #85 antes.

## O problema

Seis módulos chamam `ai.complete` em produção: `financial_intelligence` · `funnels` · `marketing` · `quotes` · `receivables` · `vima`. **Um só guardava quanto gastou** — o `juridico`, e ainda assim na própria linha do documento (`LegalDocument.input_tokens`), que não agrega por tenant nem por período. Os outros recebiam os tokens da Anthropic em `AIResult` e descartavam.

Resultado: o produto já gastava IA e **não sabia quanto, nem por quem**. Sem isso não dá para saber se o custo de IA é 3% ou 300% da receita do plano, e a descoberta vem pela fatura.

Segundo problema: `config.anthropic_model` era **um só, global**. Narrar um briefing já calculado usava o mesmo modelo que redigir peça jurídica.

## Ledger

`ai_usage` (migration 0071, `TenantMixin` + RLS `FORCE` + policy, como toda tabela de negócio): tenant, usuário, tarefa, **o modelo que realmente rodou** (não o configurado) e os quatro contadores de token.

Cache entra em colunas próprias porque tem **preço próprio** — leitura ~0,1× do input, escrita ~1,25× —, então achatá-lo em `input_tokens` produziria uma conta errada, para mais ou para menos conforme o mix. `AIResult` passou a expor os dois campos, que a Anthropic já devolvia e ninguém lia.

**`db` e `tenant_id` viraram obrigatórios em `ai.complete`.** É o que torna *impossível* chamar a IA sem contabilizar: o esquecimento vira `TypeError` na hora, não uma linha faltando na conta seis meses depois. Mesma disciplina de `payables.is_overdue`, que exige `today` como parâmetro exatamente pela mesma razão.

### ⚠️ A regra de gravação é o OPOSTO da de `facts.record`

`facts.record` grava na mesma transação e **falha junto de propósito**: um fato que existe sem o negócio é pior que nenhum fato.

Aqui é o contrário. Quando o ledger vai gravar, a chamada à Anthropic **já aconteceu e já custou dinheiro**. Derrubar a transação por causa do registro perderia o documento jurídico que o usuário esperou 40 segundos para receber — e o dinheiro teria sido gasto do mesmo jeito. Está documentado no topo de `core/ai_usage.py`, porque quem ler por analogia com `facts` vai concluir errado.

**E o `try/except` sozinho não entrega essa promessa.** Esse é o detalhe que quase passou: um `flush()` que falha deixa a `Session` em estado de rollback pendente. O `except` engole a exceção, a função retorna limpa — e o **commit do chamador** morre depois, longe daqui, com uma mensagem que não menciona IA nenhuma. `begin_nested()` (SAVEPOINT) é o que delimita a falha.

Provado por mutação, não por leitura: trocando `with db.begin_nested():` por um `if True:`, o teste `test_transacao_do_chamador_sobrevive_a_falha_do_ledger` quebra com `PendingRollbackError: ... NOT NULL constraint failed: facts.module` — o erro apontando para um módulo que não tem nada a ver com o defeito, que é exatamente o sintoma que ele existe para impedir.

**Preço assumido e documentado:** a linha vive na transação do chamador, então um rollback do *negócio* leva o registro junto e aquele gasto some da conta. É raro comparado a "o insert do ledger falhou", e a alternativa (conexão própria, commit independente) pagaria uma conexão a mais em toda chamada de IA para cobrir o caso raro.

## Roteamento por tarefa

`MODELO_POR_TAREFA` substitui o `anthropic_model` global — dívida que a própria spec da Vima já tinha registrado ("Modelo de IA único e global"). O critério é o **custo do erro**, não o tamanho do texto:

| tarefa | modelo | por quê |
|---|---|---|
| `vima.briefing` · `financeiro.diagnostico` · `receivables.cobranca` | `claude-haiku-4-5` | só reescrevem o que um motor determinístico já calculou — não originam número |
| `quotes.escopo` · `funnels.compose` · `marketing.carrossel` | `claude-sonnet-5` | redação: o texto É o produto |
| `juridico.documento` | `claude-opus-5` | anti-alucinação é crítico e o dado é sensível (segredo de justiça) |

**Tarefa desconhecida cai no default, e o default é o modelo mais CAPAZ, não o mais barato.** É assimetria de custo: uma tarefa nova roteada para Haiku por engano degrada em silêncio (texto pior, ninguém percebe); roteada para Opus, só custa mais — e o excedente aparece no ledger, que é exatamente o instrumento que este PR instala.

`claude-opus-5` no lugar de `claude-opus-4-8`: **preço idêntico** ($5/$25 por Mtok), capacidade maior. Preços e IDs conferidos contra a skill `claude-api`, não de memória.

Um gate cobre o mapa inteiro (`test_toda_tarefa_roteada_usa_um_modelo_conhecido`): um typo num ID vira 404 só em produção, na primeira chamada real daquela tarefa, e nenhum teste de comportamento pega isso.

## Escopo mantido em MEDIR

Sem lógica de cobrança, sem tela, sem teto de gasto. **Medir é reversível; decisão de preço não é**, e ela ainda não foi tomada. Sem backfill — o consumo passado não foi guardado por ninguém e não tem como ser reconstruído; a conta vale daqui para frente.

## Verificação

- **Backend:** 1797 passed, 1 skipped (`-m "not rls_e2e"`)
- **Postgres real:** 49 testes `rls_e2e`, incluindo `test_ai_usage_rls.py` (isolamento cross-tenant do ledger com controle positivo por caso negativo, e fail-closed sem GUC). O `alembic upgrade head` desses testes também exercita a 0071 como o papel não-superusuário `e1p_app`
- **Mutação:** savepoint removido → o teste do chamador quebra; savepoint restaurado → verde
- **Lint:** ruff limpo em `app/` e `tests/`

## Notas de revisão

- **`ai.complete` é todo keyword-only, `db` inclusive** — diverge de `facts.record(db, *, ...)`/`audit.record(db, *, ...)`, que tomam a sessão posicionalmente. Deliberado: vários testes de narrador substituem `ai.complete` por `lambda **kw`, e um parâmetro posicional os quebraria todos sem que nenhum tenha relação com contabilidade. Obrigatório e keyword-only são independentes — sem default, esquecer ainda é `TypeError`.
- **Quatro funções ganharam `db`/`tenant_id` só para contabilizar** (`funnels.ai_compose`, `marketing.generate_content`, `quotes.generate_scope`, `receivables._compose_dunning*`). Não leem nem escrevem negócio; está dito na docstring de cada uma para ninguém achar que passaram a tocar no banco.
- **`ai_narrator.narrate_with_source` passou a cair no template quando `db`/`tenant_id` são `None`** (eram opcionais para narração pura em teste). Sem onde contabilizar, não se chama a IA — em vez de furar a regra com um tenant fictício, essa borda usa o mesmo caminho que já existia para "sem chave".
- **`ANTHROPIC_MODEL` saiu** de `config.py` e do `.env.example`. `docs/stories/7.13.story.md` ainda o cita; é registro histórico do que era verdade então e não foi reescrito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
