### PR TITLE
fix: a Conferência dizia "sem saldo informado" a quem informou o saldo [gate 8.19/8.20]

### DIFF
--- a/apps/api/app/modules/bank/reconciliation.py
+++ b/apps/api/app/modules/bank/reconciliation.py
@@ -154,7 +154,14 @@ class ConferenciaConta:
     - **declarado, porém não comparável** (Story 8.20) — houve checkpoint na janela, mas o
       `reference_date` dele é a **própria data de abertura da conta**. O estado numérico é
       **idêntico** ao anterior, com **um** desvio deliberado: `saldo_banco_data` fica
-      **preenchido**. É o único discriminador que o consumidor tem entre *"você não me informou
+      **preenchido**. ⚠️ `saldo_banco_fonte` continua `None` aqui, mas **por outro motivo** que o do
+      estado anterior: houve porta de entrada (o checkpoint tem `origin`), e ela é **descartada de
+      propósito** — o eixo B qualifica um **valor**, e aqui não há valor (`saldo_banco_cents` é
+      `None`). Nomear a porta de um saldo que o payload não carrega é afirmar sobre o que não está
+      lá. Quem renderiza guarda por `saldo_banco_fonte is not None` e **omite a linha** — não a
+      traduz para um motivo (foi assim que a tela chegou a dizer *"sem saldo informado"* sobre esta
+      conta; ver `conferencia.ts::fonteLabel`).
+      `saldo_banco_data` é o único discriminador que o consumidor tem entre *"você não me informou
       saldo nenhum"* e *"você me informou, mas nesta data isso não decide nada"* — sem ele a tela
       responderia
       *"declare o saldo para eu conferir"* a quem acabou de declarar, em laço. Por que a comparação

