### PR TITLE
feat: Vima Onda 4 — as superfícies do briefing (tela, horário, WhatsApp)

### DIFF
--- a/apps/api/app/core/whatsapp/__init__.py
+++ b/apps/api/app/core/whatsapp/__init__.py
@@ -170,6 +170,7 @@ def send_template(
     profile: TenantProfile | None = None,
     token: str | None = None,
     phone_id: str | None = None,
+    quick_reply_payload: str | None = None,
 ) -> str:
     provider = _resolve(profile)
     to = _addressable(to)
@@ -183,6 +184,9 @@ def send_template(
         template_name=template_name,
         language=language,
         variables=variables,
+        # Só o aviso do briefing usa (ver `providers/meta.send_template`). A Evolution recusa
+        # template inteiro, então o parâmetro extra nunca a alcança de forma significativa.
+        quick_reply_payload=quick_reply_payload,
     )
 
 

--- a/apps/api/app/core/whatsapp/capabilities.py
+++ b/apps/api/app/core/whatsapp/capabilities.py
@@ -25,6 +25,7 @@ Consumidores REAIS hoje (verificáveis por grep de `capabilities.for_profile` /
 - `app/modules/notifications/service.py::process_pending` — guarda de ENTREGA: os 5 pontos do
   domínio que resolvem vínculo propósito→template no enfileiramento não sabem por qual
   transporte a mensagem sai; a decisão final é tomada aqui, onde o transporte é conhecido.
+- `app/modules/vima/scheduler.py::_entregar_no_whatsapp` — briefing em um passo × dois passos.
 """
 from __future__ import annotations
 
@@ -41,11 +42,30 @@ class Capabilities:
     session_window: bool
     media: bool
     provisioning: str  # "credentials" (Meta: cola token/phone_id) | "qrcode" (Evolution)
+    # O briefing diário precisa de um "pode mandar?" do dono ANTES do texto?
+    #
+    # Meta: sim. Parâmetro de template da Cloud API não aceita quebra de linha (e o briefing tem
+    # várias), e às 7h o dono está sempre fora da janela de 24h — então o que sai primeiro é um
+    # template curto com botão de resposta rápida; o toque abre a janela e o texto inteiro sai
+    # depois, livre. Evolution: não. Não tem janela nem template — sai direto, em um passo.
+    #
+    # NÃO é uma reescrita de `templates`/`session_window`: aquelas dizem o que o transporte
+    # SUPORTA; esta diz o que ESTE fluxo precisa fazer por causa disso. Um transporte futuro com
+    # template e sem janela (ou com janela de 7 dias) as combinaria de outro jeito.
+    #
+    # Consumidor (verificável por grep — este módulo já passou meses com zero call sites enquanto
+    # a docstring afirmava ter três):
+    #   - app/modules/vima/scheduler.py::_entregar_no_whatsapp
+    briefing_needs_optin: bool
 
 
-META = Capabilities(templates=True, session_window=True, media=True, provisioning="credentials")
+META = Capabilities(
+    templates=True, session_window=True, media=True, provisioning="credentials",
+    briefing_needs_optin=True,
+)
 EVOLUTION = Capabilities(
-    templates=False, session_window=False, media=True, provisioning="qrcode"
+    templates=False, session_window=False, media=True, provisioning="qrcode",
+    briefing_needs_optin=False,
 )
 
 

--- a/apps/api/app/core/whatsapp/inbound.py
+++ b/apps/api/app/core/whatsapp/inbound.py
@@ -36,6 +36,17 @@ class InboundMessage:
     # o telefone real mesmo quando `key.participant` vem mascarado como `@lid`.
     sender_phone: str | None = None
     sender_name: str | None = None
+    # O payload do botão de resposta rápida que o contato TOCOU, quando foi um toque e não texto.
+    #
+    # Só o provider Meta o preenche, e é o suficiente: quem produz botão neste produto é o aviso
+    # do briefing (`vima/scheduler`), e ele só é enviado sob a Meta — a Evolution recebe o
+    # briefing inteiro em um passo e nunca manda botão nenhum. Um tenant que MIGRE de Meta para
+    # QR code entre o aviso e o toque perde aquele toque; a mensagem é gravada normalmente e o
+    # briefing continua na tela.
+    #
+    # ⚠️ Vem do payload do COMPONENTE de botão que nós enviamos, não do rótulo que o tenant
+    # escreveu no console da Meta — ver `providers/meta.send_template(quick_reply_payload=...)`.
+    button_payload: str | None = None
     media_bytes: bytes | None = None  # mídia JÁ decodificada (Evolution, quando webhookBase64
     # está ligado) — ingest cria o Attachment na hora, sem depender do worker.
     media_mime_type: str | None = None

--- a/apps/api/app/core/whatsapp/providers/meta.py
+++ b/apps/api/app/core/whatsapp/providers/meta.py
@@ -151,22 +151,42 @@ def delete_template(*, waba_id: str, token: str, name: str) -> None:
 
 
 def send_template(
-    *, to: str, token: str, phone_id: str, template_name: str, language: str, variables: list[str]
+    *,
+    to: str,
+    token: str,
+    phone_id: str,
+    template_name: str,
+    language: str,
+    variables: list[str],
+    quick_reply_payload: str | None = None,
 ) -> str:
     """Retorna 'sent' | 'logged' | 'failed'.
 
     MESMO contrato/invariante de send_text: NUNCA propaga exceção (fire-and-forget, graceful
     degradation) — 'logged' quando token ou phone_id vier vazio; 'failed' se a chamada falhar;
     'sent' em 200 OK.
+
+    `quick_reply_payload` (opcional): o valor que queremos de volta quando o contato tocar o
+    PRIMEIRO botão de resposta rápida do template. Sem ele, a Meta devolve no webhook o **rótulo**
+    do botão — texto livre que o tenant escreveu no console dela ("Ver resumo", "Bora", "Sim") —, e
+    não haveria constante nenhuma para casar do lado de cá. Só o aviso do briefing usa; os outros
+    cinco propósitos não têm botão e continuam saindo sem o componente.
     """
     if not token or not phone_id:
         logger.info("[whatsapp:logged] template para=%s nome=%s", to, template_name)
         return "logged"
-    components = (
-        [{"type": "body", "parameters": [{"type": "text", "text": v} for v in variables]}]
-        if variables
-        else []
-    )
+    components: list[dict] = []
+    if variables:
+        components.append(
+            {"type": "body", "parameters": [{"type": "text", "text": v} for v in variables]}
+        )
+    if quick_reply_payload:
+        components.append({
+            "type": "button",
+            "sub_type": "quick_reply",
+            "index": "0",  # o primeiro botão do template — o único que o aviso do briefing tem
+            "parameters": [{"type": "payload", "payload": quick_reply_payload}],
+        })
     try:
         resp = httpx.post(
             f"https://graph.facebook.com/v21.0/{phone_id}/messages",
@@ -273,6 +293,20 @@ def send_media(
         return "failed"
 
 
+def _botao(msg: dict) -> tuple[str | None, str]:
+    """`(payload, rótulo)` do botão tocado. Payload não confiável: campo fora do formato vira
+    `(None, "")` — a mensagem ainda entra na conversa, só não dispara ação nenhuma."""
+    botao = msg.get("button")
+    if isinstance(botao, dict):  # botão de TEMPLATE
+        return botao.get("payload") or None, str(botao.get("text") or "")
+    interativo = msg.get("interactive")
+    if isinstance(interativo, dict):  # botão INTERATIVO
+        resposta = interativo.get("button_reply")
+        if isinstance(resposta, dict):
+            return resposta.get("id") or None, str(resposta.get("title") or "")
+    return None, ""
+
+
 def parse_inbound(payload: dict) -> list[InboundMessage]:
     """Extrai as mensagens do formato aninhado do payload da Meta. Payload não confiável (a
     Meta não garante o shape interno) — dois níveis de tolerância, preservados do antigo
@@ -307,7 +341,20 @@ def parse_inbound(payload: dict) -> list[InboundMessage]:
                     kind = msg.get("type", "text")
                     text_body = ""
                     media_ref = None
-                    if kind == "text":
+                    button_payload = None
+                    if kind in ("button", "interactive"):
+                        # Toque em botão. Duas formas, ambas conferidas na documentação da Meta:
+                        # botão de TEMPLATE vem como `type="button"` + `button:{payload,text}`;
+                        # botão interativo, como `type="interactive"` +
+                        # `interactive.button_reply:{id,title}`.
+                        #
+                        # Vira `kind="text"` a partir daqui: para a caixa de entrada é uma
+                        # mensagem do contato como outra qualquer, e o rótulo do botão é o corpo
+                        # dela — é o que o dono vê no fio da conversa. Quem age sobre o toque lê
+                        # `button_payload`, não o texto.
+                        button_payload, text_body = _botao(msg)
+                        kind = "text"
+                    elif kind == "text":
                         text_field = msg.get("text", {})
                         if not isinstance(text_field, dict):
                             continue  # isola só esta mensagem — ver docstring
@@ -331,6 +378,7 @@ def parse_inbound(payload: dict) -> list[InboundMessage]:
                         # importa num tenant que troque de transporte.
                         chat_jid=f"{from_phone}@s.whatsapp.net" if from_phone else None,
                         sender_phone=from_phone, sender_name=push_name or None,
+                        button_payload=button_payload,
                     ))
                 except (AttributeError, TypeError, KeyError):
                     continue  # isola só esta mensagem — ver docstring

--- a/apps/api/app/modules/auth/models.py
+++ b/apps/api/app/modules/auth/models.py
@@ -55,6 +55,17 @@ class User(Base, TimestampMixin):
     # True quando a senha foi gerada pela plataforma e o usuário deve trocá-la no 1º acesso.
     must_reset_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
