### PR TITLE
fix: a Fila de pagamentos era ilegivel no celular (aceite de 360px da Story 8.13)

### DIFF
--- a/apps/web/src/features/financeiro/FilaPagamentosPage.test.tsx
+++ b/apps/web/src/features/financeiro/FilaPagamentosPage.test.tsx
@@ -207,6 +207,19 @@ describe("FilaPagamentosPage — a baixa (Story 8.13, AC6)", () => {
     // `flex-wrap`: descrição + valor + copiar + baixa não cabem em 360px numa linha só. Sem ele,
     // o botão que comete a ação sai da área visível — o defeito dos PRs #56/#58, aqui pela ponta.
     expect(linha.className).toContain("flex-wrap");
+
+    // ⚠️ `flex-wrap` SOZINHO NÃO QUEBRA A LINHA — e esta asserção sozinha passava com a tela
+    // quebrada (aceite físico do AC9, 2026-08-06). Com `flex-1` (base 0%) + `min-w-0`, a descrição
+    // encolhe até caber no que sobra em vez de forçar a quebra: 29px de largura num aparelho de
+    // 360px, o nome da conta empilhando uma palavra por linha ao longo de ~300px de altura, com o
+    // valor colidindo no meio. Quem quebra a linha é a BASE 100% da descrição. jsdom não calcula
+    // layout, então o contrato verificável aqui é a classe — a medição real está no Dev Agent
+    // Record da story.
+    const descricao = linha.firstElementChild as HTMLElement;
+    expect(descricao.className).toContain("basis-full");
+    // `grow`, não `flex-1`: o shorthand `flex` reintroduz `flex-basis: 0%` e desfaz o `basis-full`
+    // dependendo da ordem das regras do Tailwind. Trocar de volta reabre o defeito em silêncio.
+    expect(descricao.className).not.toContain("flex-1");
   });
 });
 

