### PR TITLE
fix: o fuso da sessão era sempre o padrão, para todo tenant

### DIFF
--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -72,10 +72,12 @@ def create_event(
         # em vez da meia-noite UTC crua. Import lazy de settings.get_profile p/ não acoplar o
         # módulo-núcleo Agenda ao módulo settings (mesmo padrão de quotes→contracts no CLAUDE.md).
         from app.core.tz import day_window_utc
-        from app.modules.settings.service import get_profile
+        from app.modules.settings.service import tenant_timezone
 
-        profile = get_profile(db, tenant_id)
-        starts_at, ends_at = day_window_utc(data.starts_at.date(), profile.timezone)
+        # `tenant_timezone(db)`, e não `get_profile(...).timezone`: o fuso mora em `tenants` desde
+        # a 0073, e a coluna do perfil ficou congelada. Também é melhor por si — este caminho não
+        # precisava CRIAR perfil, que é o que `get_profile` faz.
+        starts_at, ends_at = day_window_utc(data.starts_at.date(), tenant_timezone(db))
 
     conflicts: list[AgendaEvent] = []
     if data.kind in OCCUPYING_KINDS:

--- a/apps/api/app/modules/auth/models.py
+++ b/apps/api/app/modules/auth/models.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE
 from app.db.base import Base, TimestampMixin, _uuid
 
 
@@ -21,6 +22,15 @@ class Tenant(Base, TimestampMixin):
     slug: Mapped[str] = mapped_column(String(63), unique=True, index=True, nullable=False)
     legal_name: Mapped[str] = mapped_column(String(255), nullable=False)
     document: Mapped[str] = mapped_column(String(18), nullable=False)  # CPF/CNPJ
+    # Fuso IANA do tenant — a âncora de "hoje" de todo o sistema (`settings.hoje_do_tenant`).
+    #
+    # Mora AQUI, e não em `TenantProfile`, porque `/auth/login` e `/auth/me` entregam o fuso junto
+    # com a sessão e rodam em sessão crua: `tenant_profiles` tem RLS FORCE e a leitura voltava
+    # vazia, caindo no padrão em silêncio para todo tenant. Fuso é identidade, não brand kit.
+    # Ver a migration 0073 e `tests/test_auth_timezone_rls.py`.
+    timezone: Mapped[str] = mapped_column(
+        String(64), default=DEFAULT_TENANT_TIMEZONE, nullable=False
+    )
 
     users: Mapped[list[User]] = relationship(back_populates="tenant")
 

--- a/apps/api/app/modules/cockpit/router.py
+++ b/apps/api/app/modules/cockpit/router.py
@@ -35,12 +35,15 @@ def summary(
     # A janela do dia é ancorada na meia-noite do FUSO do tenant (convertida p/ UTC), corrigindo a
     # antiga dívida de "meia-noite UTC crua" (CLAUDE.md §Cockpit). Import lazy de settings para não
     # acoplar o Cockpit ao módulo settings (mesmo padrão da Agenda).
-    from app.modules.settings.service import get_profile
+    from app.modules.settings.service import tenant_timezone
 
-    profile = get_profile(db, _user.tenant_id)
+    # `tenant_timezone(db)`, e não `get_profile(...).timezone`: o fuso mora em `tenants` desde a
+    # 0073, e a coluna do perfil ficou congelada. Um GET também não deveria criar perfil — era
+    # exatamente a "escrita num GET" que a revisão de QA do Cockpit já tinha removido uma vez.
+    fuso = tenant_timezone(db)
     # 'Hoje' é o dia do DONO, não o do servidor: sem isto o Cockpit virava a página às 21h.
-    base = day if day else tenant_today(profile.timezone)
-    day_start, day_end = day_window_utc(base, profile.timezone)
+    base = day if day else tenant_today(fuso)
+    day_start, day_end = day_window_utc(base, fuso)
 
     today_count, today_events, upcoming = service.agenda_summary(
         db, day_start=day_start, day_end=day_end

--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -98,9 +98,11 @@ def _compute_expires_at(db: Session, *, tenant_id: str, purpose: str | None) -> 
     if purpose in _ONE_HOUR_PURPOSES:
         return now + timedelta(hours=1)
     if purpose in _END_OF_DAY_PURPOSES:
-        profile = settings_service.get_profile(db, tenant_id)
+        # `timezone_of(db, tenant_id)`, e não `get_profile(...).timezone`: o fuso mora em
+        # `tenants` desde a 0073 e a coluna do perfil ficou congelada. Usa a variante POR ID
+        # porque `process_pending`/`enqueue` já recebem o `tenant_id` explicitamente.
         try:
-            tz = ZoneInfo(profile.timezone)
+            tz = ZoneInfo(settings_service.timezone_of(db, tenant_id))
         except (ZoneInfoNotFoundError, ValueError):
             tz = ZoneInfo("America/Sao_Paulo")
         local_now = now.astimezone(tz)

--- a/apps/api/app/modules/settings/router.py
+++ b/apps/api/app/modules/settings/router.py
@@ -14,13 +14,16 @@ router = APIRouter(prefix="/settings", tags=["settings"])
 _guard = require_module("settings")
 
 
-def _out(p: TenantProfile) -> ProfileOut:
+def _out(db: Session, p: TenantProfile) -> ProfileOut:
     return ProfileOut(
         display_name=p.display_name, document=p.document, email=p.email, phone=p.phone,
         address=p.address, website=p.website, about=p.about, logo_url=p.logo_url,
         primary_color=p.primary_color, secondary_color=p.secondary_color,
         accent_color=p.accent_color, text_color=p.text_color, bg_color=p.bg_color, font=p.font,
-        timezone=p.timezone, default_entry_funnel_id=p.default_entry_funnel_id,
+        # O fuso vem de `tenants` desde a 0073, não do perfil — ler `p.timezone` aqui mostraria
+        # a coluna congelada que ninguém mais escreve.
+        timezone=service.tenant_timezone(db),
+        default_entry_funnel_id=p.default_entry_funnel_id,
         whatsapp_configured=bool(p.whatsapp_token and p.whatsapp_phone_id and p.whatsapp_waba_id),
         whatsapp_provider=p.whatsapp_provider,
         whatsapp_phone_id=p.whatsapp_phone_id or "",
@@ -34,7 +37,7 @@ def _out(p: TenantProfile) -> ProfileOut:
 def get_profile(
     user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
 ) -> ProfileOut:
-    return _out(service.get_profile(db, user.tenant_id))
+    return _out(db, service.get_profile(db, user.tenant_id))
 
 
 @router.patch("/profile", response_model=ProfileOut)
@@ -49,4 +52,4 @@ def update_profile(
         )
     except service.SettingsError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
-    return _out(profile)
+    return _out(db, profile)

--- a/apps/api/app/modules/settings/service.py
+++ b/apps/api/app/modules/settings/service.py
@@ -54,10 +54,13 @@ def _validate_template_bindings(db: Session, bindings: dict[str, str]) -> None:
             )
 
 
+# Campos do PATCH que moram no PERFIL. `timezone` saiu daqui na 0073 (mora em `tenants` agora) e
+# é gravado à parte em `update_profile` — deixá-lo na lista escreveria numa coluna que ninguém
+# mais lê, e a tela mostraria o valor antigo depois de salvar.
 _FIELDS = (
     "display_name", "document", "email", "phone", "address", "website", "about",
     "logo_url", "primary_color", "secondary_color", "accent_color", "text_color",
-    "bg_color", "font", "timezone",
+    "bg_color", "font",
     "whatsapp_token", "whatsapp_phone_id", "whatsapp_waba_id", "whatsapp_app_secret",
 )
 
@@ -69,27 +72,39 @@ def tenant_timezone(db: Session) -> str:
 
     - **não cria** perfil e **não commita**. É chamado de dentro de regras de negócio (baixa de
       conta, projeção de caixa); um efeito colateral de escrita ali seria uma armadilha;
-    - **não pede `tenant_id`**. A sessão já é RLS-escopada (Regra de Ouro nº 1) e a query traz o
-      perfil do tenant corrente — o mesmo motivo pelo qual `get_profile` faz `select(TenantProfile)`
-      sem filtro manual.
+    - **não pede `tenant_id`**. A sessão já é RLS-escopada (Regra de Ouro nº 1).
 
-    Fail-safe por construção: tenant ainda sem perfil (ou coluna nula) cai no fuso padrão, nunca
-    levanta. A validação de que a string É um fuso IANA mora em `tenant_zone`, que também não
-    levanta — juntas, garantem que fuso ruim no banco jamais derruba uma request.
+    O fuso vive em `tenants` (global, sem RLS) desde a migration 0073, então quem faz o recorte
+    por tenant aqui é o JOIN com `tenant_profiles`, que TEM RLS: a policy resolve a linha do
+    tenant corrente e o join traz o fuso dela. Sem o join, um `select(Tenant.timezone)` sem
+    `where` numa tabela global devolveria o fuso de um tenant QUALQUER.
+
+    Fail-safe por construção: tenant ainda sem perfil cai no fuso padrão, nunca levanta — mesmo
+    comportamento de antes da 0073. A validação de que a string É um fuso IANA mora em
+    `tenant_zone`, que também não levanta.
     """
-    return db.scalar(select(TenantProfile.timezone)) or DEFAULT_TENANT_TIMEZONE
+    return (
+        db.scalar(select(Tenant.timezone).join(TenantProfile, TenantProfile.tenant_id == Tenant.id))
+        or DEFAULT_TENANT_TIMEZONE
+    )
 
 
 def timezone_of(db: Session, tenant_id: str) -> str:
     """O fuso de um tenant NOMEADO — para contextos **sem** sessão RLS.
 
-    `tenant_timezone(db)` depende do escopo RLS da sessão; `/auth/login`, `/auth/register` e
-    `/auth/me` rodam com `get_db` (sessão crua, ainda sem tenant no contexto) e ali um `select`
-    sem `where` traria o perfil errado num banco multi-tenant. Por isso o filtro é explícito
-    aqui — e é a única situação em que ele é correto.
+    `/auth/login`, `/auth/register`, `/auth/me` e `/auth/change-password` rodam com `get_db`
+    (sessão crua, sem a GUC de tenant) e é daqui que a sessão entregue ao frontend tira o fuso.
+
+    ⚠️ **Antes da 0073 esta função lia `tenant_profiles` — que tem `FORCE ROW LEVEL SECURITY` — e
+    devolvia o padrão para TODO mundo.** O `where` explícito não salvava: a policy filtra o SELECT
+    antes, e o problema nunca foi *qual* linha trazer, e sim *conseguir enxergar alguma*. Agora o
+    fuso vive em `tenants`, tabela GLOBAL sem RLS, legível em qualquer sessão.
+
+    ⚠️ **`tenants` não tem RLS: o filtro por `tenant_id` aqui é obrigatório**, mesma exceção
+    documentada de `users`. Gate em `test_auth_timezone_rls.py::test_o_fuso_NAO_atravessa_tenants`.
     """
     return (
-        db.scalar(select(TenantProfile.timezone).where(TenantProfile.tenant_id == tenant_id))
+        db.scalar(select(Tenant.timezone).where(Tenant.id == tenant_id))
         or DEFAULT_TENANT_TIMEZONE
     )
 
@@ -169,6 +184,13 @@ def update_profile(
         val = getattr(data, f)
         if val is not None:
             setattr(profile, f, val)
+    # O fuso é o único campo do PATCH que NÃO mora no perfil: desde a 0073 ele vive em `tenants`,
+    # para que `/auth/login` (sessão crua) consiga lê-lo. Filtro explícito por id porque `tenants`
+    # não tem RLS — é a exceção documentada da Regra de Ouro nº 1.
+    if data.timezone is not None:
+        tenant = db.get(Tenant, tenant_id)
+        if tenant is not None:
+            tenant.timezone = data.timezone
     # None no PATCH = "não altera"; "" desvincula (sem auto-enroll). Mesmo padrão de
     # contract_id/cost_center_id em receivables/service.py::update_charge.
     if data.default_entry_funnel_id is not None:

--- a/apps/api/migrations/versions/0073_tenant_timezone.py
+++ b/apps/api/migrations/versions/0073_tenant_timezone.py
@@ -1,0 +1,78 @@
+"""O fuso do tenant muda de `tenant_profiles` para `tenants`
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-08-06
+
+**Por quê.** `tenant_profiles` tem `FORCE ROW LEVEL SECURITY` desde a 0022, e as rotas de `/auth`
+rodam em sessão CRUA (`get_db`, sem a GUC de tenant): a policy filtrava o SELECT inteiro e
+`timezone_of` caía sempre no padrão. Todo tenant que escolheu outro fuso recebia
+`America/Sao_Paulo` na sessão — e o `useFuso()` do frontend inteiro sai desse valor.
+
+O fuso é **identidade do tenant**, não brand kit: mora em `tenants`, que é tabela GLOBAL sem RLS
+e que as rotas de auth já leem naturalmente. Isso ELIMINA a classe do problema em vez de
+contorná-la com uma sessão extra ou um bypass de RLS.
+
+⚠️ **`tenants` não tem RLS — logo, toda leitura precisa de filtro explícito por id.** É a mesma
+exceção documentada de `users` (Regra de Ouro nº 1). O gate está em
+`tests/test_auth_timezone_rls.py::test_o_fuso_NAO_atravessa_tenants`: trocar um bug de fuso por um
+vazamento entre tenants seria infinitamente pior.
+
+⚠️ **O backfill lê `tenant_profiles`, que TEM RLS — e por isso a desabilita na sua janela.** Sem
+isso o `UPDATE ... FROM` casaria zero linhas e completaria com sucesso aparente, deixando todo
+mundo no default: exatamente a armadilha das 0046/0066/0067/0068/0069, que o SQLite dos testes não
+pega. A RLS é reabilitada (com FORCE) logo depois, no mesmo `upgrade`.
+
+⚠️ **`tenant_profiles.timezone` NÃO é dropada aqui**, de propósito: `DROP COLUMN` é irreversível e
+vale manter um ciclo para conferência (mesmo critério de `whatsapp_conversation_states` na 0066).
+Nada mais a lê — o gate `test_settings_timezone.py::test_ninguem_le_mais_o_fuso_do_perfil` reprova
+quem voltar a ler. Dropar numa migration posterior.
+
+Numeração: nasceu como `0072` numa branch paralela à `feat/vima-briefing-superficies`, que
+escreveu a OUTRA `0072` (preferências de briefing) — as duas saíram da mesma `main`. Aquela
+mergeou primeiro (PR #90), então esta virou `0073` e encadeia depois dela. É o custo conhecido de
+duas frentes abertas ao mesmo tempo neste repositório.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0073"
+down_revision: str | None = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PADRAO = "America/Sao_Paulo"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenants",
+        sa.Column("timezone", sa.String(length=64), nullable=False, server_default=_PADRAO),
+    )
+
+    # Janela de RLS aberta na TABELA DE ORIGEM (não na de destino: `tenants` não tem RLS).
+    # Ver a nota no topo — é a fonte da leitura que precisa estar visível, não o alvo do UPDATE.
+    op.execute("ALTER TABLE tenant_profiles DISABLE ROW LEVEL SECURITY")
+    try:
+        op.execute(
+            """
+            UPDATE tenants AS t
+               SET timezone = p.timezone
+              FROM tenant_profiles AS p
+             WHERE p.tenant_id = t.id
+               AND p.timezone IS NOT NULL
+               AND p.timezone <> ''
+            """
+        )
+    finally:
+        op.execute("ALTER TABLE tenant_profiles ENABLE ROW LEVEL SECURITY")
+        op.execute("ALTER TABLE tenant_profiles FORCE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    # `tenant_profiles.timezone` nunca foi removida, então voltar é só descartar a coluna nova —
+    # e o que tiver sido editado em `tenants` depois desta migration se perde. É o preço de
+    # desfazer, e está registrado aqui em vez de descoberto no meio de um rollback.
+    op.drop_column("tenants", "timezone")

--- a/apps/api/tests/test_auth_timezone_rls.py
+++ b/apps/api/tests/test_auth_timezone_rls.py
@@ -1,0 +1,203 @@
+"""O fuso que a SESSÃO entrega precisa ser o fuso do tenant — no Postgres real, sob RLS.
+
+**Este bug é invisível para a suíte SQLite, e foi assim que ele passou.** `/auth/login`,
+`/auth/register`, `/auth/me` e `/auth/change-password` rodam em sessão CRUA (`get_db`, sem a GUC
+de tenant) e liam o fuso de `tenant_profiles`, que tem `FORCE ROW LEVEL SECURITY` desde a 0022.
+Sem a GUC, a policy filtra **o SELECT inteiro** — o `WHERE tenant_id = ...` explícito não ajuda,
+porque o problema nunca foi *qual* linha trazer, e sim *conseguir enxergar alguma*. O resultado
+era o fallback silencioso para `America/Sao_Paulo` em todo tenant, e o `useFuso()` do frontend
+inteiro sai desse valor.
+
+É a mesma armadilha do backfill da 0068 ("a RLS filtra SELECT também"), do outro lado do produto.
+
+Cada asserção vem com o CONTROLE POSITIVO ao lado (a mesma leitura com a GUC setada), para provar
+que ela falha pelo motivo certo — e não porque o dado não foi gravado.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+_API_DIR = Path(__file__).resolve().parents[1]
+
+# Um fuso REAL e diferente do padrão: se fosse America/Sao_Paulo, o teste passaria pelo bug.
+FUSO_DO_TENANT = "America/Manaus"
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original
+
+
+@contextmanager
+def _tenant_session(app_url: str, tenant_id: str):
+    """Sessão COM a GUC de tenant — o que as rotas de módulo de negócio usam."""
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :t, false)"), {"t": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            try:
+                yield session
+            finally:
+                session.close()
+    finally:
+        engine.dispose()
+
+
+@contextmanager
+def _raw_session(app_url: str):
+    """Sessão SEM tenant — exatamente o que `get_db` entrega às rotas de `/auth`."""
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            session = Session(bind=conn)
+            try:
+                yield session
+            finally:
+                session.close()
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def app_url() -> str:
+    with PostgresContainer("postgres:16-alpine", dbname=_DB_NAME) as pg:
+        super_url = pg.get_connection_url().replace(
+            "postgresql+psycopg2://", "postgresql+psycopg://"
+        )
+        _bootstrap_rls_role(super_url)
+        host = super_url.split("@", 1)[1]
+        url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}"
+        _run_migrations_as_app(url)
+        yield url
+
+
+@pytest.fixture()
+def tenant_com_fuso(app_url: str) -> str:
+    """Tenant que ESCOLHEU um fuso diferente do padrão, pelo caminho de produção."""
+    from app.modules.auth.models import Tenant
+    from app.modules.settings.models import TenantProfile
+
+    tenant_id = str(uuid4())
+    slug = f"manaus-{tenant_id[:8]}"
+    with _raw_session(app_url) as s:  # `tenants` é tabela GLOBAL, sem RLS
+        s.add(Tenant(id=tenant_id, slug=slug, legal_name="Manaus ME", document="11444777000161"))
+        s.commit()
+    with _tenant_session(app_url, tenant_id) as s:
+        s.add(TenantProfile(tenant_id=tenant_id, display_name="Manaus ME"))
+        s.commit()
+
+    from app.modules.settings.schemas import ProfileUpdate
+    from app.modules.settings.service import update_profile
+
+    with _tenant_session(app_url, tenant_id) as s:
+        update_profile(
+            s, tenant_id=tenant_id, actor="teste", data=ProfileUpdate(timezone=FUSO_DO_TENANT)
+        )
+        s.commit()
+    return tenant_id
+
+
+def test_a_sessao_de_auth_entrega_o_fuso_do_tenant(app_url: str, tenant_com_fuso: str):
+    """O caso que quebrava. `_tenant_out` roda em sessão crua — e precisa acertar mesmo assim."""
+    from app.modules.settings.service import timezone_of
+
+    with _raw_session(app_url) as s:
+        assert timezone_of(s, tenant_com_fuso) == FUSO_DO_TENANT
+
+
+def test_controle_positivo_a_sessao_de_tenant_tambem_acerta(app_url: str, tenant_com_fuso: str):
+    """Prova que o teste acima falha por RLS, e não porque o fuso não foi gravado."""
+    from app.modules.settings.service import tenant_timezone, timezone_of
+
+    with _tenant_session(app_url, tenant_com_fuso) as s:
+        assert timezone_of(s, tenant_com_fuso) == FUSO_DO_TENANT
+        assert tenant_timezone(s) == FUSO_DO_TENANT
+
+
+def test_tenant_sem_perfil_cai_no_padrao_sem_levantar(app_url: str):
+    """Fail-safe preservado: fuso ausente NUNCA derruba uma request de login."""
+    from app.core.tz import DEFAULT_TENANT_TIMEZONE
+    from app.modules.auth.models import Tenant
+    from app.modules.settings.service import timezone_of
+
+    tenant_id = str(uuid4())
+    with _raw_session(app_url) as s:
+        s.add(
+            Tenant(
+                id=tenant_id, slug=f"sem-perfil-{tenant_id[:8]}",
+                legal_name="Sem Perfil ME", document="11444777000161",
+            )
+        )
+        s.commit()
+        assert timezone_of(s, tenant_id) == DEFAULT_TENANT_TIMEZONE
+
+
+def test_tenant_inexistente_cai_no_padrao(app_url: str):
+    from app.core.tz import DEFAULT_TENANT_TIMEZONE
+    from app.modules.settings.service import timezone_of
+
+    with _raw_session(app_url) as s:
+        assert timezone_of(s, str(uuid4())) == DEFAULT_TENANT_TIMEZONE
+
+
+def test_o_fuso_NAO_atravessa_tenants(app_url: str, tenant_com_fuso: str):
+    """`tenants` é global e sem RLS: a leitura por id precisa continuar sendo POR ID.
+
+    Sem o filtro explícito, mover o fuso para uma tabela global trocaria um bug de fuso por um
+    vazamento entre tenants — que é infinitamente pior."""
+    from app.core.tz import DEFAULT_TENANT_TIMEZONE
+    from app.modules.auth.models import Tenant
+    from app.modules.settings.service import timezone_of
+
+    outro = str(uuid4())
+    with _raw_session(app_url) as s:
+        s.add(
+            Tenant(
+                id=outro, slug=f"outro-{outro[:8]}",
+                legal_name="Outro ME", document="11444777000161",
+            )
+        )
+        s.commit()
+        assert timezone_of(s, outro) == DEFAULT_TENANT_TIMEZONE
+        assert timezone_of(s, tenant_com_fuso) == FUSO_DO_TENANT

--- a/apps/api/tests/test_fuso_do_tenant.py
+++ b/apps/api/tests/test_fuso_do_tenant.py
@@ -96,12 +96,18 @@ def test_tenant_timezone_le_o_perfil_e_tem_default(db: Session, client: TestClie
 def test_tenant_timezone_respeita_o_fuso_configurado(
     db: Session, client: TestClient, headers: dict[str, str], tenant_id: str
 ):
-    from app.modules.settings import service as settings_service
+    """Configura pelo CAMINHO DE PRODUÇÃO (`PATCH /settings/profile`), não escrevendo no model.
+
+    A versão anterior fazia `profile.timezone = ...` — o que fixava o LOCAL DE ARMAZENAMENTO junto
+    com o comportamento. Quando o fuso saiu de `tenant_profiles` para `tenants` (migration 0072,
+    porque a RLS escondia a coluna das rotas de auth), este teste passou a falhar por gravar numa
+    coluna congelada, e não porque `tenant_timezone` tivesse quebrado. Passar pela rota testa a
+    mesma coisa sem amarrar o teste à tabela.
+    """
     from app.modules.settings.service import tenant_timezone
 
-    profile = settings_service.get_profile(db, tenant_id)
-    profile.timezone = "America/Manaus"
-    db.commit()
+    r = client.patch("/settings/profile", json={"timezone": "America/Manaus"}, headers=headers)
+    assert r.status_code == 200
 
     assert tenant_timezone(db) == "America/Manaus"
 

--- a/apps/api/tests/test_settings_timezone.py
+++ b/apps/api/tests/test_settings_timezone.py
@@ -1,0 +1,142 @@
+"""O fuso do tenant mora em `tenants` (migration 0073) — e nada mais lê a coluna do perfil.
+
+O bug que motivou a mudança só aparece no Postgres (RLS), e o gate contra a regressão vive em
+`test_auth_timezone_rls.py`. Aqui ficam as garantias que o SQLite consegue dar: o contrato de
+leitura/escrita e — principalmente — o **teste de ausência** que reprova quem voltar a ler
+`tenant_profiles.timezone`.
+
+Esse teste de ausência é o que impede o pior desfecho possível desta mudança: metade do sistema
+lendo a coluna nova e a outra metade a antiga, com as duas divergindo em silêncio no dia em que
+alguém trocar o fuso.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE
+from app.modules.auth.models import Tenant
+from app.modules.settings.service import tenant_timezone, timezone_of
+
+REGISTER = {
+    "legal_name": "Fuso ME",
+    "document": "11444777000161",
+    "slug": "fusome",
+    "email": "fuso@example.com",
+    "name": "Flávio",
+    "password": "uma-senha-bem-grande",
+}
+
+_APP = Path(__file__).resolve().parents[1] / "app"
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_o_padrao_e_sao_paulo(client: TestClient, headers):
+    assert client.get("/auth/me", headers=headers).json()["tenant"]["timezone"] == (
+        DEFAULT_TENANT_TIMEZONE
+    )
+
+
+def test_salvar_o_fuso_reverbera_na_SESSAO(client: TestClient, headers):
+    """O caminho inteiro: `/settings/profile` grava e `/auth/me` entrega.
+
+    São sessões diferentes (uma com tenant, outra crua) e é justamente essa fronteira que estava
+    quebrada — a tela salvava, e o login continuava devolvendo o padrão."""
+    r = client.patch(
+        "/settings/profile", json={"timezone": "America/Manaus"}, headers=headers
+    )
+    assert r.status_code == 200
+    assert r.json()["timezone"] == "America/Manaus"
+
+    assert client.get("/auth/me", headers=headers).json()["tenant"]["timezone"] == (
+        "America/Manaus"
+    )
+    assert client.get("/settings/profile", headers=headers).json()["timezone"] == (
+        "America/Manaus"
+    )
+
+
+def test_o_fuso_grava_em_TENANTS_nao_no_perfil(client: TestClient, headers, db: Session):
+    """Prova de onde o dado foi parar — não só de que a rota respondeu certo."""
+    from app.modules.settings.models import TenantProfile
+
+    client.patch("/settings/profile", json={"timezone": "America/Manaus"}, headers=headers)
+
+    assert db.query(Tenant).one().timezone == "America/Manaus"
+    # A coluna antiga fica congelada no default até ser dropada numa migration posterior.
+    assert db.query(TenantProfile).one().timezone == DEFAULT_TENANT_TIMEZONE
+
+
+def test_fuso_invalido_e_recusado(client: TestClient, headers):
+    r = client.patch("/settings/profile", json={"timezone": "Marte/Olympus"}, headers=headers)
+    assert r.status_code == 422
+
+
+def test_os_dois_resolvedores_concordam(client: TestClient, headers, db: Session):
+    """`tenant_timezone(db)` (sessão de tenant) e `timezone_of(db, id)` (sessão crua) respondem a
+    mesma pergunta. Divergirem seria o bug de novo, só que ao contrário."""
+    client.patch("/settings/profile", json={"timezone": "America/Belem"}, headers=headers)
+    tenant_id = db.query(Tenant).one().id
+
+    assert tenant_timezone(db) == "America/Belem"
+    assert timezone_of(db, tenant_id) == "America/Belem"
+
+
+def test_tenant_sem_perfil_cai_no_padrao(db: Session):
+    """Fail-safe: um fuso ausente nunca pode derrubar uma request."""
+    t = Tenant(slug="sem-perfil", legal_name="Sem Perfil", document="11444777000161")
+    db.add(t)
+    db.commit()
+
+    assert timezone_of(db, t.id) == DEFAULT_TENANT_TIMEZONE
+    assert tenant_timezone(db) == DEFAULT_TENANT_TIMEZONE
+
+
+# ── Teste de AUSÊNCIA ───────────────────────────────────────────────────────────────────
+
+# `settings/models.py` DECLARA a coluna (ela existe até ser dropada) e `settings/router.py` a
+# menciona só num comentário explicando por que não a usa. Fora daí, ninguém pode lê-la.
+_PODEM_MENCIONAR = {"modules/settings/models.py", "modules/settings/router.py"}
+
+
+def test_ninguem_le_mais_o_fuso_do_perfil():
+    """**Teste de ausência.** `tenant_profiles.timezone` está congelada: quem a ler vai receber o
+    valor do dia da migration, não o que o dono configurou depois.
+
+    Quando o fuso saiu do perfil, TRÊS consumidores continuavam lendo a coluna antiga — a Agenda
+    (evento de dia inteiro), o Cockpit (a janela do dia) e a validade das notificações. Nenhum
+    teste teria protestado: a coluna existe, tem valor e a leitura funciona. Só o dono, meses
+    depois, veria a Agenda discordar do login sobre que dia é hoje.
+
+    Este teste é o consumidor mecânico que aquela mudança não tinha.
+    """
+    ofensores: list[str] = []
+    for arquivo in _APP.rglob("*.py"):
+        rel = arquivo.relative_to(_APP).as_posix()
+        if rel in _PODEM_MENCIONAR:
+            continue
+        arvore = ast.parse(arquivo.read_text(encoding="utf-8"))
+        for no in ast.walk(arvore):
+            # `<algo>.timezone` onde `<algo>` é claramente um perfil — o padrão que existia nos
+            # três call sites (`profile.timezone`, `p.timezone`, `TenantProfile.timezone`).
+            if not isinstance(no, ast.Attribute) or no.attr != "timezone":
+                continue
+            base = no.value
+            nome = base.id if isinstance(base, ast.Name) else None
+            if nome in {"profile", "p", "perfil", "TenantProfile"}:
+                ofensores.append(f"{rel}:{no.lineno} ({nome}.timezone)")
+
+    assert not ofensores, (
+        "Estes pontos leem o fuso do PERFIL, que está congelado desde a migration 0073. "
+        "Use `settings.service.tenant_timezone(db)` (sessão de tenant) ou "
+        f"`timezone_of(db, tenant_id)` (sessão crua): {ofensores}"
+    )


### PR DESCRIPTION
## O bug

`/auth/login`, `/auth/register`, `/auth/me` e `/auth/change-password` rodam em sessão **crua**
(`get_db`, sem a GUC de tenant) e liam o fuso de `tenant_profiles` — que tem
`FORCE ROW LEVEL SECURITY` desde a migration 0022.

A policy filtra o **SELECT inteiro**. O `WHERE tenant_id = ...` explícito não ajudava: o problema
nunca foi *qual* linha trazer, e sim *conseguir enxergar alguma*. Todo tenant recebia
`America/Sao_Paulo`, e o `useFuso()` do frontend inteiro sai desse valor.

A docstring de `_tenant_out` explicava a escolha assim:

> *"Usa `timezone_of`, e não `tenant_timezone`, porque as rotas de auth rodam em sessão crua,
> ainda sem tenant no contexto de RLS."*

O raciocínio está certo e a conclusão está errada. É a mesma armadilha do backfill da 0068 já
registrada no `CLAUDE.md` — **a RLS filtra SELECT também** —, do outro lado do produto.

## Reprodução

Contra Postgres real (testcontainers, papel não-superusuário `e1p_app`), com controle positivo:

```
gravado no banco            : America/Manaus
timezone_of COM a GUC       : America/Manaus   ← controle positivo
timezone_of SEM a GUC (auth): America/Sao_Paulo
linhas visíveis sem a GUC   : 0
```

## O desenho

O fuso passa a morar em **`tenants`** — tabela GLOBAL sem RLS, que as rotas de auth já leem
naturalmente. Fuso é **identidade do tenant**, não brand kit. Isso elimina a classe do problema
em vez de contorná-la com uma sessão extra por login ou um bypass de RLS (as duas alternativas
consideradas; a segunda foge da decisão de arquitetura de que a RLS é a garantia única).

`tenants` não tem RLS, então **toda leitura precisa de filtro explícito por id** — mesma exceção
documentada de `users`. O gate `test_o_fuso_NAO_atravessa_tenants` existe porque trocar um bug de
fuso por um vazamento entre tenants seria infinitamente pior.

## O achado que importa mais que o bug

**Três consumidores liam a coluna do perfil** e não apareciam na investigação original: a Agenda
(âncora de evento de dia inteiro), o Cockpit (janela do dia) e a validade das notificações.

Corrigir só o `timezone_of` teria consertado o login e **quebrado os três em silêncio** — passariam
a ler uma coluna congelada, e o dono veria a Agenda discordar do login sobre que dia é hoje. Nenhum
teste protestaria: a coluna existe, tem valor, e a leitura funciona.

`test_ninguem_le_mais_o_fuso_do_perfil` (varredura AST) é o consumidor mecânico que faltava.
Validado por mutação: reintroduzido um `profile.timezone` no Cockpit, ele aponta
`modules/cockpit/router.py:44`.

## Sobre o alcance real

A tela `/config` **não tem seletor de fuso**. O campo existe na API e valida, mas nenhum
componente o escreve — então hoje o impacto em produção é provavelmente **zero**: todos estão no
default, que é o valor que o código quebrado devolvia.

Isso não diminui o bug, muda o risco de corrigi-lo: **não há dado divergente para migrar**. E
inverte a urgência — é uma armadilha armada para quem for adicionar o seletor, que veria o PATCH
responder certo e o login continuar errado.

## Migration 0072

- Backfill de `tenant_profiles` → `tenants`, com a **RLS desabilitada na janela**. Sem isso o
  `UPDATE ... FROM` casaria zero linhas e completaria com sucesso aparente (armadilha das
  0046/0066/0067/0068/0069, que o SQLite não pega).
- ⚠️ A RLS é aberta na tabela de **ORIGEM** (`tenant_profiles`), não na de destino — é a fonte da
  leitura que precisa estar visível.
- `tenant_profiles.timezone` **não é dropada**: um ciclo de conferência, como a 0066 fez.

## ⚠️ Colisão de numeração

A branch de #90 (Vima Onda 4) também escreveu uma `0072`. As duas saíram da mesma `main`; **a
segunda a mergear precisa virar `0073`**. Cada uma é válida isoladamente (`0071 ← 0072`), então o
CI passa nas duas.

## Verificação

- Backend: `1857 passed, 1 skipped`
- `test_auth_timezone_rls.py`: 5 testes contra **Postgres real**, cada asserção com controle positivo
- Gate de ausência validado por mutação
- `ruff` limpo

Um teste existente (`test_tenant_timezone_respeita_o_fuso_configurado`) foi atualizado: ele
configurava por `profile.timezone = ...`, o que fixava o local de armazenamento junto com o
comportamento. Agora passa por `PATCH /settings/profile` — mesma garantia, sem amarrar à tabela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)