### PR TITLE
docs: Story 8.20 fecha em Done — o F-1 do gate mergeou [Story 8.20]

### DIFF
--- a/docs/stories/8.20.story.md
+++ b/docs/stories/8.20.story.md
@@ -1,7 +1,11 @@
 # Story 8.20: A comparação degenerada — um checkpoint na data de abertura não pode dizer "está tudo batendo"
 
 ## Status
-InReview
+**Done** — gate da @architect em 2026-08-07: **PASS**
+(`docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md`). O único achado, o **F-1** (o AC5 tinha enumerado
+três superfícies agregadas e havia uma quarta, em forma de rótulo de campo), foi corrigido e
+**mergeado na PR #95** com os 4 checks verdes — incluindo o `test-in-prod-image`, que roda a suíte
+completa na imagem de produção. Ver "QA Results" no fim do arquivo.
 
 ## Executor Assignment
 ```yaml
@@ -875,11 +879,14 @@ F-1 é uma docstring (sem efeito em runtime); a mudança com risco real é front
 pela suíte completa de vitest. Os 3 agentes de QA do `CLAUDE.md` §5 não foram executados
 (substituídos pelos mutantes, como nas duas stories).
 
-### Status
+### Status — **Done** (2026-08-07)
 
-Segue **`InReview`** até a correção do F-1 mergear: ela é do escopo do **AC5 desta story**, não um
-achado vizinho. A correção vive na branch `gate/story-8-19-8-20` e precisa de **PR** — `main` é
-protegida e `git push` é exclusivo do **@devops**. Mergeada, vai para `Done` sem novo gate.
+Ficou em `InReview` até a correção do F-1 mergear, porque ela é do escopo do **AC5 desta story**, não
+um achado vizinho. **Mergeada na PR #95** (`3c0be65`), com os 4 checks obrigatórios verdes.
+
+O `test-in-prod-image` fechou o limite que este gate havia declarado: a suíte backend completa rodou
+**com** as alterações do F-1, na imagem de produção — verificação que nem o gate nem a execução
+paralela do fundador tinham feito sobre esse diff.
 
 ### Achados desta story confirmados abertos (não corrigidos aqui)
 


### PR DESCRIPTION
## Resumo

Só o **Status** da Story 8.20: `InReview` → **Done**. Nenhuma outra linha da story muda, nenhum arquivo de código.

Ela ficou em `InReview` de propósito depois do gate da @architect, porque o achado **F-1** era do escopo do **AC5 dela** — não um achado vizinho. O AC5 mandou remover a afirmação *"sem saldo informado"* de toda superfície agregada, enumerou três, e havia uma quarta, em forma de **rótulo de campo** (`fonteLabel`).

Corrigido e mergeado na **PR #95** (`3c0be65`), com os 4 checks obrigatórios verdes.

O `test-in-prod-image` fechou o limite que o gate havia **declarado por escrito**: ele rodou a suíte backend completa **com** as alterações do F-1, na imagem de produção — verificação que nem o gate (worktree isolado, suíte parcial por decisão do fundador) nem a execução paralela na outra janela (checkout sem o diff) tinham feito.

Gate completo: `docs/qa/epic-8-gate-8.19-8.20-2026-08-07.md`. A Story 8.19 já fechou em `Done` na #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