+    # Briefing da Vima (Onda 4) — preferência DO USUÁRIO, não da empresa. Mora aqui, e não em
+    # `TenantProfile`, porque dois usuários do mesmo tenant têm horários e telefones diferentes;
+    # no perfil da empresa um sobrescreveria o outro. Também é o que permite editá-la sem o
+    # módulo `settings` (ver `auth/router.py::preferences`).
+    briefing_whatsapp_enabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+    # "HH:MM" no relógio de parede do dono — comparada com a hora LOCAL do tenant pelo scheduler,
+    # nunca com UTC. Ver a migration 0072 para o porquê de ser texto e não `Time`.
+    briefing_hour: Mapped[str] = mapped_column(String(5), default="07:00", nullable=False)
+
     # Recuperação de senha: guardamos o HASH (sha256) do token, nunca o token cru.
     reset_token_hash: Mapped[str | None] = mapped_column(String(64), index=True, nullable=True)
     reset_token_expires: Mapped[datetime | None] = mapped_column(

--- a/apps/api/app/modules/auth/router.py
+++ b/apps/api/app/modules/auth/router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core.security import create_access_token, decode_access_token, refresh_access_token
-from app.core.tenancy import CurrentUser, get_current_user
+from app.core.tenancy import CurrentUser, get_current_user, get_tenant_db
 from app.db.session import get_db
 from app.modules.auth.models import Tenant, User
 from app.modules.auth.schemas import (
@@ -14,6 +14,8 @@ from app.modules.auth.schemas import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
     LoginRequest,
+    PreferencesOut,
+    PreferencesUpdate,
     RefreshedToken,
     RegisterRequest,
     ResetPasswordRequest,
@@ -24,10 +26,12 @@ from app.modules.auth.schemas import (
 from app.modules.auth.service import (
     AuthError,
     authenticate,
+    preferences_of,
     register_tenant,
     request_password_reset,
     reset_password,
     set_own_password,
+    update_preferences,
 )
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -150,6 +154,44 @@ def change_password(
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     tenant = db.get(Tenant, user.tenant_id)
     return SessionInfo(user=UserOut.model_validate(user), tenant=_tenant_out(db, tenant))
+
+
+@router.get("/me/preferences", response_model=PreferencesOut)
+def get_preferences(
+    current: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_tenant_db),
+) -> PreferencesOut:
+    """As preferências de briefing DESTE usuário.
+
+    ⚠️ **Sem `require_module`, de propósito** — mesma razão do router da Vima. `/settings/profile`
+    (que a tela `/config` usa) exige o módulo `settings`; um sub-usuário sem ele ficaria sem
+    conseguir escolher o próprio horário nem ligar o próprio WhatsApp. Configurar a PRÓPRIA
+    entrega não é configuração de empresa.
+
+    Usa `get_tenant_db` (e não o `get_db` das demais rotas deste router) porque a disponibilidade
+    da entrega depende do perfil e dos templates do tenant — tabelas de negócio, sob RLS. Numa
+    sessão crua elas voltariam vazias (fail-closed) e todo tenant pareceria "sem template".
+    `users` é global e não tem RLS, então ler/gravar o `User` daqui funciona igual.
+    """
+    user = db.get(User, current.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=401, detail="Sessão inválida")
+    return preferences_of(db, user)
+
+
+@router.patch("/me/preferences", response_model=PreferencesOut)
+def patch_preferences(
+    data: PreferencesUpdate,
+    current: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_tenant_db),
+) -> PreferencesOut:
+    user = db.get(User, current.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=401, detail="Sessão inválida")
+    try:
+        return update_preferences(db, user, data)
+    except AuthError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
 
 
 @router.get("/me", response_model=SessionInfo)

--- a/apps/api/app/modules/auth/schemas.py
+++ b/apps/api/app/modules/auth/schemas.py
@@ -111,6 +111,32 @@ class ChangePasswordRequest(BaseModel):
     new_password: str = Field(min_length=8, max_length=128)
 
 
+HOUR_RE = r"^([01]\d|2[0-3]):[0-5]\d$"
+
+
+class PreferencesOut(BaseModel):
+    """As preferências de briefing DESTE usuário, mais o que o tenant consegue entregar.
+
+    Os dois campos de disponibilidade existem para a tela **dizer o motivo** em vez de oferecer
+    um botão que não entrega nada: num tenant Meta o template com botão depende de aprovação da
+    Meta, que é externa ao repositório e demora. Sem eles a UI só poderia mostrar um switch que
+    liga e nada acontece — a forma mais rápida de perder a confiança num canal.
+    """
+
+    briefing_whatsapp_enabled: bool
+    briefing_hour: str
+    briefing_whatsapp_disponivel: bool
+    # `None` quando disponível. Texto pronto para a tela: quem lê é o dono, não um switch.
+    briefing_whatsapp_indisponivel_motivo: str | None = None
+
+
+class PreferencesUpdate(BaseModel):
+    """Ambos opcionais: a tela salva um campo de cada vez, sem reenviar o outro."""
+
+    briefing_whatsapp_enabled: bool | None = None
+    briefing_hour: str | None = Field(default=None, pattern=HOUR_RE)
+
+
 class SessionInfo(BaseModel):
     """Retorno de /auth/me — apenas identidade, SEM reemitir credencial."""
 

--- a/apps/api/app/modules/auth/service.py
+++ b/apps/api/app/modules/auth/service.py
@@ -16,7 +16,7 @@ from app.core.security import (
     verify_password,
 )
 from app.modules.auth.models import Tenant, User
-from app.modules.auth.schemas import RegisterRequest
+from app.modules.auth.schemas import PreferencesOut, PreferencesUpdate, RegisterRequest
 
 logger = logging.getLogger("e1p.auth")
 
@@ -140,3 +140,47 @@ def authenticate(db: Session, email: str, password: str) -> tuple[Tenant, User]:
     if tenant is None:
         raise AuthError("Tenant não encontrado", 404)
     return tenant, user
+
+
+# ── Preferências de briefing (Vima, Onda 4) ─────────────────────────────────────────────
+
+
+def preferences_of(db: Session, user: User) -> PreferencesOut:
+    """Monta o retorno, resolvendo a disponibilidade da entrega no tenant do usuário.
+
+    Import tardio de `vima.delivery` pelo mesmo motivo de `_tenant_out` importar `settings` de
+    dentro da função: `auth` é a base que os módulos de negócio importam, e importá-los de volta
+    no topo fecha o ciclo.
+    """
+    from app.modules.vima import delivery
+
+    entrega = delivery.avaliar(db, phone=user.phone)
+    return PreferencesOut(
+        briefing_whatsapp_enabled=user.briefing_whatsapp_enabled,
+        briefing_hour=user.briefing_hour,
+        briefing_whatsapp_disponivel=entrega.disponivel,
+        briefing_whatsapp_indisponivel_motivo=entrega.motivo,
+    )
+
+
+def update_preferences(db: Session, user: User, data: PreferencesUpdate) -> PreferencesOut:
+    """Grava o que veio. Campo ausente (`None`) não é "apague" — é "não mexi nisso".
+
+    LIGAR o WhatsApp exige que a entrega seja possível AGORA; DESLIGAR nunca é bloqueado. A
+    guarda existe para impedir promessa vazia (um switch ligado que não entrega nada), não para
+    prender ninguém numa preferência que ele já não quer.
+    """
+    from app.modules.vima import delivery
+
+    if data.briefing_hour is not None:
+        user.briefing_hour = data.briefing_hour
+    if data.briefing_whatsapp_enabled is True:
+        entrega = delivery.avaliar(db, phone=user.phone)
+        if not entrega.disponivel:
+            raise AuthError(entrega.motivo or "Entrega por WhatsApp indisponível", 422)
+        user.briefing_whatsapp_enabled = True
+    elif data.briefing_whatsapp_enabled is False:
+        user.briefing_whatsapp_enabled = False
+    db.commit()
+    db.refresh(user)
+    return preferences_of(db, user)

--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -25,8 +25,11 @@ from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
 from app.modules.whatsapp_session.models import PublicWhatsappInstance
 from app.modules.whatsapp_templates.models import (
+    PAYLOAD_BOTAO_BRIEFING,
     PURPOSE_CLIENT_MOVED,
     PURPOSE_STAFF_INVITE,
+    PURPOSE_VIMA_BRIEFING,
+    PURPOSE_VIMA_BRIEFING_TEXTO,
     STATUS_APPROVED,
     WhatsappTemplate,
 )
@@ -81,6 +84,11 @@ def _render_template_preview(body_text: str, variables: list[str]) -> str:
 # operacional expira em 1h. Ausente da tabela (ou purpose=None) = nunca expira (compat).
 _MONEY_PURPOSES = frozenset({"charge_reminder", "contract_send", "quote_send"})
 _ONE_HOUR_PURPOSES = frozenset({"client_moved", "staff_invite", "funnel_node"})
+# O briefing expira no fim do DIA do tenant, pela mesma mecânica de `_MONEY_PURPOSES` e por outra
+# razão: o briefing de hoje entregue amanhã não é notícia atrasada, é ruído. Uma hora (a validade
+# "operacional") seria curta demais — o worker pode ficar minutos atrás numa manhã movimentada, e
+# perder o briefing por isso seria pior do que entregá-lo às 9h.
+_END_OF_DAY_PURPOSES = _MONEY_PURPOSES | {PURPOSE_VIMA_BRIEFING, PURPOSE_VIMA_BRIEFING_TEXTO}
 
 
 def _compute_expires_at(db: Session, *, tenant_id: str, purpose: str | None) -> datetime | None:
@@ -89,7 +97,7 @@ def _compute_expires_at(db: Session, *, tenant_id: str, purpose: str | None) -> 
     now = datetime.now(UTC)
     if purpose in _ONE_HOUR_PURPOSES:
         return now + timedelta(hours=1)
-    if purpose in _MONEY_PURPOSES:
+    if purpose in _END_OF_DAY_PURPOSES:
         profile = settings_service.get_profile(db, tenant_id)
         try:
             tz = ZoneInfo(profile.timezone)
@@ -262,6 +270,14 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
                     template_name=notification.whatsapp_template_name,
                     language=notification.whatsapp_template_language or "pt_BR",
                     variables=notification.whatsapp_template_variables or [],
+                    # O botão é característica do PROPÓSITO, não da linha: derivá-lo aqui evita
+                    # uma coluna nova em `notifications` para um dado que é constante por
+                    # propósito. Só o aviso do briefing tem botão.
+                    quick_reply_payload=(
+                        PAYLOAD_BOTAO_BRIEFING
+                        if notification.purpose == PURPOSE_VIMA_BRIEFING
+                        else None
+                    ),
                 )
             else:
                 status = whatsapp.send_text(

--- a/apps/api/app/modules/vima/delivery.py
+++ b/apps/api/app/modules/vima/delivery.py
@@ -30,6 +30,10 @@ from app.modules.whatsapp_templates.models import (
 )
 
 SEM_TELEFONE = "Cadastre um WhatsApp no seu perfil para receber o briefing por lá."
+SEM_WHATSAPP = (
+    "O WhatsApp da empresa ainda não está conectado. Conecte em Configurações e o briefing "
+    "passa a sair por lá também."
+)
 TEMPLATE_PENDENTE = (
     "O template do briefing ainda não foi aprovado pela Meta. Enquanto isso, o briefing "
     "continua na tela todo dia — só o envio por WhatsApp é que não sai."
@@ -61,6 +65,12 @@ def avaliar(db: Session, *, phone: str | None) -> Entrega:
     if not capabilities.for_profile(profile).templates:
         # Evolution: sem template e sem janela de 24h — o briefing inteiro sai em um passo.
         return Entrega(disponivel=True, motivo=None)
+
+    # `for_profile(None)` é Meta por definição documentada — inclusive para quem nunca conectou
+    # WhatsApp nenhum. Sem esta guarda, esse tenant leria "a Meta ainda não aprovou o template",
+    # que é verdade e é a resposta errada: ele não está esperando a Meta, está esperando conectar.
+    if not profile or not (profile.whatsapp_token and profile.whatsapp_phone_id):
+        return Entrega(disponivel=False, motivo=SEM_WHATSAPP)
 
     template = _template_do_aviso(db, profile)
     if template is None:

--- a/apps/api/app/modules/vima/delivery.py
+++ b/apps/api/app/modules/vima/delivery.py
@@ -1,0 +1,86 @@
+"""*"Este usuário consegue receber o briefing por WhatsApp — e por qual caminho?"*
+
+Uma pergunta, uma resposta, dois consumidores:
+
+- `app/modules/auth/router.py::get_preferences` / `update_preferences` — a tela mostra o motivo
+  e o PATCH recusa ligar o que não entrega.
+- `app/modules/vima/scheduler.py::_entregar_no_whatsapp` — escolhe entre o texto inteiro
+  (Evolution) e o aviso com botão (Meta).
+
+Os dois precisam da MESMA resposta. Se divergissem, a tela diria "ligado" e o job não mandaria
+nada — a pior forma de falha possível num canal diário, porque é silenciosa dos dois lados.
+
+⚠️ A indisponibilidade da Meta é uma dependência **externa ao repositório**: o template com botão
+de resposta rápida precisa passar pela aprovação da Meta, que leva dias e não depende de deploy.
+Enquanto não passa, o tenant Meta fica sem briefing por WhatsApp — e a tela **diz por quê**.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.whatsapp import capabilities
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_VIMA_BRIEFING,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
+
+SEM_TELEFONE = "Cadastre um WhatsApp no seu perfil para receber o briefing por lá."
+TEMPLATE_PENDENTE = (
+    "O template do briefing ainda não foi aprovado pela Meta. Enquanto isso, o briefing "
+    "continua na tela todo dia — só o envio por WhatsApp é que não sai."
+)
+
+
+@dataclass(frozen=True)
+class Entrega:
+    """O veredito. `template_id` só é preenchido quando o caminho passa por template."""
+
+    disponivel: bool
+    motivo: str | None
+    template_id: str | None = None
+
+
+def avaliar(db: Session, *, phone: str | None) -> Entrega:
+    """Sessão RLS-escopada (o perfil e os templates são do tenant corrente, Regra de Ouro nº 1).
+
+    Ordem das guardas: telefone primeiro, porque sem destinatário nem faz sentido perguntar por
+    qual transporte — e porque é o motivo que o usuário resolve sozinho, em um campo.
+    """
+    if not phone or not phone.strip():
+        return Entrega(disponivel=False, motivo=SEM_TELEFONE)
+
+    # `select(TenantProfile)` sem `where`, igual a `settings.get_profile`: a sessão já é
+    # RLS-escopada e o perfil que vem é o do tenant corrente. Não CRIA perfil — isto é leitura
+    # dentro de uma regra de negócio, e um efeito colateral de escrita aqui seria armadilha.
+    profile = db.scalar(select(TenantProfile))
+    if not capabilities.for_profile(profile).templates:
+        # Evolution: sem template e sem janela de 24h — o briefing inteiro sai em um passo.
+        return Entrega(disponivel=True, motivo=None)
+
+    template = _template_do_aviso(db, profile)
+    if template is None:
+        return Entrega(disponivel=False, motivo=TEMPLATE_PENDENTE)
+    return Entrega(disponivel=True, motivo=None, template_id=template.id)
+
+
+def _template_do_aviso(db: Session, profile) -> WhatsappTemplate | None:
+    """O template vinculado ao aviso do briefing, se existir E continuar aprovado.
+
+    A aprovação é reconferida na LEITURA, e não só no vínculo: a Meta despausa e repausa
+    template por conta própria (`PAUSED`/`DISABLED`), e um vínculo criado quando estava
+    `APPROVED` continuaria no banco apontando para um template que já não entrega.
+    """
+    binding = (getattr(profile, "whatsapp_template_bindings", None) or {}).get(
+        PURPOSE_VIMA_BRIEFING
+    )
+    if not binding:
+        return None
+    template = db.get(WhatsappTemplate, binding)
+    if template is None or template.status != STATUS_APPROVED:
+        return None
+    return template

--- a/apps/api/app/modules/vima/scheduler.py
+++ b/apps/api/app/modules/vima/scheduler.py
@@ -16,17 +16,28 @@ segundo laço de tenants aqui dentro duplicaria essa estrutura e teria o seu pr�
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.phone import normalize_br
 from app.core.tenancy import CurrentUser
-from app.core.tz import tenant_zone
+from app.core.tz import day_window_utc, tenant_zone
+from app.core.whatsapp import capabilities
 from app.modules.auth.models import User
+from app.modules.notifications import service as notifications
+from app.modules.notifications.models import Notification
+from app.modules.settings.models import TenantProfile
 from app.modules.settings.service import hoje_do_tenant, tenant_timezone
-from app.modules.vima import service
+from app.modules.vima import delivery, service
 from app.modules.vima.models import Briefing
+from app.modules.whatsapp_templates.models import (
+    PAYLOAD_BOTAO_BRIEFING,
+    PURPOSE_VIMA_BRIEFING,
+    PURPOSE_VIMA_BRIEFING_TEXTO,
+    WhatsappTemplate,
+)
 
 logger = logging.getLogger("e1p.vima")
 
@@ -42,6 +53,13 @@ def tick(db: Session, *, tenant_id: str, agora: datetime) -> int:
     Devolve quantos foram **gerados agora** — não quantos existem. Rodar de novo no mesmo dia é
     no-op (a unique key `(tenant, usuário, dia)` já garantia a idempotência; aqui ela não é nem
     exercitada, porque o briefing existente é lido antes).
+
+    ⚠️ **A entrega por WhatsApp acontece SÓ quando este tick gerou o briefing.** É o que impede o
+    dono de receber a mesma mensagem a cada passada do sweep (que roda de minutos em minutos) até
+    a meia-noite, sem precisar de coluna nova nem de aritmética de janela sobre `created_at`.
+    O caso que isso deixa de fora é estreito e a troca é deliberada: quem abriu o app antes do
+    próprio horário já teve o briefing gerado na tela — e a tela o marca como lido ao montar, que
+    é exatamente quando mandar de novo seria eco.
     """
     fuso = tenant_timezone(db)
     local = agora.astimezone(tenant_zone(fuso))
@@ -58,8 +76,9 @@ def tick(db: Session, *, tenant_id: str, agora: datetime) -> int:
             )
         )
         if existente is None:
-            service.gerar_ou_ler(db, user=_como_ator(user), hoje=hoje)
+            briefing = service.gerar_ou_ler(db, user=_como_ator(user), hoje=hoje)
             gerados += 1
+            _entregar_no_whatsapp(db, user=user, briefing=briefing)
 
     db.commit()
     return gerados
@@ -106,4 +125,148 @@ def _minutos(hora: str | None) -> int:
         return int(h) * 60 + int(m)
 
 
-__all__ = ["HORA_PADRAO", "tick"]
+def _entregar_no_whatsapp(db: Session, *, user: User, briefing: Briefing) -> None:
+    """Enfileira o briefing no WhatsApp — em um passo ou dois, conforme o transporte.
+
+    **Dia sem novidade não sai.** Um "bom dia, nada aconteceu" diário é a forma mais rápida de ser
+    silenciado, e um canal silenciado não entrega o dia em que importa. A TELA continua dizendo
+    que está tranquilo; é só o WhatsApp que fica quieto.
+
+    Nunca levanta: uma falha de enfileiramento não pode custar o briefing dos usuários seguintes
+    do mesmo tenant. O sweep já isola falha por TENANT (`worker.run_sweep`); aqui o isolamento é
+    por USUÁRIO, um nível abaixo.
+    """
+    if not user.briefing_whatsapp_enabled or briefing.vazio:
+        return
+
+    # Mesmo veredito que a tela de preferências usa (`auth/router.py`). Cobre "sem telefone" e
+    # "tenant Meta ainda sem template aprovado" — se divergissem, a tela diria "ligado" e o job
+    # não mandaria nada, falha silenciosa dos dois lados.
+    entrega = delivery.avaliar(db, phone=user.phone)
+    if not entrega.disponivel:
+        logger.info(
+            "[vima] briefing de %s não sai no whatsapp: %s", user.id, entrega.motivo
+        )
+        return
+
+    profile = db.scalar(select(TenantProfile))
+    try:
+        if capabilities.for_profile(profile).briefing_needs_optin:
+            _aviso_com_botao(db, user=user, entrega=entrega)
+        else:
+            # Evolution: sem template e sem janela. O briefing INTEIRO, como texto livre.
+            notifications.enqueue(
+                db,
+                tenant_id=user.tenant_id,
+                channel="whatsapp",
+                recipient=user.phone or "",
+                message=briefing.texto,
+                purpose=PURPOSE_VIMA_BRIEFING_TEXTO,
+            )
+    except Exception:  # noqa: BLE001 — ver docstring: isola a falha por usuário
+        logger.exception("[vima] falha ao enfileirar o briefing de %s", user.id)
+
+
+def _aviso_com_botao(db: Session, *, user: User, entrega: delivery.Entrega) -> None:
+    """Meta, primeiro passo: o AVISO, não o briefing.
+
+    Uma linha, sem quebra — parâmetro de template da Cloud API **não aceita `\\n`**, e o briefing
+    tem várias. O que destrava o texto inteiro é o BOTÃO: o toque conta como mensagem do contato,
+    abre a janela de 24h, e aí o texto sai livre (`responder_optin`).
+    """
+    template = db.get(WhatsappTemplate, entrega.template_id)
+    if template is None:  # `avaliar` já garantiu que existe; guarda contra corrida de desvínculo
+        return
+    primeiro_nome = (user.name or "").split(" ")[0] or "você"
+    notifications.enqueue(
+        db,
+        tenant_id=user.tenant_id,
+        channel="whatsapp",
+        recipient=user.phone or "",
+        # O corpo renderizado é o que a tela de histórico mostra E o que sai como texto livre se
+        # o tenant migrar para a Evolution antes da entrega (`process_pending` cai em `send_text`
+        # quando o transporte não tem template).
+        message=_render(template.body_text, [primeiro_nome]),
+        purpose=PURPOSE_VIMA_BRIEFING,
+        whatsapp_template_name=template.name,
+        whatsapp_template_language=template.language,
+        whatsapp_template_variables=[primeiro_nome],
+    )
+
+
+def _render(corpo: str, variaveis: list[str]) -> str:
+    for i, valor in enumerate(variaveis, start=1):
+        corpo = corpo.replace(f"{{{{{i}}}}}", valor)
+    return corpo
+
+
+def responder_optin(db: Session, *, tenant_id: str, phone: str | None) -> bool:
+    """O dono tocou o botão: a janela de 24h abriu — manda o briefing inteiro, em texto livre.
+
+    Chamado por `whatsapp_inbox.service.ingest_webhook_payload` quando reconhece o toque. Devolve
+    se algo foi enfileirado.
+
+    **Não commita.** Roda dentro da transação-por-mensagem do ingest, que commita a mensagem e o
+    opt-in juntos — se o commit falhar, nenhum dos dois fica pela metade.
+
+    ⚠️ **O toque precisa vir do telefone de um USUÁRIO deste tenant.** O payload do botão é uma
+    constante conhecida, e um cliente qualquer poderia repeti-la: sem o vínculo com um usuário, o
+    briefing do dono sairia para quem escrevesse a string certa. É a mesma guarda que impede o
+    dono de virar lead do próprio funil (`whatsapp_inbox._e_telefone_da_equipe`), usada aqui para
+    o outro lado da mesma decisão.
+    """
+    chave = normalize_br(phone) if phone else None
+    if chave is None:
+        return False
+
+    user = next(
+        (
+            u
+            for u in _usuarios_ativos(db, tenant_id)
+            if u.phone and normalize_br(u.phone) == chave
+        ),
+        None,
+    )
+    if user is None:
+        return False
+
+    briefing = db.scalar(
+        select(Briefing).where(
+            Briefing.user_id == user.id,
+            Briefing.reference_date == hoje_do_tenant(db),
+        )
+    )
+    # Toque atrasado (aviso de ontem, respondido hoje) não tem briefing de hoje para liberar — e
+    # mandar o de ontem seria pior do que não mandar nada.
+    if briefing is None or briefing.vazio:
+        return False
+
+    ja_saiu = db.scalar(
+        select(Notification.id).where(
+            Notification.purpose == PURPOSE_VIMA_BRIEFING_TEXTO,
+            Notification.recipient == user.phone,
+            Notification.created_at >= _inicio_do_dia(db, briefing.reference_date),
+        )
+    )
+    # Dedo escorregando no celular não pode custar duas mensagens iguais.
+    if ja_saiu is not None:
+        return False
+
+    notifications.enqueue(
+        db,
+        tenant_id=tenant_id,
+        channel="whatsapp",
+        recipient=user.phone or "",
+        message=briefing.texto,
+        purpose=PURPOSE_VIMA_BRIEFING_TEXTO,
+    )
+    return True
+
+
+def _inicio_do_dia(db: Session, dia: date) -> datetime:
+    """Meia-noite do tenant, em UTC — a fronteira certa para "já saiu hoje?"."""
+    inicio, _fim = day_window_utc(dia, tenant_timezone(db))
+    return inicio
+
+
+__all__ = ["HORA_PADRAO", "PAYLOAD_BOTAO_BRIEFING", "responder_optin", "tick"]

--- a/apps/api/app/modules/vima/scheduler.py
+++ b/apps/api/app/modules/vima/scheduler.py
@@ -1,0 +1,109 @@
+"""O job que gera o briefing no horário de cada usuário — no fuso do tenant.
+
+⚠️ **O relógio é sempre INJETADO** (`agora=`). Um job que lê `datetime.now()` por conta própria só
+é testável esperando o relógio da máquina chegar na hora certa, e o teste que sobra é o que não
+pega a inversão de fuso. Mesma disciplina de `funnels.engine.tick` e `payables.promote_scheduled`.
+
+⚠️ **"Já chegou o horário?" é comparação com a hora LOCAL do tenant**, nunca com UTC. Às 07:05 UTC
+ainda são 04:05 em São Paulo: comparar em UTC entregaria o briefing das 7h às 4 da manhã, todo
+dia, para todo tenant brasileiro.
+
+**Assinatura por TENANT, e não a `tick(db_factory)` do plano.** O worker já itera tenants e abre
+uma sessão por etapa, com isolamento de falha por tenant (uma falha não trava as demais). Um
+segundo laço de tenants aqui dentro duplicaria essa estrutura e teria o seu próprio — e diferente
+— tratamento de falha.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser
+from app.core.tz import tenant_zone
+from app.modules.auth.models import User
+from app.modules.settings.service import hoje_do_tenant, tenant_timezone
+from app.modules.vima import service
+from app.modules.vima.models import Briefing
+
+logger = logging.getLogger("e1p.vima")
+
+# Usado quando `briefing_hour` está ilegível no banco. As rotas validam por regex, então isto só
+# alcança linha escrita fora da API — e ficar de fora do briefing em silêncio seria pior do que
+# recebê-lo no horário padrão.
+HORA_PADRAO = "07:00"
+
+
+def tick(db: Session, *, tenant_id: str, agora: datetime) -> int:
+    """Gera o briefing de hoje de cada usuário deste tenant cujo horário já chegou.
+
+    Devolve quantos foram **gerados agora** — não quantos existem. Rodar de novo no mesmo dia é
+    no-op (a unique key `(tenant, usuário, dia)` já garantia a idempotência; aqui ela não é nem
+    exercitada, porque o briefing existente é lido antes).
+    """
+    fuso = tenant_timezone(db)
+    local = agora.astimezone(tenant_zone(fuso))
+    hoje = hoje_do_tenant(db, now=agora)
+
+    gerados = 0
+    for user in _usuarios_ativos(db, tenant_id):
+        if not _ja_chegou(user.briefing_hour, local):
+            continue
+
+        existente = db.scalar(
+            select(Briefing).where(
+                Briefing.user_id == user.id, Briefing.reference_date == hoje
+            )
+        )
+        if existente is None:
+            service.gerar_ou_ler(db, user=_como_ator(user), hoje=hoje)
+            gerados += 1
+
+    db.commit()
+    return gerados
+
+
+def _usuarios_ativos(db: Session, tenant_id: str) -> list[User]:
+    """⚠️ `users` é tabela GLOBAL, SEM RLS — o filtro por `tenant_id` aqui é explícito e
+    obrigatório. É a exceção documentada da Regra de Ouro nº 1, a mesma de
+    `whatsapp_inbox.service._e_telefone_da_equipe`."""
+    return list(
+        db.scalars(
+            select(User)
+            .where(User.tenant_id == tenant_id)
+            .where(User.is_active.is_(True))
+            .order_by(User.created_at, User.id)
+        ).all()
+    )
+
+
+def _como_ator(user: User) -> CurrentUser:
+    """O `CurrentUser` que o serviço espera. O `allowed_modules` vem do BANCO, não de um token:
+    é ele que recorta quais fatos entram no briefing deste usuário (`vima/permissions.py`), e um
+    token não existe num job."""
+    return CurrentUser(
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        role=user.role,
+        allowed_modules=list(user.allowed_modules or []),
+        is_platform_admin=user.is_platform_admin,
+    )
+
+
+def _ja_chegou(hora: str | None, local: datetime) -> bool:
+    return _minutos(hora) <= local.hour * 60 + local.minute
+
+
+def _minutos(hora: str | None) -> int:
+    try:
+        h, m = (hora or HORA_PADRAO).split(":")
+        return int(h) * 60 + int(m)
+    except (AttributeError, ValueError):
+        logger.warning("[vima] briefing_hour ilegível (%r) — usando %s", hora, HORA_PADRAO)
+        h, m = HORA_PADRAO.split(":")
+        return int(h) * 60 + int(m)
+
+
+__all__ = ["HORA_PADRAO", "tick"]

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -26,6 +26,7 @@ from app.modules.crm.models import Client
 from app.modules.crm.schemas import ClientCreate
 from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
+from app.modules.vima import scheduler as vima_scheduler
 from app.modules.whatsapp_inbox.models import (
     CHAT_KIND_GROUP,
     DIRECTION_IN,
@@ -40,7 +41,11 @@ from app.modules.whatsapp_inbox.models import (
     WhatsappChat,
     WhatsappMessage,
 )
-from app.modules.whatsapp_templates.models import STATUS_APPROVED, WhatsappTemplate
+from app.modules.whatsapp_templates.models import (
+    PAYLOAD_BOTAO_BRIEFING,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
 
 logger = logging.getLogger("e1p.whatsapp_inbox")
 
@@ -363,6 +368,17 @@ def ingest_webhook_payload(
                     subject_type="whatsapp_chat",
                     subject_id=chat.id if chat is not None else None,
                 )
+
+            # O toque no botão do aviso do briefing (Vima, Onda 4). Fica DEPOIS do registro da
+            # mensagem (a conversa mostra o toque como qualquer outra) e DENTRO do mesmo `try` —
+            # a mesma transação-por-mensagem commita as duas coisas juntas.
+            #
+            # ⚠️ **Precisa vir aqui, e não junto do bloco de `facts` acima**: aquele bloco é
+            # pulado quando `da_equipe` é verdadeiro, e o toque no botão do briefing vem
+            # SEMPRE do telefone de um usuário do tenant. Colocado lá dentro, o opt-in seria
+            # descartado junto com as demais mensagens do time e o briefing nunca sairia.
+            if msg.button_payload == PAYLOAD_BOTAO_BRIEFING and da_equipe:
+                vima_scheduler.responder_optin(db, tenant_id=tenant_id, phone=msg.from_phone)
 
             if msg.media_bytes:
                 # Evolution: bytes já vieram decodificados no payload (webhookBase64) — cria o

--- a/apps/api/app/modules/whatsapp_templates/models.py
+++ b/apps/api/app/modules/whatsapp_templates/models.py
@@ -39,6 +39,14 @@ PURPOSE_CONTRACT_SEND = "contract_send"
 PURPOSE_QUOTE_SEND = "quote_send"
 PURPOSE_STAFF_INVITE = "staff_invite"
 PURPOSE_CLIENT_MOVED = "client_moved"
+# Vima (Onda 4) — o AVISO do briefing, não o briefing. É o único propósito cujo template PRECISA
+# de um botão de resposta rápida: às 7h o dono está sempre fora da janela de 24h, e parâmetro de
+# template da Cloud API não aceita quebra de linha (o briefing tem várias). O toque no botão abre
+# a janela e o texto inteiro sai depois, livre — ver `vima/scheduler.py`.
+PURPOSE_VIMA_BRIEFING = "vima_briefing_aviso"
+# O briefing inteiro, já dentro da janela aberta pelo toque. Texto livre: NÃO tem template e por
+# isso não entra em `PURPOSE_VARIABLE_SPECS` (que é a tabela de vínculo propósito→template).
+PURPOSE_VIMA_BRIEFING_TEXTO = "vima_briefing_texto"
 
 PURPOSE_VARIABLE_SPECS: dict[str, list[str]] = {
     PURPOSE_CHARGE_REMINDER: [
@@ -49,6 +57,10 @@ PURPOSE_VARIABLE_SPECS: dict[str, list[str]] = {
     PURPOSE_QUOTE_SEND: ["Nome do cliente", "Título do orçamento", "Valor", "Link da proposta"],
     PURPOSE_STAFF_INVITE: ["Nome", "Empresa", "E-mail de login", "Senha temporária"],
     PURPOSE_CLIENT_MOVED: ["Nome do cliente", "Nome da nova etapa"],
+    # Uma só, e curta: o corpo do aviso não carrega o briefing (não caberia — parâmetro de
+    # template não aceita quebra de linha). O que destrava o briefing é o BOTÃO, que não é
+    # variável e por isso não conta aqui.
+    PURPOSE_VIMA_BRIEFING: ["Primeiro nome de quem recebe"],
 }
 
 PURPOSE_LABELS: dict[str, str] = {
@@ -57,6 +69,9 @@ PURPOSE_LABELS: dict[str, str] = {
     PURPOSE_QUOTE_SEND: "Envio de orçamento/proposta",
     PURPOSE_STAFF_INVITE: "Convite de funcionário (senha temporária)",
     PURPOSE_CLIENT_MOVED: "Aviso interno: cliente mudou de etapa no CRM",
+    PURPOSE_VIMA_BRIEFING: (
+        "Briefing da Vima (precisa de um botão de resposta rápida no template)"
+    ),
 }
 
 

--- a/apps/api/app/modules/whatsapp_templates/models.py
+++ b/apps/api/app/modules/whatsapp_templates/models.py
@@ -44,6 +44,14 @@ PURPOSE_CLIENT_MOVED = "client_moved"
 # template da Cloud API não aceita quebra de linha (o briefing tem várias). O toque no botão abre
 # a janela e o texto inteiro sai depois, livre — ver `vima/scheduler.py`.
 PURPOSE_VIMA_BRIEFING = "vima_briefing_aviso"
+# O que pedimos de volta quando o dono TOCA o botão do aviso. Mora aqui, e não em `vima/`, porque
+# quem o envia (`notifications.process_pending`) e quem o reconhece (`whatsapp_inbox.service`)
+# importariam `vima.scheduler` — que por sua vez importa `notifications`, fechando o ciclo.
+#
+# ⚠️ É NOSSO valor, definido no componente de botão do envio (`meta.send_template`), e não o
+# rótulo que o tenant escreve no console da Meta. Sem enviá-lo, a Meta devolveria o rótulo —
+# texto livre — e não haveria constante nenhuma para casar do lado de cá.
+PAYLOAD_BOTAO_BRIEFING = "vima_briefing"
 # O briefing inteiro, já dentro da janela aberta pelo toque. Texto livre: NÃO tem template e por
 # isso não entra em `PURPOSE_VARIABLE_SPECS` (que é a tabela de vínculo propósito→template).
 PURPOSE_VIMA_BRIEFING_TEXTO = "vima_briefing_texto"

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -35,6 +35,7 @@ from app.modules.funnels import engine as funnels_engine
 from app.modules.notifications import service as notifications_service
 from app.modules.payables import service as payables_service
 from app.modules.receivables import service as receivables_service
+from app.modules.vima import scheduler as vima_scheduler
 from app.modules.whatsapp_inbox import service as whatsapp_inbox_service
 from app.modules.whatsapp_session import service as whatsapp_session_service
 from app.seed import PLATFORM_SLUG
@@ -92,6 +93,10 @@ def run_sweep(
         # vida da sessão (uma subiu × uma caiu), não dois recortes de um mesmo número. Somá-los
         # produziria um total sem significado. Ver `test_o_sweep_NAO_ganhou_contador_novo`.
         "whatsapp_connections_promoted": 0,
+        # Quantos briefings da Vima este sweep GEROU (não quantos existem). Contador PRÓPRIO pelo
+        # mesmo critério de `whatsapp_connections_promoted`: responde a uma pergunta que nenhum
+        # dos outros responde, e somá-lo a qualquer um deles não produziria número nenhum.
+        "briefings_gerados": 0,
         "errors": [],
     }
 
@@ -204,10 +209,31 @@ def run_sweep(
                 {"tenant_id": tenant_id, "stage": "whatsapp_connections", "error": str(exc)}
             )
 
+        # Etapa 6 — o briefing da Vima, no horário de cada usuário (sessão SEPARADA das outras
+        # cinco). Roda DEPOIS da fila de notificações (etapa 2) de propósito: o WhatsApp que ela
+        # enfileira sai no sweep SEGUINTE, e não no mesmo. É uma diferença de minutos no intervalo
+        # do worker, e mantém a etapa fazendo uma coisa só — gerar. Inverter a ordem faria a
+        # entrega depender de a geração ter acontecido antes no mesmo laço, que é justamente o
+        # tipo de acoplamento entre etapas que o isolamento de falha por etapa existe para evitar.
+        #
+        # ⚠️ `now` é o MESMO relógio das outras etapas (ver a docstring): duas noções de "agora"
+        # dentro de um sweep fariam as etapas discordarem sobre que dia é hoje.
+        try:
+            with tenant_session_factory(tenant_id) as db:
+                briefings = vima_scheduler.tick(
+                    db, tenant_id=tenant_id, agora=now or datetime.now(UTC)
+                )
+            result["briefings_gerados"] += briefings
+        except Exception as exc:  # noqa: BLE001 — idem: isola a falha por tenant (IV2)
+            logger.exception("[worker] briefing da vima falhou tenant=%s", tenant_id)
+            result["errors"].append(
+                {"tenant_id": tenant_id, "stage": "vima_briefing", "error": str(exc)}
+            )
+
     logger.info(
         "[worker] sweep: tenants=%s funil_resumido=%s notificacoes=%s midia_whatsapp=%s "
         "agendadas_promovidas=%s conexoes_whatsapp_promovidas=%s conexoes_whatsapp_caidas=%s "
-        "erros=%s",
+        "briefings=%s erros=%s",
         result["tenants_checked"],
         result["funnel_resumed"],
         result["notifications_processed"],
@@ -215,6 +241,7 @@ def run_sweep(
         result["scheduled_promoted"],
         result["whatsapp_connections_promoted"],
         result["whatsapp_connections_dropped"],
+        result["briefings_gerados"],
         len(result["errors"]),
     )
     return result

--- a/apps/api/migrations/versions/0072_user_briefing_prefs.py
+++ b/apps/api/migrations/versions/0072_user_briefing_prefs.py
@@ -1,0 +1,52 @@
+"""Preferências de briefing por usuário
+
+Revision ID: 0072
+Revises: 0071
+Create Date: 2026-08-06
+
+⚠️ **O plano da Onda 4 dizia "migration 0071" — o número já estava tomado** pelo `ai_usage`, de
+uma frente paralela que mergeou primeiro. Escrever a 0071 de novo produziria duas revisions com o
+mesmo id e o `alembic upgrade head` escolheria uma delas em silêncio. Ao abrir uma branch longa,
+reconfira o head a cada merge de `main`, não só na hora de escrever.
+
+⚠️ `users` é tabela GLOBAL, SEM RLS (login por e-mail é global). Não há janela de RLS a abrir aqui
+— e é justamente por isso que toda consulta a `users` precisa de filtro explícito por `tenant_id`,
+que é a exceção documentada da Regra de Ouro nº 1.
+
+Só DDL com `server_default`: as linhas existentes recebem o padrão sem `UPDATE`, então a armadilha
+do backfill sob RLS (ver 0046/0066/0067/0068/0069) não se aplica.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0072"
+down_revision: str | None = "0071"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "briefing_whatsapp_enabled", sa.Boolean(), nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # `String(5)`, não `Time`: é a hora do RELÓGIO DE PAREDE do dono ("às 7h"), não um instante.
+    # Um `Time` convidaria a comparar com `datetime.now().time()` em UTC — exatamente o bug que a
+    # correção de fuso de 2026-08-05 eliminou. O scheduler compara "07:00" com a hora local do
+    # tenant, e a string deixa isso explícito.
+    op.add_column(
+        "users",
+        sa.Column(
+            "briefing_hour", sa.String(length=5), nullable=False, server_default="07:00",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "briefing_hour")
+    op.drop_column("users", "briefing_whatsapp_enabled")

--- a/apps/api/tests/test_notifications_queue.py
+++ b/apps/api/tests/test_notifications_queue.py
@@ -164,12 +164,14 @@ def test_process_pending_uses_send_template_when_fields_set(db, monkeypatch):
     calls = {"template": 0, "text": 0}
 
     def _send_template(*, to, template_name, language, variables, profile=None, token=None,
-                       phone_id=None):
+                       phone_id=None, quick_reply_payload=None):
         calls["template"] += 1
         assert to == "dono@example.com"
         assert template_name == "tmpl_client_moved"
         assert language == "pt_BR"
         assert variables == ["Maria Cliente", "Proposta Enviada"]
+        # Só o aviso do briefing da Vima leva botão; os outros propósitos saem sem componente.
+        assert quick_reply_payload is None
         return "sent"
 
     def _send_text(*_a, **_k):

--- a/apps/api/tests/test_vima_preferencias.py
+++ b/apps/api/tests/test_vima_preferencias.py
@@ -130,8 +130,20 @@ def test_horario_muda_sem_mexer_no_whatsapp(client: TestClient, headers):
     assert r.json()["briefing_whatsapp_enabled"] is False
 
 
+@pytest.fixture()
+def tenant_meta_conectado(db: Session, tenant_id: str) -> TenantProfile:
+    """Tenant na Cloud API COM credenciais — mas ainda sem o template do briefing aprovado."""
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME", whatsapp_provider="meta",
+        whatsapp_token="tok", whatsapp_phone_id="pid",
+    )
+    db.add(perfil)
+    db.commit()
+    return perfil
+
+
 def test_tenant_meta_sem_template_diz_por_que_nao_da(
-    client: TestClient, headers, dono_com_telefone
+    client: TestClient, headers, dono_com_telefone, tenant_meta_conectado
 ):
     """A dependência é EXTERNA (aprovação da Meta) e fora do repositório. A tela precisa dizer
     o motivo em vez de oferecer um botão que não entrega nada."""