--- a/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
+++ b/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
@@ -212,6 +212,10 @@ describe("AC4 — a frase vem ANTES da tabela, e nomeia a conta", () => {
     // repete a mesma resposta nas células de saldo — em nenhum lugar aparece um R$ 0,00 falso).
     expect(screen.getAllByText("Não sei").length).toBeGreaterThan(0);
     expect(screen.queryByText(/R\$\s*0,00/)).toBeNull();
+    // O eixo B qualifica um VALOR — com "Não sei" no lugar do valor não há porta de entrada que
+    // nomear, e o rótulo antigo ("sem saldo informado") afirmava sobre uma conta que **tem** saldo
+    // de partida, informado no cadastro (Story 8.19). A linha inteira sai.
+    expect(screen.queryByText("sem saldo informado")).toBeNull();
   });
 
   it("Story 8.20 — saldo informado na data de ABERTURA: a tela não manda declarar de novo", async () => {
@@ -251,6 +255,11 @@ describe("AC4 — a frase vem ANTES da tabela, e nomeia a conta", () => {
     // A data declarada continua visível na coluna do lado do banco (o campo segue preenchido).
     const corpo = container.querySelector("tbody") as HTMLElement;
     expect(within(corpo).getByText(/em 30\/07\/2026/)).toBeInTheDocument();
+    // ⚠️ **O achado do gate (F-1).** O AC5 enumerou três superfícies agregadas e faltou a quarta:
+    // o rótulo do eixo B, que renderizava `fonteLabel(null)` = "sem saldo informado" — na MESMA
+    // célula em que esta story acabou de escrever a data da declaração, e ao lado da nota que diz
+    // "Você informou o saldo desta conta em 30/07/2026". A linha se contradizia.
+    expect(within(corpo).queryByText("sem saldo informado")).toBeNull();
     // Nenhum ícone de alerta: é "não dá para conferir", não é erro.
     expect(screen.queryByLabelText("Divergência fora da tolerância")).toBeNull();
   });

--- a/apps/web/src/features/financeiro/ConferenciaPage.tsx
+++ b/apps/web/src/features/financeiro/ConferenciaPage.tsx
@@ -319,7 +319,13 @@ function LinhaConta({ conta: c }: { conta: ConferenciaConta }) {
         </p>
         {/* Os DOIS eixos, lado a lado e sem se misturarem: A = plano, B = porta de entrada. */}
         <p className="text-xs text-neutral-400">{origemLabel(c.saldo_banco_origem)}</p>
-        <p className="text-xs text-neutral-400">{fonteLabel(c.saldo_banco_fonte)}</p>
+        {/* O eixo B qualifica o VALOR acima. Sem valor não há porta a nomear: a linha some, em vez
+            de afirmar um motivo. O rótulo antigo dizia "sem saldo informado" também na conta que
+            declarou o saldo na data de abertura (8.20) e na que tem saldo de partida do cadastro
+            (8.19) — ver `fonteLabel`. */}
+        {c.saldo_banco_fonte !== null && (
+          <p className="text-xs text-neutral-400">{fonteLabel(c.saldo_banco_fonte)}</p>
+        )}
         {c.saldo_banco_data && (
           <p className="text-xs text-neutral-400">em {formatDateBR(c.saldo_banco_data)}</p>
         )}

--- a/apps/web/src/features/financeiro/conferencia.test.ts
+++ b/apps/web/src/features/financeiro/conferencia.test.ts
@@ -288,8 +288,12 @@ describe("FONTE_LABEL — eixo B, mapa SEPARADO do eixo A (D-3)", () => {
   it("traduz a porta de entrada do saldo externo", () => {
     expect(fonteLabel("manual")).toBe("informado por você");
     expect(fonteLabel("ofx")).toBe("lido do extrato");
-    expect(fonteLabel(null)).toBe("sem saldo informado");
     expect(fonteLabel("csv")).toBe("csv");
+    // ⚠️ **O caso `null` deixou de existir, e a ausência dele é a correção.** Ele devolvia
+    // "sem saldo informado" — falso nos DOIS estados não avaliáveis (ver o JSDoc de `fonteLabel`).
+    // Quem chama agora guarda por `saldo_banco_fonte !== null` e não renderiza a linha. A guarda de
+    // regressão não é uma asserção aqui: é o **tipo** (`string`, não `string | null`), que faz o
+    // `tsc` reprovar quem tentar reintroduzir a chamada com `null`.
   });
 
   it("os dois vocabulários NÃO se misturam — nenhuma chave em comum", () => {

--- a/apps/web/src/features/financeiro/conferencia.ts
+++ b/apps/web/src/features/financeiro/conferencia.ts
@@ -106,9 +106,26 @@ export const FONTE_LABEL: Record<string, string> = {
   ofx: "lido do extrato",
 };
 
-/** Rótulo do eixo B. `null` = nenhuma porta de entrada (não houve saldo informado). */
-export function fonteLabel(fonte: string | null): string {
-  if (fonte === null) return "sem saldo informado";
+/**
+ * Rótulo do eixo B. **O parâmetro NÃO aceita `null`, e isso é a correção — não estilo.**
+ *
+ * A forma anterior era `fonteLabel(fonte: string | null)` e devolvia **`"sem saldo informado"`**
+ * para `null`. `saldo_banco_fonte` é `null` nos **dois** estados não avaliáveis, e nos dois a frase
+ * era falsa:
+ *
+ * - **declarado, porém não comparável** (Story 8.20): o dono informou o saldo, e a célula ao lado
+ *   exibia a data dele (`em 30/07/2026`) enquanto esta linha dizia que não havia saldo informado —
+ *   a mesma linha se contradizia. É a quarta superfície agregada, que o AC5 da 8.20 não enumerou.
+ * - **sem checkpoint na janela** (Story 8.19): a conta **tem** saldo de partida, informado no
+ *   cadastro; `opening_balance_cents` e `opening_date` são `NOT NULL`. Dizer "sem saldo informado"
+ *   é a mesma afirmação sem lastro que a 8.19 removeu da nota do bloco 4.
+ *
+ * **O eixo B qualifica um VALOR** — ele diz por qual porta *aquele saldo* entrou. Onde o valor é
+ * `null` (a célula mostra "Não sei"), não há porta a nomear, e o consumidor **não renderiza a
+ * linha** em vez de inventar um motivo. O tipo estreito é a guarda mecânica: a frase falsa não pode
+ * voltar sem o `tsc` reprovar.
+ */
+export function fonteLabel(fonte: string): string {
   return FONTE_LABEL[fonte] ?? fonte;
 }
 

--- a/docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md
+++ b/docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md
@@ -1,0 +1,226 @@
+# Quality Gate — Epic 8, Stories 8.19 e 8.20 (o saldo de abertura e a comparação degenerada)
+
+> **Agente:** Aria (@architect) — o `quality_gate` nomeado nas duas stories · **Data:** 2026-08-07
+> **Base da revisão:** `main` @ `38053aa` — o código das duas stories **já está mergeado** (PR #71,
+> `deb7a1c`), então este gate revisa **produção**, não uma branch de entrega.
+> **Worktree isolado:** `.claude/worktrees/gate-8-19-8-20`, branch `gate/story-8-19-8-20`.
+> **Escopo:** 8.19 (AC1–AC7, IV1–IV7) e 8.20 (AC1–AC8, IV1–IV8).
+
+---
+
+## Veredito
+
+| Story | Veredito |
+|---|---|
+| **8.19** — *O saldo de abertura é uma declaração* | ✅ **PASS** — nada a corrigir |
+| **8.20** — *A comparação degenerada* | ✅ **PASS com correção aplicada** — 1 achado (**F-1**), corrigido neste gate |
+
+**Por que este gate não é formalidade.** As duas stories mudam o comportamento de um relatório que
+já roda em produção, e o arquivo central (`bank/reconciliation.py`) foi **tocado depois** do merge
+delas, pela PR #78 (o fuso do tenant). O gate precisava responder duas perguntas que a leitura das
+stories não responde: *os testes ainda matam os defeitos que elas corrigiram?* e *a restrição de
+verdade que elas escreveram vale em todas as superfícies?* A primeira: **sim**. A segunda: **não —
+faltava uma**.
+
+---
+
+## Os 7 quality checks
+
+| # | Check | Resultado | Evidência |
+|---|---|---|---|
+| 1 | **Testes passando** | ✅ PASS | Backend, os 2 arquivos do gate: **77 passed** (20,7s). Frontend, suíte **completa**: **57 files / 528 tests** passed. A suíte backend cheia e o `rls_e2e` foram executados **pelo fundador em outra janela**, sobre o checkout principal — ver *Limites deste gate* |
+| 2 | **Lint / typecheck** | ✅ PASS | `ruff check` → *All checks passed!* · `tsc --noEmit` (app web inteiro) exit 0 · `eslint --max-warnings 0` nos 4 arquivos tocados, exit 0 |
+| 3 | **ACs implementados** | ⚠️ → ✅ | Todos verificados em `arquivo:linha`. **AC5 da 8.20 estava incompleto** (F-1) — corrigido neste gate |
+| 4 | **Segurança / isolamento** | ✅ PASS | Nenhuma query nova nas duas stories; `opening_date` já vinha da `BankAccount` carregada. A correção do F-1 é frontend + docstring: **não toca banco, rota, schema nem query** |
+| 5 | **Regressão** | ✅ PASS | `projection.py`, `money_planes.py`, `financial_intelligence/schemas.py`, `bank/models.py`, `bank/schemas.py` e `bank/router.py` fora do diff. Nenhum campo de API mudou de tipo ou de valor |
+| 6 | **Qualidade dos testes (não-vácuo)** | ✅ PASS | **6 mutantes, 6 mortos** (tabela abaixo) — rodados agora, contra `main`, não contra a branch do @dev. Mais a prova de que as 2 asserções novas do F-1 **falham** antes da correção |
+| 7 | **Documentação / rastreabilidade** | ✅ PASS | A docstring da dataclass documentava a razão **errada** do `saldo_banco_fonte = None` no terceiro estado — corrigida junto (ver F-1) |
+
+---
+
+## Mutação — os 6 mutantes, todos MORTOS
+
+Rodados contra `main` @ `38053aa`, com a suíte de gate
+(`test_bank_reconciliation_report.py` + `test_financial_intelligence_diagnostics_completude.py`,
+77 testes). Reversão sempre por **cópia de arquivo**, com verificação byte a byte no fim.
+
+| # | Story | Mutação | Resultado |
+|---|---|---|---|
+| M1 | 8.19 | a queda para `opening_date` some (volta ao `None` da 8.5) | **MORTO** — 7 falhas |
+| M4 | 8.19 | sem `min(end, today)` — relatório de período passado conta até hoje | **MORTO** — 7 falhas |
+| M1 | 8.20 | `degenerada = False` — a guarda inteira some | **MORTO** — 3 falhas |
+| M2 | 8.20 | o remédio errado *"se der zero, ignore"* (`… and balance_cents == opening_balance_cents`) | **MORTO** — 1 falha, **só** o teste do ramo B |
+| M3 | 8.20 | `saldo_banco_data=None` (o alinhamento estrito do §Escalado 1) | **MORTO** — 2 falhas |
+| M4 | 8.20 | a nota reusada (`_note_sem_checkpoint` no caso degenerado) | **MORTO** — 2 falhas |
+
+**O que o M1 da 8.19 e o M4 da 8.20 provam juntos:** a reescrita de `today` que a PR #78 fez neste
+mesmo arquivo, **depois** do merge das duas stories, não esvaziou nenhum dos dois testes. Era a
+pergunta central deste gate.
+
+---
+
+## F-1 — o AC5 da 8.20 enumerou três superfícies agregadas; havia uma quarta
+
+**Severidade:** média. Afirmação falsa na tela, sem número errado. **Status: CORRIGIDO neste gate.**
+
+### O defeito
+
+`saldo_banco_fonte` (eixo B — a porta por onde o saldo externo entrou) é `None` nos **dois** estados
+não avaliáveis. O rótulo dele, `conferencia.ts::fonteLabel`, traduzia `null` para a string literal
+**`"sem saldo informado"`**, e `ConferenciaPage.tsx` a renderizava **sem guarda**. Na linha da conta
+degenerada, a célula do lado do banco saía assim:
+
+```
+Não sei                  ← saldo_banco_cents = None
+indisponível             ← eixo A
+sem saldo informado      ← eixo B  ⚠️ FALSO: o dono informou
+em 30/07/2026            ← saldo_banco_data, acrescentado pela PRÓPRIA 8.20
+```
+
+…com a nota da conta, na coluna ao lado, dizendo *"Você informou o saldo desta conta em
+30/07/2026"*. **A mesma linha se contradizia.**
+
+É exatamente a restrição que a 8.20 escreveu para si mesma, no *Contrato entregue à Story 8.16*:
+
+> *"nenhuma superfície agregada pode voltar a afirmar 'sem saldo informado' — a conta **tem** saldo
+> informado."*
+
+A story enumerou três (`_note_total_parcial`, o motivo do `engine.py`, `avisoTotalParcial` + o
+contador da tela) e corrigiu as três. A quarta não estava na lista porque não é uma frase sobre o
+agregado: é um **rótulo de campo**, e ninguém procurou a mentira nessa forma.
+
+**O mesmo rótulo atinge a linha da 8.19** (conta sem checkpoint na janela): ali `fonte` é `null` de
+verdade, mas a conta **tem** saldo de partida do cadastro — e dizer *"sem saldo informado"* ao lado
+de uma nota que diz *"O e1p tem o saldo de partida desta conta, informado por você em {data}"* é a
+mesma afirmação sem lastro que a 8.19 removeu da nota. A 8.19 registrou `conferencia.ts:331` como
+achado vizinho e **não viu** este.
+
+### A prova (medida, não deduzida)
+
+Sonda inserida no próprio teste da 8.20 para o caso degenerado, contra o código de produção:
+
+```
+AssertionError: expected <p class="text-xs text-neutral-400">sem saldo informado</p> to be null
+```
+
+A mesma asserção falhou também no teste do caso sem checkpoint. **Duas falhas, dois cenários** —
+foi assim que as asserções entraram: falhando primeiro.
+
+### A correção — desenho **A**, decidido pelo fundador
+
+Três desenhos foram postos na mesa. O escolhido é o que **não reabre contrato**:
+
+| | Linha degenerada | Linha sem checkpoint | Custo |
+|---|---|---|---|
+| **A** — só frontend, guardando por `fonte === null` | rótulo some | rótulo some | **nenhuma AC contrariada, nenhuma asserção mudada** |
+| B — só backend (`fonte = na_janela.origin`) | *"informado por você"* | **continua mentindo** | contraria o AC1 da 8.20 + a asserção de `_assert_degenerada` |
+| C — os dois, desenhados juntos | *"informado por você"* | rótulo some | o mais informativo; alarga o contrato |
+
+**Por que A, e o argumento é de informação — não de esforço.** Na linha degenerada,
+*"informado por você"* seria a **terceira cópia do mesmo fato na mesma linha**: a nota já diz
+*"Você informou o saldo desta conta em 30/07/2026"* e `saldo_banco_data` já renderiza
+*"em 30/07/2026"*. O eixo B existe para distinguir `manual` × `ofx`, e na Onda 1 só existe `manual`
+— hoje ele não distingue nada. **Ele ganha o lugar dele ao lado de um número, não ao lado de um
+"Não sei".** O desenho B compra coerência de contrato e **zero informação nova** na tela, ao preço
+de reabrir uma AC e uma asserção de duas stories já mergeadas.
+
+⚠️ **A armadilha que o desenho A evita, e que fica registrada:** empilhar a guarda do frontend
+sobre a correção do backend, guardando por `saldo_banco_cents === null`, faria o campo novo do
+backend virar **código morto** — carregado e nunca renderizado. É a lição do item 12 do
+`CLAUDE.md` (§WhatsApp Evolution): *capacidade nova nasce com o consumidor no mesmo passo*. Se um
+dia o desenho C for retomado, a guarda tem de ser `fonte === null`, nunca `cents === null`.
+
+### O diff (5 arquivos, +49/−6) — zero lógica de negócio
+
+| Arquivo | Mudança |
+|---|---|
+| `apps/web/src/features/financeiro/conferencia.ts` | `fonteLabel(fonte: string)` — o parâmetro **deixa de aceitar `null`** e o ramo que devolvia a frase falsa deixa de existir |
+| `apps/web/src/features/financeiro/ConferenciaPage.tsx` | a linha do eixo B só é renderizada quando `saldo_banco_fonte !== null` |
+| `apps/web/src/features/financeiro/ConferenciaPage.test.tsx` | 2 asserções — os dois estados não avaliáveis não afirmam mais sobre a porta |
+| `apps/web/src/features/financeiro/conferencia.test.ts` | cai o caso `fonteLabel(null)`, com o registro do porquê |
+| `apps/api/app/modules/bank/reconciliation.py` | **doc-only** — a docstring justificava o `fonte = None` do terceiro estado com *"não houve porta de entrada"*, que é **falso ali**: houve checkpoint e ele tem `origin`. Agora diz que a porta existe e é descartada de propósito, e nomeia quem renderiza |
+
+### A guarda de regressão é o TIPO, e ela morde
+
+O tipo estreito (`string`, não `string | null`) é o que impede a frase falsa de voltar. Verificado
+por mutação, não afirmado: removida a guarda do consumidor, o `tsc` reprova.
+
+```
+src/features/financeiro/ConferenciaPage.tsx(326,61): error TS2345:
+  Argument of type 'string | null' is not assignable to parameter of type 'string'.
+```
+
+Escolha deliberada: uma **asserção** de teste só protege o caminho que ela exercita; o tipo protege
+todos os call sites, inclusive os que ainda não existem. É a mesma disciplina de
+`payables.is_overdue` exigir `today` como parâmetro obrigatório.
+
+---
+
+## Limites deste gate — o que NÃO foi verificado aqui
+
+Registrado com honestidade, porque um gate que esconde o que não cobriu é pior que nenhum gate.
+
+1. **A suíte backend completa e o `rls_e2e` não foram executados neste worktree.** Foram rodados
+   pelo fundador em outra janela, **sobre o checkout principal** — ou seja, **sem as 5 alterações
+   do F-1**. O risco disso é baixo e é nomeável: a única mudança backend do F-1 é uma **docstring**,
+   sem efeito em runtime. A mudança com risco real é frontend, e essa foi coberta pela suíte
+   **completa** de vitest aqui (57 files / 528 tests).
+2. **Os 3 agentes de QA do `CLAUDE.md` §5** (regression-tester, bug-hunter, dedup-checker) não
+   foram executados. Substituídos, como nas duas stories, pelos 6 mutantes + a prova de falha das
+   asserções novas.
+3. **Aceite visual em ~360px não foi feito.** A correção **remove** uma linha de texto da célula,
+   então não pode estourar layout que já cabia — mas isso é raciocínio, não medição. Some-se à
+   dívida de 360px já registrada no `CLAUDE.md` para a tela de Conferência.
+4. **`packages/shared-types/src/generated.ts`** segue defasado e sem menção a `bank` (dívida
+   conhecida). Este gate não muda contrato de API, então não agrava.
+
+---
+
+## Achados herdados — confirmados abertos, NÃO corrigidos aqui
+
+Nenhum é regressão destas stories; todos já estavam registrados por elas.
+
+1. **`conferencia.ts:331`** — `if (dias === null) return "Esta conta nunca teve saldo informado."`
+   virou **código morto** com a 8.19 (o backend nunca mais devolve `null`). Ramo defensivo,
+   registrado pela própria 8.19 (desvio 3). **Não tocado** — removê-lo é escopo a mais e tiraria a
+   defesa se algum consumidor futuro voltar a mandar `null`.
+2. **`bank/router.py:624`** — o OpenAPI da rota de conferência descreve **um** dos dois motivos de
+   `indisponivel`, e quem ler conclui que `indisponivel ⇒ saldo_banco_data === null`. Registrado
+   pela 8.20 (achado 1); `router.py` está na lista **NÃO TOCAR** do AC7 dela. Recomendação mantida:
+   é da **8.16**.
+3. **`contas_sem_checkpoint`** — o nome do campo ficou impreciso (conta também as que **têm**
+   checkpoint, o degenerado). O **texto** de todas as superfícies foi corrigido; o **nome do campo
+   de API** não, porque renomear é campo novo. Recomendação mantida: aposentar na **8.16**.
+4. **SIG-001** (a virada de mês apaga uma conferência recente) e **REL-002** (conta arquivada sai
+   do relatório sem nota) continuam abertos, intocados.
+5. **`days_since_last_declared_balance`** continua implementada e **sem consumidor** — e as duas
+   stories **proíbem** usá-la na conferência (pergunta diferente, conjunto diferente).
+
+---
+
+## A lição de método que vale mais que o achado
+
+As duas stories caçaram afirmações falsas com um rigor incomum — e a 8.20 chegou a escrever a
+restrição de verdade em forma de contrato para a story seguinte. Mesmo assim, o AC5 varreu as
+superfícies **em forma de frase** (`_note_total_parcial`, o motivo do motor, `avisoTotalParcial`) e
+não alcançou a que estava em forma de **rótulo de campo**.
+
+> **Regra que fica:** ao remover uma afirmação falsa, a varredura é pelo **fato afirmado**, não pela
+> forma da frase. `grep` pela string é o começo — o que fecha é perguntar *quais elementos da tela
+> qualificam este campo*, porque um rótulo de enum afirma tanto quanto uma sentença, e não parece
+> uma sentença para quem procura.
+
+É a mesma família da **INSTANCIAÇÃO OBRIGATÓRIA** já registrada no `CLAUDE.md`: um conjunto definido
+por descrição (*"as superfícies agregadas"*) nasceu com três membros escritos e nenhum não-membro —
+e o quarto membro nunca teve quem protestasse por ele.
+
+---
+
+## Encaminhamento
+
+- **8.19 → `Done`.** Nada pendente.
+- **8.20 → segue `InReview`** até a correção do F-1 mergear, porque o F-1 é do escopo do **AC5
+  dela**, não um achado vizinho. Mergeada a correção, vai para `Done` sem novo gate.
+- A correção vive na branch **`gate/story-8-19-8-20`** e precisa de **PR** — `main` é protegida
+  (4 checks obrigatórios) e `git push` é exclusivo do **@devops**. **Nada foi enviado por este
+  gate.**

--- a/docs/stories/8.19.story.md
+++ b/docs/stories/8.19.story.md
@@ -1,7 +1,10 @@
 # Story 8.19: O saldo de abertura é uma declaração — o e1p para de dizer que ela não existe
 
 ## Status
-InReview — ⚠️ **ESCOPO REDUZIDO E BLOQUEADO EM PARTE.** Ver "Como esta story chegou aqui" antes de qualquer coisa: a premissa da versão 0.1 (*"a Projeção afirma sem lastro"*) foi **refutada pelo fundador** e a Projeção **não é mais tocada por esta story**. O que sobrou é real, menor, e uma parte depende de decisão da @architect.
+**Done** — gate da @architect em 2026-08-07: **PASS**, nada a corrigir
+(`docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md`). Ver "QA Results" no fim do arquivo.
+
+⚠️ **ESCOPO REDUZIDO E BLOQUEADO EM PARTE.** Ver "Como esta story chegou aqui" antes de qualquer coisa: a premissa da versão 0.1 (*"a Projeção afirma sem lastro"*) foi **refutada pelo fundador** e a Projeção **não é mais tocada por esta story**. O que sobrou é real, menor, e uma parte depende de decisão da @architect.
 
 ## Executor Assignment
 ```yaml
@@ -406,3 +409,36 @@ Test Files  53 passed (53)
 - `apps/api/tests/test_financial_intelligence_diagnostics_completude.py` — 2 pontos da lista fechada atualizados + `_account` ganhou o parâmetro opcional `opening_date` + **2 testes novos** (o do AC4 e o da verificação de que ele não é vazio)
 
 **Não alterados, e isso é parte do entregável:** `projection.py`, `money_planes.py`, `engine.py`, `financial_intelligence/schemas.py`, `financial_intelligence/diagnostics.py`, `bank/service.py`, `bank/models.py`, `bank/schemas.py`, `bank/router.py`, `projecao.ts`, `ProjecaoCaixaPage.tsx`, `ContasSaldosPage.tsx`, `conferencia.ts`, `ConferenciaPage.tsx`. **Sem migration, sem backfill, sem coluna, sem campo novo de API.**
+
+## QA Results
+
+**Gate da @architect (Aria) — 2026-08-07 · veredito: ✅ PASS.** Artefato completo:
+`docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md`. Revisto contra `main` @ `38053aa` (o código já está
+mergeado, PR #71), em worktree isolado.
+
+**O que o gate verificou, e não apenas releu:**
+
+| AC/IV | Evidência |
+|---|---|
+| AC1 | `reconciliation.py::_conferir_conta` — a queda para `account.opening_date` está viva, com `min(end, today)` e `max(0, …)` comuns aos dois ramos |
+| AC2 | `_note_sem_checkpoint(opening_date)` é função, separa as duas afirmações, sem `"no banco"` |
+| AC4 | `divergencia_cents is not None` é o **primeiro** termo de `todas_batendo` (`engine.py`) — a guarda do 🟢 não foi tocada |
+| AC5 | `service.days_since_last_declared_balance` intacta e **ainda sem consumidor** (só testes a chamam) |
+| AC6 | `projection.py` fora do diff |
+
+**Mutação (a pergunta que só o gate podia responder).** `reconciliation.py` foi tocado **depois**
+do merge desta story, pela PR #78 (o fuso do tenant). Os dois mutantes que importam foram rodados
+agora, contra `main`: a queda para `opening_date` sumindo → **7 falhas**; sem `min(end, today)` →
+**7 falhas**. **A reescrita de `today` não esvaziou nenhum dos testes desta story.**
+
+**Um achado, e ele não é desta story — mas atinge uma linha dela.** O gate encontrou que
+`conferencia.ts::fonteLabel` traduzia `saldo_banco_fonte === null` para a string
+**`"sem saldo informado"`**, renderizada sem guarda. Na conta sem checkpoint na janela — o cenário
+desta story — isso aparecia **ao lado** da nota do AC2, que diz *"O e1p tem o saldo de partida desta
+conta, informado por você em {data}"*. É a mesma afirmação sem lastro que o AC2 removeu da nota,
+sobrevivendo num rótulo de campo. Registrado como **F-1** no gate, sob a Story 8.20 (é o AC5 dela),
+e **corrigido lá** — a correção fecha as duas linhas de uma vez.
+
+**Achado vizinho confirmado aberto, não corrigido:** `conferencia.ts:331` segue sendo o código morto
+que o desvio 3 desta story registrou. Recomendação mantida — não tocar; é defesa, não mentira
+exibida.

--- a/docs/stories/8.20.story.md
+++ b/docs/stories/8.20.story.md
@@ -789,7 +789,103 @@ recomendava. A razão, e ela é verificável e não estética:
 **Sem migration, sem campo novo de API ou schema, sem escrita em banco, sem arquivo novo.**
 
 ## QA Results
-_(a preencher pelo @qa)_
+
+**Gate da @architect (Aria) — 2026-08-07 · veredito: ✅ PASS com correção aplicada.** Artefato
+completo: `docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md`. Revisto contra `main` @ `38053aa` (código
+já mergeado, PR #71), em worktree isolado.
+
+AC1, AC2, AC3, AC4, AC6, AC7 e AC8 conferem em `arquivo:linha`. **O AC5 estava incompleto** — ver
+F-1. Um achado, corrigido neste gate.
+
+### Mutação — 4 mutantes desta story, todos MORTOS
+
+Rodados **agora, contra `main`**, com os 77 testes dos dois arquivos de gate. Importa porque
+`reconciliation.py` foi tocado **depois** do merge desta story, pela PR #78 (o fuso do tenant).
+
+| Mutante | Resultado |
+|---|---|
+| `degenerada = False` — a guarda inteira some | **MORTO** — 3 falhas |
+| o remédio errado *"se der zero, ignore"* | **MORTO** — 1 falha, **só** o teste do ramo B |
+| `saldo_banco_data=None` (o §Escalado 1) | **MORTO** — 2 falhas |
+| a nota reusada (`_note_sem_checkpoint`) | **MORTO** — 2 falhas |
+
+O segundo é o mais valioso: confirma, em `main`, que **o teste do ramo B é o único** que separa
+*"a comparação não vale"* de *"se der zero, ignore"*. A decisão de escrevê-lo se paga aqui.
+
+### F-1 — o AC5 enumerou TRÊS superfícies agregadas; havia uma QUARTA
+
+**Severidade: média** (afirmação falsa na tela, sem número errado). **CORRIGIDO neste gate.**
+
+`saldo_banco_fonte` é `None` nos dois estados não avaliáveis, e
+`conferencia.ts::fonteLabel` traduzia esse `null` para a string literal **`"sem saldo informado"`**,
+renderizada em `ConferenciaPage.tsx` **sem guarda**. Na linha da conta degenerada:
+
+```
+Não sei                  ← saldo_banco_cents = None
+indisponível             ← eixo A
+sem saldo informado      ← eixo B  ⚠️ FALSO
+em 30/07/2026            ← saldo_banco_data, que ESTA story acrescentou
+```
+
+…com a nota desta story, na coluna ao lado, dizendo *"Você informou o saldo desta conta em
+30/07/2026"*. **A mesma linha se contradizia** — e é exatamente a restrição que esta story escreveu
+no *Contrato entregue à Story 8.16*: *"nenhuma superfície agregada pode voltar a afirmar 'sem saldo
+informado' — a conta **tem** saldo informado"*.
+
+**Por que escapou:** o AC5 varreu as superfícies **em forma de frase** e as corrigiu todas. A quarta
+está em forma de **rótulo de campo**, e não parece uma sentença para quem procura uma sentença.
+
+**Provado, não deduzido:** sonda no próprio teste desta story falhou com
+`expected <p class="text-xs text-neutral-400">sem saldo informado</p> to be null` — e a mesma
+asserção falhou também no cenário da 8.19 (conta sem checkpoint), o que mostra que o rótulo atinge
+as **duas** linhas.
+
+**Correção — desenho A, decidido pelo fundador:** o consumidor guarda por
+`saldo_banco_fonte !== null` e **omite a linha**; `fonteLabel` deixa de aceitar `null`. Rejeitado o
+desenho B (preencher `saldo_banco_fonte = na_janela.origin` no ramo degenerado): contrariaria o AC1
+e a asserção de `_assert_degenerada`, e compraria **zero informação nova** — *"informado por você"*
+seria a **terceira cópia do mesmo fato na mesma linha** (a nota e `saldo_banco_data` já o dizem). O
+eixo B qualifica um **valor**; ao lado de um "Não sei" ele não distingue nada — na Onda 1 só existe
+`manual`.
+
+⚠️ **Se o desenho B/C for retomado um dia, a guarda tem de ser `fonte === null` e nunca
+`cents === null`** — esta segunda faria o campo do backend virar código morto, a armadilha do item
+12 do `CLAUDE.md` (*capacidade nova nasce com o consumidor no mesmo passo*).
+
+**5 arquivos, +49/−6, zero lógica de negócio:** `conferencia.ts` (o tipo estreito),
+`ConferenciaPage.tsx` (a guarda), os 2 arquivos de teste do frontend, e `reconciliation.py` —
+**doc-only**: a docstring da dataclass justificava o `saldo_banco_fonte = None` do terceiro estado
+com *"não houve porta de entrada"*, que é **falso ali** (houve checkpoint e ele tem `origin`; a
+porta é descartada de propósito, porque não há valor a qualificar).
+
+**A guarda de regressão é o TIPO, e ela morde** — verificado por mutação: removida a guarda do
+consumidor, `tsc` reprova com `TS2345: Argument of type 'string | null' is not assignable to
+parameter of type 'string'`. Uma asserção protegeria só o caminho que exercita; o tipo protege todos
+os call sites, inclusive os que ainda não existem.
+
+### Verificação
+
+`ruff` limpo · `tsc --noEmit` limpo no app web inteiro · `eslint --max-warnings 0` limpo nos 4
+arquivos · backend, os 2 arquivos de gate: **77 passed** · frontend, suíte **completa**:
+**57 files / 528 tests** passed.
+
+⚠️ **Limite declarado:** a suíte backend completa e o `rls_e2e` foram executados pelo fundador em
+outra janela, **sobre o checkout principal — sem estas 5 alterações**. A única mudança backend do
+F-1 é uma docstring (sem efeito em runtime); a mudança com risco real é frontend, e essa foi coberta
+pela suíte completa de vitest. Os 3 agentes de QA do `CLAUDE.md` §5 não foram executados
+(substituídos pelos mutantes, como nas duas stories).
+
+### Status
+
+Segue **`InReview`** até a correção do F-1 mergear: ela é do escopo do **AC5 desta story**, não um
+achado vizinho. A correção vive na branch `gate/story-8-19-8-20` e precisa de **PR** — `main` é
+protegida e `git push` é exclusivo do **@devops**. Mergeada, vai para `Done` sem novo gate.
+
+### Achados desta story confirmados abertos (não corrigidos aqui)
+
+`bank/router.py:624` (o OpenAPI descreve um só dos dois motivos) e `contas_sem_checkpoint` (nome
+impreciso) seguem como estavam, com a recomendação mantida: são da **8.16**. SIG-001 e REL-002,
+idem.
 
 ---
 


### PR DESCRIPTION
## Resumo

Gate da **@architect** sobre as Stories **8.19** e **8.20**, que já estão em produção (PR #71). O gate revisa `main`, não uma entrega. Veredito: **8.19 PASS**, **8.20 PASS com uma correção** — que é o que este PR traz.

O AC5 da 8.20 mandou remover a afirmação *"sem saldo informado"* de toda superfície agregada e enumerou três. **Havia uma quarta.**

`saldo_banco_fonte` é `None` nos dois estados não avaliáveis, e `conferencia.ts::fonteLabel` traduzia esse `null` para a string literal `"sem saldo informado"`, renderizada em `ConferenciaPage.tsx` **sem guarda**. Na linha da conta que declarou o saldo na data de abertura:

```
Não sei                  ← saldo_banco_cents = None
indisponível             ← eixo A
sem saldo informado      ← eixo B  ⚠️ FALSO: o dono informou
em 30/07/2026            ← saldo_banco_data, que a PRÓPRIA 8.20 acrescentou
```

…com a nota da conta, na coluna ao lado, dizendo *"Você informou o saldo desta conta em 30/07/2026"*. **A mesma linha se contradizia.** Na conta sem checkpoint na janela, o mesmo rótulo repetia a afirmação sem lastro que o AC2 da 8.19 tinha acabado de remover da nota.

**Por que escapou:** o AC5 varreu as superfícies **em forma de frase** e corrigiu todas. A quarta está em forma de **rótulo de campo** — e não parece uma sentença para quem procura uma sentença.

## A correção

O **eixo B qualifica um VALOR**: ele diz por qual porta *aquele saldo* entrou. Sem valor (a célula mostra "Não sei") não há porta a nomear, e o consumidor **omite a linha** em vez de inventar um motivo.

`fonteLabel` deixa de aceitar `null` — o tipo estreito é a **guarda mecânica**, e ela morde. Removida a guarda do consumidor, o `tsc` reprova:

```
src/features/financeiro/ConferenciaPage.tsx(326,61): error TS2345:
  Argument of type 'string | null' is not assignable to parameter of type 'string'.
```

Escolha deliberada: uma asserção protege só o caminho que exercita; o tipo protege **todos os call sites**, inclusive os que ainda não existem. Mesma disciplina de `payables.is_overdue` exigir `today` obrigatório.

**Desenho alternativo rejeitado** (preencher `saldo_banco_fonte = na_janela.origin` no ramo degenerado): contrariaria o AC1 da 8.20 e a asserção de `_assert_degenerada`, e compraria **zero informação nova** — *"informado por você"* seria a **terceira cópia do mesmo fato na mesma linha**. O eixo B só distingue `manual` × `ofx`, e na Onda 1 só existe `manual`.

⚠️ Registrado no gate: se esse desenho for retomado, a guarda tem de ser `fonte === null` e **nunca** `cents === null` — esta segunda faria o campo do backend virar código morto (a lição do item 12 do `CLAUDE.md`: *capacidade nova nasce com o consumidor no mesmo passo*).

`reconciliation.py` entra **só por docstring**: ela justificava o `fonte = None` do terceiro estado com *"não houve porta de entrada"*, que é falso ali — houve checkpoint e ele tem `origin`; a porta é descartada de propósito.

## Arquivos (+49/−6 de código, zero lógica de negócio)

| Arquivo | Mudança |
|---|---|
| `apps/web/.../conferencia.ts` | `fonteLabel(fonte: string)` — o ramo da frase falsa deixa de existir |
| `apps/web/.../ConferenciaPage.tsx` | a linha do eixo B só renderiza com `saldo_banco_fonte !== null` |
| `apps/web/.../ConferenciaPage.test.tsx` | 2 asserções — os dois estados não avaliáveis |
| `apps/web/.../conferencia.test.ts` | cai o caso `fonteLabel(null)`, com o porquê |
| `apps/api/.../bank/reconciliation.py` | **doc-only** |
| `docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md` | o artefato do gate |
| `docs/stories/8.19.story.md` | → **Done** + QA Results |
| `docs/stories/8.20.story.md` | QA Results (segue `InReview` até este PR mergear — o F-1 é o AC5 dela) |

## Como foi verificado

**As 2 asserções novas falharam contra o código de produção antes da correção**, nos dois cenários:

```
AssertionError: expected <p class="text-xs text-neutral-400">sem saldo informado</p> to be null
```

**6 mutantes das duas stories, rodados contra `main`** — depois da PR #78, que reescreveu `today` neste mesmo arquivo. **Todos mortos:**

| Mutante | Resultado |
|---|---|
| 8.19 — a queda para `opening_date` some | MORTO (7 falhas) |
| 8.19 — sem `min(end, today)` | MORTO (7 falhas) |
| 8.20 — `degenerada = False` | MORTO (3 falhas) |
| 8.20 — o remédio errado *"se der zero, ignore"* | MORTO (1 falha, **só** o teste do ramo B) |
| 8.20 — `saldo_banco_data=None` | MORTO (2 falhas) |
| 8.20 — a nota reusada | MORTO (2 falhas) |

**Suítes:** `ruff` limpo · `tsc --noEmit` limpo no app web inteiro · `eslint --max-warnings 0` limpo · backend **77 passed** nos 2 arquivos de gate · frontend, suíte **completa**: **57 files / 528 tests** passed.

⚠️ **Limite declarado:** a suíte backend completa e o `rls_e2e` foram executados sobre o checkout principal, **sem estas alterações**. A única mudança backend aqui é uma docstring (sem efeito em runtime); a mudança com risco real é frontend, e essa está coberta pela suíte completa de vitest. Os 4 checks obrigatórios do CI fecham essa lacuna.

## Sem risco de migration

Zero migration, zero coluna, zero campo de API, zero query. Nenhum contrato HTTP mudou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