--- a/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
+++ b/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
@@ -239,7 +239,15 @@ function Bucket({
             // defeito que os PRs #56/#58 pagaram duas vezes, aqui pela ponta da linha.
             className="flex flex-wrap items-center gap-3 px-4 py-3"
           >
-            <div className="min-w-0 flex-1">
+            {/* `basis-full sm:basis-0` (aceite físico do AC9, 2026-08-06): o `flex-wrap` acima
+                sozinho NÃO quebrava a linha. Com base 0 e `min-w-0`, a descrição encolhia até
+                caber no que sobrasse de valor + botão — 29px num aparelho de 360px — e o nome da
+                conta empilhava uma palavra por linha, 300px de altura, com o valor colidindo no
+                meio. Base 100% obriga a descrição a tomar a primeira linha e joga valor + botão
+                para a segunda; do `sm` para cima volta a dividir a linha, como no desktop.
+                `grow` no lugar de `flex-1` de propósito: o shorthand `flex` reintroduziria
+                `flex-basis: 0%` e desfaria isto conforme a ordem das regras do Tailwind. */}
+            <div className="min-w-0 grow basis-full sm:basis-0">
               <span className="text-neutral-800">{p.description || p.supplier || "Conta"}</span>
               <span className="block text-xs text-neutral-400">
                 {p.supplier ? `${p.supplier} · ` : ""}

--- a/docs/stories/8.13.story.md
+++ b/docs/stories/8.13.story.md
@@ -1,7 +1,7 @@
 # Story 8.13: As telas da baixa — seletor de conta e data, do desktop ao 360px
 
 ## Status
-InReview — **AC9 (aceite manual em ~360px) NÃO verificado, bloqueante confirmado pelo founder (F-D8). Ver Dev Agent Record.**
+InReview — **AC9 EXECUTADO E SATISFEITO em 2026-08-06** (os 5 itens (a)–(e) medidos a 360×740, evidência no Dev Agent Record). O aceite achou **um defeito real na terceira superfície** (`FilaPagamentosPage`, AC6), que foi corrigido e coberto por guarda de regressão. **O bloqueio F-D8 está levantado**; a story aguarda o gate da @architect.
 
 ## Executor Assignment
 ```yaml
@@ -237,11 +237,13 @@ quality_gate_tools: ["pnpm --filter @e1p/web test (PagarPage.test.tsx, Comprovan
   - [x] `FilaPagamentosPage.test.tsx`: **novo**
   - [x] `contas.test.ts` verde **sem edição** (colisão de rótulo)
 
-- [ ] **Task 8 — ⚠️ Aceite manual em ~360px (AC: 9) — BLOQUEANTE**
-  - [ ] Os 5 itens (a)–(e) do AC9, em aparelho real ou emulação fiel
-  - [ ] **Registrar evidência** no Dev Agent Record (captura ou descrição verificável)
-  - [ ] ⚠️ **Se qualquer item falhar, a story não fecha.** Não é "dívida para depois": o fundador já
-        decidiu (F-D8), e a terceira rodada de fix de campo seria imperdoável
+- [x] **Task 8 — ⚠️ Aceite manual em ~360px (AC: 9) — BLOQUEANTE** — **EXECUTADO 2026-08-06**
+  - [x] Os 5 itens (a)–(e) do AC9, em emulação fiel (viewport 360×740, stack de dev viva com
+        autenticação real) — **todos os 5 passam**, medidos por `getBoundingClientRect()`
+  - [x] **Evidência registrada** no Dev Agent Record (medições reproduzíveis + método)
+  - [x] ⚠️ **Nenhum dos 5 itens falhou** — mas o aceite achou um **6º defeito**, fora dos itens
+        (a)–(e), na terceira superfície da story (`FilaPagamentosPage`, AC6): corrigido nesta mesma
+        passagem, com guarda de regressão provada por mutação. Ver Dev Agent Record
 
 - [x] **Task 9 — Fechamento (AC: todos)**
   - [x] `pnpm --filter @e1p/web test`, `tsc --noEmit`, `eslint --max-warnings 0` — **individualmente**
@@ -427,6 +429,7 @@ do input.
 |------|---------|-------------|--------|
 | 2026-07-30 | 0.1 | Story criada a partir do Epic 8 §5 (item 2.14 + superfície de 2.6/2.7) e §6, Onda 2 — River (@sm). Inclui o **[ACHADO DO @SM]** do AC6: `FilaPagamentosPage.tsx:60` é uma **terceira** superfície que chama `POST /bills/{id}/pay` e não é nomeada em nenhum documento da onda — sem ela, a Fila quebra e a Integration Verification obrigatória da onda falha | River (@sm) |
 | 2026-07-30 | 0.2 | **Validação do @po — nenhum bloqueio; 1 correção de premissa.** A dependência da Story 8.19 na IV5 estava desatualizada (a v0.2 dela removeu `projection.py` do escopo). O AC6 (a terceira superfície) é **ratificado pelo @po**: o epic §6 permite reagrupar *"desde que nenhum item da §5 caia fora"*, nenhum cai, e a alternativa era entregar a onda com uma tela do financeiro quebrada. O AC9 (aceite em ~360px) permanece **bloqueante de merge** — é o veredito F-D8 do fundador, não recomendação. | Pax (@po) |
+| 2026-08-06 | 0.3 | **AC9 executado — bloqueio F-D8 levantado, e o aceite pagou por si.** Terceira sessão, a primeira com stack de dev viva e autenticada (Postgres isolado + API + Vite, viewport 360×740, medição por `getBoundingClientRect()`). **Os 5 itens (a)–(e) passam.** Mas o aceite achou um **6º defeito, fora dos itens (a)–(e)**: `FilaPagamentosPage` (a terceira superfície, AC6) estava quebrada a 360px — descrição espremida a 44×280px, valor colidindo no meio do texto, linha de 304px. Causa: `flex-wrap` sozinho não quebra a linha quando a descrição é `flex-1 min-w-0` (base 0, encolhe até caber). **O teste que deveria guardar isso passava com a tela quebrada** — afirmava a presença do `flex-wrap`, não o efeito. Corrigido (`basis-full sm:basis-0`), guarda estendida e provada por mutação, gate completo re-rodado (512 testes verdes). **A conclusão que fica: a "auditoria estrutural" das duas sessões anteriores teria continuado dando confiança indefinidamente — o veredito F-D8 do fundador estava certo.** | @dev |
 
 ## Dev Agent Record
 
@@ -468,17 +471,64 @@ Baseline antes desta story: backend 1154/1/29 (pós-8.12); frontend 330/50. Delt
   - `PagarPage.tsx`: tabela mantém `overflow-x-auto` (não `overflow-hidden`), com o comentário do achado de campo preservado — não houve regressão do PR #58.
   - `FilaPagamentosPage.tsx`: importa `DialogDeBaixa` de `EscolhaDaBaixa` e envia corpo (`corpo`) no `POST /bills/{id}/pay` — reusa, não duplica.
   - `receipts.py`: o texto `TODO(8.13)` só aparece agora dentro de um comentário histórico explicando que o default de conta primária **foi removido** — não há mais TODO vivo no código.
-- **AC9 — NÃO satisfeito. Este é o item que bloqueia o fechamento da story.** A validação em aparelho real (ou emulação fiel a ~360px) dos 5 itens (a)–(e) não foi executada em nenhuma das duas sessões: nem a original (interrompida antes de chegar lá) nem a de recuperação (sem acesso a stack de dev viva com autenticação neste ambiente — o mesmo limite que já havia sido registrado na Story 8.7). A auditoria estrutural que **pôde** ser feita (acima) dá confiança de que o código está desenhado corretamente para 360px, mas **não substitui** o veredito F-D8 do fundador, que exige verificação física.
+- **AC9 — SATISFEITO em 2026-08-06, numa terceira sessão** (as duas anteriores não tinham stack de dev viva com autenticação; esta subiu uma). Os 5 itens (a)–(e) foram medidos, não inspecionados. Ver a seção de evidência abaixo.
 - **Os 3 agentes de QA do `CLAUDE.md` §5 não foram executados** — mesma limitação estrutural já registrada em todas as stories anteriores da onda (sem ferramenta de spawn a partir do executor).
 
-### Evidência do aceite em ~360px (AC9 — bloqueante)
+### Evidência do aceite em ~360px (AC9 — bloqueante) — EXECUTADO 2026-08-06
 
-**NÃO CAPTURADA.** Nenhum dos itens (a)–(e) foi verificado em aparelho real ou emulador nesta rodada. Auditoria estrutural (proxy, não substituto):
-- (a) confirmado por leitura: `EscolhaDaBaixa compact` está dentro do container fixo, ao lado do botão — mas altura total do bloco fixo em 360px não foi medida contra o viewport.
-- (d) confirmado por leitura: `overflow-x-auto` presente, `overflow-hidden` ausente em `PagarPage.tsx`.
-- (b), (c), (e): não verificados.
+**Método.** Emulação fiel, não leitura de código: viewport **360×740** (Playwright sobre Chromium), contra
+uma **stack de dev viva e isolada** — Postgres próprio (volume dedicado, papel não-superusuário `e1p_app`
+criado pelo `01-rls-enforce.sql`), `alembic upgrade head` até a **0071**, API em `:8001`, Vite em `:5175`
+(portas fora das padrão para não disputar com outra sessão). Tenant real criado por `POST /auth/register`,
+login pela tela, três contas bancárias (uma com nome deliberadamente longo — *"Banco Cooperativo Sicredi -
+Conta Corrente Principal PJ"*, o caso de estresse da truncagem) e quatro contas a pagar. Cada item foi
+**medido** por `getBoundingClientRect()` — o que se registra abaixo são números, não impressões.
 
-**Este item precisa ser fechado pelo founder (dispositivo real) ou por uma sessão futura com acesso a ambiente de dev + Playwright antes do merge para `main`**, conforme o veredito F-D8 já registrado no epic.
+**Resultado: os 5 itens passam.**
+
+| Item | Medição | Veredito |
+|---|---|---|
+| **(a)** seletor + data + ação simultaneamente visíveis, sem rolagem, na barra fixa da `ComprovantePage` | Barra fixa em y=539–740 (viewport 740). Seletor y=624–661; campo de data y=624–664; botão y=676–724. Com o nome longo o botão quebra em 3 linhas e cresce para y=628–724 — **continua dentro**. `documentElement.scrollWidth` = 345 < 360 (sem rolagem horizontal) | ✅ |
+| **(b)** nome da conta legível, truncagem não come o nome inteiro | `<select>` com `clientWidth` 151 e `scrollWidth` 385: mostra *"Banco Cooperativo"* — prefixo que já distingue das outras duas contas. E o **botão de ação repete a conta por extenso**: *"Anexar e dar baixa · sai do Banco Cooperativo Sicredi - Conta Corrente Principal PJ"*. É exatamente o que o AC5 exigia e o motivo de ele existir | ✅ |
+| **(c)** confirmação de baixa da `PagarPage` cabe na tela, botões alcançáveis | Diálogo `position: fixed`, 345×716 em viewport 360×740. Os 4 controles — fechar (y=270), seletor (y=402–439), data (y=402–442), *"Confirmar baixa"* (y=454–498) — **todos integralmente dentro do viewport**. Baixa executada de verdade: a conta foi para `Pago` | ✅ |
+| **(d)** tabela da `PagarPage` com `overflow-x-auto`, **não** `overflow-hidden` (regressão do PR #58) | Computado `overflow-x: auto` no wrapper (`overflow-x-auto rounded-2xl bg-white shadow-sm`); tabela 902px em wrapper de 297px → rola. Coluna **Status** presente e, após baixar uma conta, o botão **Estornar** existe e fica em x=257 / right=305 com o wrapper rolado ao máximo (`scrollLeft` 585 = máximo) — **dentro dos 360px** | ✅ |
+| **(e)** nada coberto pela sidebar; `/comprovante/:id` sem sidebar/topbar | A 360px a sidebar **nem é montada** (`AppShell` faz `useState(isDesktopWidth)`, e o bloco é `{open && …}`) — nasce fechada. Aberta pelo botão da topbar: `<aside>` `position: fixed`, z-40, 256px, com backdrop fixo z-30, e o `main` **permanece em x=0 / 345px** — não foi empurrado (fix do PR #56). Em `/comprovante/:id` o DOM não tem `<aside>` nem topbar: só o header próprio da tela (`ProtectedBareLayout`) | ✅ |
+
+**Reprodução do desktop (não-regressão):** a 1280×800 a `flex-basis` da descrição volta a `0px`, linhas de 64px, tudo numa linha só.
+
+#### ⚠️ O que o aceite achou — um 6º defeito, real, fora dos itens (a)–(e)
+
+`FilaPagamentosPage` — a **terceira superfície** desta story (AC6, o achado do @sm) — estava **quebrada a
+360px**, e nenhum dos cinco itens do AC9 apontava para ela.
+
+**Sintoma medido (antes):** na linha da fila, a descrição ficava com **44px de largura por 280px de
+altura** — o nome da conta empilhava ~uma palavra por linha — e o valor, verticalmente centrado contra
+esse bloco, **colidia visualmente no meio do texto**. Altura da linha: **304px** para uma única conta.
+
+**Causa.** O `<li>` já tinha `flex-wrap`, com um comentário atribuindo-o à *"auditoria de ~360px, AC9"*. Mas
+`flex-wrap` **sozinho não quebra a linha**: a descrição era `min-w-0 flex-1`, isto é `flex: 1 1 0%` — base
+zero e encolhimento livre. Em vez de transbordar e forçar a quebra, ela **encolhia até caber no que
+sobrasse** de valor + botão. O `flex-wrap` nunca chegava a agir.
+
+**Por que a suíte não pegou.** Havia um teste chamado *"em ~360px a linha da fila QUEBRA em vez de empurrar
+o botão para fora (AC9)"* que afirmava `expect(linha.className).toContain("flex-wrap")` — e **passava com a
+tela quebrada**. Ele verificava a presença do mecanismo, não o efeito dele. É o registro mais útil desta
+sessão: *a auditoria estrutural das duas sessões anteriores teria continuado dando confiança indefinidamente*.
+
+**Correção.** `min-w-0 grow basis-full sm:basis-0` na descrição: base 100% obriga-a a tomar a primeira
+linha e joga valor + botão para a segunda; do `sm` para cima volta ao layout de uma linha. `grow` em vez de
+`flex-1` **de propósito** — o shorthand `flex` reintroduziria `flex-basis: 0%` e desfaria o `basis-full`
+conforme a ordem das regras do Tailwind.
+
+**Depois (medido):** descrição **265×64px**, valor abaixo dela, botão em x=148–264 — dentro do viewport.
+Altura da linha: **304px → 128px**. Verificado nas três linhas da fila.
+
+**Guarda.** O teste acima foi estendido para exigir `basis-full` e **proibir** `flex-1` na descrição.
+Provado por mutação (cópia de arquivo, não `git checkout`): revertida a classe para `min-w-0 flex-1`, o
+teste **falha** (`Received: "min-w-0 flex-1"`); restaurado, os 11 testes do arquivo passam.
+
+**Gate rodado após a correção:** `tsc --noEmit` limpo, `eslint --max-warnings 0` limpo,
+`pnpm --filter @e1p/web test` → **55 arquivos, 512 testes, 0 falhas**.
 
 ### File List
 
@@ -499,7 +549,7 @@ Baseline antes desta story: backend 1154/1/29 (pós-8.12); frontend 330/50. Delt
 **Frontend (produção, alterados):**
 - `apps/web/src/features/pagar/PagarPage.tsx`
 - `apps/web/src/features/pagar/ComprovantePage.tsx`
-- `apps/web/src/features/financeiro/FilaPagamentosPage.tsx`
+- `apps/web/src/features/financeiro/FilaPagamentosPage.tsx` (⚠️ **alterado de novo em 2026-08-06**, pelo aceite do AC9: `basis-full sm:basis-0` na descrição da linha da fila — ver Dev Agent Record)
 - `apps/web/src/features/financeiro/ContasSaldosPage.tsx` (refatorado para consumir `AccountModal.tsx` extraído)
 - `apps/web/src/lib/api.ts`
 - `packages/shared-types/src/index.ts`


### PR DESCRIPTION
## O que é

O **aceite manual em ~360px da Story 8.13** — bloqueante por decisão do fundador (**F-D8**), aberto desde a Onda 1 e nunca executado em duas sessões anteriores — foi finalmente feito, contra uma stack de dev viva e autenticada, com medição por `getBoundingClientRect()` num viewport de **360×740**.

Ele achou um defeito real. Este PR o corrige.

## Os 5 itens do AC9 passam

| | Verificação | Medição |
|---|---|---|
| **(a)** | Seletor + data + ação simultaneamente visíveis na barra fixa da `ComprovantePage` | Barra em y=539–740 (viewport 740); seletor 624–661, data 624–664, botão 676–724. Com nome de conta longo o botão quebra em 3 linhas e **ainda cabe** |
| **(b)** | Nome da conta legível, truncagem não come o nome inteiro | `<select>` mostra *"Banco Cooperativo"*; o **botão repete a conta por extenso** — é o AC5 fazendo o trabalho para o qual foi escrito |
| **(c)** | Confirmação de baixa da `PagarPage` cabe na tela | Diálogo `fixed` 345×716 em 360×740; os 4 controles integralmente dentro do viewport. Baixa executada de verdade |
| **(d)** | `overflow-x-auto`, **não** `overflow-hidden` (regressão do PR #58) | Computado `overflow-x: auto`; tabela 902px em wrapper de 297px. **Estornar** alcançável em x=257 com o wrapper rolado ao máximo |
| **(e)** | Nada coberto pela sidebar | A 360px ela **nem é montada**; aberta é `fixed` z-40 com backdrop, e o `main` **não é empurrado** (fix do PR #56). `/comprovante/:id` sem `<aside>` nem topbar |

## O 6º defeito — fora dos itens (a)–(e)

`FilaPagamentosPage`, a **terceira superfície** da story (AC6, o achado do @sm), estava **quebrada a 360px**:

- descrição da linha com **44px de largura por 280px de altura** — o nome da conta empilhando ~uma palavra por linha;
- o valor, verticalmente centrado contra esse bloco, **colidindo no meio do texto**;
- linha de **304px** de altura para uma única conta.

**Causa.** O `<li>` já tinha `flex-wrap`, com um comentário creditando-o à *"auditoria de ~360px, AC9"*. Mas `flex-wrap` **sozinho não quebra a linha** quando o filho é `flex-1 min-w-0` — `flex: 1 1 0%`, base zero e encolhimento livre. A descrição encolhia até caber no que sobrasse de valor + botão em vez de transbordar. O `flex-wrap` nunca chegava a agir.

**Por que a suíte não pegou.** Havia um teste chamado *"em ~360px a linha da fila QUEBRA em vez de empurrar o botão para fora (AC9)"* que afirmava `expect(linha.className).toContain("flex-wrap")` — e **passava com a tela quebrada**. Verificava a presença do mecanismo, não o efeito dele. Era a fonte da confiança das duas sessões anteriores, que declararam o código *"desenhado corretamente para 360px"* por leitura.

## A correção

`min-w-0 grow basis-full sm:basis-0` na descrição: base 100% obriga-a a tomar a primeira linha e joga valor + botão para a segunda; do `sm` para cima volta ao layout de uma linha.

`grow` em vez de `flex-1` **de propósito** — o shorthand `flex` reintroduziria `flex-basis: 0%` e desfaria o `basis-full` conforme a ordem das regras do Tailwind.

**Depois (medido):** descrição **265×64px**, valor abaixo dela, botão dentro do viewport. Linha de **304px → 128px**, nas três linhas da fila. Desktop (1280×800) intacto: `flex-basis` volta a `0px`, linhas de 64px.

## Guarda de regressão

O teste acima foi estendido para exigir `basis-full` e **proibir** `flex-1` na descrição. Provado por **mutação** (cópia de arquivo, não `git checkout`): revertida a classe para `min-w-0 flex-1`, o teste **falha** (`Received: "min-w-0 flex-1"`); restaurada, os 11 testes do arquivo passam.

## Gate

- `tsc --noEmit` — limpo
- `eslint --max-warnings 0` — limpo
- `pnpm --filter @e1p/web test` — **55 arquivos, 512 testes, 0 falhas** (re-rodado após o rebase sobre `b344be9`)

Sem mudança de backend, sem migration.

## Efeito na Story 8.13

O **bloqueio F-D8 está levantado**. [`docs/stories/8.13.story.md`](docs/stories/8.13.story.md) traz a Task 8 marcada, a evidência completa no Dev Agent Record (método + medições reproduzíveis) e o Change Log v0.3. A story segue **InReview**, aguardando o gate da @architect — não a marquei como Done por conta própria.

Era o único bloqueio formal do Epic 8, cujas 20 stories estão em InReview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)