@@ -143,6 +155,18 @@ def test_tenant_meta_sem_template_diz_por_que_nao_da(
         "/auth/me/preferences", json={"briefing_whatsapp_enabled": True}, headers=headers
     )
     assert r.status_code == 422
+
+
+def test_quem_nunca_conectou_whatsapp_le_o_motivo_CERTO(
+    client: TestClient, headers, dono_com_telefone
+):
+    """Perfil ausente cai em Meta por definição (`for_profile(None)`), mas este tenant não está
+    esperando a Meta aprovar nada — está esperando conectar. Dizer "a Meta ainda não aprovou"
+    seria verdade e resposta errada: manda o dono esperar em vez de agir."""
+    p = client.get("/auth/me/preferences", headers=headers).json()
+    assert p["briefing_whatsapp_disponivel"] is False
+    assert "não está conectado" in p["briefing_whatsapp_indisponivel_motivo"]
+    assert "Meta" not in p["briefing_whatsapp_indisponivel_motivo"]
 
 
 def test_tenant_evolution_pode_ligar_sem_template_nenhum(
@@ -172,6 +196,7 @@ def test_tenant_meta_com_template_aprovado_pode_ligar(
     db.flush()
     perfil = TenantProfile(
         tenant_id=tenant_id, display_name="Vima ME",
+        whatsapp_token="tok", whatsapp_phone_id="pid",
         whatsapp_template_bindings={PURPOSE_VIMA_BRIEFING: tpl.id},
     )
     db.add(perfil)

--- a/apps/api/tests/test_vima_preferencias.py
+++ b/apps/api/tests/test_vima_preferencias.py
@@ -1,0 +1,209 @@
+"""A preferência é DO USUÁRIO — não pode exigir o módulo `settings`.
+
+`/settings/profile` é configuração de EMPRESA e exige o módulo. Escolher o próprio horário e
+ligar o próprio WhatsApp é outra coisa: um sub-usuário sem `settings` precisa poder fazer as
+duas. Por isso a preferência vive em `users` e as rotas não têm `require_module`.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token
+from app.modules.auth.models import User
+from app.modules.settings.models import TenantProfile
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_VIMA_BRIEFING,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio Kato",
+    "password": "uma-senha-bem-grande",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    """O dono, ainda SEM telefone cadastrado (é como `/register` o cria)."""
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+@pytest.fixture()
+def headers_sem_telefone(headers: dict[str, str]) -> dict[str, str]:
+    return headers
+
+
+@pytest.fixture()
+def dono_com_telefone(db: Session, client: TestClient, headers: dict[str, str]) -> User:
+    user_id = client.get("/auth/me", headers=headers).json()["user"]["id"]
+    dono = db.get(User, user_id)
+    dono.phone = "43984074017"
+    db.commit()
+    return dono
+
+
+@pytest.fixture()
+def tenant_evolution(db: Session, tenant_id: str) -> TenantProfile:
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME", whatsapp_provider="evolution"
+    )
+    db.add(perfil)
+    db.commit()
+    return perfil
+
+
+@pytest.fixture()
+def headers_sub_crm(db: Session, client: TestClient, tenant_id: str) -> dict[str, str]:
+    """Funcionário que só enxerga o CRM — sem o módulo `settings`, com telefone próprio."""
+    sub = User(
+        tenant_id=tenant_id, email="contador@example.com", name="Contador",
+        password_hash="x", role="sub_user", allowed_modules=["crm"],
+        phone="43999998888",
+    )
+    db.add(sub)
+    db.commit()
+    token = create_access_token(
+        {
+            "sub": sub.id, "tenant_id": tenant_id, "role": "sub_user",
+            "allowed_modules": ["crm"], "is_platform_admin": False,
+        }
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_default_e_desligado(client: TestClient, headers):
+    """Ninguém ganha WhatsApp diário sem pedir."""
+    p = client.get("/auth/me/preferences", headers=headers).json()
+    assert p["briefing_whatsapp_enabled"] is False
+    assert p["briefing_hour"] == "07:00"
+
+
+def test_sub_usuario_sem_settings_configura_o_proprio_briefing(
+    client: TestClient, headers_sub_crm, tenant_evolution
+):
+    """`/config` exige o módulo `settings`. Um sub-usuário sem ele precisa poder ligar o
+    próprio WhatsApp e escolher o próprio horário — configurar a própria entrega não é
+    configuração de empresa."""
+    r = client.patch(
+        "/auth/me/preferences",
+        json={"briefing_whatsapp_enabled": True, "briefing_hour": "08:30"},
+        headers=headers_sub_crm,
+    )
+    assert r.status_code == 200
+    assert r.json()["briefing_hour"] == "08:30"
+    assert r.json()["briefing_whatsapp_enabled"] is True
+
+
+def test_sem_telefone_nao_pode_ligar(client: TestClient, headers_sem_telefone, tenant_evolution):
+    """Ligar a entrega sem destinatário produziria uma fila de envios que falham calados."""
+    r = client.patch(
+        "/auth/me/preferences", json={"briefing_whatsapp_enabled": True},
+        headers=headers_sem_telefone,
+    )
+    assert r.status_code == 422
+    assert "WhatsApp" in r.json()["detail"]
+
+
+def test_horario_invalido_e_recusado(client: TestClient, headers):
+    r = client.patch("/auth/me/preferences", json={"briefing_hour": "25:00"}, headers=headers)
+    assert r.status_code == 422
+
+
+def test_horario_muda_sem_mexer_no_whatsapp(client: TestClient, headers):
+    """Escolher o horário da TELA não exige telefone — só a entrega por WhatsApp exige."""
+    r = client.patch("/auth/me/preferences", json={"briefing_hour": "09:15"}, headers=headers)
+    assert r.status_code == 200
+    assert r.json()["briefing_hour"] == "09:15"
+    assert r.json()["briefing_whatsapp_enabled"] is False
+
+
+def test_tenant_meta_sem_template_diz_por_que_nao_da(
+    client: TestClient, headers, dono_com_telefone
+):
+    """A dependência é EXTERNA (aprovação da Meta) e fora do repositório. A tela precisa dizer
+    o motivo em vez de oferecer um botão que não entrega nada."""
+    p = client.get("/auth/me/preferences", headers=headers).json()
+    assert p["briefing_whatsapp_disponivel"] is False
+    assert "Meta" in p["briefing_whatsapp_indisponivel_motivo"]
+
+    r = client.patch(
+        "/auth/me/preferences", json={"briefing_whatsapp_enabled": True}, headers=headers
+    )
+    assert r.status_code == 422
+
+
+def test_tenant_evolution_pode_ligar_sem_template_nenhum(
+    client: TestClient, headers, dono_com_telefone, tenant_evolution
+):
+    """A Evolution não conhece template: o briefing sai como texto livre, em um passo."""
+    p = client.get("/auth/me/preferences", headers=headers).json()
+    assert p["briefing_whatsapp_disponivel"] is True
+    assert p["briefing_whatsapp_indisponivel_motivo"] is None
+
+    r = client.patch(
+        "/auth/me/preferences", json={"briefing_whatsapp_enabled": True}, headers=headers
+    )
+    assert r.status_code == 200
+
+
+def test_tenant_meta_com_template_aprovado_pode_ligar(
+    db: Session, client: TestClient, headers, tenant_id, dono_com_telefone
+):
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="vima_briefing", language="pt_BR",
+        category_requested="UTILITY", status=STATUS_APPROVED,
+        body_text="Bom dia, {{1}}. Seu resumo de hoje está pronto.", variable_count=1,
+        variable_examples=["Flávio"],
+    )
+    db.add(tpl)
+    db.flush()
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME",
+        whatsapp_template_bindings={PURPOSE_VIMA_BRIEFING: tpl.id},
+    )
+    db.add(perfil)
+    db.commit()
+
+    p = client.get("/auth/me/preferences", headers=headers).json()
+    assert p["briefing_whatsapp_disponivel"] is True
+
+    r = client.patch(
+        "/auth/me/preferences", json={"briefing_whatsapp_enabled": True}, headers=headers
+    )
+    assert r.status_code == 200
+
+
+def test_desligar_nunca_e_bloqueado(client: TestClient, headers, dono_com_telefone):
+    """Mesmo num tenant que não consegue entregar, DESLIGAR sempre passa — a guarda existe para
+    impedir promessa vazia, não para prender ninguém numa preferência."""
+    r = client.patch(
+        "/auth/me/preferences", json={"briefing_whatsapp_enabled": False}, headers=headers
+    )
+    assert r.status_code == 200
+    assert r.json()["briefing_whatsapp_enabled"] is False
+
+
+def test_a_preferencia_e_de_cada_UM(client: TestClient, headers, headers_sub_crm, tenant_evolution):
+    """Dois usuários do mesmo tenant, dois horários. Se morasse no perfil da empresa, um
+    sobrescreveria o outro."""
+    client.patch("/auth/me/preferences", json={"briefing_hour": "06:30"}, headers=headers)
+    client.patch("/auth/me/preferences", json={"briefing_hour": "10:00"}, headers=headers_sub_crm)
+
+    assert client.get("/auth/me/preferences", headers=headers).json()["briefing_hour"] == "06:30"
+    assert (
+        client.get("/auth/me/preferences", headers=headers_sub_crm).json()["briefing_hour"]
+        == "10:00"
+    )

--- a/apps/api/tests/test_vima_scheduler.py
+++ b/apps/api/tests/test_vima_scheduler.py
@@ -161,7 +161,13 @@ def test_quem_nao_ligou_o_whatsapp_recebe_so_a_tela(
 def test_briefing_ja_lido_na_tela_nao_vira_whatsapp(
     db: Session, tenant_id, tenant_br, dono, aconteceu_algo
 ):
-    """Quem abriu o app antes da hora já recebeu a notícia. Mandar de novo é eco, não aviso."""
+    """Quem abriu o app antes da hora já recebeu a notícia. Mandar de novo é eco, não aviso.
+
+    ⚠️ O mecanismo é *"o tick só entrega o que ele mesmo gerou"*, e não uma checagem de `read_at`:
+    o briefing já existia (a tela o criou), então o tick não gera e não entrega. A leitura em si
+    não é consultada. Vale a distinção porque o caso vizinho — gerado pela tela e **não** lido —
+    também fica sem WhatsApp, e é uma consequência aceita, não um descuido (ver a docstring de
+    `scheduler.tick`)."""
     from app.core.tenancy import CurrentUser
     from app.modules.vima import service
 

--- a/apps/api/tests/test_vima_scheduler.py
+++ b/apps/api/tests/test_vima_scheduler.py
@@ -1,0 +1,175 @@
+"""Gera no horário de cada usuário, no fuso do tenant — não em UTC cru.
+
+O relógio é sempre INJETADO (`agora=`). Um job que lê `datetime.now()` sozinho só é testável
+esperando o relógio da máquina chegar na hora certa, e é assim que o bug de fuso volta.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import facts
+from app.core.facts import FIN_PAGAMENTO_RECEBIDO
+from app.modules.auth.models import User
+from app.modules.notifications.models import Notification
+from app.modules.receivables.models import METHOD_PIX, STATUS_PAID, Charge
+from app.modules.settings.models import TenantProfile
+from app.modules.vima.models import Briefing
+from app.modules.vima.scheduler import tick
+from app.modules.wallet.models import KIND_SERVICE
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio Kato",
+    "password": "uma-senha-bem-grande",
+}
+
+# 07:05 em America/Sao_Paulo (UTC−3). O dono de horário 07:00 já chegou; o de 09:00 não.
+DEZ_E_CINCO_UTC = datetime(2026, 8, 6, 10, 5, tzinfo=UTC)
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient) -> str:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return client.get("/auth/me", headers={"Authorization": f"Bearer {token}"}).json()["user"][
+        "tenant_id"
+    ]
+
+
+@pytest.fixture()
+def tenant_br(db: Session, tenant_id: str) -> TenantProfile:
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME", timezone="America/Sao_Paulo",
+        whatsapp_provider="evolution",
+    )
+    db.add(perfil)
+    db.commit()
+    return perfil
+
+
+@pytest.fixture()
+def dono(db: Session, tenant_id: str) -> User:
+    """O owner criado pelo /register — às 07:00, com telefone, WhatsApp ligado."""
+    user = db.query(User).filter(User.tenant_id == tenant_id).one()
+    user.phone = "43984074017"
+    user.briefing_hour = "07:00"
+    user.briefing_whatsapp_enabled = True
+    db.commit()
+    return user
+
+
+@pytest.fixture()
+def dorminhoco(db: Session, tenant_id: str) -> User:
+    """Outro usuário do mesmo tenant, que pediu o briefing às 09:00."""
+    user = User(
+        tenant_id=tenant_id, email="tarde@example.com", name="Contador",
+        password_hash="x", role="sub_user", allowed_modules=[],
+        phone="43999998888", briefing_hour="09:00", briefing_whatsapp_enabled=True,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+@pytest.fixture()
+def aconteceu_algo(db: Session, tenant_id: str) -> Charge:
+    """Sem isto o briefing sai `vazio=True` e as regras de entrega mudam de propósito."""
+    cobranca = Charge(
+        tenant_id=tenant_id, description="Consultoria", kind=KIND_SERVICE,
+        method=METHOD_PIX, amount_cents=320_000, due_date=date(2026, 8, 3),
+        status=STATUS_PAID, paid_at=datetime(2026, 8, 6, 12, 0, tzinfo=UTC),
+    )
+    db.add(cobranca)
+    db.flush()
+    facts.record(
+        db, tenant_id=tenant_id, module="financeiro", kind=FIN_PAGAMENTO_RECEBIDO,
+        title="Pagamento de João recebido", actor="system",
+        subject_type="charge", subject_id=cobranca.id,
+    )
+    db.commit()
+    return cobranca
+
+
+def test_gera_apenas_para_quem_ja_chegou_no_horario(
+    db: Session, tenant_id, tenant_br, dono, dorminhoco, aconteceu_algo
+):
+    gerados = tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+
+    assert gerados == 1
+    donos = [b.user_id for b in db.query(Briefing).all()]
+    assert donos == [dono.id]
+
+
+def test_o_das_nove_recebe_o_dele_quando_a_hora_chega(
+    db: Session, tenant_id, tenant_br, dono, dorminhoco, aconteceu_algo
+):
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    # 09:30 em São Paulo = 12:30 UTC.
+    assert tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 6, 12, 30, tzinfo=UTC)) == 1
+    assert db.query(Briefing).count() == 2
+
+
+def test_nao_gera_duas_vezes_no_mesmo_dia(
+    db: Session, tenant_id, tenant_br, dono, aconteceu_algo
+):
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    assert tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 6, 11, 0, tzinfo=UTC)) == 0
+    assert db.query(Briefing).count() == 1
+
+
+def test_o_horario_e_do_TENANT_nao_de_UTC(
+    db: Session, tenant_id, tenant_br, dono, aconteceu_algo
+):
+    """Às 07:05 **UTC** ainda são 04:05 em São Paulo: ninguém pediu briefing às 4 da manhã.
+
+    Sem o fuso, todo tenant brasileiro receberia o briefing 3h antes do que escolheu — e o das
+    07:00 acordaria com a notificação às 4h."""
+    assert tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 6, 7, 5, tzinfo=UTC)) == 0
+
+
+def test_usuario_inativo_nao_recebe(db: Session, tenant_id, tenant_br, dono, aconteceu_algo):
+    dono.is_active = False
+    db.commit()
+    assert tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC) == 0
+
+
+def test_briefing_vazio_nao_enfileira_whatsapp(db: Session, tenant_id, tenant_br, dono):
+    """Um 'bom dia, nada aconteceu' diário é a forma mais rápida de ser silenciado — e um canal
+    silenciado não entrega o dia em que importa.
+
+    Note que o briefing É gerado: a TELA diz que está tranquilo. O que não sai é o WhatsApp."""
+    assert tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC) == 1
+    assert db.query(Briefing).one().vazio is True
+    assert db.query(Notification).count() == 0
+
+
+def test_quem_nao_ligou_o_whatsapp_recebe_so_a_tela(
+    db: Session, tenant_id, tenant_br, dono, aconteceu_algo
+):
+    dono.briefing_whatsapp_enabled = False
+    db.commit()
+    assert tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC) == 1
+    assert db.query(Notification).count() == 0
+
+
+def test_briefing_ja_lido_na_tela_nao_vira_whatsapp(
+    db: Session, tenant_id, tenant_br, dono, aconteceu_algo
+):
+    """Quem abriu o app antes da hora já recebeu a notícia. Mandar de novo é eco, não aviso."""
+    from app.core.tenancy import CurrentUser
+    from app.modules.vima import service
+
+    atual = CurrentUser(
+        user_id=dono.id, tenant_id=tenant_id, role=dono.role, allowed_modules=[]
+    )
+    briefing = service.gerar_ou_ler(db, user=atual, hoje=date(2026, 8, 6))
+    service.marcar_lido(db, briefing_id=briefing.id, user=atual)
+
+    assert tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC) == 0
+    assert db.query(Notification).count() == 0

--- a/apps/api/tests/test_vima_whatsapp_evolution.py
+++ b/apps/api/tests/test_vima_whatsapp_evolution.py
@@ -1,0 +1,147 @@
+"""Tenant Evolution recebe o briefing inteiro, em um passo.
+
+A Evolution (Baileys) não conhece template nem janela de 24h: o texto sai direto, como mensagem
+livre. Este é o caso simples — o de dois tempos é o da Meta (`test_vima_whatsapp_meta.py`).
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import facts
+from app.core.facts import FIN_PAGAMENTO_RECEBIDO
+from app.core.whatsapp.capabilities import for_profile
+from app.modules.auth.models import User
+from app.modules.notifications.models import Notification
+from app.modules.receivables.models import METHOD_PIX, STATUS_PAID, Charge
+from app.modules.settings.models import TenantProfile
+from app.modules.vima.scheduler import tick
+from app.modules.wallet.models import KIND_SERVICE
+from app.modules.whatsapp_templates.models import PURPOSE_VIMA_BRIEFING_TEXTO
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio Kato",
+    "password": "uma-senha-bem-grande",
+}
+
+DEZ_E_CINCO_UTC = datetime(2026, 8, 6, 10, 5, tzinfo=UTC)  # 07:05 em America/Sao_Paulo
+
+
+class _Profile:
+    def __init__(self, provider: str | None) -> None:
+        self.whatsapp_provider = provider
+
+
+def test_evolution_nao_precisa_de_optin() -> None:
+    assert for_profile(_Profile("evolution")).briefing_needs_optin is False
+
+
+def test_meta_precisa_de_optin() -> None:
+    """Parâmetro de template da Cloud API não aceita quebra de linha, e às 7h o dono está sempre
+    fora da janela de 24h — então o briefing completo só sai depois que ELE responder."""
+    assert for_profile(_Profile("meta")).briefing_needs_optin is True
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient) -> str:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return client.get("/auth/me", headers={"Authorization": f"Bearer {token}"}).json()["user"][
+        "tenant_id"
+    ]
+
+
+@pytest.fixture()
+def tenant_evolution(db: Session, tenant_id: str) -> TenantProfile:
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME", timezone="America/Sao_Paulo",
+        whatsapp_provider="evolution",
+    )
+    db.add(perfil)
+    db.commit()
+    return perfil
+
+
+@pytest.fixture()
+def usuario_com_optin(db: Session, tenant_id: str) -> User:
+    user = db.query(User).filter(User.tenant_id == tenant_id).one()
+    user.phone = "43984074017"
+    user.briefing_hour = "07:00"
+    user.briefing_whatsapp_enabled = True
+    db.commit()
+    return user
+
+
+@pytest.fixture()
+def aconteceu_algo(db: Session, tenant_id: str) -> Charge:
+    cobranca = Charge(
+        tenant_id=tenant_id, description="Consultoria", kind=KIND_SERVICE,
+        method=METHOD_PIX, amount_cents=320_000, due_date=date(2026, 8, 3),
+        status=STATUS_PAID, paid_at=datetime(2026, 8, 6, 12, 0, tzinfo=UTC),
+    )
+    db.add(cobranca)
+    db.flush()
+    facts.record(
+        db, tenant_id=tenant_id, module="financeiro", kind=FIN_PAGAMENTO_RECEBIDO,
+        title="Pagamento de João recebido", actor="system",
+        subject_type="charge", subject_id=cobranca.id,
+    )
+    db.commit()
+    return cobranca
+
+
+def test_enfileira_o_texto_inteiro_em_tenant_evolution(
+    db: Session, tenant_id, tenant_evolution, usuario_com_optin, aconteceu_algo
+):
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+
+    n = db.query(Notification).one()
+    assert n.channel == "whatsapp"
+    assert n.purpose == PURPOSE_VIMA_BRIEFING_TEXTO
+    assert n.recipient == usuario_com_optin.phone
+    # É o briefing, não um aviso: o texto narrado inteiro, com quebras de linha e tudo.
+    assert len(n.message) > 40
+    # Texto livre — sem template. A Evolution recusa template por design.
+    assert n.whatsapp_template_name is None
+    # Notificação INTERNA ao dono: não é mensagem para um cliente do CRM.
+    assert n.client_id is None
+
+
+def test_nao_enfileira_duas_vezes_no_mesmo_dia(
+    db: Session, tenant_id, tenant_evolution, usuario_com_optin, aconteceu_algo
+):
+    """O sweep roda a cada poucos minutos. Sem a guarda, o dono receberia o mesmo briefing a cada
+    passada até a meia-noite."""
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 6, 10, 20, tzinfo=UTC))
+    tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 6, 15, 0, tzinfo=UTC))
+
+    assert db.query(Notification).count() == 1
+
+
+def test_dia_seguinte_enfileira_de_novo(
+    db: Session, tenant_id, tenant_evolution, usuario_com_optin, aconteceu_algo
+):
+    """A guarda é do DIA, não permanente — senão o briefing sairia uma vez na vida."""
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=datetime(2026, 8, 7, 10, 5, tzinfo=UTC))
+
+    assert db.query(Notification).count() == 2
+
+
+def test_sem_telefone_nao_enfileira(
+    db: Session, tenant_id, tenant_evolution, usuario_com_optin, aconteceu_algo
+):
+    """A preferência pode ter sido ligada e o telefone apagado depois. Enfileirar com destinatário
+    vazio é o que `notifications.enqueue` rejeita — e a exceção derrubaria o sweep do tenant."""
+    usuario_com_optin.phone = None
+    db.commit()
+
+    assert tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC) == 1
+    assert db.query(Notification).count() == 0

--- a/apps/api/tests/test_vima_whatsapp_meta.py
+++ b/apps/api/tests/test_vima_whatsapp_meta.py
@@ -1,0 +1,332 @@
+"""Meta em dois tempos: template com botão → ele toca → a janela abre → sai o texto inteiro.
+
+Por que dois tempos: parâmetro de template da Cloud API **não aceita quebra de linha** (e o
+briefing tem várias), e às 7h o dono está sempre fora da janela de 24h. O único jeito de mandar o
+texto livre é ele falar primeiro — e o toque num botão de resposta rápida é a forma mais barata de
+"falar" que existe.
+
+⚠️ O formato do webhook foi conferido contra a documentação da Meta, não suposto:
+`messages[].type == "button"` com `button: {payload, text}` para botão de TEMPLATE; e
+`type == "interactive"` com `interactive.button_reply.{id,title}` para botão interativo.
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import facts
+from app.core.facts import FIN_PAGAMENTO_RECEBIDO
+from app.core.whatsapp.providers import meta as meta_provider
+from app.modules.auth.models import User
+from app.modules.crm.models import Client
+from app.modules.notifications.models import Notification
+from app.modules.receivables.models import METHOD_PIX, STATUS_PAID, Charge
+from app.modules.settings.models import TenantProfile
+from app.modules.vima.scheduler import PAYLOAD_BOTAO_BRIEFING, tick
+from app.modules.wallet.models import KIND_SERVICE
+from app.modules.whatsapp_inbox.service import ingest_webhook_payload
+from app.modules.whatsapp_templates.models import (
+    PURPOSE_VIMA_BRIEFING,
+    PURPOSE_VIMA_BRIEFING_TEXTO,
+    STATUS_APPROVED,
+    WhatsappTemplate,
+)
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio Kato",
+    "password": "uma-senha-bem-grande",
+}
+
+DEZ_E_CINCO_UTC = datetime(2026, 8, 6, 10, 5, tzinfo=UTC)
+TELEFONE = "5543984074017"
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient) -> str:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return client.get("/auth/me", headers={"Authorization": f"Bearer {token}"}).json()["user"][
+        "tenant_id"
+    ]
+
+
+@pytest.fixture()
+def tenant_meta(db: Session, tenant_id: str) -> TenantProfile:
+    """Tenant na Cloud API da Meta, com o template do aviso já aprovado e vinculado."""
+    tpl = WhatsappTemplate(
+        tenant_id=tenant_id, name="vima_briefing_aviso", language="pt_BR",
+        category_requested="UTILITY", status=STATUS_APPROVED,
+        body_text="Bom dia, {{1}}. Seu resumo de hoje está pronto.", variable_count=1,
+        variable_examples=["Flávio"],
+    )
+    db.add(tpl)
+    db.flush()
+    perfil = TenantProfile(
+        tenant_id=tenant_id, display_name="Vima ME", timezone="America/Sao_Paulo",
+        whatsapp_provider="meta",
+        # Credenciais da Cloud API preenchidas: sem elas o tenant não está "esperando a Meta
+        # aprovar o template", está esperando CONECTAR — e a entrega recusa antes, com outra
+        # frase (ver `vima/delivery.SEM_WHATSAPP`).
+        whatsapp_token="tok-de-teste", whatsapp_phone_id="phone-id-de-teste",
+        whatsapp_template_bindings={PURPOSE_VIMA_BRIEFING: tpl.id},
+    )
+    db.add(perfil)
+    db.commit()
+    return perfil
+
+
+@pytest.fixture()
+def usuario_com_optin(db: Session, tenant_id: str) -> User:
+    user = db.query(User).filter(User.tenant_id == tenant_id).one()
+    user.phone = TELEFONE
+    user.briefing_hour = "07:00"
+    user.briefing_whatsapp_enabled = True
+    db.commit()
+    return user
+
+
+@pytest.fixture()
+def aconteceu_algo(db: Session, tenant_id: str) -> Charge:
+    cobranca = Charge(
+        tenant_id=tenant_id, description="Consultoria", kind=KIND_SERVICE,
+        method=METHOD_PIX, amount_cents=320_000, due_date=date(2026, 8, 3),
+        status=STATUS_PAID, paid_at=datetime(2026, 8, 6, 12, 0, tzinfo=UTC),
+    )
+    db.add(cobranca)
+    db.flush()
+    facts.record(
+        db, tenant_id=tenant_id, module="financeiro", kind=FIN_PAGAMENTO_RECEBIDO,
+        title="Pagamento de João recebido", actor="system",
+        subject_type="charge", subject_id=cobranca.id,
+    )
+    db.commit()
+    return cobranca
+
+
+def _toque_no_botao(de: str = TELEFONE, payload: str = PAYLOAD_BOTAO_BRIEFING) -> dict:
+    """Payload REAL da Meta para o toque num botão de resposta rápida de template."""
+    return {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "contacts": [{"profile": {"name": "Flávio Kato"}, "wa_id": de}],
+                            "messages": [
+                                {
+                                    "from": de,
+                                    "id": f"wamid.BTN-{payload}-{de}",
+                                    "timestamp": "1754470000",
+                                    "type": "button",
+                                    "button": {"payload": payload, "text": "Ver meu resumo"},
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+
+# ── O parser ────────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_inbound_le_o_botao_do_template() -> None:
+    (msg,) = meta_provider.parse_inbound(_toque_no_botao())
+    assert msg.button_payload == PAYLOAD_BOTAO_BRIEFING
+    # O rótulo do botão é o corpo da mensagem: é o que o dono vê no fio da conversa.
+    assert msg.text_body == "Ver meu resumo"
+    assert msg.kind == "text"
+
+
+def test_parse_inbound_le_o_botao_interativo() -> None:
+    """A outra forma que a Meta usa (`interactive.button_reply`), aceita pelo mesmo caminho."""
+    payload = {
+        "entry": [{"changes": [{"value": {
+            "contacts": [{"profile": {"name": "Flávio"}, "wa_id": TELEFONE}],
+            "messages": [{
+                "from": TELEFONE, "id": "wamid.INT1", "type": "interactive",
+                "interactive": {
+                    "type": "button_reply",
+                    "button_reply": {"id": PAYLOAD_BOTAO_BRIEFING, "title": "Ver meu resumo"},
+                },
+            }],
+        }}]}]
+    }
+    (msg,) = meta_provider.parse_inbound(payload)
+    assert msg.button_payload == PAYLOAD_BOTAO_BRIEFING
+
+
+def test_mensagem_de_texto_comum_nao_tem_payload_de_botao() -> None:
+    payload = {
+        "entry": [{"changes": [{"value": {
+            "contacts": [{"profile": {"name": "João"}, "wa_id": "5511999998888"}],
+            "messages": [{
+                "from": "5511999998888", "id": "wamid.T1", "type": "text",
+                "text": {"body": "bom dia"},
+            }],
+        }}]}]
+    }
+    (msg,) = meta_provider.parse_inbound(payload)
+    assert msg.button_payload is None
+
+
+# ── Primeiro passo: o aviso ─────────────────────────────────────────────────────────────
+
+
+def test_primeiro_passo_e_o_template_curto(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
+):
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+
+    n = db.query(Notification).one()
+    assert n.purpose == PURPOSE_VIMA_BRIEFING
+    assert n.whatsapp_template_name == "vima_briefing_aviso"
+    # É o aviso, não o briefing: uma linha, sem quebra — parâmetro de template não aceita `\n`.
+    assert "\n" not in n.message
+    assert len(n.message) < 200
+    assert n.whatsapp_template_variables == ["Flávio"]
+
+
+def test_o_botao_sai_com_payload_NOSSO_nao_com_o_rotulo_do_tenant(monkeypatch) -> None:
+    """A Meta devolve, no toque, o `payload` do componente de botão — e quando não mandamos
+    componente nenhum ela devolve o RÓTULO que o tenant escreveu no console dela. Como o rótulo
+    é livre ("Ver resumo", "Bora", "Sim"), casar por constante só funciona se formos NÓS a
+    definir o payload no envio."""
+    capturado: dict = {}
+
+    def _fake_post(url, **kwargs):
+        capturado.update(kwargs.get("json") or {})
+
+        class _R:
+            def raise_for_status(self) -> None:
+                return None
+
+        return _R()
+
+    monkeypatch.setattr(meta_provider.httpx, "post", _fake_post)
+    meta_provider.send_template(
+        to=TELEFONE, token="tok", phone_id="pid", template_name="vima_briefing_aviso",
+        language="pt_BR", variables=["Flávio"], quick_reply_payload=PAYLOAD_BOTAO_BRIEFING,
+    )
+
+    componentes = capturado["template"]["components"]
+    botao = next(c for c in componentes if c["type"] == "button")
+    assert botao["sub_type"] == "quick_reply"
+    assert botao["index"] == "0"
+    assert botao["parameters"] == [{"type": "payload", "payload": PAYLOAD_BOTAO_BRIEFING}]
+
+
+def test_sem_payload_o_template_sai_como_sempre(monkeypatch) -> None:
+    """Os outros 5 propósitos não têm botão — o componente não pode aparecer para eles."""
+    capturado: dict = {}
+
+    def _fake_post(url, **kwargs):
+        capturado.update(kwargs.get("json") or {})
+
+        class _R:
+            def raise_for_status(self) -> None:
+                return None
+
+        return _R()
+
+    monkeypatch.setattr(meta_provider.httpx, "post", _fake_post)
+    meta_provider.send_template(
+        to=TELEFONE, token="tok", phone_id="pid", template_name="cobranca",
+        language="pt_BR", variables=["João"],
+    )
+
+    tipos = {c["type"] for c in capturado["template"]["components"]}
+    assert tipos == {"body"}
+
+
+# ── Segundo passo: o toque ──────────────────────────────────────────────────────────────
+
+
+def test_toque_no_botao_libera_o_briefing_inteiro(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
+):
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    ingest_webhook_payload(
+        db, tenant_id=tenant_id, messages=meta_provider.parse_inbound(_toque_no_botao())
+    )
+
+    completos = (
+        db.query(Notification)
+        .filter(Notification.purpose == PURPOSE_VIMA_BRIEFING_TEXTO)
+        .all()
+    )
+    assert len(completos) == 1
+    assert len(completos[0].message) > 40
+    # Texto LIVRE: a janela de 24h acabou de abrir, então não precisa (nem pode) ser template.
+    assert completos[0].whatsapp_template_name is None
+
+
+def test_o_toque_nao_cria_contato_no_crm(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
+):
+    """A guarda `_e_telefone_da_equipe` vale aqui: a resposta vem do telefone do PRÓPRIO dono.
+
+    Sem ela o dono viraria lead do próprio funil todo dia — um card novo a cada toque no botão."""
+    antes = db.query(Client).count()
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    ingest_webhook_payload(
+        db, tenant_id=tenant_id, messages=meta_provider.parse_inbound(_toque_no_botao())
+    )
+    assert db.query(Client).count() == antes
+
+
+def test_tocar_duas_vezes_nao_manda_o_briefing_duas_vezes(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
+):
+    """Dedo escorregando no celular não pode custar duas mensagens iguais."""
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    for i in range(2):
+        (msg,) = meta_provider.parse_inbound(_toque_no_botao())
+        # `wa_message_id` distinto: dois toques DE VERDADE, não a reentrega do mesmo evento (que
+        # o ingest já descarta por idempotência — não seria este o comportamento sob teste).
+        ingest_webhook_payload(
+            db, tenant_id=tenant_id,
+            messages=[dataclasses.replace(msg, wa_message_id=f"wamid.BTN-{i}")],
+        )
+
+    assert (
+        db.query(Notification).filter(Notification.purpose == PURPOSE_VIMA_BRIEFING_TEXTO).count()
+        == 1
+    )
+
+
+def test_toque_de_um_estranho_nao_libera_briefing_nenhum(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
+):
+    """O payload do botão é conhecido e um cliente qualquer poderia repeti-lo. Sem o vínculo com
+    um usuário DO TENANT, o briefing do dono sairia para quem escrevesse a string certa."""
+    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    ingest_webhook_payload(
+        db,
+        tenant_id=tenant_id,
+        messages=meta_provider.parse_inbound(_toque_no_botao(de="5511977776666")),
+    )
+
+    assert (
+        db.query(Notification).filter(Notification.purpose == PURPOSE_VIMA_BRIEFING_TEXTO).count()
+        == 0
+    )
+
+
+def test_toque_sem_briefing_do_dia_nao_quebra(
+    db: Session, tenant_id, tenant_meta, usuario_com_optin
+):
+    """Toque atrasado (ontem à noite, respondido hoje de manhã) não pode derrubar o webhook."""
+    ingest_webhook_payload(
+        db, tenant_id=tenant_id, messages=meta_provider.parse_inbound(_toque_no_botao())
+    )
+    assert db.query(Notification).count() == 0

--- a/apps/api/tests/test_vima_whatsapp_meta.py
+++ b/apps/api/tests/test_vima_whatsapp_meta.py
@@ -12,7 +12,8 @@ texto livre é ele falar primeiro — e o toque num botão de resposta rápida �
 from __future__ import annotations
 
 import dataclasses
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
+from zoneinfo import ZoneInfo
 
 import pytest
 from fastapi.testclient import TestClient
@@ -45,8 +46,27 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-DEZ_E_CINCO_UTC = datetime(2026, 8, 6, 10, 5, tzinfo=UTC)
 TELEFONE = "5543984074017"
+
+_SP = ZoneInfo("America/Sao_Paulo")
+
+
+def _sete_e_cinco_de_hoje() -> datetime:
+    """07:05 no fuso do tenant, **no dia de HOJE de verdade**.
+
+    ⚠️ Não fixe a data aqui. Este arquivo injeta o relógio numa ponta (`tick(agora=...)`) e a
+    outra ponta lê o relógio de parede: `responder_optin` resolve o dia com `hoje_do_tenant(db)`,
+    sem `now` injetado, porque é uma FRONTEIRA — o toque no botão acontece agora, e é o briefing
+    de hoje que ele libera. Com uma data literal, o briefing gerado e o procurado passam a ser de
+    dias diferentes assim que a suíte cruza a meia-noite.
+
+    Aconteceu: a versão anterior usava `datetime(2026, 8, 6, 10, 5, UTC)`, passou local às 23h de
+    São Paulo do dia 6 e reprovou no CI às 00:01 do dia 7 (PR #90). O `tick` só compara a HORA
+    local com `briefing_hour`, então derivar o dia do relógio real não afrouxa nada — só faz as
+    duas pontas concordarem por construção.
+    """
+    hoje = datetime.now(_SP).date()
+    return datetime.combine(hoje, time(7, 5), tzinfo=_SP).astimezone(UTC)
 
 
 @pytest.fixture()
@@ -185,7 +205,7 @@ def test_mensagem_de_texto_comum_nao_tem_payload_de_botao() -> None:
 def test_primeiro_passo_e_o_template_curto(
     db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
 ):
-    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=_sete_e_cinco_de_hoje())
 
     n = db.query(Notification).one()
     assert n.purpose == PURPOSE_VIMA_BRIEFING
@@ -254,7 +274,7 @@ def test_sem_payload_o_template_sai_como_sempre(monkeypatch) -> None:
 def test_toque_no_botao_libera_o_briefing_inteiro(
     db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
 ):
-    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=_sete_e_cinco_de_hoje())
     ingest_webhook_payload(
         db, tenant_id=tenant_id, messages=meta_provider.parse_inbound(_toque_no_botao())
     )
@@ -277,7 +297,7 @@ def test_o_toque_nao_cria_contato_no_crm(
 
     Sem ela o dono viraria lead do próprio funil todo dia — um card novo a cada toque no botão."""
     antes = db.query(Client).count()
-    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=_sete_e_cinco_de_hoje())
     ingest_webhook_payload(
         db, tenant_id=tenant_id, messages=meta_provider.parse_inbound(_toque_no_botao())
     )
@@ -288,7 +308,7 @@ def test_tocar_duas_vezes_nao_manda_o_briefing_duas_vezes(
     db: Session, tenant_id, tenant_meta, usuario_com_optin, aconteceu_algo
 ):
     """Dedo escorregando no celular não pode custar duas mensagens iguais."""
-    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=_sete_e_cinco_de_hoje())
     for i in range(2):
         (msg,) = meta_provider.parse_inbound(_toque_no_botao())
         # `wa_message_id` distinto: dois toques DE VERDADE, não a reentrega do mesmo evento (que
@@ -309,7 +329,7 @@ def test_toque_de_um_estranho_nao_libera_briefing_nenhum(
 ):
     """O payload do botão é conhecido e um cliente qualquer poderia repeti-lo. Sem o vínculo com
     um usuário DO TENANT, o briefing do dono sairia para quem escrevesse a string certa."""
-    tick(db, tenant_id=tenant_id, agora=DEZ_E_CINCO_UTC)
+    tick(db, tenant_id=tenant_id, agora=_sete_e_cinco_de_hoje())
     ingest_webhook_payload(
         db,
         tenant_id=tenant_id,

--- a/apps/api/tests/test_whatsapp_capabilities.py
+++ b/apps/api/tests/test_whatsapp_capabilities.py
@@ -23,12 +23,14 @@ class _Profile:
 def test_meta_capabilities() -> None:
     assert META == Capabilities(
         templates=True, session_window=True, media=True, provisioning="credentials",
+        briefing_needs_optin=True,
     )
 
 
 def test_evolution_capabilities() -> None:
     assert EVOLUTION == Capabilities(
         templates=False, session_window=False, media=True, provisioning="qrcode",
+        briefing_needs_optin=False,
     )
 
 

--- a/apps/api/tests/test_worker.py
+++ b/apps/api/tests/test_worker.py
@@ -500,6 +500,12 @@ def test_o_sweep_NAO_ganhou_contador_novo(client: TestClient, db):
     promoção de agendadas, onde os dois lados somam. Aqui os dois contadores são eventos
     OPOSTOS do ciclo de vida da sessão (uma conexão subiu × uma caiu); a soma deles não
     responde pergunta nenhuma, e cada um sozinho responde a sua.
+
+    ⚠️ **`briefings_gerados` entrou na Onda 4 da Vima (etapa 6) pelo MESMO critério.** Responde a
+    *"quantos briefings este sweep gerou?"* — pergunta que nenhum dos outros responde, e cuja soma
+    com qualquer um deles não produziria número nenhum. Não é uma partição de `notifications_
+    processed`: um briefing gerado pode não virar notificação alguma (dia sem novidade, WhatsApp
+    desligado), e uma notificação pode não vir de briefing nenhum.
     """
     client.post("/auth/register", json=REGISTER)
     cm = _cm_factory(db)
@@ -512,6 +518,7 @@ def test_o_sweep_NAO_ganhou_contador_novo(client: TestClient, db):
         "scheduled_promoted",
         "whatsapp_connections_dropped",
         "whatsapp_connections_promoted",
+        "briefings_gerados",
         "errors",
     }
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -43,6 +43,8 @@ import ProdutosPage from "../features/produtos/ProdutosPage";
 import PageBuilderPage from "../features/sites/PageBuilderPage";
 import PublicPage from "../features/sites/PublicPage";
 import SitesPage from "../features/sites/SitesPage";
+import BriefingPage from "../features/vima/BriefingPage";
+import EntradaDoDia from "../features/vima/EntradaDoDia";
 import IdleWarningModal from "../components/IdleWarningModal";
 import { AuthProvider, useAuth } from "../store/auth";
 import { useIdleTimeout } from "../store/useIdleTimeout";
@@ -58,7 +60,19 @@ export default function App() {
         <Route path="/contrato/:slug" element={<PublicContractPage />} />
         <Route path="/p/:slug" element={<PublicPage />} />
         <Route element={<ProtectedLayout />}>
-          <Route path="/" element={<CockpitPage />} />
+          {/*
+            A raiz autenticada não é mais o Cockpit direto: `EntradaDoDia` decide a porta do dia
+            (briefing de hoje ainda não lido → `/vima`; já lido → o Cockpit). Ver a decisão em
+            `features/vima/EntradaDoDia.tsx` — uma vez por dia, não a cada login.
+          */}
+          <Route
+            path="/"
+            element={
+              <EntradaDoDia>
+                <CockpitPage />
+              </EntradaDoDia>
+            }
+          />
           <Route path="/agenda" element={<AgendaPage />} />
           <Route path="/crm" element={<CrmPage />} />
           <Route path="/crm/clients/:id" element={<ClientDetailPage />} />
@@ -105,6 +119,12 @@ export default function App() {
         </Route>
         {/* Telas de tarefa única vindas do share sheet do celular: mesma proteção, sem shell. */}
         <Route element={<ProtectedBareLayout />}>
+          {/*
+            Sem sidebar e sem topbar, pelo mesmo motivo de `/comprovante/:id`: o briefing é uma
+            tela de leitura única, lida no celular de manhã, e o menu ali é ruído disputando uma
+            largura que o polegar já disputa. A saída fica na própria tela.
+          */}
+          <Route path="/vima" element={<BriefingPage />} />
           <Route path="/compartilhar" element={<CompartilharPage />} />
           <Route path="/comprovante/:id" element={<ComprovantePage />} />
         </Route>

--- a/apps/web/src/features/cockpit/CockpitPage.tsx
+++ b/apps/web/src/features/cockpit/CockpitPage.tsx
@@ -1,5 +1,5 @@
 import type { CockpitSummary } from "@e1p/shared-types";
-import { AlertTriangle, CalendarDays, FileSignature, ListChecks, Sparkles, TrendingUp, Wallet } from "lucide-react";
+import { AlertTriangle, CalendarDays, FileSignature, ListChecks, Sparkles, Sun, TrendingUp, Wallet } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Modal from "../../components/Modal";
@@ -61,13 +61,28 @@ export default function CockpitPage() {
             Bom dia, {user?.name?.split(" ")[0] ?? ""} 👋
           </h1>
         </div>
-        <Link
-          to="/financeiro/fila-pagamentos"
-          className="flex items-center gap-1.5 rounded-pill bg-white px-3 py-1.5 text-xs font-semibold text-primary-600 shadow-sm transition hover:bg-primary-50"
-        >
-          <ListChecks size={14} />
-          Fila de pagamentos
-        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          {/*
+            O caminho de volta ao briefing do dia. DISCRETO de propósito: a porta de entrada
+            aparece sozinha uma vez por dia (ver `features/vima/EntradaDoDia.tsx`), e depois de
+            lida vira consulta — quem quiser reler tem por onde, sem que o resumo volte a
+            interromper quem já o viu.
+          */}
+          <Link
+            to="/vima"
+            className="flex items-center gap-1.5 rounded-pill px-3 py-1.5 text-xs font-medium text-neutral-500 transition hover:bg-white hover:text-primary-600"
+          >
+            <Sun size={14} />
+            Rever o resumo de hoje
+          </Link>
+          <Link
+            to="/financeiro/fila-pagamentos"
+            className="flex items-center gap-1.5 rounded-pill bg-white px-3 py-1.5 text-xs font-semibold text-primary-600 shadow-sm transition hover:bg-primary-50"
+          >
+            <ListChecks size={14} />
+            Fila de pagamentos
+          </Link>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/web/src/features/vima/BriefingPage.test.tsx
+++ b/apps/web/src/features/vima/BriefingPage.test.tsx
@@ -164,4 +164,29 @@ describe("BriefingPage — preferências na própria tela", () => {
     expect(await screen.findByText(/não foi aprovado pela Meta/)).toBeInTheDocument();
     expect(screen.getByLabelText(/whatsapp/i)).toBeDisabled();
   });
+
+  it("entrega perdida não tranca a troca de horário", async () => {
+    const user = userEvent.setup();
+    mockGet(BRIEFING, {
+      ...PREFS,
+      // O estado que trava: ligado ANTES, indisponível AGORA (a Meta pausou o template, ou o
+      // WhatsApp da empresa caiu). Reenviar `enabled: true` levaria 422 do backend e o dono
+      // ficaria sem conseguir mudar nem o próprio horário.
+      briefing_whatsapp_enabled: true,
+      briefing_whatsapp_disponivel: false,
+      briefing_whatsapp_indisponivel_motivo: "O template do briefing foi pausado pela Meta.",
+    });
+    vi.mocked(api.patch).mockResolvedValue({ data: PREFS });
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /prefer/i }));
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/auth/me/preferences", {
+        briefing_hour: "07:00",
+        briefing_whatsapp_enabled: false,
+      }),
+    );
+  });
 });

--- a/apps/web/src/features/vima/BriefingPage.test.tsx
+++ b/apps/web/src/features/vima/BriefingPage.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import BriefingPage from "./BriefingPage";
+
+// Rede sempre mockada: nenhum teste bate em /vima real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
+    "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({
+  useAuth: () => ({ user: { name: "Flávio Kato" } }),
+  useFuso: () => "America/Sao_Paulo",
+}));
+
+const BRIEFING = {
+  id: "b1",
+  reference_date: "2026-08-06",
+  texto: "Bom dia, Flávio. Entrou um pagamento de R$ 3.200,00 do João.",
+  por_ia: true,
+  vazio: false,
+  excedente: 0,
+  linhas: [
+    { secao: "PENDENTE", module: "financeiro", texto: "Cobrança do João vencida há 4 dias" },
+    { secao: "ACONTECEU", module: "financeiro", texto: "Pagamento de R$ 3.200,00 recebido" },
+  ],
+  read_at: null,
+  created_at: "2026-08-06T10:05:00Z",
+};
+
+const PREFS = {
+  briefing_whatsapp_enabled: false,
+  briefing_hour: "07:00",
+  briefing_whatsapp_disponivel: true,
+  briefing_whatsapp_indisponivel_motivo: null,
+};
+
+/**
+ * Responde por rota: a tela pede o briefing E as preferências. O `POST .../read` ECOA o mesmo
+ * briefing com `read_at` preenchido — como a rota real faz. Devolver outro objeto aqui faria o
+ * mock sobrescrever campos do caso sob teste (foi como este arquivo escondeu o caso `por_ia`).
+ */
+function mockGet(briefing: Record<string, unknown>, prefs: unknown = PREFS) {
+  vi.mocked(api.get).mockImplementation((url: string) =>
+    Promise.resolve({ data: url.includes("preferences") ? prefs : briefing }),
+  );
+  vi.mocked(api.post).mockResolvedValue({
+    data: { ...briefing, read_at: "2026-08-06T10:06:00Z" },
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BriefingPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+  vi.mocked(api.post).mockReset();
+  vi.mocked(api.patch).mockReset();
+});
+
+describe("BriefingPage", () => {
+  it("mostra o texto do briefing e marca como lido", async () => {
+    mockGet(BRIEFING);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Entrou um pagamento/)).toBeInTheDocument());
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/vima/briefing/b1/read"));
+  });
+
+  it("marca como lido UMA vez — reabrir a tela não regrava a leitura", async () => {
+    mockGet({ ...BRIEFING, read_at: "2026-08-06T10:06:00Z" });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Entrou um pagamento/)).toBeInTheDocument());
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("dia sem nada não parece erro", async () => {
+    mockGet({
+      ...BRIEFING,
+      id: "b2",
+      texto: "Bom dia, Flávio. Tudo tranquilo por aqui.",
+      vazio: true,
+      linhas: [],
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Tudo tranquilo/)).toBeInTheDocument());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("mostra as linhas como apoio, agrupadas por seção", async () => {
+    mockGet(BRIEFING);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/vencida há 4 dias/)).toBeInTheDocument());
+    expect(screen.getByText(/Pagamento de R\$ 3\.200,00 recebido/)).toBeInTheDocument();
+  });
+
+  it("rotula o rastro da IA quando a narração veio dela (Regra de Ouro nº 3)", async () => {
+    mockGet(BRIEFING);
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Escrito pela IA/i)).toBeInTheDocument());
+  });
+
+  it("NÃO rotula quando o texto veio do template — dizer que foi a IA seria falso", async () => {
+    mockGet({ ...BRIEFING, por_ia: false });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Entrou um pagamento/)).toBeInTheDocument());
+    expect(screen.queryByText(/Escrito pela IA/i)).not.toBeInTheDocument();
+  });
+
+  it("falha de rede não deixa a tela em branco — o caminho para o painel continua", async () => {
+    vi.mocked(api.get).mockRejectedValue({ response: { data: { detail: "Serviço indisponível" } } });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Serviço indisponível/)).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /painel/i })).toBeInTheDocument();
+  });
+});
+
+describe("BriefingPage — preferências na própria tela", () => {
+  it("salva o horário sem exigir módulo nenhum", async () => {
+    const user = userEvent.setup();
+    mockGet(BRIEFING);
+    vi.mocked(api.patch).mockResolvedValue({ data: { ...PREFS, briefing_hour: "08:30" } });
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /prefer/i }));
+    const hora = await screen.findByLabelText(/horário/i);
+    await user.clear(hora);
+    await user.type(hora, "08:30");
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith("/auth/me/preferences", {
+        briefing_hour: "08:30",
+        briefing_whatsapp_enabled: false,
+      }),
+    );
+  });
+
+  it("tenant sem template aprovado: o switch fica desligado E a tela diz por quê", async () => {
+    const user = userEvent.setup();
+    mockGet(BRIEFING, {
+      ...PREFS,
+      briefing_whatsapp_disponivel: false,
+      briefing_whatsapp_indisponivel_motivo:
+        "O template do briefing ainda não foi aprovado pela Meta.",
+    });
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /prefer/i }));
+    expect(await screen.findByText(/não foi aprovado pela Meta/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/whatsapp/i)).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/vima/BriefingPage.tsx
+++ b/apps/web/src/features/vima/BriefingPage.tsx
@@ -1,0 +1,175 @@
+import type { Briefing, BriefingLinha, BriefingPreferences } from "@e1p/shared-types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { api, apiErrorMessage } from "../../lib/api";
+import { formatTime } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+import PreferenciasSection from "./PreferenciasSection";
+
+/**
+ * A tela do briefing — a porta de entrada do dia.
+ *
+ * **360px primeiro.** O dono lê isto no celular, de manhã, antes de sentar. Nenhuma largura fixa:
+ * tudo em `max-w-prose` com padding responsivo, um alvo de toque por linha. Este repositório já
+ * pagou caro por esquecer isso — o `AppShell` sem breakpoint fez uma conta real ser marcada como
+ * paga sem o dono conseguir ver o checkbox (PR #56).
+ *
+ * A prosa vem primeiro e as linhas são APOIO. O texto é para ler; as linhas existem para conferir
+ * um item sem reler o parágrafo inteiro.
+ */
+export default function BriefingPage() {
+  const fuso = useFuso();
+  const [briefing, setBriefing] = useState<Briefing | null>(null);
+  const [prefs, setPrefs] = useState<BriefingPreferences | null>(null);
+  const [erro, setErro] = useState<string | null>(null);
+  const [verPrefs, setVerPrefs] = useState(false);
+  // A marcação de leitura acontece UMA vez por montagem. Sem a trava, um re-render entre a
+  // resposta do POST e a atualização do estado dispararia um segundo POST — e é `read_at` que
+  // decide a janela do briefing de amanhã (`service._inicio_da_janela`).
+  const marcado = useRef(false);
+
+  const carregar = useCallback(async () => {
+    try {
+      const { data } = await api.get<Briefing>("/vima/briefing");
+      setBriefing(data);
+    } catch (err) {
+      setErro(apiErrorMessage(err));
+    }
+    try {
+      const { data } = await api.get<BriefingPreferences>("/auth/me/preferences");
+      setPrefs(data);
+    } catch {
+      // Preferência é acessório: não poder carregá-la não pode esconder o briefing do dia.
+      setPrefs(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  useEffect(() => {
+    if (!briefing || briefing.read_at || marcado.current) return;
+    marcado.current = true;
+    void api
+      .post<Briefing>(`/vima/briefing/${briefing.id}/read`)
+      .then(({ data }) => setBriefing(data))
+      // Falhar em marcar como lido não pode derrubar a leitura: o pior efeito é a janela do
+      // briefing de amanhã ficar mais larga, e ele repetir um item. Ruído, não perda.
+      .catch(() => undefined);
+  }, [briefing]);
+
+  if (erro && !briefing) {
+    return (
+      <div className="mx-auto w-full max-w-prose">
+        <p role="alert" className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-danger">
+          {erro}
+        </p>
+        <VoltarAoPainel />
+      </div>
+    );
+  }
+
+  if (!briefing) {
+    return (
+      <div className="mx-auto w-full max-w-prose py-10 text-center text-sm text-neutral-500">
+        Preparando seu resumo…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-prose pb-10">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <h1 className="text-sm font-medium uppercase tracking-wide text-neutral-500">
+          Seu dia
+        </h1>
+        <span className="text-xs text-neutral-400">{formatTime(briefing.created_at, fuso)}</span>
+      </header>
+
+      {/* A narração. Tipografia grande porque é o que se lê, não o que se consulta. */}
+      <p className="mt-3 whitespace-pre-line text-lg leading-relaxed text-neutral-800 sm:text-xl">
+        {briefing.texto}
+      </p>
+
+      {/*
+        Rastro da IA (Regra de Ouro nº 3) — e só quando foi a IA mesmo. Sem chave configurada o
+        briefing sai íntegro pelo template, e rotular esse texto como escrito pela IA seria falso.
+      */}
+      {briefing.por_ia && (
+        <p className="mt-2 text-xs text-neutral-400">Escrito pela IA a partir dos seus dados.</p>
+      )}
+
+      <Secoes linhas={briefing.linhas} excedente={briefing.excedente} />
+
+      <VoltarAoPainel />
+
+      <div className="mt-6 border-t border-neutral-200 pt-4">
+        <button
+          type="button"
+          onClick={() => setVerPrefs((v) => !v)}
+          className="text-sm text-neutral-500 underline underline-offset-2"
+        >
+          {verPrefs ? "Fechar preferências" : "Preferências do briefing"}
+        </button>
+        {verPrefs && prefs && (
+          <PreferenciasSection prefs={prefs} onSaved={(p) => setPrefs(p)} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** O caminho de volta é sempre visível — o briefing é porta de entrada, não pedágio. */
+function VoltarAoPainel() {
+  return (
+    <Link
+      to="/"
+      className="mt-8 block w-full rounded-md bg-primary px-4 py-3 text-center text-base font-medium text-white"
+    >
+      Ir para o painel
+    </Link>
+  );
+}
+
+const TITULO_DA_SECAO: Record<string, string> = {
+  PENDENTE: "Esperando você",
+  ACONTECEU: "O que aconteceu",
+  NÚMEROS: "Números",
+};
+// Mesma ordem do compositor (`vima/composer._ORDEM_DAS_SECOES`): ausência primeiro, porque pede
+// ação; número por último, porque é contexto e não notícia.
+const ORDEM = ["PENDENTE", "ACONTECEU", "NÚMEROS"];
+
+function Secoes({ linhas, excedente }: { linhas: BriefingLinha[]; excedente: number }) {
+  const presentes = ORDEM.filter((s) => linhas.some((l) => l.secao === s));
+  if (presentes.length === 0) return null;
+  return (
+    <div className="mt-8 flex flex-col gap-6">
+      {presentes.map((secao) => (
+        <section key={secao}>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+            {TITULO_DA_SECAO[secao] ?? secao}
+          </h2>
+          <ul className="mt-2 flex flex-col gap-2">
+            {linhas
+              .filter((l) => l.secao === secao)
+              .map((l, i) => (
+                <li
+                  key={`${secao}-${i}`}
+                  className="rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-700"
+                >
+                  {l.texto}
+                </li>
+              ))}
+          </ul>
+        </section>
+      ))}
+      {excedente > 0 && (
+        <p className="text-xs text-neutral-400">
+          e mais {excedente} {excedente === 1 ? "item" : "itens"} de menor peso.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/vima/EntradaDoDia.test.tsx
+++ b/apps/web/src/features/vima/EntradaDoDia.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { today } from "../../lib/datetime";
+import EntradaDoDia, { CHAVE_ENTRADA } from "./EntradaDoDia";
+
+const FUSO = "America/Sao_Paulo";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn() },
+  apiErrorMessage: () => "erro",
+}));
+
+vi.mock("../../store/auth", () => ({
+  useFuso: () => FUSO,
+}));
+
+function renderEntrada() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <EntradaDoDia>
+              <p>o cockpit</p>
+            </EntradaDoDia>
+          }
+        />
+        <Route path="/vima" element={<p>a tela do briefing</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.mocked(api.get).mockReset();
+});
+
+describe("EntradaDoDia — o briefing é porta de entrada UMA VEZ POR DIA", () => {
+  it("briefing de hoje ainda não lido: a entrada é a Vima", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("a tela do briefing")).toBeInTheDocument());
+  });
+
+  it("briefing já lido: a entrada é o Cockpit", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: "2026-08-06T10:06:00Z" } });
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("o cockpit")).toBeInTheDocument());
+  });
+
+  it("já entrou hoje neste aparelho: vai direto ao Cockpit, SEM perguntar de novo", async () => {
+    // A marca é o dia do TENANT, não `toISOString().slice(0,10)` (que é o dia UTC). A primeira
+    // versão deste teste usou UTC e falhou só depois das 21h no Brasil — a mesma classe de bug
+    // que a correção de fuso de 2026-08-05 eliminou de ~25 telas.
+    localStorage.setItem(CHAVE_ENTRADA, today(FUSO));
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("o cockpit")).toBeInTheDocument());
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("marca de ONTEM não vale: o briefing é diário", async () => {
+    localStorage.setItem(CHAVE_ENTRADA, "2020-01-01");
+    vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("a tela do briefing")).toBeInTheDocument());
+  });
+
+  it("marca o dia ao decidir — quem volta ao painel não é reenviado à Vima em loop", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("a tela do briefing")).toBeInTheDocument());
+    expect(localStorage.getItem(CHAVE_ENTRADA)).toBeTruthy();
+  });
+
+  it("briefing indisponível não tranca a entrada: cai no Cockpit e tenta de novo depois", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("500"));
+    renderEntrada();
+    await waitFor(() => expect(screen.getByText("o cockpit")).toBeInTheDocument());
+    // Sem marca: falhar hoje não pode custar o briefing de hoje na próxima tentativa.
+    expect(localStorage.getItem(CHAVE_ENTRADA)).toBeNull();
+  });
+});

--- a/apps/web/src/features/vima/EntradaDoDia.tsx
+++ b/apps/web/src/features/vima/EntradaDoDia.tsx
@@ -1,0 +1,78 @@
+import type { Briefing } from "@e1p/shared-types";
+import { type ReactNode, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { api } from "../../lib/api";
+import { today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+
+/**
+ * Marca de "a entrada de hoje já foi decidida NESTE aparelho", no formato `YYYY-MM-DD` do fuso do
+ * TENANT.
+ *
+ * Existe por dois motivos, e o segundo é o que importa: (1) poupa uma ida ao servidor em toda
+ * visita ao painel depois da primeira do dia; (2) quebra o laço — quem é mandado à Vima e toca
+ * "Ir para o painel" antes de a marcação de leitura chegar ao servidor voltaria à Vima
+ * indefinidamente. A AUTORIDADE continua sendo `read_at` no servidor; isto é só cache do dia.
+ */
+export const CHAVE_ENTRADA = "e1p_briefing_dia";
+
+type Decisao = "perguntando" | "vima" | "cockpit";
+
+/**
+ * Decide qual é a porta de entrada do dia.
+ *
+ * **O briefing aparece UMA VEZ POR DIA, não a cada login.** Quem entra cinco vezes veria cinco
+ * vezes, e a porta de entrada viraria obstáculo. O mecanismo é `read_at`: primeiro acesso do dia
+ * → a Vima; já lido → o Cockpit, com o caminho de volta à Vima na própria tela dela.
+ *
+ * Falha de rede cai no Cockpit e **não** grava a marca: o produto não fica trancado por causa do
+ * briefing, e a tentativa seguinte ainda pode entregá-lo.
+ */
+export default function EntradaDoDia({ children }: { children: ReactNode }) {
+  const fuso = useFuso();
+  const hoje = today(fuso);
+  const [decisao, setDecisao] = useState<Decisao>(() =>
+    lerMarca() === hoje ? "cockpit" : "perguntando",
+  );
+
+  useEffect(() => {
+    if (decisao !== "perguntando") return;
+    let vivo = true;
+    api
+      .get<Briefing>("/vima/briefing")
+      .then(({ data }) => {
+        if (!vivo) return;
+        gravarMarca(hoje);
+        setDecisao(data?.read_at ? "cockpit" : "vima");
+      })
+      .catch(() => {
+        if (vivo) setDecisao("cockpit");
+      });
+    return () => {
+      vivo = false;
+    };
+  }, [decisao, hoje]);
+
+  if (decisao === "perguntando") {
+    return <div className="py-10 text-center text-sm text-neutral-400">Um instante…</div>;
+  }
+  if (decisao === "vima") return <Navigate to="/vima" replace />;
+  return <>{children}</>;
+}
+
+/** `localStorage` pode lançar (modo privativo do Safari, cota) — e isso não pode derrubar a app. */
+function lerMarca(): string | null {
+  try {
+    return localStorage.getItem(CHAVE_ENTRADA);
+  } catch {
+    return null;
+  }
+}
+
+function gravarMarca(dia: string): void {
+  try {
+    localStorage.setItem(CHAVE_ENTRADA, dia);
+  } catch {
+    // Sem cache do dia a entrada volta a perguntar ao servidor toda visita — mais lento, correto.
+  }
+}

--- a/apps/web/src/features/vima/PreferenciasSection.tsx
+++ b/apps/web/src/features/vima/PreferenciasSection.tsx
@@ -33,7 +33,11 @@ export default function PreferenciasSection({
     try {
       const { data } = await api.patch<BriefingPreferences>("/auth/me/preferences", {
         briefing_hour: hora,
-        briefing_whatsapp_enabled: zap,
+        // Manda o que está NA TELA, não o que veio do servidor. Um tenant que tinha o WhatsApp
+        // ligado e perdeu a entrega (template despausado pela Meta, WhatsApp desconectado) chega
+        // aqui com `enabled=true` e `disponivel=false`: reenviar `true` levaria um 422 do
+        // backend e o usuário não conseguiria nem trocar o próprio horário.
+        briefing_whatsapp_enabled: zap && !indisponivel,
       });
       onSaved(data);
       setOk(true);

--- a/apps/web/src/features/vima/PreferenciasSection.tsx
+++ b/apps/web/src/features/vima/PreferenciasSection.tsx
@@ -1,0 +1,111 @@
+import type { BriefingPreferences } from "@e1p/shared-types";
+import { useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+/**
+ * Preferências do briefing, DENTRO da tela do briefing.
+ *
+ * Não mora em `/config` de propósito: aquela rota exige o módulo `settings`, e escolher o próprio
+ * horário / ligar o próprio WhatsApp é preferência de PESSOA, não configuração de empresa. Um
+ * sub-usuário sem `settings` precisa das duas coisas.
+ *
+ * 360px primeiro: um controle por linha, alvos de toque altos, nenhuma largura fixa.
+ */
+export default function PreferenciasSection({
+  prefs,
+  onSaved,
+}: {
+  prefs: BriefingPreferences;
+  onSaved: (p: BriefingPreferences) => void;
+}) {
+  const [hora, setHora] = useState(prefs.briefing_hour);
+  const [zap, setZap] = useState(prefs.briefing_whatsapp_enabled);
+  const [busy, setBusy] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+  const [ok, setOk] = useState(false);
+
+  const indisponivel = !prefs.briefing_whatsapp_disponivel;
+
+  async function salvar() {
+    setBusy(true);
+    setErro(null);
+    setOk(false);
+    try {
+      const { data } = await api.patch<BriefingPreferences>("/auth/me/preferences", {
+        briefing_hour: hora,
+        briefing_whatsapp_enabled: zap,
+      });
+      onSaved(data);
+      setOk(true);
+    } catch (err) {
+      setErro(apiErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="mt-8 rounded-lg border border-neutral-200 bg-white p-4">
+      <h2 className="text-base font-semibold text-neutral-800">Como você quer receber</h2>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <label className="flex flex-col gap-1 text-sm text-neutral-700">
+          <span id="label-hora">Horário do briefing</span>
+          <input
+            type="time"
+            aria-labelledby="label-hora"
+            value={hora}
+            onChange={(e) => setHora(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 px-3 py-2 text-base"
+          />
+          <span className="text-xs text-neutral-500">
+            No seu horário — o do escritório, não o do servidor.
+          </span>
+        </label>
+
+        <label className="flex items-start gap-3 text-sm text-neutral-700">
+          <input
+            type="checkbox"
+            aria-label="Receber o briefing no WhatsApp"
+            checked={zap && !indisponivel}
+            disabled={indisponivel}
+            onChange={(e) => setZap(e.target.checked)}
+            className="mt-1 h-5 w-5 shrink-0 rounded border-neutral-300 disabled:opacity-40"
+          />
+          <span className="min-w-0">
+            Receber também no WhatsApp
+            {/*
+              A dependência da Meta é EXTERNA ao repositório e demora. Dizer o motivo é o que
+              separa "ainda não dá" de "está quebrado" — sem a frase, o switch desligado parece
+              defeito nosso.
+            */}
+            {indisponivel && prefs.briefing_whatsapp_indisponivel_motivo && (
+              <span className="mt-1 block text-xs text-amber-700">
+                {prefs.briefing_whatsapp_indisponivel_motivo}
+              </span>
+            )}
+            <span className="mt-1 block text-xs text-neutral-500">
+              Em dia sem novidade nenhuma o WhatsApp não sai — só a tela.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      {erro && (
+        <p role="alert" className="mt-3 text-sm text-danger">
+          {erro}
+        </p>
+      )}
+      {ok && !erro && <p className="mt-3 text-sm text-accent-700">Preferências salvas.</p>}
+
+      <button
+        type="button"
+        onClick={salvar}
+        disabled={busy}
+        className="mt-4 w-full rounded-md bg-primary px-4 py-2.5 text-base font-medium text-white disabled:opacity-60 sm:w-auto"
+      >
+        {busy ? "Salvando…" : "Salvar"}
+      </button>
+    </section>
+  );
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1092,3 +1092,44 @@ export interface LegalDocument {
   status: string;
   created_at: string;
 }
+
+// ── Vima: briefing do dia (Onda 4) ───────────────────────────────────────────
+
+/**
+ * Uma linha do payload determinístico. `texto` é a mesma informação que a narração reescreveu —
+ * está aqui para que um cliente possa AGIR sobre um item sem fazer parsing de prosa.
+ */
+export interface BriefingLinha {
+  secao: "PENDENTE" | "ACONTECEU" | "NÚMEROS";
+  module: string;
+  texto: string;
+}
+
+export interface Briefing {
+  id: UUID;
+  /** Data de CALENDÁRIO (YYYY-MM-DD) no fuso do tenant — não é instante, não converta fuso. */
+  reference_date: string;
+  texto: string;
+  /** Se a narração veio da IA ou do template. Rotular como IA um texto de template seria falso. */
+  por_ia: boolean;
+  /** `true` = nada ACONTECEU na janela. Pendência e tendência podem existir mesmo assim. */
+  vazio: boolean;
+  excedente: number;
+  linhas: BriefingLinha[];
+  read_at: string | null;
+  created_at: string;
+}
+
+/**
+ * Preferência de briefing DO USUÁRIO (mora em `users`, não no perfil da empresa) — por isso
+ * editável sem o módulo `settings`.
+ */
+export interface BriefingPreferences {
+  briefing_whatsapp_enabled: boolean;
+  /** "HH:MM" no relógio de parede do dono. */
+  briefing_hour: string;
+  /** O tenant consegue entregar por WhatsApp hoje? Meta sem template aprovado → false. */
+  briefing_whatsapp_disponivel: boolean;
+  /** Texto pronto para a tela quando indisponível; `null` quando disponível. */
+  briefing_whatsapp_indisponivel_motivo: string | null;
+}


### PR DESCRIPTION
Tasks 15–19 do plano `docs/superpowers/plans/2026-08-06-vima-registro-de-fatos-e-briefing.md`.
O dono passa a **ver o briefing na tela** e **recebê-lo no WhatsApp**, nos dois transportes.

## O que entra

| Task | Entrega |
|---|---|
| 15 | Preferências do usuário (`users.briefing_whatsapp_enabled`, `briefing_hour`) + `GET/PATCH /auth/me/preferences` |
| 16 | Tela do briefing + roteamento de entrada uma vez por dia |
| 17 | Job que gera no horário de cada usuário, no fuso do tenant (etapa 6 do sweep) |
| 18 | Entrega por Evolution — o briefing inteiro, em um passo |
| 19 | Entrega por Meta — template com botão, opt-in de volta |

## As decisões que valem revisão

**A preferência não mora em `/config`.** Aquela rota exige o módulo `settings`, e a preferência é
do USUÁRIO: dois usuários do mesmo tenant têm telefones e horários diferentes, e no perfil da
empresa um sobrescreveria o outro. Vive em `users`, editável da própria tela do briefing, sem
exigir módulo nenhum.

**O briefing é porta de entrada UMA VEZ POR DIA, não a cada login.** O mecanismo é `read_at`.
`EntradaDoDia` guarda o dia decidido em `localStorage` (no fuso do TENANT, não em UTC) por dois
motivos, e o segundo é o que importa: poupa uma ida ao servidor por visita e **quebra o laço** de
quem toca "Ir para o painel" antes de a marcação de leitura chegar. A autoridade continua sendo o
`read_at` do servidor.

**Dia sem novidade: a tela diz que está tranquilo, o WhatsApp não sai.** Um "bom dia, nada
aconteceu" diário é a forma mais rápida de ser silenciado — e um canal silenciado não entrega o
dia em que importa.

**`briefing_needs_optin` nasce com o consumidor no mesmo passo.** `capabilities.py` já passou
meses com zero call sites enquanto a docstring afirmava ter três, e aquilo custou dois bugs reais
em produção. A lista de consumidores agora é verificável por grep.

## O que exigiu ir além do plano

`send_template` não enviava componente de botão — e **sem ele a Meta devolve, no toque, o rótulo
que o tenant escreveu no console dela** (texto livre), não haveria constante nenhuma para casar
com `PAYLOAD_BOTAO_BRIEFING`. O formato do webhook foi conferido [contra a documentação da
Meta](https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/button),
não suposto. O payload do botão é derivado do `purpose` em `process_pending` — sem coluna nova.

O reconhecimento do toque fica **depois** do registro da mensagem e **fora** do bloco de `facts`:
aquele bloco é pulado quando a mensagem vem do telefone do time, e o toque vem sempre de lá.
Dentro dele, o opt-in seria descartado junto e o briefing nunca sairia.

## Desvios do plano, deliberados

- **`tick(db, *, tenant_id, agora)`** em vez de `tick(db_factory, *, agora)`: o worker já itera
  tenants com isolamento de falha por etapa, e um segundo laço aqui duplicaria essa estrutura com
  um tratamento de falha próprio e diferente.
- **`ingest_webhook_payload` recebe `list[InboundMessage]`**, não um dict — a assinatura do plano
  estava defasada.
- **Migration `0072`, não `0071`**: o número já estava tomado pelo `ai_usage` (#87).

## ⚠️ Colisão de numeração

A branch `fix/fuso-do-tenant-na-sessao` também escreveu uma `0072`. As duas saíram da mesma
`main`; **a segunda a mergear precisa virar `0073`**, com `down_revision` apontando para a
primeira. Cada branch é válida isoladamente (cadeia `0071 ← 0072`), então o CI passa nas duas.

## Verificação

- Backend: `1883 passed, 1 skipped` (36 testes novos da Vima)
- Frontend: `528 passed, 57 arquivos` (16 novos em `features/vima/`)
- `ruff` limpo, `tsc --noEmit` limpo, head único do alembic
- Migration validada contra **Postgres real** (testcontainers, papel não-superusuário `e1p_app`)

## Pendências que não bloqueiam o merge

- **Validação manual em ~360px** da tela do briefing — bloqueia release, como nas ondas anteriores.
- **Template com botão depende de aprovação da Meta**, que é externa ao repositório. Enquanto não
  houver, o tenant Meta fica sem briefing por WhatsApp e a UI **diz por quê** em vez de oferecer um
  switch que liga e não entrega nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)