### PR TITLE
feat: a perna bancária do rendimento fecha o termo P3 [Epic 8, Onda 2b-i]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,13 +581,13 @@ A pré-condição, lida ao pé da letra (*"toda cobrança recebida precisa ter c
 terá `bank_account_id` — e o trilho é o caminho normal do produto. A ratificação a reescreveu em
 quatro termos, cada um com o predicado que o decide e a **onda que o zera**: **P1** baixa de Contas a
 Pagar sem conta (Onda 2) · **P2** recebimento fora do trilho sem conta (Onda 2) · **P3** rendimento de
-aplicação sem perna bancária (**Onda 2b**) · **P4** payout da Carteira (**Onda 3**, hoje vazio por
+aplicação sem perna bancária (**Onda 2b-i** ✅, ver abaixo) · **P4** payout da Carteira (**Onda 3**, hoje vazio por
 construção — `request_payout` só marca `withdrawn`).
 
 **Consequência que muda a leitura do épico:** o gate abre depois da Onda 2 **apenas para um tenant
 cujos únicos eventos que movem conta real sejam P1 e P2**. Quem registra rendimento de aplicação
-precisa da **2b**; quando o payout virar real, da **3**. Não é escopo novo — P3 e P4 sempre foram
-termos da divergência.
+precisava da **2b-i** — ✅ **entregue**, ver a seção dela abaixo; quando o payout virar real,
+precisa da **3**. Não é escopo novo — P3 e P4 sempre foram termos da divergência.
 
 ⚠️ **O achado A-1, que teria fechado a métrica primária do épico para sempre.** A `Charge` sintética
 de rendimento (`investments/service.py`, Story 5.6) nasce `paid` com `transaction_id=NULL` **e**
@@ -837,6 +837,90 @@ desde a Onda 0 **sem gatilho nenhum**; esta story é o gatilho.
   AC9 da 8.13. E: conta `is_known=false` + recuo de data pede um saldo cujo campo está escondido no
   formulário; tem saída (marcar *"sei o saldo"* revela o campo), mas a mensagem de erro pede algo que
   não está visível.
+
+### Onda 2b-i — a perna bancária do rendimento (o termo P3 fecha)
+
+> Spec: `docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento.md`
+
+**A Onda 2b foi PARTIDA EM DUAS, e o recorte é a decisão.** O §647 do PRD descreve cinco
+entregáveis; só dois tocam o gate, e o mais arriscado do épico inteiro (o backfill de
+`principal_cents` sob `FORCE RLS`) não é nenhum dos dois. **2b-i** entrega o vínculo e o movimento;
+**2b-ii** fica com o principal derivado, o backfill, o 409 de edição e o extrato na tela. Manter o
+backfill colado ao destravamento da métrica primária refaria o acoplamento que o épico já desfez
+uma vez ao separar a 2b da Onda 2.
+
+#### O achado que motivou o recorte, e que teria custado a onda inteira
+
+`receivables.contar_rendimentos_sem_perna_bancaria` **não verificava se existia perna bancária** —
+nenhum join, nenhum `NOT EXISTS`. Contava todo rendimento da janela. Pré-2b era inofensivo, porque
+*"todos os rendimentos"* e *"os sem perna"* eram o mesmo conjunto. Ligado o movimento, eles se
+separam e P3 seguiria contando o que passou a ter perna: **o gate não abriria nem depois da onda que
+existe para destravá-lo**, e a nota continuaria dizendo *"este termo só fecha na Onda 2b"* sobre uma
+onda já fechada. O único teste que tocava a função afirmava que ela era `callable`.
+
+> **A regra que fica (reverberar): função cujo NOME promete um filtro tem de tê-lo, mesmo quando o
+> filtro é hoje redundante.** Ela esteve certa **por coincidência de população** durante uma onda
+> inteira. A coincidência não deixa rastro no código, não quebra teste ao terminar, e o dia em que
+> ela termina é exatamente o dia em que a função vira defeito. É a família do §2 desta seção (o
+> teste que passa e não prova nada) com um agravante: **aqui o teste correto não podia sequer ser
+> escrito** no caminho de produção — o membro que o mataria era inconstruível.
+
+#### O que foi construído
+
+- [x] **`investment_accounts.bank_account_id`** (migration `0075`) — ligação 1:1 com a
+  `bank_account` `kind='investment'`. `investment_accounts` **não** é absorvida: ela é a faceta de
+  PRODUTO (rentabilidade, indexador), a `bank_account` é ONDE o dinheiro está. Índice único parcial
+  com `tenant_id` na FRENTE (índice único é global e não respeita RLS — lição da 8.2). **Sem
+  `UPDATE`:** `ADD COLUMN`/`CREATE INDEX` são DDL e a RLS não os alcança; a aplicação que já existia
+  é vinculada pelo dono, **por ato**, na tela. Validada contra Postgres real via `rls_e2e`.
+- [x] **`register_yield` sem vínculo recusa com 409 acionável** (`{"acao":"cadastrar_conta"}`,
+  terceira cópia da string, sincronia por teste). **É isso que põe P3 em zero POR CONSTRUÇÃO** — o
+  mesmo mecanismo pelo qual a 8.12 zerou P1. A degradação graciosa da Onda 3 (*"nada acontece, nada
+  quebra"*) foi rejeitada aqui, e a diferença é **quem está na sala**: o payout é disparado pelo
+  sistema, sem humano a quem perguntar; o rendimento é o dono digitando um valor agora.
+- [x] **`register_yield` gera `bank_transaction` `source='yield'`** pelo mesmo
+  `sync_origin_movement`, na mesma transação, nascido conciliado. **`SOURCE_YIELD` já estava em
+  `SOURCES_SISTEMA` desde a `0059`** — como nenhuma regra do repo é escrita contra `source` solto,
+  todas já cobriam `yield` sem uma linha de mudança. Precisa de `db.flush()` antes: o id da `Charge`
+  tem default **Python-side** e sem ele o `origin_id` nasceria vazio (o defeito MNT-001).
+  **A IV1 da 5.6 NÃO foi relaxada:** `bank_transactions` é o plano do BANCO,
+  `Transaction`/`PlatformEarning` são o da PLATAFORMA, e continuam intocados.
+- [x] **`posted_at` = data do rendimento, não o instante do registro** — que erraria sempre que o
+  dono lançasse com atraso. O resíduo (competência 31/07 × crédito 01/08) é o **termo 3** da
+  decomposição da divergência, que a banda de tolerância existe para absorver. **A escolha só é
+  barata porque o predicado de P3 é `NOT EXISTS`:** ele pergunta *"existe perna?"*, não *"a perna
+  caiu nesta janela?"*. Se a data fosse o eixo do termo, isto seria decisão de gate.
+- [x] **Data futura: 422** — a decisão que `bank/transfers.py:185` exigia que a 2b tomasse **em vez
+  de copiar**. A razão não é a da transferência: um rendimento que ainda não caiu não é um
+  rendimento, e não teria para onde ir — não existe `scheduled` para rendimento, nem superfície,
+  nem caminho de promoção (Art. IV). Comparação com `hoje_do_tenant`, nunca com `now(UTC)`.
+- [x] **A nota de P3 deixou de nomear uma onda e passou a nomear a AÇÃO** (*"Vincule a aplicação à
+  conta bancária dela"*). Ela fica mesmo inalcançável no caminho normal: se disparar, é linha legada
+  ou defeito, e apagá-la deixaria a 2b-ii sem quem avise se os dados voltarem inconsistentes.
+- [x] **A tela vincula** — seletor único para os dois modais, e no 409 o modal vincula e **reenvia o
+  rendimento sem o dono redigitar valor e data**. Sem esta parte o 409 seria um beco: backend
+  pedindo um vínculo que não tinha onde ser criado (a classe do item 12 do WhatsApp).
+
+#### Três coisas que só apareceram implementando
+
+- **O gate da allowlist do `sync_origin_movement` pegou o chamador novo, e é para isso que ele
+  existe.** `investments/service.py` entrou em `_CHAMADORES_PERMITIDOS` **com a justificativa** —
+  que é o que faz a revisão acontecer, e não uma linha na lista.
+- **Um teste meu passou ANTES da implementação, pelo motivo errado.** `register_yield` grava
+  `paid_at = now()` (o instante do registro) enquanto `posted_at` usa a competência informada: uma
+  janela em julho não continha o `paid_at` de um rendimento registrado em agosto, e P3 dava `(0,0)`
+  por vacuidade. Corrigido com **controle positivo** (o mesmo rendimento sem perna, que conta).
+- **`date.today()` é a data LOCAL e `paid_at` é `now(UTC)`** — às 23h em UTC−3 as duas já são dias
+  diferentes, e uma janela de teste de um dia só perdia o rendimento pela borda, em silêncio.
+
+- **Dívida:** o ramo *"origem desliquidada → apaga"* de `sync_origin_movement` é **inalcançável**
+  para `source='yield'` (não existe estorno nem exclusão de rendimento; o router só expõe
+  `register_yield`). Está na docstring para não parecer esquecimento na 2b-ii.
+- **Dívida:** **aceite visual em ~360px do campo de vínculo NÃO foi feito** — mesma dívida da 8.13
+  AC9 e da 8.21. Bloqueia release, não bloqueia merge.
+- **Dívida:** a 2b-ii continua com o único backfill do épico, e ele continua sendo o item de maior
+  risco.
 
 
 ## WhatsApp Evolution: em produção de verdade (deploy 2026-08-04)

--- a/apps/api/app/modules/bank/reconciliation.py
+++ b/apps/api/app/modules/bank/reconciliation.py
@@ -482,12 +482,15 @@ def _note_total_parcial(sem_checkpoint: int) -> str:
 # Moram aqui, ao lado de `_note_sem_checkpoint` e `_note_total_parcial`, pelo mesmo motivo delas:
 # duas redações do mesmo fato viram duas frases diferentes na tela conforme o caminho.
 #
-# **Por que P1/P2 e P3 têm frases separadas, e não uma só com a soma:** P1 e P2 **somem sozinhos**
-# quando o dono terminar de corrigir os lançamentos legados — a ação existe e é dele. P3 **não some
-# nesta onda**: fecha na Onda 2b, e não há nada que ele possa fazer à mão. Uma nota que promete
-# *"isso some quando você terminar o mutirão"* sobre um termo que não some é a mesma classe de
-# afirmação sem lastro que a Onda 0 removeu da Projeção — e nomear a onda em cada nota é o que
-# impede o dono de caçar um termo que software nenhum consegue fechar ainda.
+# **Por que P1/P2 e P3 continuam com frases separadas depois da Onda 2b-i:** os dois termos pedem
+# ações DIFERENTES do dono. P1/P2 pedem informar a conta em cada lançamento legado, um por um; P3
+# pede vincular a aplicação à conta bancária dela, **uma vez**. Achatá-las numa frase só mandaria o
+# dono caçar lançamento a lançamento um termo que se resolve num clique.
+#
+# ⚠️ **Antes da Onda 2b-i a razão era outra, e ela mudou junto com o produto:** P3 não fechava com
+# trabalho nenhum, e a frase NOMEAVA A ONDA que o fecharia, para impedir o dono de caçar um termo
+# que software nenhum conseguia fechar ainda. Entregue a 2b-i, nomear aquela onda viraria promessa
+# sobre coisa já entregue — a nota passou a nomear a AÇÃO. Ver `_note_rendimento_sem_perna`.
 #
 # **Zero termo não-zero ⇒ zero nota.** Silêncio, mesma disciplina anti-ruído do resto do épico — e
 # é exatamente esse silêncio que sinaliza *"agora o gate pode ser lido"*.
@@ -505,13 +508,25 @@ def _note_sem_conta_informada(quantidade: int, valor_cents: int) -> str:
 
 
 def _note_rendimento_sem_perna(quantidade: int, valor_cents: int) -> str:
-    """P3 — o termo que **NÃO fecha nesta onda**. A frase diz isso, para ninguém tentar
-    corrigi-lo à mão."""
+    """P3 — o termo que a **Onda 2b-i fechou por construção**, e a frase mudou junto.
+
+    Antes da 2b-i esta nota dizia *"este termo só fecha na Onda 2b"*, porque não havia **nada** que
+    o dono pudesse fazer. Agora há: `investments.register_yield` recusa (409 acionável) rendimento
+    em aplicação sem conta vinculada, então todo rendimento novo nasce com perna e a população é
+    vazia. Manter a frase antiga seria prometer na tela uma onda **já entregue** — a mesma classe
+    de afirmação sem lastro que a Onda 0 removeu da Projeção, só que ao contrário.
+
+    **A nota fica, mesmo inalcançável no caminho normal.** Se ela disparar, não é mais uma onda
+    faltando: é linha legada ou defeito, e ela precisa dizer o que **FAZER**. Apagar contador e
+    nota foi a alternativa rejeitada — a 2b-ii mexe justamente nesses dados, e um termo apagado
+    não avisa se eles voltarem inconsistentes.
+    """
     plural = "s" if quantidade > 1 else ""
     return (
         f"{quantidade} rendimento{plural} de aplicação deste período ({_brl(valor_cents)}) ainda "
         f"não gera{'m' if quantidade > 1 else ''} movimento bancário. A divergência abaixo "
-        "**inclui** esse valor. Este termo só fecha na Onda 2b — não há o que corrigir à mão."
+        "**inclui** esse valor. Vincule a aplicação à conta bancária dela para que o rendimento "
+        "passe a aparecer no extrato."
     )
 
 

--- a/apps/api/app/modules/investments/models.py
+++ b/apps/api/app/modules/investments/models.py
@@ -50,3 +50,9 @@ class InvestmentAccount(Base, TenantMixin, TimestampMixin):
     # Rendimento acumulado (centavos) — soma dos rendimentos já lançados via register_yield.
     accrued_yield_cents: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
     opened_at: Mapped[date] = mapped_column(Date, nullable=False)
+    # A conta bancária ONDE ESTE DINHEIRO ESTÁ (Onda 2b-i, migration 0075). Ligação 1:1 com uma
+    # `bank_account` `kind='investment'`, por referência SOLTA (sem FK dura — padrão do projeto).
+    # `None` = ainda não vinculada, e nesse estado `register_yield` recusa com **409 acionável**:
+    # rendimento sem perna bancária é o termo P3 da pré-condição do gate do Epic 8, e é a recusa
+    # que o mantém vazio POR CONSTRUÇÃO (mesmo mecanismo pelo qual a 8.12 zerou P1).
+    bank_account_id: Mapped[str | None] = mapped_column(String(36), default=None, nullable=True)

--- a/apps/api/app/modules/investments/router.py
+++ b/apps/api/app/modules/investments/router.py
@@ -37,7 +37,13 @@ def _out(a: InvestmentAccount) -> InvestmentAccountOut:
 
 
 def _err(e: service.InvestmentError) -> HTTPException:
-    return HTTPException(status_code=e.status_code, detail=str(e))
+    """`detail` estruturado quando o erro é ACIONÁVEL; string em todo o resto.
+
+    Só `ContaNaoVinculadaError` preenche `detail` — é o contrato do 409 que a 8.12 fixou (AC9) e
+    que a tela consome para oferecer o vínculo sem o dono perder o que já digitou. Sem o `detail`,
+    o front recebe uma frase e não tem como saber que existe uma ação.
+    """
+    return HTTPException(status_code=e.status_code, detail=e.detail or str(e))
 
 
 @router.get("", response_model=list[InvestmentAccountOut])

--- a/apps/api/app/modules/investments/router.py
+++ b/apps/api/app/modules/investments/router.py
@@ -31,6 +31,7 @@ def _out(a: InvestmentAccount) -> InvestmentAccountOut:
         principal_cents=a.principal_cents,
         accrued_yield_cents=a.accrued_yield_cents,
         opened_at=a.opened_at,
+        bank_account_id=a.bank_account_id,
         created_at=a.created_at,
     )
 
@@ -53,7 +54,11 @@ def create_account(
     user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> InvestmentAccountOut:
-    acc = service.create_account(db, tenant_id=user.tenant_id, actor=user.user_id, data=data)
+    # Onda 2b-i: passou a poder levantar `InvestmentError` (validação do vínculo bancário).
+    try:
+        acc = service.create_account(db, tenant_id=user.tenant_id, actor=user.user_id, data=data)
+    except service.InvestmentError as e:
+        raise _err(e) from e
     return _out(acc)
 
 

--- a/apps/api/app/modules/investments/schemas.py
+++ b/apps/api/app/modules/investments/schemas.py
@@ -18,6 +18,9 @@ class InvestmentAccountCreate(BaseModel):
     index_rate_label: str = Field(default="", max_length=64)  # rótulo do indexador/taxa
     principal_cents: int = Field(default=0, ge=0)  # principal aplicado (centavos)
     opened_at: date
+    # A conta bancária da aplicação (Onda 2b-i). Opcional na criação, obrigatória para lançar
+    # rendimento — ver `service.ContaNaoVinculadaError`.
+    bank_account_id: str | None = Field(default=None, max_length=36)
 
     @field_validator("name")
     @classmethod
@@ -39,6 +42,9 @@ class InvestmentAccountUpdate(BaseModel):
     kind: str | None = Field(default=None, max_length=24)
     index_rate_label: str | None = Field(default=None, max_length=64)
     principal_cents: int | None = Field(default=None, ge=0)
+    # Onda 2b-i. `None` = não altera (o vínculo não é removível por aqui: desvincular reabriria o
+    # termo P3 para os rendimentos futuros, e não existe caso de uso para isso).
+    bank_account_id: str | None = Field(default=None, max_length=36)
 
     @field_validator("name")
     @classmethod
@@ -76,6 +82,7 @@ class InvestmentAccountOut(BaseModel):
     principal_cents: int
     accrued_yield_cents: int
     opened_at: date
+    bank_account_id: str | None
     created_at: datetime
 
 

--- a/apps/api/app/modules/investments/service.py
+++ b/apps/api/app/modules/investments/service.py
@@ -66,6 +66,42 @@ class InvestmentError(Exception):
     def __init__(self, message: str, status_code: int = 400):
         super().__init__(message)
         self.status_code = status_code
+        # `None` = o router serializa `str(e)` como sempre. Só o erro ACIONÁVEL abaixo preenche.
+        self.detail: dict | None = None
+
+
+# ── O 409 ACIONÁVEL, no MESMO formato que a Story 8.12 fixou (AC9) ───────────────────────────
+#
+# ⚠️ **A string é duplicada de `payables.service.ACAO_CADASTRAR_CONTA` DE PROPÓSITO**, e a
+# sincronia é garantida por **teste**, não por comentário:
+# `test_investments.py::test_a_acao_do_409_e_a_MESMA_string_de_payables_e_receivables` compara as
+# três constantes. Fazer `investments` importar `payables` só por causa de uma palavra seria
+# acoplamento gratuito entre dois módulos de negócio — o mesmo motivo pelo qual `receivables` a
+# duplica em vez de importar.
+ACAO_CADASTRAR_CONTA = "cadastrar_conta"
+
+SEM_CONTA_VINCULADA_MSG = (
+    "Para registrar o rendimento o e1p precisa saber em qual conta o dinheiro entrou — é isso "
+    "que faz o movimento aparecer no seu extrato e a conferência valer alguma coisa. Vincule "
+    "esta aplicação à conta bancária dela uma vez e o rendimento segue normalmente."
+)
+
+
+class ContaNaoVinculadaError(InvestmentError):
+    """A aplicação não aponta para conta bancária nenhuma, e o rendimento precisa de uma perna.
+
+    **É esta recusa que mantém o termo P3 vazio POR CONSTRUÇÃO** (pré-condição do gate do Epic 8),
+    e não a disciplina de o dono lembrar de vincular. Mesmo mecanismo pelo qual a Story 8.12 zerou
+    P1 ao tornar a conta obrigatória na baixa.
+
+    ⚠️ **409, e o formato é o mesmo dos outros dois módulos**: a tela reconhece a situação por
+    `detail["acao"]` e oferece o vínculo ali mesmo. Um segundo valor no `acao` quebraria isso
+    **sem erro nenhum**, só deixando de funcionar.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(SEM_CONTA_VINCULADA_MSG, 409)
+        self.detail = {"acao": ACAO_CADASTRAR_CONTA, "mensagem": SEM_CONTA_VINCULADA_MSG}
 
 
 def get_account(db: Session, account_id: str) -> InvestmentAccount:
@@ -198,6 +234,9 @@ def register_yield(
     tabela de origem (`Charge` = +1), nunca do grupo_dre (convenção canônica ratificada na 5.3).
     """
     acc = get_account(db, account_id)
+    # Onda 2b-i: a perna bancária exige saber ONDE o dinheiro entrou. Sem vínculo, 409 ACIONÁVEL.
+    if not acc.bank_account_id:
+        raise ContaNaoVinculadaError()
     if chart_account_id:
         _validate_financeiro_account(db, chart_account_id)
 

--- a/apps/api/app/modules/investments/service.py
+++ b/apps/api/app/modules/investments/service.py
@@ -35,6 +35,13 @@ baixado (`status=paid`), sem NUNCA chamar `receivables.mark_paid`/`wallet.build_
   `external_ref LIKE 'investment:%'` em `list_charges`/`summary`; ou a alternativa do @sm de uma
   tabela de lançamentos financeiros dedicada). A DRE (5.3) já inclui este lançamento corretamente,
   pois agrega `charges` por `chart_account_id`+competência direto (não via `list_charges`).
+
+⚠️ ONDA 2b-i: `register_yield` passou a gerar TAMBÉM um `bank_transaction` `source='yield'`, pelo
+`sync_origin_movement`. Isso **NÃO relaxa a IV1** acima: `bank_transactions` é o plano do BANCO;
+`Transaction`/`PlatformEarning` são o plano da PLATAFORMA, e continuam intocados. Misturar os dois
+é a Regra dos Planos do Epic 8, e foi exatamente essa mistura que produziu o bug de origem dele.
+A perna existe porque rendimento **move dinheiro numa conta real do dono** — e um evento assim sem
+`bank_transaction` correspondente é o termo P3, que invalida a leitura do gate do épico.
 """
 from __future__ import annotations
 
@@ -44,8 +51,9 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import audit
+from app.modules.bank import origin as bank_origin
 from app.modules.bank import service as bank_service
-from app.modules.bank.models import KIND_INVESTMENT
+from app.modules.bank.models import KIND_INVESTMENT, SOURCE_YIELD
 from app.modules.chart_of_accounts import service as chart_service
 from app.modules.chart_of_accounts.models import GRUPO_FINANCEIRO
 from app.modules.investments.models import InvestmentAccount, external_ref_for
@@ -54,6 +62,7 @@ from app.modules.investments.schemas import (
     InvestmentAccountUpdate,
 )
 from app.modules.receivables.models import STATUS_PAID, Charge
+from app.modules.settings.service import hoje_do_tenant
 
 # Valores INERTES nos campos que só teriam efeito no split (kind/method) — nunca são usados porque
 # a Charge de rendimento não passa por mark_paid/build_transaction. Mantidos válidos por serem
@@ -217,6 +226,21 @@ def _validate_bank_account(db: Session, bank_account_id: str) -> None:
         raise InvestmentError(_CONTA_ARQUIVADA_MSG, 409)
 
 
+def _today(db: Session) -> date:
+    """A MESMA âncora de "hoje" do sistema (fuso do tenant) — nunca um segundo relógio.
+
+    `datetime.now(UTC).date()` aqui adiantaria o dia das 21h à meia-noite em UTC−3 e recusaria,
+    como "futuro", um rendimento legítimo lançado à noite. Gate: `tests/test_fuso_do_tenant.py`.
+    """
+    return hoje_do_tenant(db)
+
+
+_DATA_FUTURA_MSG = (
+    "A data do rendimento não pode ser futura — um rendimento que ainda não caiu não é um "
+    "rendimento. Lance-o no dia em que o banco creditar."
+)
+
+
 def register_yield(
     db: Session,
     *,
@@ -237,6 +261,14 @@ def register_yield(
     # Onda 2b-i: a perna bancária exige saber ONDE o dinheiro entrou. Sem vínculo, 409 ACIONÁVEL.
     if not acc.bank_account_id:
         raise ContaNaoVinculadaError()
+    # ⚠️ `bank/transfers.py:185` EXIGE que a 2b decida isto em vez de copiar a forma da
+    # transferência — e a razão aqui é outra. Não é "o e1p registra o que já aconteceu": é que um
+    # rendimento que ainda não caiu não é um rendimento, e ele não teria PARA ONDE ir. Ao contrário
+    # de uma `Payable` com data futura, não existe estado `scheduled` para rendimento, nem
+    # superfície onde ele apareceria, nem caminho de promoção. Aceitá-lo inventaria a quarta
+    # semântica de agendamento que o Art. IV proíbe.
+    if date > _today(db):
+        raise InvestmentError(_DATA_FUTURA_MSG, 422)
     if chart_account_id:
         _validate_financeiro_account(db, chart_account_id)
 
@@ -261,6 +293,35 @@ def register_yield(
         external_ref=external_ref_for(account_id),  # MARCA a origem (rendimento) + correlação
     )
     db.add(charge)
+    db.flush()  # o id da Charge tem default PYTHON-side; sem o flush o `origin_id` nasceria vazio
+
+    # ── A perna bancária (Onda 2b-i) ─────────────────────────────────────────────────────────
+    # Pelo MESMO `sync_origin_movement` de payables/receivables/transfers — a **única** função do
+    # repositório que escreve `source ∈ SOURCES_SISTEMA`. Não commita: movimento e lançamento
+    # entram na MESMA transação, e é o commit abaixo que fecha os dois. Nasce `status='matched'`.
+    #
+    # **`posted_at=date` e não `paid_at::date`:** o `date` é o dia em que o rendimento caiu para o
+    # dono. Usar o instante do registro erraria sempre que ele lançasse com qualquer atraso. O
+    # resíduo (competência 31/07 × crédito 01/08) é o **termo 3** da decomposição da divergência —
+    # resíduo estrutural, que a banda de tolerância existe para absorver. E ele **não alcança o
+    # gate**: o predicado de P3 pergunta *"existe perna?"*, não *"a perna caiu nesta janela?"*.
+    #
+    # ⚠️ O ramo *"origem desliquidada → apaga"* de `sync_origin_movement` é **INALCANÇÁVEL** para
+    # `source='yield'`: não existe caminho de estorno nem de exclusão de rendimento hoje (o router
+    # só expõe `register_yield`). Escrito aqui para quem reencontrar o ramo morto na 2b-ii não
+    # achar que foi esquecimento.
+    bank_origin.sync_origin_movement(
+        db,
+        tenant_id=tenant_id,
+        actor=actor,
+        source=SOURCE_YIELD,
+        origin_id=charge.id,
+        bank_account_id=acc.bank_account_id,
+        posted_at=date,
+        amount_cents=amount_cents,  # crédito: o sinal vem da tabela de origem (Charge = +1)
+        description=f"Rendimento de aplicação: {acc.name}",
+    )
+
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="investment.register_yield", target=acc.id
     )

--- a/apps/api/app/modules/investments/service.py
+++ b/apps/api/app/modules/investments/service.py
@@ -44,6 +44,8 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import audit
+from app.modules.bank import service as bank_service
+from app.modules.bank.models import KIND_INVESTMENT
 from app.modules.chart_of_accounts import service as chart_service
 from app.modules.chart_of_accounts.models import GRUPO_FINANCEIRO
 from app.modules.investments.models import InvestmentAccount, external_ref_for
@@ -77,6 +79,8 @@ def get_account(db: Session, account_id: str) -> InvestmentAccount:
 def create_account(
     db: Session, *, tenant_id: str, actor: str, data: InvestmentAccountCreate
 ) -> InvestmentAccount:
+    if data.bank_account_id:
+        _validate_bank_account(db, data.bank_account_id)
     acc = InvestmentAccount(
         tenant_id=tenant_id,
         name=data.name,
@@ -85,6 +89,7 @@ def create_account(
         principal_cents=data.principal_cents,
         accrued_yield_cents=0,
         opened_at=data.opened_at,
+        bank_account_id=data.bank_account_id,
     )
     db.add(acc)
     audit.record(db, tenant_id=tenant_id, actor=actor, action="investment.create", target=acc.id)
@@ -107,6 +112,10 @@ def update_account(
         acc.index_rate_label = data.index_rate_label
     if data.principal_cents is not None:
         acc.principal_cents = data.principal_cents
+    if data.bank_account_id is not None:
+        # Onda 2b-i: é por aqui que a aplicação LEGADA é vinculada — ato do dono, não backfill.
+        _validate_bank_account(db, data.bank_account_id)
+        acc.bank_account_id = data.bank_account_id
     audit.record(db, tenant_id=tenant_id, actor=actor, action="investment.update", target=acc.id)
     db.commit()
     db.refresh(acc)
@@ -133,6 +142,43 @@ def _validate_financeiro_account(db: Session, chart_account_id: str) -> None:
         raise InvestmentError(
             "A conta do plano de contas do rendimento deve pertencer ao grupo FINANCEIRO", 422
         )
+
+
+_CONTA_NAO_E_APLICACAO_MSG = (
+    "A conta bancária de uma aplicação precisa ser do tipo 'aplicação'. Se o dinheiro está numa "
+    "conta corrente, ele não está aplicado — e o rendimento cairia na conta errada, fazendo os "
+    "dois saldos derivados mentirem juntos."
+)
+
+# ⚠️ Duplicada em substância de `payables.service._CONTA_ARQUIVADA_MSG` DE PROPÓSITO. Aquela
+# constante é privada do módulo de Contas a Pagar, e importar um símbolo `_` entre dois módulos de
+# negócio seria acoplamento gratuito — o mesmo motivo pelo qual `receivables` duplica
+# `ACAO_CADASTRAR_CONTA` em vez de importá-la. O que NÃO é duplicado é o `acao` do 409, porque
+# aquele é contrato com a UI e tem teste de sincronia.
+_CONTA_ARQUIVADA_MSG = (
+    "A conta bancária escolhida está arquivada e não recebe lançamentos novos. Escolha outra "
+    "conta ou cadastre a conta que você usa hoje — com o saldo de abertura do dia."
+)
+
+
+def _validate_bank_account(db: Session, bank_account_id: str) -> None:
+    """A conta bancária do vínculo existe (RLS), é aplicação e está ativa? (Onda 2b-i)
+
+    **404 se inexistente ou de outro tenant** — `bank_service.get_account` é fail-closed e a RLS
+    esconde a linha alheia. Nunca 409 nesse caso: 409 confirmaria a existência da linha, que é
+    vazamento de existência com cara de validação (critério já fixado no módulo `bank`).
+
+    **422 se a conta não for `kind='investment'`.** A faceta de produto fala de UMA aplicação; se
+    ela apontasse para uma conta corrente, o rendimento creditaria onde o dinheiro não está.
+    """
+    try:
+        acc = bank_service.get_account(db, bank_account_id)
+    except bank_service.BankError as e:
+        raise InvestmentError("Conta bancária não encontrada", e.status_code) from e
+    if acc.kind != KIND_INVESTMENT:
+        raise InvestmentError(_CONTA_NAO_E_APLICACAO_MSG, 422)
+    if acc.archived_at is not None:
+        raise InvestmentError(_CONTA_ARQUIVADA_MSG, 409)
 
 
 def register_yield(

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -49,7 +49,7 @@ from app.modules.agenda.models import (
 # a reprova.
 from app.modules.bank import origin as bank_origin
 from app.modules.bank import service as bank_service
-from app.modules.bank.models import SOURCE_CHARGE, BankAccount
+from app.modules.bank.models import SOURCE_CHARGE, SOURCE_YIELD, BankAccount, BankTransaction
 from app.modules.chart_of_accounts import service as chart_service
 from app.modules.contracts import service as contracts_service
 from app.modules.cost_centers import service as cost_centers_service
@@ -986,14 +986,37 @@ def contar_rendimentos_sem_perna_bancaria(
     O predicado é a **negação** do mesmo `_not_investment_yield()` usado em P2 — literalmente o
     complemento, e não uma segunda escrita do `LIKE 'investment:%'`. As duas populações particionam
     as cobranças pelo mesmo corte, então elas não podem divergir.
+
+    ⚠️ **A partir da Onda 2b-i o predicado inclui o `NOT EXISTS` sobre `bank_transactions`, e sem
+    ele esta função MENTIA pelo nome.** Antes dela o corpo contava TODO rendimento da janela:
+    coincidia com a intenção só porque perna nenhuma existia. Ligado o movimento
+    (`investments.register_yield` → `sync_origin_movement`), os dois conjuntos se separam, e contar
+    o rendimento que JÁ tem perna manteria o gate fechado depois da própria onda que o destrava —
+    com a nota do bloco 4 prometendo na tela uma onda já entregue. **Função cujo nome promete um
+    filtro tem de tê-lo, mesmo quando o filtro é hoje redundante:** a redundância não deixa rastro
+    no código e termina sem quebrar teste nenhum.
     """
     de, ate = janela_de_caixa(start, end)
+    # Correlaciona por `origin_id`, que para origem de perna única **É** o id do lançamento
+    # (`bank/transfers.py:18`) — nunca por data: a pergunta do termo é *"existe perna?"*, e não
+    # *"a perna caiu nesta janela?"*. É essa indiferença à data que torna barata a escolha de
+    # `posted_at` em `register_yield` (o resíduo de um dia é o termo 3 da divergência, que a banda
+    # de tolerância absorve, e não um problema de gate).
+    _tem_perna_bancaria = (
+        select(BankTransaction.id)
+        .where(
+            BankTransaction.source == SOURCE_YIELD,
+            BankTransaction.origin_id == Charge.id,
+        )
+        .exists()
+    )
     row = db.execute(
         select(func.count(), func.coalesce(func.sum(Charge.amount_cents), 0)).where(
             ~_not_investment_yield(),
             Charge.paid_at.is_not(None),
             Charge.paid_at >= de,
             Charge.paid_at < ate,
+            ~_tem_perna_bancaria,
         )
     ).one()
     return int(row[0] or 0), int(row[1] or 0)

--- a/apps/api/migrations/versions/0075_investment_bank_account.py
+++ b/apps/api/migrations/versions/0075_investment_bank_account.py
@@ -1,0 +1,69 @@
+"""A aplicação aponta para a conta bancária dela (Onda 2b-i)
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-08-07
+
+**Por quê.** `investments.register_yield` cria uma `Charge` sintética paga (Story 5.6) e nada mais:
+o dinheiro que entrou na aplicação real não vira `bank_transaction` nenhum. Isso é o termo **P3** da
+pré-condição do gate do Epic 8, e enquanto ele for não-vazio numa janela a divergência daquele ciclo
+**não pode ser lida** — nenhuma onda é liberada nem morta com base nele. Esta coluna é o que diz ao
+`sync_origin_movement` QUAL conta creditar.
+
+**`investment_accounts` NÃO é absorvida por `bank_accounts`.** Ela é a faceta de PRODUTO
+(rentabilidade, indexador, principal); a `bank_account` `kind='investment'` é ONDE o dinheiro está.
+São duas coisas, e a ligação é 1:1. Transferir para uma conta de aplicação **já funciona** desde a
+Onda 1 — o que faltava era a faceta de produto saber de qual conta ela fala.
+
+⚠️ **NENHUM `UPDATE`, e isso não é economia — é a razão de esta migration ser segura.** As seis
+armadilhas registradas neste repo (`0046`, `0066`, `0067`, `0068`, `0069`, `0073`) são todas a
+mesma: um `UPDATE` de backfill filtrado em silêncio pela RLS, completando com **sucesso aparente** e
+invisível para o SQLite da suíte. `ADD COLUMN` e `CREATE INDEX` são **DDL** — a RLS não os alcança.
+A aplicação que já existe em produção é vinculada pelo dono, **por ato**, na tela. **O backfill que
+não existe é o backfill que não pode falhar em silêncio.**
+
+⚠️ **`tenant_id` é a PRIMEIRA coluna do índice único, e a ordem não é estética.** Índice único é
+global e **não respeita RLS**: sem o `tenant_id` na frente, o tenant B receberia violação de
+unicidade causada por dado do tenant A — bug **e** vazamento de existência. Lição já paga na 8.2.
+
+**A cláusula parcial** (`WHERE bank_account_id IS NOT NULL`) mantém N aplicações não-vinculadas
+convivendo. Ela **não** é o que garante a distinção dos `NULL` — em índice único `NULL` já é
+distinto de `NULL` por padrão, e desde o PG15 isso é inclusive configurável (`NULLS NOT DISTINCT`).
+Está aqui por tamanho e por intenção declarada. A justificativa é esta, e não a que o AC da 8.9
+escreveu (que era falsa, e cujo mutante sobreviveu por isso).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0075"
+down_revision: str | None = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "investment_accounts"
+_COLUMN = "bank_account_id"
+_INDEX = "uq_investment_accounts_bank_account"
+
+
+def upgrade() -> None:
+    op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(36), nullable=True))
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["tenant_id", _COLUMN],
+        unique=True,
+        postgresql_where=sa.text("bank_account_id IS NOT NULL"),
+        sqlite_where=sa.text("bank_account_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # Não-destrutivo para o que existia antes: `principal_cents` e `accrued_yield_cents` nunca
+    # foram tocados. O que se perde é o VÍNCULO — e com ele `register_yield` volta a aceitar
+    # rendimento sem perna bancária, reabrindo o termo P3 e fechando o gate do épico de novo.
+    # Fica escrito aqui em vez de ser descoberto no meio de um rollback.
+    op.drop_index(_INDEX, table_name=_TABLE)
+    op.drop_column(_TABLE, _COLUMN)

--- a/apps/api/tests/test_bank_origin.py
+++ b/apps/api/tests/test_bank_origin.py
@@ -826,6 +826,20 @@ _CHAMADORES_PERMITIDOS: dict[str, str] = {
         "ponto de escrita das pernas, e `delete_transfer` reusa o mesmo sincronizador "
         "(`bank_account_id=None`) em vez de recopiar a guarda da linha puramente sintética."
     ),
+    "modules/investments/service.py": (
+        "**Onda 2b-i** — o rendimento de aplicação é o QUARTO chamador de produção da Regra da "
+        "Origem (`source='yield'`, `amount_cents` POSITIVO, perna única ⇒ `origin_id = charge.id` "
+        "sem sufixo). `register_yield` chama o sincronizador na MESMA transação da `Charge` "
+        "sintética, depois de um `db.flush()` — o id da Charge tem default Python-side e sem o "
+        "flush o `origin_id` nasceria vazio. "
+        "⚠️ **A perna NÃO relaxa a IV1 da Story 5.6:** `bank_transactions` é o plano do BANCO; "
+        "`Transaction`/`PlatformEarning` são o plano da PLATAFORMA e continuam intocados. Ela "
+        "existe porque rendimento move dinheiro numa conta REAL do dono, e um evento assim sem "
+        "movimento correspondente é o termo **P3** da pré-condição do gate do Epic 8 — o termo "
+        "que esta onda existe para zerar. "
+        "Direção `investments → bank` permitida e pré-decidida em `test_money_planes.py`; a "
+        "volta (`bank → investments`) segue proibida por dois gates, AST e texto cru."
+    ),
     "modules/receivables/service.py": (
         "**Story 8.15** — o recebimento fora do trilho (`settle_off_rail`/`update_off_rail_"
         "payment`) é o SEGUNDO chamador de produção da Regra da Origem, e o primeiro do lado das "

--- a/apps/api/tests/test_bank_reconciliation_report.py
+++ b/apps/api/tests/test_bank_reconciliation_report.py
@@ -38,6 +38,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.money_planes import ORIGEM_BANCO, ORIGEM_INDISPONIVEL, ORIGENS
+from app.modules.bank import origin as bank_origin
 from app.modules.bank import reconciliation
 from app.modules.bank import service as bank_service
 from app.modules.bank.models import (
@@ -46,6 +47,7 @@ from app.modules.bank.models import (
     KIND_SAVINGS,
     ORIGIN_MANUAL,
     ORIGIN_OFX,
+    SOURCE_YIELD,
     BankAccount,
     BankBalanceCheckpoint,
     BankTransaction,
@@ -1432,6 +1434,50 @@ def test_a1_o_rendimento_de_aplicacao_nao_entra_no_termo_de_conta_informada(
     assert "R$ 480,00" in nota
     assert "Onda 2b" in nota, "o termo P3 NÃO fecha nesta onda — a nota tem de dizer isso"
     assert "não há o que corrigir à mão" in nota
+
+
+def test_rendimento_COM_perna_bancaria_sai_do_termo_P3(
+    client: TestClient, headers, db: Session
+):
+    """**O membro que era inconstruível no caminho de produção, e por isso o defeito viveu.**
+
+    `contar_rendimentos_sem_perna_bancaria` contava TODO rendimento da janela — nenhum join,
+    nenhum `NOT EXISTS`. Pré-2b isso era inofensivo, porque *"todos os rendimentos"* e *"os
+    rendimentos sem perna"* eram o mesmo conjunto. Ligado o movimento (Onda 2b-i), os dois se
+    separam, e sem este predicado P3 seguiria contando os rendimentos que passaram a ter perna:
+    **o gate não abriria nem depois da onda que existe para destravá-lo**, e a nota diria *"este
+    termo só fecha na Onda 2b"* sobre uma onda já fechada.
+
+    O saldo declarado já inclui o rendimento (1.000.000 + 48.000) justamente para que a conta
+    continue batendo e a única coisa medida aqui seja o termo P3.
+
+    **Mutantes que este teste mata:** remover o `~_tem_perna_bancaria` do `where` (P3 volta a 1);
+    trocar `SOURCE_YIELD` por outro `source` no `NOT EXISTS` (idem).
+    """
+    tenant_id = _tenant_id(client, headers)
+    conta = _account(client, headers, opening=1_000_000)
+    _declarar(client, headers, conta["id"], balance_cents=1_048_000)
+    rendimento = _charge_de_rendimento(db, tenant_id, valor=48_000, pago_em=date(2026, 7, 14))
+
+    bank_origin.sync_origin_movement(
+        db,
+        tenant_id=tenant_id,
+        actor="teste",
+        source=SOURCE_YIELD,
+        origin_id=rendimento.id,
+        bank_account_id=conta["id"],
+        posted_at=date(2026, 7, 14),
+        amount_cents=48_000,
+        description="Rendimento CDB",
+    )
+    db.commit()
+
+    r = _report(db)
+    assert r.rendimentos_sem_perna_bancaria == 0, (
+        "o rendimento TEM perna bancária — contá-lo em P3 mantém o gate fechado depois da 2b"
+    )
+    assert r.valor_rendimentos_sem_perna_cents == 0
+    assert r.notes == [], "zero termo não-zero ⇒ zero nota"
 
 
 def test_os_dois_termos_geram_duas_notas_com_ondas_diferentes(

--- a/apps/api/tests/test_bank_reconciliation_report.py
+++ b/apps/api/tests/test_bank_reconciliation_report.py
@@ -1432,8 +1432,13 @@ def test_a1_o_rendimento_de_aplicacao_nao_entra_no_termo_de_conta_informada(
     nota = r.notes[0]
     assert "1 rendimento de aplicação" in nota
     assert "R$ 480,00" in nota
-    assert "Onda 2b" in nota, "o termo P3 NÃO fecha nesta onda — a nota tem de dizer isso"
-    assert "não há o que corrigir à mão" in nota
+    # ⚠️ MUDANÇA DELIBERADA na Onda 2b-i, e não "ajuste para o teste passar": a nota deixou de
+    # nomear a onda porque a onda foi ENTREGUE. Prometer "fecha na Onda 2b" depois da 2b-i é
+    # afirmação sobre coisa já feita. O que a nota nomeia agora é a AÇÃO, que passou a existir.
+    assert "Onda 2b" not in nota, (
+        "a Onda 2b-i fechou este termo — prometer uma onda já entregue é mentira na tela"
+    )
+    assert "Vincule a aplicação" in nota, "a nota nomeia a AÇÃO, agora que existe uma"
 
 
 def test_rendimento_COM_perna_bancaria_sai_do_termo_P3(
@@ -1499,7 +1504,11 @@ def test_os_dois_termos_geram_duas_notas_com_ondas_diferentes(
     assert r.lancamentos_sem_conta_informada == 1 and r.rendimentos_sem_perna_bancaria == 1
     assert len(r.notes) == 2
     assert "Onda 2:" in r.notes[0] and "Onda 2b" not in r.notes[0]
-    assert "Onda 2b" in r.notes[1]
+    # A segunda nota deixou de nomear onda nenhuma na Onda 2b-i (ver `_note_rendimento_sem_perna`).
+    # O que a distingue da primeira continua sendo o mesmo: elas pedem AÇÕES diferentes — informar
+    # a conta em cada lançamento legado × vincular a aplicação uma vez.
+    assert "Vincule a aplicação" in r.notes[1]
+    assert "Onda 2b" not in r.notes[1]
 
 
 def test_zero_termo_nao_zero_e_zero_nota(client: TestClient, headers, db: Session):

--- a/apps/api/tests/test_invariante_do_trilho.py
+++ b/apps/api/tests/test_invariante_do_trilho.py
@@ -172,6 +172,20 @@ def _cenario_completo(client: TestClient, headers, tenant_id: str, conta: dict) 
         headers=headers,
     )
     assert conta_dre.status_code == 201, conta_dre.text
+    # Onda 2b-i: a aplicação precisa apontar para a conta bancária dela — sem vínculo,
+    # `register_yield` recusa com 409 acionável, e é essa recusa que mantém o termo P3 vazio.
+    conta_aplicacao = client.post(
+        "/bank/accounts",
+        json={
+            "name": "CDB Itaú",
+            "kind": "investment",
+            "opening_balance_cents": 0,
+            "opening_balance_is_known": True,
+            "opening_date": ABERTURA.isoformat(),
+        },
+        headers=headers,
+    )
+    assert conta_aplicacao.status_code == 201, conta_aplicacao.text
     aplicacao = client.post(
         "/investments",
         json={
@@ -179,6 +193,7 @@ def _cenario_completo(client: TestClient, headers, tenant_id: str, conta: dict) 
             "kind": "CDB",
             "principal_cents": 1_000_000,
             "opened_at": ABERTURA.isoformat(),
+            "bank_account_id": conta_aplicacao.json()["id"],
         },
         headers=headers,
     )

--- a/apps/api/tests/test_investments.py
+++ b/apps/api/tests/test_investments.py
@@ -16,7 +16,7 @@ RLS/isolamento cross-tenant é validado à parte no Postgres real (test_investme
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
 
 import pytest
 from fastapi.testclient import TestClient
@@ -346,7 +346,10 @@ def test_rentability_total_and_period(client: TestClient, headers):
     rend = _account(client, headers, "FINANCEIRO", "Rendimento de aplicação")
     acc = _investment(client, headers, principal=1_000_000)
     # dois rendimentos em julho + um em agosto (fora do período consultado)
-    for amount, d in [(20_000, "2026-07-05"), (30_000, "2026-07-25"), (5_000, "2026-08-10")]:
+    # ⚠️ A data de agosto é 01, não 10: desde a Onda 2b-i `register_yield` recusa data FUTURA com
+    # 422, e o teste precisa de uma data de agosto que já tenha passado. A intenção do caso é
+    # "agosto não entra no período de julho" — ela sobrevive intacta.
+    for amount, d in [(20_000, "2026-07-05"), (30_000, "2026-07-25"), (5_000, "2026-08-01")]:
         client.post(
             f"/investments/{acc['id']}/yield",
             json={"amount_cents": amount, "date": d, "chart_account_id": rend},
@@ -537,3 +540,170 @@ def test_erro_comum_de_investments_continua_sendo_string(client: TestClient, hea
     r = client.patch("/investments/nao-existe", json={"name": "X"}, headers=headers)
     assert r.status_code == 404
     assert isinstance(r.json()["detail"], str)
+
+
+# ── Onda 2b-i — a perna bancária do rendimento ───────────────────────────────────────────────
+
+
+def test_registrar_rendimento_gera_o_movimento_bancario_NASCIDO_CONCILIADO(
+    client: TestClient, headers, db: Session
+):
+    """O coração da Onda 2b-i: o rendimento passa a ter perna bancária.
+
+    **Crédito** (sinal positivo — o sinal vem da tabela de origem, `Charge` = +1, convenção
+    canônica ratificada na 5.3), `origin_id = charge.id` **sem sufixo** (perna única ⇒ o
+    `origin_id` É o id), e `status='matched'` porque movimento de origem do sistema **nasce
+    conciliado**: ele não passa pelo matcher, e é isso que a Regra da Origem compra.
+    """
+    from app.modules.bank.models import SOURCE_YIELD, BankTransaction
+
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+
+    r = client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    charge = db.scalars(
+        select(Charge).where(Charge.external_ref == f"investment:{acc['id']}")
+    ).one()
+    tx = db.scalars(select(BankTransaction).where(BankTransaction.source == SOURCE_YIELD)).one()
+
+    assert tx.origin_id == charge.id, "perna única ⇒ o origin_id É o id, sem sufixo"
+    assert tx.bank_account_id == conta["id"]
+    assert tx.amount_cents == 48_000, "crédito: o sinal vem da tabela de origem (Charge = +1)"
+    assert tx.posted_at == date(2026, 7, 14)
+    assert tx.status == "matched", "movimento de origem do sistema NASCE conciliado"
+
+
+def test_o_rendimento_com_perna_SAI_do_termo_P3(client: TestClient, headers, db: Session):
+    """A ponta que fecha o círculo, pelo caminho REAL.
+
+    O predicado (`contar_rendimentos_sem_perna_bancaria`) e o movimento foram construídos
+    separados; os dois poderiam estar corretos e **não se encontrarem** — é este teste que prova
+    que a onda entrega o que a justifica.
+
+    ⚠️ **A janela é a de HOJE, e a primeira versão deste teste passava sem implementação nenhuma
+    por não ser.** `register_yield` grava `paid_at = now()` (o INSTANTE do registro), enquanto
+    `posted_at` do movimento usa a data de COMPETÊNCIA informada. Uma janela em julho não continha
+    o `paid_at` de um rendimento registrado hoje, então P3 dava `(0, 0)` por vacuidade — o teste
+    verde sobre o vazio, que é a família de defeito dominante deste épico.
+
+    O **controle positivo** (a aplicação sem vínculo, que conta) é o que impede a vacuidade de
+    voltar: se a janela deixar de conter o rendimento, ele quebra primeiro. E foi ele que pegou a
+    segunda armadilha — a janela é aberta em ±1 dia porque `date.today()` é a data LOCAL da
+    máquina enquanto `paid_at` é `now(UTC)`: às 22h em UTC−3 as duas já são dias diferentes, e uma
+    janela de um dia só perderia o rendimento pela borda, silenciosamente.
+    """
+    from datetime import timedelta
+
+    from app.modules.receivables.service import contar_rendimentos_sem_perna_bancaria
+
+    hoje = date.today()
+    de, ate = hoje - timedelta(days=1), hoje + timedelta(days=1)
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+    r = client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 48_000, "date": hoje.isoformat()},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    assert contar_rendimentos_sem_perna_bancaria(db, start=de, end=ate) == (0, 0), (
+        "o rendimento tem perna — P3 tem de estar vazio"
+    )
+
+    # CONTROLE POSITIVO: o mesmo rendimento, sem perna, CONTA. Sem isto o assert acima passaria
+    # por qualquer motivo que esvaziasse a população — janela errada inclusive.
+    legada = _investment(client, headers, name="Legada", bank_account_id=None)
+    from app.modules.investments.models import external_ref_for
+
+    db.add(
+        Charge(
+            tenant_id=db.scalars(select(Charge)).first().tenant_id,
+            description="Rendimento legado",
+            amount_cents=7_000,
+            due_date=hoje,
+            method="pix",
+            kind="service",
+            status=STATUS_PAID,
+            external_ref=external_ref_for(legada["id"]),
+            paid_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+    assert contar_rendimentos_sem_perna_bancaria(db, start=de, end=ate) == (1, 7_000), (
+        "o rendimento SEM perna tem de contar — senão a janela do teste não mede nada"
+    )
+
+
+def test_rendimento_com_data_FUTURA_e_recusado(client: TestClient, headers):
+    """**A decisão que `bank/transfers.py:185` exige que a 2b tome em vez de copiar a forma.**
+
+    A razão NÃO é a mesma da transferência. É que um rendimento que ainda não caiu não é um
+    rendimento; e, ao contrário de uma `Payable` com data futura, ele não teria para onde ir — não
+    existe estado `scheduled` para rendimento, nem superfície onde apareceria, nem caminho de
+    promoção. Aceitá-lo inventaria a quarta semântica de agendamento que o Art. IV proíbe.
+    """
+    from datetime import timedelta
+
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+    # +2 dias, e não +1: com +1 a borda das 21h em UTC−3 tornaria o teste dependente da hora em
+    # que a suíte roda — exatamente a classe de flake que `hoje_do_tenant` existe para eliminar.
+    futuro = date.today() + timedelta(days=2)
+
+    r = client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 48_000, "date": futuro.isoformat()},
+        headers=headers,
+    )
+    assert r.status_code == 422, r.text
+    assert "ainda não caiu" in r.json()["detail"]
+
+
+def test_rendimento_de_HOJE_e_aceito(client: TestClient, headers):
+    """**A borda, do lado de dentro** — sem este par, a guarda acima passaria com `>=` no lugar de
+    `>` e recusaria o rendimento que o dono lança no dia em que ele caiu.
+
+    (É a lição do mutante `posted_at > since` → `>=` que sobreviveu a 58 testes verdes na Onda 2:
+    par de recortes complementares sem caso na borda não prova partição nenhuma.)
+    """
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+
+    r = client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 1_000, "date": date.today().isoformat()},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_registrar_rendimento_CONTINUA_sem_criar_Transaction_nem_PlatformEarning(
+    client: TestClient, headers, db: Session
+):
+    """**IV1 da Story 5.6, reafirmada e NÃO relaxada pela perna bancária.**
+
+    `bank_transactions` é o plano do BANCO; `Transaction`/`PlatformEarning` são o plano da
+    PLATAFORMA. Misturar os dois é a Regra dos Planos do Epic 8 — e foi essa mistura que produziu
+    o bug de origem daquele épico.
+    """
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+    tx_antes = len(list(db.scalars(select(Transaction)).all()))
+    pe_antes = len(list(db.scalars(select(PlatformEarning)).all()))
+
+    client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+
+    db.expire_all()
+    assert len(list(db.scalars(select(Transaction)).all())) == tx_antes
+    assert len(list(db.scalars(select(PlatformEarning)).all())) == pe_antes

--- a/apps/api/tests/test_investments.py
+++ b/apps/api/tests/test_investments.py
@@ -88,8 +88,19 @@ def _investment(
     name="CDB Banco X",
     principal=1_000_000,
     opened="2026-01-10",
-    bank_account_id: str | None = None,
+    bank_account_id: str | None = "auto",
 ) -> dict:
+    """A aplicação **nasce vinculada por padrão** (Onda 2b-i), e isso não é conveniência de teste.
+
+    Depois do 409 de `register_yield`, aplicação sem vínculo é um estado de transição — o dono
+    passa por ele uma vez e sai. Fazer o helper refletir o estado NORMAL é o que mantém os treze
+    call sites de rendimento exercitando o caminho real. Quem quer o estado de transição pede
+    `bank_account_id=None`, explicitamente, e há exatamente um teste que o faz.
+
+    Cada aplicação ganha a SUA conta: o índice único `(tenant_id, bank_account_id)` é 1:1.
+    """
+    if bank_account_id == "auto":
+        bank_account_id = _conta_bancaria(client, headers, name=f"Conta {name}")["id"]
     r = client.post(
         "/investments",
         json={
@@ -418,7 +429,7 @@ def test_vincular_a_aplicacao_a_conta_bancaria_dela(client: TestClient, headers)
     justamente o backfill ausente que a mantém fora da armadilha do `FORCE ROW LEVEL SECURITY`.
     """
     conta = _conta_bancaria(client, headers)
-    acc = _investment(client, headers)
+    acc = _investment(client, headers, bank_account_id=None)  # o estado LEGADO, pré-2b-i
     assert acc["bank_account_id"] is None
 
     r = client.patch(
@@ -474,3 +485,55 @@ def test_conta_bancaria_arquivada_e_recusada(client: TestClient, headers):
     )
     assert r.status_code == 409, r.text
     assert "arquivada" in r.json()["detail"]
+
+
+def test_a_acao_do_409_e_a_MESMA_string_de_payables_e_receivables():
+    """**O contrato do 409 acionável é UM, com três constantes — e o teste é a sincronia.**
+
+    A string é duplicada de propósito: fazer `investments` importar `payables` só por uma palavra
+    seria acoplamento gratuito entre módulos de negócio (mesmo motivo pelo qual `receivables` já a
+    duplica). O que garante que as três não divirjam é **este teste**, não um comentário — a UI
+    reconhece a situação por `acao`, e um segundo valor faria a tela deixar de oferecer o vínculo
+    **sem erro nenhum**, só sem funcionar.
+    """
+    from app.modules.investments import service as investments_service
+    from app.modules.payables import service as payables_service
+    from app.modules.receivables import service as receivables_service
+
+    assert (
+        investments_service.ACAO_CADASTRAR_CONTA
+        == payables_service.ACAO_CADASTRAR_CONTA
+        == receivables_service.ACAO_CADASTRAR_CONTA
+    )
+
+
+def test_registrar_rendimento_sem_vinculo_da_409_ACIONAVEL(client: TestClient, headers):
+    """**É este 409 que põe P3 em zero POR CONSTRUÇÃO** — o mesmo mecanismo pelo qual a 8.12 zerou
+    P1 ao tornar a coluna obrigatória: a população esvazia sozinha e não depende de o dono lembrar
+    de vincular.
+
+    A degradação graciosa da Onda 3 (*"nada acontece, nada quebra"*) é certa LÁ e errada AQUI, e a
+    diferença é quem está na sala: o payout é disparado pelo sistema, sem humano na tela a quem
+    perguntar; o rendimento é o dono digitando um valor agora.
+
+    **Mutante que este teste mata:** remover a guarda — o rendimento volta a ser criável sem perna,
+    e P3 deixa de ser zero por construção.
+    """
+    acc = _investment(client, headers, bank_account_id=None)
+    r = client.post(
+        f"/investments/{acc['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert detail["acao"] == "cadastrar_conta", "a UI reconhece a situação por este campo"
+    assert "Vincule esta aplicação" in detail["mensagem"]
+
+
+def test_erro_comum_de_investments_continua_sendo_string(client: TestClient, headers):
+    """Controle negativo do `detail` estruturado: **só** o erro acionável o preenche. Se todo erro
+    virasse dict, a tela quebraria em toda mensagem que ela hoje lê como texto."""
+    r = client.patch("/investments/nao-existe", json={"name": "X"}, headers=headers)
+    assert r.status_code == 404
+    assert isinstance(r.json()["detail"], str)

--- a/apps/api/tests/test_investments.py
+++ b/apps/api/tests/test_investments.py
@@ -57,8 +57,38 @@ def _account(client: TestClient, headers, grupo: str, categoria: str) -> str:
     return r.json()["id"]
 
 
+def _conta_bancaria(
+    client: TestClient, headers, *, name="CDB Itaú", kind="investment", opening_date="2026-01-01"
+) -> dict:
+    """A `bank_account` ONDE O DINHEIRO DA APLICAÇÃO ESTÁ (Onda 2b-i).
+
+    `kind='investment'` funciona desde a Onda 1 — o que a 2b-i acrescenta é a ligação 1:1 com a
+    faceta de PRODUTO (`investment_accounts`), que é quem sabe rentabilidade e indexador.
+    """
+    r = client.post(
+        "/bank/accounts",
+        json={
+            "name": name,
+            "kind": kind,
+            "number": "",
+            "opening_balance_cents": 0,
+            "opening_balance_is_known": True,
+            "opening_date": opening_date,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
 def _investment(
-    client: TestClient, headers, *, name="CDB Banco X", principal=1_000_000, opened="2026-01-10"
+    client: TestClient,
+    headers,
+    *,
+    name="CDB Banco X",
+    principal=1_000_000,
+    opened="2026-01-10",
+    bank_account_id: str | None = None,
 ) -> dict:
     r = client.post(
         "/investments",
@@ -68,6 +98,7 @@ def _investment(
             "index_rate_label": "CDI 110%",
             "principal_cents": principal,
             "opened_at": opened,
+            "bank_account_id": bank_account_id,
         },
         headers=headers,
     )
@@ -375,3 +406,71 @@ def test_yield_appears_in_dre_financeiro_group(client: TestClient, headers, db: 
     assert cats["Rendimento de aplicação"] == 18_000
     # e conta no resultado operacional (FINANCEIRO ∈ RESULT_GROUPS)
     assert report.resultado_cents == 18_000
+
+
+# ── Onda 2b-i — o vínculo 1:1 com a conta bancária da aplicação ──────────────────────────────
+
+
+def test_vincular_a_aplicacao_a_conta_bancaria_dela(client: TestClient, headers):
+    """O caminho feliz do vínculo, pelo PATCH — é assim que a aplicação LEGADA é vinculada.
+
+    O vínculo é ato do dono, na tela: por isso a migration 0075 não faz backfill nenhum, e é
+    justamente o backfill ausente que a mantém fora da armadilha do `FORCE ROW LEVEL SECURITY`.
+    """
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers)
+    assert acc["bank_account_id"] is None
+
+    r = client.patch(
+        f"/investments/{acc['id']}", json={"bank_account_id": conta["id"]}, headers=headers
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["bank_account_id"] == conta["id"]
+
+
+def test_vincular_ja_na_criacao(client: TestClient, headers):
+    """A aplicação NOVA nasce vinculada — senão o dono cadastra e leva um 409 no primeiro
+    rendimento, que é o beco que o 409 acionável existe para evitar."""
+    conta = _conta_bancaria(client, headers)
+    acc = _investment(client, headers, bank_account_id=conta["id"])
+    assert acc["bank_account_id"] == conta["id"]
+
+
+def test_a_conta_vinculada_precisa_ser_do_tipo_aplicacao(client: TestClient, headers):
+    """Vincular a aplicação a uma conta CORRENTE creditaria o rendimento no lugar errado — e os
+    dois saldos derivados passariam a mentir juntos."""
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    acc = _investment(client, headers)
+
+    r = client.patch(
+        f"/investments/{acc['id']}", json={"bank_account_id": corrente["id"]}, headers=headers
+    )
+    assert r.status_code == 422, r.text
+    assert "aplicação" in r.json()["detail"]
+
+
+def test_conta_bancaria_inexistente_da_404_e_NUNCA_409(client: TestClient, headers):
+    """404 fail-closed. **409 confirmaria a existência da linha** — e conta de outro tenant chega
+    aqui exatamente assim, escondida pela RLS. O equivalente cross-tenant real mora em
+    `test_investments_rls.py` (`rls_e2e`): no SQLite desta suíte a RLS não existe."""
+    acc = _investment(client, headers)
+    r = client.patch(
+        f"/investments/{acc['id']}",
+        json={"bank_account_id": "00000000-0000-0000-0000-000000000000"},
+        headers=headers,
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_conta_bancaria_arquivada_e_recusada(client: TestClient, headers):
+    """Conta arquivada não recebe lançamento novo — vinculá-la produziria um rendimento que o
+    dono não consegue mais ver movimentar."""
+    conta = _conta_bancaria(client, headers)
+    assert client.post(f"/bank/accounts/{conta['id']}/archive", headers=headers).status_code == 200
+    acc = _investment(client, headers)
+
+    r = client.patch(
+        f"/investments/{acc['id']}", json={"bank_account_id": conta["id"]}, headers=headers
+    )
+    assert r.status_code == 409, r.text
+    assert "arquivada" in r.json()["detail"]

--- a/apps/api/tests/test_investments_rls.py
+++ b/apps/api/tests/test_investments_rls.py
@@ -67,6 +67,7 @@ def _seed_tenant(app_url: str, tenant_id: str, *, principal: int, yield_cents: i
     """Cria, para um tenant (GUC setada ANTES dos INSERTs), uma conta FINANCEIRO + uma conta de
     investimento e registra um rendimento (via o service real). Retorna o id da conta de
     investimento."""
+    from app.modules.bank.models import BankAccount
     from app.modules.chart_of_accounts.models import ChartAccount
     from app.modules.investments import service as inv_service
     from app.modules.investments.models import InvestmentAccount
@@ -85,9 +86,19 @@ def _seed_tenant(app_url: str, tenant_id: str, *, principal: int, yield_cents: i
             rend = ChartAccount(
                 tenant_id=tenant_id, grupo_dre="FINANCEIRO", categoria="Rendimento de aplicação"
             )
+            # Onda 2b-i: sem vínculo, `register_yield` recusa com 409 — e é essa recusa que mantém
+            # o termo P3 vazio por construção. O seed reflete o estado NORMAL da aplicação.
+            banco = BankAccount(
+                tenant_id=tenant_id, name="CDB Itaú", kind="investment", number="",
+                opening_balance_cents=0, opening_balance_is_known=True,
+                opening_date=date(2026, 1, 1),
+            )
+            session.add(banco)
+            session.flush()
             acc = InvestmentAccount(
                 tenant_id=tenant_id, name="CDB", kind="CDB", index_rate_label="CDI",
                 principal_cents=principal, accrued_yield_cents=0, opened_at=date(2026, 1, 10),
+                bank_account_id=banco.id,
             )
             session.add_all([rend, acc])
             session.flush()

--- a/apps/api/tests/test_investments_rls.py
+++ b/apps/api/tests/test_investments_rls.py
@@ -128,6 +128,103 @@ def _rentability_under(app_url: str, tenant_id: str, account_id: str) -> dict | 
         engine.dispose()
 
 
+def _bank_account_for(app_url: str, tenant_id: str) -> str:
+    """Cria uma `bank_account` `kind='investment'` para o tenant. Devolve o id."""
+    from app.modules.bank.models import BankAccount
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            acc = BankAccount(
+                tenant_id=tenant_id, name="CDB Itaú", kind="investment", number="",
+                opening_balance_cents=0, opening_balance_is_known=True,
+                opening_date=date(2026, 1, 1),
+            )
+            session.add(acc)
+            session.commit()
+            acc_id = acc.id
+            session.close()
+            return acc_id
+    finally:
+        engine.dispose()
+
+
+def _tentar_vincular(app_url: str, tenant_id: str, inv_id: str, bank_id: str) -> int | None:
+    """Tenta vincular sob a ótica de `tenant_id`. Devolve o `status_code` do erro, ou None se
+    o vínculo foi aceito."""
+    from app.modules.investments import service as inv_service
+    from app.modules.investments.schemas import InvestmentAccountUpdate
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            try:
+                inv_service.update_account(
+                    session, account_id=inv_id, tenant_id=tenant_id, actor="teste",
+                    data=InvestmentAccountUpdate(bank_account_id=bank_id),
+                )
+                return None
+            except inv_service.InvestmentError as e:
+                return e.status_code
+            finally:
+                session.close()
+    finally:
+        engine.dispose()
+
+
+def test_vincular_a_conta_bancaria_de_OUTRO_tenant_da_404_e_NUNCA_409() -> None:
+    """A conta existe — no tenant B. Para o tenant A ela **não existe**, e a resposta é 404.
+
+    **409 aqui confirmaria a existência da linha alheia**: seria vazamento de existência com cara
+    de validação. É o mesmo critério já fixado em `bank_service.get_account`, e o que a 8.2 pagou
+    para aprender.
+
+    ⚠️ **Só o Postgres reproduz.** No SQLite da suíte unitária a linha do tenant B é visível, o
+    vínculo seria ACEITO, e o teste equivalente lá (`test_conta_bancaria_inexistente_da_404...`)
+    passa por outro motivo — ele usa um id que não existe em lugar nenhum.
+    """
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)  # aplica a cadeia inteira, incl. a 0075
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+        inv_a = _seed_tenant(app_url, tenant_a, principal=1_000_000, yield_cents=10_000)
+        bank_b = _bank_account_for(app_url, tenant_b)
+
+        # CONTROLE POSITIVO: a própria conta de A é aceita — sem isto, um 404 universal
+        # (por bug na validação) passaria como se fosse isolamento funcionando.
+        bank_a = _bank_account_for(app_url, tenant_a)
+        assert _tentar_vincular(app_url, tenant_a, inv_a, bank_a) is None, (
+            "a conta do PRÓPRIO tenant tem de ser aceita — senão o 404 abaixo não prova nada"
+        )
+
+        assert _tentar_vincular(app_url, tenant_a, inv_a, bank_b) == 404, (
+            "RLS falhou, ou o erro virou 409: A não pode nem saber que a conta de B existe"
+        )
+
+
 def test_investment_cross_tenant_a_nao_ve_b() -> None:
     with PostgresContainer(
         "postgres:16-alpine",

--- a/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
+++ b/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
@@ -525,8 +525,8 @@ describe("Story 8.16 — as notas do bloco 4 na tela: declaração de limite, n�
     "lançamento informar a conta, ele vai a zero sozinho.";
   const NOTA_P3 =
     "3 rendimentos de aplicação deste período (R$ 480,00) ainda não geram movimento bancário. " +
-    "A divergência abaixo **inclui** esse valor. Este termo só fecha na Onda 2b — não há o que " +
-    "corrigir à mão.";
+    "A divergência abaixo **inclui** esse valor. Vincule a aplicação à conta bancária dela " +
+    "para que o rendimento passe a aparecer no extrato.";
 
   it("as notas aparecem JUNTO das que já existem, sem bloco novo e sem cor de alerta", async () => {
     // AC10: a nota é declaração de limite, não problema. Ela entra no mesmo `<ul>` de `notes` que a

--- a/apps/web/src/features/financeiro/InvestimentosPage.tsx
+++ b/apps/web/src/features/financeiro/InvestimentosPage.tsx
@@ -4,11 +4,14 @@ import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
 import { type ChartAccount } from "./planoContas";
+import type { BankAccount } from "./contas";
 import {
+  contasDeAplicacao,
   formatBRL,
   formatPct,
   type InvestmentAccount,
   type Rentability,
+  rotuloDoVinculo,
   SUGGESTED_KINDS,
 } from "./investimentos";
 
@@ -26,12 +29,17 @@ export default function InvestimentosPage() {
   const [open, setOpen] = useState(false);
   const [yieldFor, setYieldFor] = useState<InvestmentAccount | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Onda 2b-i: as contas de aplicação disponíveis para vínculo. Carregadas UMA vez aqui e passadas
+  // aos dois modais — refazer o GET dentro de cada um daria duas listas que podem divergir.
+  const [contas, setContas] = useState<BankAccount[]>([]);
 
   const hasPeriod = Boolean(start && end);
 
   const load = useCallback(async () => {
     const { data } = await api.get<InvestmentAccount[]>("/investments");
     setAccounts(data);
+    const { data: bancarias } = await api.get<BankAccount[]>("/bank/accounts");
+    setContas(contasDeAplicacao(bancarias));
     const params = hasPeriod ? { start, end } : undefined;
     const entries = await Promise.all(
       data.map(async (a) => {
@@ -113,7 +121,12 @@ export default function InvestimentosPage() {
                   Registrar rendimento
                 </button>
               </div>
-              <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-5">
+                <Stat
+                  label="Conta bancária"
+                  value={rotuloDoVinculo(a, contas)}
+                  tone={a.bank_account_id ? undefined : "text-amber-700"}
+                />
                 <Stat label="Principal" value={formatBRL(a.principal_cents)} />
                 <Stat label="Rendimento acumulado" value={formatBRL(a.accrued_yield_cents)} />
                 <Stat
@@ -136,12 +149,18 @@ export default function InvestimentosPage() {
         })}
       </div>
 
-      <NewAccountModal open={open} onClose={() => setOpen(false)} onCreated={load} />
+      <NewAccountModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onCreated={load}
+        contas={contas}
+      />
       <RegisterYieldModal
         account={yieldFor}
         onClose={() => setYieldFor(null)}
         onDone={load}
         onError={setError}
+        contas={contas}
       />
     </div>
   );
@@ -156,20 +175,65 @@ function Stat({ label, value, tone }: { label: string; value: string; tone?: str
   );
 }
 
+/**
+ * O seletor da conta bancária da aplicação (Onda 2b-i). UM componente, dois consumidores — o
+ * cadastro e o caminho de recuperação do 409. Duas cópias divergiriam no primeiro ajuste.
+ *
+ * A lista já chega filtrada por `contasDeAplicacao`: conta corrente não aparece, porque escolhê-la
+ * levaria a um 422 depois de o dono já ter decidido.
+ */
+function SeletorDeConta({
+  contas,
+  value,
+  onChange,
+}: {
+  contas: BankAccount[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-neutral-600">
+        Conta bancária da aplicação
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+      >
+        <option value="">Escolha a conta…</option>
+        {contas.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      {contas.length === 0 && (
+        <span className="mt-1 block text-xs text-amber-700">
+          Nenhuma conta do tipo aplicação cadastrada. Cadastre-a em Contas &amp; Saldos.
+        </span>
+      )}
+    </label>
+  );
+}
+
 function NewAccountModal({
   open,
   onClose,
   onCreated,
+  contas,
 }: {
   open: boolean;
   onClose: () => void;
   onCreated: () => void;
+  contas: BankAccount[];
 }) {
   const [name, setName] = useState("");
   const [kind, setKind] = useState<string>(SUGGESTED_KINDS[0]);
   const [indexLabel, setIndexLabel] = useState("");
   const [principal, setPrincipal] = useState("");
   const [openedAt, setOpenedAt] = useState("");
+  const [bankAccountId, setBankAccountId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -183,12 +247,16 @@ function NewAccountModal({
         index_rate_label: indexLabel,
         principal_cents: Math.round(Number(principal.replace(",", ".")) * 100) || 0,
         opened_at: openedAt,
+        // Onda 2b-i: a aplicação nasce vinculada. Sem isso o dono cadastra e leva um 409 no
+        // primeiro rendimento — o beco que o 409 acionável existe justamente para evitar.
+        bank_account_id: bankAccountId || null,
       });
       onCreated();
       setName("");
       setIndexLabel("");
       setPrincipal("");
       setOpenedAt("");
+      setBankAccountId("");
       onClose();
     } catch (err) {
       setError(apiErrorMessage(err));
@@ -229,6 +297,7 @@ function NewAccountModal({
           placeholder="Ex.: 10000,00"
         />
         <Field label="Data de aplicação" value={openedAt} onChange={setOpenedAt} type="date" />
+        <SeletorDeConta contas={contas} value={bankAccountId} onChange={setBankAccountId} />
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}
@@ -247,11 +316,13 @@ function RegisterYieldModal({
   onClose,
   onDone,
   onError,
+  contas,
 }: {
   account: InvestmentAccount | null;
   onClose: () => void;
   onDone: () => void;
   onError: (msg: string) => void;
+  contas: BankAccount[];
 }) {
   const [amount, setAmount] = useState("");
   const [date, setDate] = useState("");
@@ -259,6 +330,9 @@ function RegisterYieldModal({
   const [financeiro, setFinanceiro] = useState<ChartAccount[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Onda 2b-i: ligado pelo 409 acionável do backend (`detail.acao === "cadastrar_conta"`).
+  const [precisaVincular, setPrecisaVincular] = useState(false);
+  const [bankAccountId, setBankAccountId] = useState("");
 
   // Carrega só as contas do grupo FINANCEIRO (o rendimento é receita financeira — AC2).
   useEffect(() => {
@@ -276,6 +350,13 @@ function RegisterYieldModal({
     setError(null);
     setSaving(true);
     try {
+      // Se o 409 pediu o vínculo e o dono acabou de escolher a conta, vincula ANTES de reenviar —
+      // assim ele não perde o valor e a data que já digitou. É o que transforma o 409 num desvio
+      // de um passo em vez de um beco.
+      if (precisaVincular && bankAccountId) {
+        await api.patch(`/investments/${account.id}`, { bank_account_id: bankAccountId });
+        setPrecisaVincular(false);
+      }
       await api.post(`/investments/${account.id}/yield`, {
         amount_cents: Math.round(Number(amount.replace(",", ".")) * 100),
         date,
@@ -284,8 +365,23 @@ function RegisterYieldModal({
       onDone();
       setAmount("");
       setDate("");
+      setBankAccountId("");
       onClose();
     } catch (err) {
+      // O 409 acionável não é erro de tela: é um pedido de dado que falta, com o caminho junto.
+      // Por isso ele NÃO sobe para `onError` (a faixa vermelha da página) — fica no modal, ao
+      // lado do campo que o resolve.
+      const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data
+        ?.detail;
+      if (
+        typeof detail === "object" &&
+        detail !== null &&
+        (detail as { acao?: string }).acao === "cadastrar_conta"
+      ) {
+        setPrecisaVincular(true);
+        setError((detail as { mensagem?: string }).mensagem ?? null);
+        return;
+      }
       const msg = apiErrorMessage(err);
       setError(msg);
       onError(msg);
@@ -324,10 +420,13 @@ function RegisterYieldModal({
             ))}
           </select>
         </label>
+        {precisaVincular && (
+          <SeletorDeConta contas={contas} value={bankAccountId} onChange={setBankAccountId} />
+        )}
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}
-          disabled={saving || !amount.trim() || !date}
+          disabled={saving || !amount.trim() || !date || (precisaVincular && !bankAccountId)}
           className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
         >
           {saving ? "Registrando..." : "Registrar rendimento"}

--- a/apps/web/src/features/financeiro/conferencia.test.ts
+++ b/apps/web/src/features/financeiro/conferencia.test.ts
@@ -405,7 +405,7 @@ describe("Story 8.16 — as notas do bloco 4: a tela ANOTA, nunca recalcula", ()
     valor_rendimentos_sem_perna_cents: 48_000,
     notes: [
       "7 lançamentos deste período não informam de qual conta saiu ou entrou (R$ 3.120,00). A divergência abaixo **inclui** esse valor. Este termo fecha na Onda 2: assim que todo lançamento informar a conta, ele vai a zero sozinho.",
-      "3 rendimentos de aplicação deste período (R$ 480,00) ainda não geram movimento bancário. A divergência abaixo **inclui** esse valor. Este termo só fecha na Onda 2b — não há o que corrigir à mão.",
+      "3 rendimentos de aplicação deste período (R$ 480,00) ainda não geram movimento bancário. A divergência abaixo **inclui** esse valor. Vincule a aplicação à conta bancária dela para que o rendimento passe a aparecer no extrato.",
     ],
   });
 
@@ -438,15 +438,23 @@ describe("Story 8.16 — as notas do bloco 4: a tela ANOTA, nunca recalcula", ()
     // do mesmo fato viram duas frases diferentes conforme o caminho.
     expect(comTermos.notes).toHaveLength(2);
     expect(comTermos.notes[0]).toContain("Onda 2:");
-    expect(comTermos.notes[1]).toContain("Onda 2b");
+    // MUDANÇA DELIBERADA na Onda 2b-i: a nota deixou de nomear a onda porque a onda foi
+    // ENTREGUE, e passou a nomear a AÇÃO que passou a existir (vincular a aplicação).
+    expect(comTermos.notes[1]).toContain("Vincule a aplicação");
+    expect(comTermos.notes[1]).not.toContain("Onda 2b");
   });
 
-  it("cada nota nomeia a ONDA que a fecha, e elas são diferentes", () => {
-    // P1/P2 somem quando o dono terminar de corrigir os lançamentos; P3 NÃO some nesta onda. Uma
-    // nota que promete "isso some quando você terminar o mutirão" sobre um termo que não some é a
-    // mesma afirmação sem lastro que a Onda 0 removeu da Projeção.
-    expect(comTermos.notes[0]).not.toContain("Onda 2b");
-    expect(comTermos.notes[1]).toContain("não há o que corrigir à mão");
+  it("cada nota pede a AÇÃO que fecha o seu termo, e elas são diferentes", () => {
+    // Até a Onda 2b-i, P3 não fechava com trabalho nenhum e a nota NOMEAVA A ONDA que o fecharia
+    // — era o que impedia o dono de caçar um termo que software nenhum conseguia fechar.
+    // Entregue a 2b-i, a ação existe, e a nota passou a nomeá-la. O que continua separando as
+    // duas frases é que elas pedem coisas diferentes: informar a conta em cada lançamento legado,
+    // um por um (P1/P2), × vincular a aplicação à conta bancária dela, UMA vez (P3). Achatá-las
+    // mandaria o dono caçar lançamento a lançamento um termo que se resolve num clique.
+    expect(comTermos.notes[0]).toContain("Este termo fecha na Onda 2:");
+    expect(comTermos.notes[0]).not.toContain("Vincule a aplicação");
+    expect(comTermos.notes[1]).toContain("Vincule a aplicação");
+    expect(comTermos.notes[1]).not.toContain("Onda 2b");
   });
 
   it("UX-001: as notas novas não reusam 'no banco' nem os rótulos de saldo vizinhos", () => {

--- a/apps/web/src/features/financeiro/conferencia.ts
+++ b/apps/web/src/features/financeiro/conferencia.ts
@@ -85,7 +85,8 @@ export interface ConferenciaReport {
    */
   lancamentos_sem_conta_informada: number;
   valor_sem_conta_informada_cents: number;
-  /** Fecha na **Onda 2b**, não nesta — por isso tem contador e frase próprios. */
+  /** Fechou na **Onda 2b-i** (o rendimento passou a gerar movimento). Contador e frase próprios
+   *  continuam: P1/P2 e P3 pedem AÇÕES diferentes do dono. */
   rendimentos_sem_perna_bancaria: number;
   valor_rendimentos_sem_perna_cents: number;
 }

--- a/apps/web/src/features/financeiro/investimentos.test.ts
+++ b/apps/web/src/features/financeiro/investimentos.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatPct } from "./investimentos";
+import type { BankAccount } from "./contas";
+import {
+  contasDeAplicacao,
+  formatPct,
+  type InvestmentAccount,
+  rotuloDoVinculo,
+} from "./investimentos";
 
 /**
  * Smoke test do helper de formatação de rentabilidade (Story 5.6). O projeto não tem infra de teste
@@ -15,5 +21,35 @@ describe("formatPct (rentabilidade — Story 5.6)", () => {
   it("mostra '—' quando a rentabilidade é null (principal 0 — divisão evitada)", () => {
     expect(formatPct(null)).toBe("—");
     expect(formatPct(Number.NaN)).toBe("—");
+  });
+});
+
+describe("contasDeAplicacao / rotuloDoVinculo (Onda 2b-i)", () => {
+  const aplicacao = { id: "c1", name: "CDB Itaú", kind: "investment", archived_at: null };
+  const corrente = { id: "c2", name: "Itaú PJ", kind: "checking", archived_at: null };
+  const arquivada = { id: "c3", name: "CDB velho", kind: "investment", archived_at: "2026-01-01" };
+  const contas = [aplicacao, corrente, arquivada] as unknown as BankAccount[];
+
+  it("só oferece conta de APLICAÇÃO e não arquivada", () => {
+    // Oferecer a corrente levaria o dono a creditar o rendimento onde o dinheiro não está — e o
+    // backend recusaria com 422 depois de ele já ter escolhido.
+    expect(contasDeAplicacao(contas).map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  it("nomeia a conta quando a aplicação está vinculada", () => {
+    const app = { id: "a1", bank_account_id: "c1" } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, contas)).toBe("CDB Itaú");
+  });
+
+  it("diz o que FAZER quando não está vinculada — nunca só 'sem conta'", () => {
+    // É este vínculo que o 409 de `register_yield` pede. Um rótulo que só descreve o estado
+    // deixaria o dono sabendo do problema e não do caminho.
+    const app = { id: "a1", bank_account_id: null } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, contas)).toBe("Vincular a uma conta");
+  });
+
+  it("não inventa nome quando o vínculo aponta para conta fora da lista", () => {
+    const app = { id: "a1", bank_account_id: "sumida" } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, contas)).toBe("Vincular a uma conta");
   });
 });

--- a/apps/web/src/features/financeiro/investimentos.ts
+++ b/apps/web/src/features/financeiro/investimentos.ts
@@ -9,6 +9,7 @@
  * — NÃO é venda com split de Carteira (por isso a tela usa o seletor de contas FINANCEIRO do plano
  * de contas, não o fluxo de cobrança normal).
  */
+import type { BankAccount } from "./contas";
 import { formatBRL } from "./dre";
 
 export { formatBRL };
@@ -25,6 +26,13 @@ export interface InvestmentAccount {
   accrued_yield_cents: number;
   opened_at: string;
   created_at: string;
+  /**
+   * Onda 2b-i — a conta bancária ONDE ESTE DINHEIRO ESTÁ (`kind='investment'`), 1:1.
+   * `null` = ainda não vinculada, e nesse estado o backend recusa o rendimento com **409
+   * acionável** (`detail.acao === "cadastrar_conta"`): rendimento sem perna bancária é o termo P3
+   * da pré-condição do gate do Epic 8.
+   */
+  bank_account_id: string | null;
 }
 
 export interface Rentability {
@@ -48,4 +56,32 @@ export function formatPct(fraction: number | null): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }) + "%";
+}
+
+// ── Onda 2b-i: o vínculo da aplicação com a conta bancária dela ─────────────────────────────
+
+/** A ação que o rótulo mostra quando não há vínculo. Uma redação, um lugar. */
+export const VINCULAR_LABEL = "Vincular a uma conta";
+
+/**
+ * As contas que PODEM receber o vínculo: `kind='investment'` e não arquivadas. PURA.
+ *
+ * Oferecer uma conta corrente levaria o dono a creditar o rendimento onde o dinheiro não está —
+ * e o backend recusaria com 422 **depois** de ele já ter escolhido. Filtrar aqui é o que impede
+ * a escolha errada de existir.
+ */
+export function contasDeAplicacao(contas: BankAccount[]): BankAccount[] {
+  return contas.filter((c) => c.kind === "investment" && c.archived_at === null);
+}
+
+/**
+ * Rótulo do vínculo da aplicação com a conta bancária dela. PURA.
+ *
+ * Sem vínculo — ou com vínculo apontando para conta que sumiu da lista — devolve a **AÇÃO**, nunca
+ * um estado passivo tipo "sem conta": é este vínculo que o 409 de `register_yield` pede, e um
+ * rótulo que só descreve o problema deixa o dono sabendo do problema e não do caminho.
+ */
+export function rotuloDoVinculo(account: InvestmentAccount, contas: BankAccount[]): string {
+  const conta = contas.find((c) => c.id === account.bank_account_id);
+  return conta ? conta.name : VINCULAR_LABEL;
 }

--- a/docs/superpowers/plans/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento.md
+++ b/docs/superpowers/plans/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento.md
@@ -1,0 +1,1380 @@
+# Onda 2b-i — a perna bancária do rendimento · Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fazer o rendimento de aplicação gerar o `bank_transaction` correspondente, para que o termo **P3** da pré-condição do gate do Epic 8 vá a zero por construção e a métrica primária do épico possa ser lida.
+
+**Architecture:** Três peças. (1) O contador de P3 passa a verificar de fato se existe perna bancária (`NOT EXISTS`), honrando o próprio nome. (2) `investment_accounts` ganha `bank_account_id` — ligação 1:1 com a `bank_account` `kind='investment'` — e `register_yield` recusa com **409 acionável** sem ela. (3) `register_yield` chama `sync_origin_movement(source='yield')`, o mesmo ponto único de escrita usado por `payables`/`receivables`/`transfers`, na mesma transação.
+
+**Tech Stack:** FastAPI (Python 3.13), SQLAlchemy 2 + Alembic, PostgreSQL 16 (SQLite na suíte unitária), React 18 + Vite + TypeScript, pytest, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md`
+
+---
+
+## Global Constraints
+
+Valem em **toda** task. Não repetidas nas tasks individuais.
+
+- **Idioma:** domínio, comentários e mensagens de erro em **PT-BR**; identificadores em inglês.
+- **Dinheiro em centavos**, `BigInteger`. Nunca float.
+- **RLS é a ÚNICA garantia de isolamento** — nenhuma query filtra `tenant_id` manualmente (Regra de Ouro nº 1). Conta de outro tenant → **404 fail-closed**, nunca 403 e nunca 409 (409 vazaria existência).
+- **`sync_origin_movement` é a ÚNICA função do repositório que escreve `source ∈ SOURCES_SISTEMA`.** Não abra um segundo caminho: se faltar algo, o que se acrescenta é um **parâmetro nela**.
+- **Direção de import:** `investments` **pode** importar `bank`. `bank` **NUNCA** importa `investments`/`payables`/`receivables` — dois gates (AST + texto cru) em `tests/test_money_planes.py`. Nenhuma task deste plano toca esses gates.
+- **"Hoje" nunca é `datetime.now(UTC).date()`** — é `settings.service.hoje_do_tenant(db)`. Gate AST em `tests/test_fuso_do_tenant.py`.
+- **Nenhuma migration deste plano faz `UPDATE`.** `ADD COLUMN`/`CREATE INDEX` são DDL e a RLS não os alcança. Um `UPDATE` de backfill em tabela sob `FORCE ROW LEVEL SECURITY` é filtrado a **zero linhas em silêncio** e o SQLite dos testes **não pega** — seis migrations deste repo já pagaram por isso (`0046`, `0066`, `0067`, `0068`, `0069`, `0073`).
+- **Head do alembic:** verificado como `0074` em 2026-08-07. **Reconfira programaticamente antes de mergear** (`alembic heads`), não só ao escrever: branches paralelas já colidiram numeração neste repo.
+- **Commits:** Conventional Commits, em PT-BR, referenciando a onda. Ex.: `feat: o rendimento de aplicação gera o movimento bancário [Onda 2b-i]`.
+- **Rodar os testes:**
+  - Backend: `cd apps/api && .venv/Scripts/python -m pytest <arquivo> -v` (Windows) — **em primeiro plano, nunca em background.**
+  - Frontend: `pnpm --filter @e1p/web test -- --run <arquivo>`
+  - ⚠️ **NÃO use `scripts/check.sh` como prova** — ele mascara falha de frontend com `|| true`. Rode as etapas individualmente.
+- **Última task é a entrada no `CLAUDE.md`** — é AC obrigatório de toda story neste projeto (`CLAUDE.md` §5, passo 4), com o mesmo peso do teste.
+
+---
+
+## File Structure
+
+**Backend — modificados:**
+
+| Arquivo | Responsabilidade nesta onda |
+|---|---|
+| `apps/api/app/modules/receivables/service.py` | Contador de P3 passa a exigir ausência de perna (`NOT EXISTS`) |
+| `apps/api/migrations/versions/0075_investment_bank_account.py` | **Criar** — coluna + índice único parcial. Sem `UPDATE` |
+| `apps/api/app/modules/investments/models.py` | Coluna `bank_account_id` |
+| `apps/api/app/modules/investments/schemas.py` | `bank_account_id` em Create/Update/Out |
+| `apps/api/app/modules/investments/service.py` | Validação do alvo, 409 acionável, chamada a `sync_origin_movement`, 422 de data futura |
+| `apps/api/app/modules/investments/router.py` | `detail` estruturado no erro acionável; `bank_account_id` no `_out` |
+| `apps/api/app/modules/bank/reconciliation.py` | Frase da nota de P3 deixa de nomear uma onda |
+
+**Frontend — modificados:**
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `apps/web/src/features/financeiro/investimentos.ts` | Tipo `InvestmentAccount` ganha `bank_account_id`; helper puro de rótulo do vínculo |
+| `apps/web/src/features/financeiro/InvestimentosPage.tsx` | Campo de vínculo no formulário da aplicação |
+
+**Testes — modificados/criados:**
+
+| Arquivo | O que cobre |
+|---|---|
+| `apps/api/tests/test_bank_reconciliation_report.py` | P3 com perna sai da população; a frase nova da nota |
+| `apps/api/tests/test_investments.py` | Vínculo, 409, o movimento, o 422 de data futura, IV1 preservada |
+| `apps/web/src/features/financeiro/conferencia.test.ts` | Asserção da frase da nota |
+| `apps/web/src/features/financeiro/ConferenciaPage.test.tsx` | Idem |
+| `apps/web/src/features/financeiro/investimentos.test.ts` | Helper do rótulo do vínculo |
+
+---
+
+### Task 1: O predicado de P3 passa a honrar o próprio nome
+
+**Files:**
+- Modify: `apps/api/app/modules/receivables/service.py:52` (import) e `:972-999` (o contador)
+- Test: `apps/api/tests/test_bank_reconciliation_report.py`
+
+**Interfaces:**
+- Consumes: nada de tasks anteriores (é a primeira).
+- Produces: `contar_rendimentos_sem_perna_bancaria(db, *, start: date, end: date) -> tuple[int, int]` — assinatura **inalterada**; só o predicado muda. Continua consumida por `app/main.py::probe_termos_do_gate`.
+
+**Por que esta task vem primeiro.** Ela é a definição executável do resultado que as tasks 2-4 precisam produzir. E o membro que a prova — *um rendimento **com** perna* — é construtível no teste **agora**, chamando `sync_origin_movement` diretamente: `SOURCE_YIELD` já está em `SOURCES_SISTEMA` e a função já aceita. O que não existe ainda é o caminho de **produção** que a chama; isso é a Task 4.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescentar em `apps/api/tests/test_bank_reconciliation_report.py`, logo após `test_a1_o_rendimento_de_aplicacao_nao_entra_no_termo_de_conta_informada` (por volta da linha 1436):
+
+```python
+def test_rendimento_COM_perna_bancaria_sai_do_termo_P3(
+    client: TestClient, headers, db: Session
+):
+    """**O membro que era inconstruível, e por isso o defeito viveu.**
+
+    `contar_rendimentos_sem_perna_bancaria` contava TODO rendimento da janela — nenhum join,
+    nenhum `NOT EXISTS`. Pré-2b isso era inofensivo, porque *"todos os rendimentos"* e *"os
+    rendimentos sem perna"* eram o mesmo conjunto. Ligado o movimento (Task 4), os dois se
+    separam, e sem este predicado P3 seguiria contando os rendimentos que passaram a ter perna:
+    **o gate não abriria nem depois da onda que existe para destravá-lo.**
+
+    O saldo declarado já inclui o rendimento (1.000.000 + 48.000) justamente para que a conta
+    continue batendo e a única coisa medida aqui seja o termo P3.
+
+    **Mutante que este teste mata:** remover o `~_tem_perna_bancaria` do `where` — P3 volta a 1.
+    Segundo mutante: trocar `SOURCE_YIELD` por outro `source` no `NOT EXISTS` — idem.
+    """
+    tenant_id = _tenant_id(client, headers)
+    conta = _account(client, headers, opening=1_000_000)
+    _declarar(client, headers, conta["id"], balance_cents=1_048_000)
+    rendimento = _charge_de_rendimento(db, tenant_id, valor=48_000, pago_em=date(2026, 7, 14))
+
+    bank_origin.sync_origin_movement(
+        db,
+        tenant_id=tenant_id,
+        actor="teste",
+        source=SOURCE_YIELD,
+        origin_id=rendimento.id,
+        bank_account_id=conta["id"],
+        posted_at=date(2026, 7, 14),
+        amount_cents=48_000,
+        description="Rendimento CDB",
+    )
+    db.commit()
+
+    r = _report(db)
+    assert r.rendimentos_sem_perna_bancaria == 0, (
+        "o rendimento TEM perna bancária — contá-lo em P3 mantém o gate fechado depois da 2b"
+    )
+    assert r.valor_rendimentos_sem_perna_cents == 0
+    assert r.notes == [], "zero termo não-zero ⇒ zero nota"
+```
+
+E acrescentar aos imports do topo do arquivo de teste:
+
+```python
+from app.modules.bank import origin as bank_origin
+from app.modules.bank.models import SOURCE_YIELD
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_bank_reconciliation_report.py::test_rendimento_COM_perna_bancaria_sai_do_termo_P3 -v`
+
+Expected: **FAIL** — `assert 1 == 0`, com a mensagem sobre o gate fechado.
+
+Se falhar por `posted_at` recusado (piso `> opening_date`), confira a constante `OPENING` no topo do arquivo: ela precisa ser anterior a 2026-07-14. Ajuste a data do movimento, **não** o piso.
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/api/app/modules/receivables/service.py`, linha 52, acrescentar `SOURCE_YIELD` e `BankTransaction` ao import existente:
+
+```python
+from app.modules.bank.models import SOURCE_CHARGE, SOURCE_YIELD, BankAccount, BankTransaction
+```
+
+E no corpo de `contar_rendimentos_sem_perna_bancaria` (a partir da linha 990), substituir a query:
+
+```python
+    de, ate = janela_de_caixa(start, end)
+    # O `NOT EXISTS` é o que faz a função HONRAR o próprio nome. Sem ele, ela conta todo
+    # rendimento da janela — o que coincidia com "sem perna" só enquanto perna nenhuma existia.
+    # Correlaciona por `origin_id`, que para origem de perna única É o id do lançamento
+    # (bank/transfers.py:18), e nunca por data: a pergunta do termo é *"existe perna?"*, não
+    # *"a perna caiu nesta janela?"*.
+    _tem_perna_bancaria = (
+        select(BankTransaction.id)
+        .where(
+            BankTransaction.source == SOURCE_YIELD,
+            BankTransaction.origin_id == Charge.id,
+        )
+        .exists()
+    )
+    row = db.execute(
+        select(func.count(), func.coalesce(func.sum(Charge.amount_cents), 0)).where(
+            ~_not_investment_yield(),
+            Charge.paid_at.is_not(None),
+            Charge.paid_at >= de,
+            Charge.paid_at < ate,
+            ~_tem_perna_bancaria,
+        )
+    ).one()
+    return int(row[0] or 0), int(row[1] or 0)
+```
+
+Acrescentar ao final da docstring da função:
+
+```
+    **A partir da Onda 2b-i o predicado inclui `NOT EXISTS` sobre `bank_transactions`
+    (`source='yield'`, `origin_id = charge.id`).** Antes dela a função contava TODO rendimento da
+    janela: coincidia com a intenção só porque perna nenhuma existia. Ligado o movimento, contar
+    o rendimento que JÁ tem perna manteria o gate fechado depois da própria onda que o destrava.
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_bank_reconciliation_report.py -v`
+
+Expected: **PASS**, incluindo `test_a1_o_rendimento_de_aplicacao_nao_entra_no_termo_de_conta_informada` (rendimento **sem** perna continua contando) e `test_os_dois_termos_geram_duas_notas_com_ondas_diferentes`.
+
+- [ ] **Step 5: Matar os dois mutantes**
+
+⚠️ **Restaure por CÓPIA DE ARQUIVO, nunca por `git checkout`** — um `checkout` sobre arquivo com trabalho não commitado já apagou uma sessão inteira neste épico.
+
+```bash
+cd apps/api
+cp app/modules/receivables/service.py /tmp/service.py.bak
+```
+
+Mutante M1 — remova a linha `~_tem_perna_bancaria,` do `where`. Rode o teste da Step 2: **deve FALHAR**.
+Mutante M2 — troque `BankTransaction.source == SOURCE_YIELD` por `== SOURCE_CHARGE`. Rode: **deve FALHAR**.
+
+```bash
+cp /tmp/service.py.bak app/modules/receivables/service.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/receivables/service.py apps/api/tests/test_bank_reconciliation_report.py
+git commit -m "fix: o contador de P3 passa a verificar se existe perna bancária [Onda 2b-i]"
+```
+
+---
+
+### Task 2: A aplicação aponta para a conta bancária dela
+
+**Files:**
+- Create: `apps/api/migrations/versions/0075_investment_bank_account.py`
+- Modify: `apps/api/app/modules/investments/models.py:54` (fim da classe)
+- Modify: `apps/api/app/modules/investments/schemas.py` (Create, Update, Out)
+- Modify: `apps/api/app/modules/investments/service.py` (validação + create/update)
+- Modify: `apps/api/app/modules/investments/router.py:25-35` (`_out`)
+- Test: `apps/api/tests/test_investments.py`
+
+**Interfaces:**
+- Consumes: nada da Task 1.
+- Produces:
+  - `InvestmentAccount.bank_account_id: Mapped[str | None]`
+  - `investments.service._validate_bank_account(db: Session, bank_account_id: str) -> None` — levanta `InvestmentError` (404 inexistente/cross-tenant, 422 `kind` errado, 409 arquivada)
+  - `InvestmentAccountCreate.bank_account_id: str | None`, `InvestmentAccountUpdate.bank_account_id: str | None`, `InvestmentAccountOut.bank_account_id: str | None`
+
+⚠️ **Desvio declarado da spec §4.1.** A spec dizia *"409 reaproveitando `_CONTA_ARQUIVADA_MSG`"*. Essa constante é **privada de `payables/service.py`** e importá-la de `investments` seria acoplamento gratuito entre dois módulos de negócio — exatamente o que o repo evita duplicando `ACAO_CADASTRAR_CONTA` de propósito. A mensagem é **escrita localmente**, abaixo.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Acrescentar ao fim de `apps/api/tests/test_investments.py`:
+
+```python
+# ── Onda 2b-i — o vínculo 1:1 com a conta bancária da aplicação ──────────────────────────────
+
+
+def _conta_bancaria(client: TestClient, headers, *, kind: str = "investment") -> dict:
+    resp = client.post(
+        "/bank/accounts",
+        json={
+            "name": "CDB Itaú",
+            "kind": kind,
+            "number": "",
+            "opening_balance_cents": 0,
+            "opening_balance_is_known": True,
+            "opening_date": "2026-06-01",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _aplicacao(client: TestClient, headers, **extra) -> dict:
+    body = {"name": "CDB", "kind": "CDB", "principal_cents": 100_000, "opened_at": "2026-06-01"}
+    body.update(extra)
+    resp = client.post("/investments", json=body, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_vincular_a_aplicacao_a_conta_bancaria_dela(client: TestClient, headers):
+    """O caminho feliz do vínculo 1:1, pelo PATCH — é assim que a aplicação legada é vinculada."""
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers)
+    assert app_["bank_account_id"] is None
+
+    resp = client.patch(
+        f"/investments/{app_['id']}", json={"bank_account_id": conta["id"]}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["bank_account_id"] == conta["id"]
+
+
+def test_a_conta_vinculada_precisa_ser_do_tipo_aplicacao(client: TestClient, headers):
+    """Vincular a aplicação a uma conta CORRENTE creditaria o rendimento no lugar errado — e o
+    saldo derivado das duas contas passaria a mentir junto."""
+    corrente = _conta_bancaria(client, headers, kind="checking")
+    app_ = _aplicacao(client, headers)
+
+    resp = client.patch(
+        f"/investments/{app_['id']}", json={"bank_account_id": corrente["id"]}, headers=headers
+    )
+    assert resp.status_code == 422, resp.text
+    assert "aplicação" in resp.json()["detail"]
+
+
+def test_conta_bancaria_inexistente_da_404_e_nunca_409(client: TestClient, headers):
+    """404 fail-closed. **409 confirmaria a existência da linha** — e conta de outro tenant chega
+    aqui exatamente assim, escondida pela RLS."""
+    app_ = _aplicacao(client, headers)
+    resp = client.patch(
+        f"/investments/{app_['id']}",
+        json={"bank_account_id": "00000000-0000-0000-0000-000000000000"},
+        headers=headers,
+    )
+    assert resp.status_code == 404, resp.text
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -k "vincular or tipo_aplicacao or inexistente" -v`
+
+Expected: **FAIL** — `KeyError: 'bank_account_id'` no primeiro, 200 em vez de 422/404 nos demais.
+
+- [ ] **Step 3: A migration**
+
+Criar `apps/api/migrations/versions/0075_investment_bank_account.py`:
+
+```python
+"""A aplicação aponta para a conta bancária dela (Onda 2b-i)
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-08-07
+
+**Por quê.** `register_yield` cria uma `Charge` sintética paga (Story 5.6) e nada mais: o dinheiro
+que entrou na aplicação real não vira `bank_transaction` nenhum. Isso é o termo **P3** da
+pré-condição do gate do Epic 8, e enquanto ele for não-vazio numa janela a divergência daquele
+ciclo **não pode ser lida**. Esta coluna é o que diz ao `sync_origin_movement` QUAL conta creditar.
+
+**`investment_accounts` NÃO é absorvida por `bank_accounts`** — ela é a faceta de PRODUTO
+(rentabilidade, indexador, principal), e a `bank_account` `kind='investment'` é onde o dinheiro
+está. São duas coisas, e a ligação é 1:1.
+
+⚠️ **NENHUM `UPDATE`, e é isso que torna esta migration segura.** As seis armadilhas registradas
+neste repo (`0046`, `0066`, `0067`, `0068`, `0069`, `0073`) são a mesma: backfill filtrado em
+silêncio pela RLS, completando com **sucesso aparente**, invisível para o SQLite da suíte.
+`ADD COLUMN` e `CREATE INDEX` são **DDL** — a RLS não os alcança. A aplicação que já existe em
+produção é vinculada pelo dono, **por ato**, na tela. O backfill que não existe é o backfill que
+não pode falhar em silêncio.
+
+⚠️ **`tenant_id` é a PRIMEIRA coluna do índice único, e a ordem não é estética.** Índice único é
+global e **não respeita RLS**: sem o `tenant_id` na frente, o tenant B receberia violação de
+unicidade causada por dado do tenant A — bug **e** vazamento de existência. Lição já paga na 8.2.
+
+**A cláusula parcial** (`WHERE bank_account_id IS NOT NULL`) mantém N aplicações não-vinculadas
+convivendo. Ela não é o que garante a unicidade dos `NULL` (em índice único `NULL` já é distinto
+de `NULL` por padrão) — está aqui por tamanho e por intenção declarada, e a justificativa é esta,
+não a que a 8.9 escreveu e que era falsa.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0075"
+down_revision: str | None = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "investment_accounts"
+_COLUMN = "bank_account_id"
+_INDEX = "uq_investment_accounts_bank_account"
+
+
+def upgrade() -> None:
+    op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(36), nullable=True))
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["tenant_id", _COLUMN],
+        unique=True,
+        postgresql_where=sa.text("bank_account_id IS NOT NULL"),
+        sqlite_where=sa.text("bank_account_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # Não-destrutivo para o que existia antes: `principal_cents` e `accrued_yield_cents` nunca
+    # foram tocados. O que se perde é o VÍNCULO — e com ele o `register_yield` volta a aceitar
+    # rendimento sem perna bancária, reabrindo o termo P3. Escrito aqui para não ser descoberto
+    # no meio de um rollback.
+    op.drop_index(_INDEX, table_name=_TABLE)
+    op.drop_column(_TABLE, _COLUMN)
+```
+
+- [ ] **Step 4: O model**
+
+Em `apps/api/app/modules/investments/models.py`, ao final da classe `InvestmentAccount` (após `opened_at`):
+
+```python
+    # A conta bancária ONDE ESTE DINHEIRO ESTÁ (Onda 2b-i). Ligação 1:1 com uma `bank_account`
+    # `kind='investment'`. Referência SOLTA, sem FK dura — mesmo padrão do resto do projeto.
+    # `None` = ainda não vinculada; nesse estado `register_yield` recusa com 409 acionável, porque
+    # um rendimento sem perna bancária é o termo P3 e ele fecha o gate do Epic 8.
+    bank_account_id: Mapped[str | None] = mapped_column(String(36), default=None, nullable=True)
+```
+
+- [ ] **Step 5: Os schemas**
+
+Em `apps/api/app/modules/investments/schemas.py`, acrescentar o campo nas três classes:
+
+```python
+# em InvestmentAccountCreate, após `opened_at`:
+    bank_account_id: str | None = Field(default=None, max_length=36)
+
+# em InvestmentAccountUpdate, após `principal_cents`:
+    bank_account_id: str | None = Field(default=None, max_length=36)
+
+# em InvestmentAccountOut, após `opened_at`:
+    bank_account_id: str | None
+```
+
+- [ ] **Step 6: A validação e a escrita no service**
+
+Em `apps/api/app/modules/investments/service.py`, acrescentar aos imports:
+
+```python
+from app.modules.bank import service as bank_service
+from app.modules.bank.models import KIND_INVESTMENT
+```
+
+Acrescentar a mensagem e o validador, logo após `_validate_financeiro_account`:
+
+```python
+_CONTA_NAO_E_APLICACAO_MSG = (
+    "A conta bancária de uma aplicação precisa ser do tipo 'aplicação'. Se o dinheiro está numa "
+    "conta corrente, ele não está aplicado — e o rendimento cairia na conta errada, fazendo os "
+    "dois saldos derivados mentirem juntos."
+)
+
+_CONTA_ARQUIVADA_MSG = (
+    "A conta bancária escolhida está arquivada e não recebe lançamentos novos. Escolha outra "
+    "conta ou cadastre a conta que você usa hoje — com o saldo de abertura do dia."
+)
+
+
+def _validate_bank_account(db: Session, bank_account_id: str) -> None:
+    """A conta bancária do vínculo existe (RLS), é aplicação e está ativa? (Onda 2b-i)
+
+    404 se inexistente/de outro tenant — a RLS a esconde e `bank_service.get_account` é
+    fail-closed. **Nunca 409 aqui**: 409 confirmaria a existência da linha.
+    """
+    try:
+        acc = bank_service.get_account(db, bank_account_id)
+    except bank_service.BankError as e:
+        raise InvestmentError("Conta bancária não encontrada", e.status_code) from e
+    if acc.kind != KIND_INVESTMENT:
+        raise InvestmentError(_CONTA_NAO_E_APLICACAO_MSG, 422)
+    if acc.archived_at is not None:
+        raise InvestmentError(_CONTA_ARQUIVADA_MSG, 409)
+```
+
+Em `create_account`, antes do `InvestmentAccount(...)`:
+
+```python
+    if data.bank_account_id:
+        _validate_bank_account(db, data.bank_account_id)
+```
+
+e acrescentar `bank_account_id=data.bank_account_id,` ao construtor.
+
+Em `update_account`, após o bloco de `principal_cents`:
+
+```python
+    if data.bank_account_id is not None:
+        _validate_bank_account(db, data.bank_account_id)
+        acc.bank_account_id = data.bank_account_id
+```
+
+- [ ] **Step 7: O router**
+
+Em `apps/api/app/modules/investments/router.py`, dentro de `_out`, acrescentar:
+
+```python
+        bank_account_id=a.bank_account_id,
+```
+
+E envolver `create_account` no mesmo `try/except` que `update_account` já tem, porque agora ele pode levantar `InvestmentError`:
+
+```python
+@router.post("", response_model=InvestmentAccountOut, status_code=201)
+def create_account(
+    data: InvestmentAccountCreate,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> InvestmentAccountOut:
+    try:
+        acc = service.create_account(db, tenant_id=user.tenant_id, actor=user.user_id, data=data)
+    except service.InvestmentError as e:
+        raise _err(e) from e
+    return _out(acc)
+```
+
+- [ ] **Step 8: Rodar e confirmar que passa**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -v`
+
+Expected: **PASS** — os 3 testes novos e todos os antigos, inclusive o IV1 (`register_yield` não cria `Transaction`/`PlatformEarning`).
+
+- [ ] **Step 9: Confirmar que a migration aplica**
+
+Run: `cd apps/api && .venv/Scripts/python -m alembic heads`
+Expected: `0075 (head)` — **um head só**. Dois heads = colisão de numeração; renumere antes de seguir.
+
+- [ ] **Step 10: O cross-tenant, no Postgres REAL**
+
+⚠️ **O teste de 404 do Step 1 roda em SQLite, que NÃO exercita RLS** — ele prova que a conversão de
+erro está certa, não que a RLS esconde a linha. A garantia real mora em `rls_e2e`.
+
+Acrescentar em `apps/api/tests/test_investments_rls.py` (o módulo já é `pytestmark =
+pytest.mark.rls_e2e`), no mesmo padrão de `test_investment_cross_tenant_a_nao_ve_b`:
+
+```python
+def test_vincular_a_conta_bancaria_de_OUTRO_tenant_da_404_e_nunca_409() -> None:
+    """A conta existe — no tenant B. Para o tenant A ela **não existe**, e a resposta tem de ser
+    404.
+
+    409 aqui confirmaria a existência da linha alheia: seria vazamento de existência com cara de
+    validação. É o mesmo critério já fixado em `bank_service.get_account` e o mesmo que a 8.2
+    pagou para aprender. **Só o Postgres reproduz** — no SQLite a linha do tenant B é visível e o
+    teste passaria pelo motivo errado.
+    """
+```
+
+Implemente o corpo seguindo a montagem de tenants que o arquivo já usa (dois tenants, `tenant_session`
+de cada um): crie a `bank_account` `kind='investment'` no tenant **B**, a `InvestmentAccount` no
+tenant **A**, e tente vincular pela sessão de A — esperando `InvestmentError` com `status_code == 404`.
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest -m rls_e2e tests/test_investments_rls.py -v` (exige Docker)
+Expected: **PASS**
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/api/migrations/versions/0075_investment_bank_account.py apps/api/app/modules/investments/ apps/api/tests/test_investments.py apps/api/tests/test_investments_rls.py
+git commit -m "feat: a aplicação aponta para a conta bancária dela [Onda 2b-i]"
+```
+
+---
+
+### Task 3: `register_yield` sem vínculo recusa com 409 acionável
+
+**Files:**
+- Modify: `apps/api/app/modules/investments/service.py` (`InvestmentError`, constantes, `register_yield`)
+- Modify: `apps/api/app/modules/investments/router.py:38-39` (`_err`)
+- Test: `apps/api/tests/test_investments.py`
+
+**Interfaces:**
+- Consumes: `InvestmentAccount.bank_account_id` (Task 2).
+- Produces:
+  - `investments.service.ACAO_CADASTRAR_CONTA: str` — **igual** a `payables.service.ACAO_CADASTRAR_CONTA` e `receivables.service.ACAO_CADASTRAR_CONTA`
+  - `investments.service.SEM_CONTA_VINCULADA_MSG: str`
+  - `InvestmentError.detail: dict | None` — `None` = o router serializa `str(e)`, como sempre
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Acrescentar em `apps/api/tests/test_investments.py`:
+
+```python
+def test_a_acao_do_409_e_a_MESMA_string_de_payables_e_receivables():
+    """**O contrato do 409 acionável é UM, com três constantes — e o teste é a sincronia.**
+
+    A string é duplicada de propósito: fazer `investments` importar `payables` só por uma palavra
+    seria acoplamento gratuito entre módulos de negócio. O que garante que as três não divirjam é
+    **este teste**, não um comentário — a UI reconhece a situação por `acao`, e um segundo valor
+    faria a tela deixar de abrir o caminho do vínculo **sem erro nenhum**, só sem funcionar.
+    """
+    from app.modules.investments import service as investments_service
+    from app.modules.payables import service as payables_service
+    from app.modules.receivables import service as receivables_service
+
+    assert (
+        investments_service.ACAO_CADASTRAR_CONTA
+        == payables_service.ACAO_CADASTRAR_CONTA
+        == receivables_service.ACAO_CADASTRAR_CONTA
+    )
+
+
+def test_registrar_rendimento_sem_vinculo_da_409_ACIONAVEL(client: TestClient, headers):
+    """**É este 409 que põe P3 em zero POR CONSTRUÇÃO** — o mesmo mecanismo pelo qual a 8.12
+    zerou P1 ao tornar a coluna obrigatória: a população esvazia sozinha e não depende de o dono
+    lembrar de vincular.
+
+    A degradação graciosa da Onda 3 (*"nada acontece, nada quebra"*) é certa LÁ e errada AQUI: o
+    payout é disparado pelo sistema, sem humano na tela a quem perguntar; o rendimento é o dono
+    digitando um valor agora.
+
+    **Mutante que este teste mata:** remover a guarda — o rendimento volta a ser criável sem
+    perna, e P3 deixa de ser zero por construção.
+    """
+    app_ = _aplicacao(client, headers)
+    resp = client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["acao"] == "cadastrar_conta", "a UI reconhece a situação por este campo"
+    assert "Vincule esta aplicação" in detail["mensagem"]
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -k "acao_do_409 or sem_vinculo" -v`
+
+Expected: **FAIL** — `AttributeError: module 'app.modules.investments.service' has no attribute 'ACAO_CADASTRAR_CONTA'` e 200 em vez de 409.
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/api/app/modules/investments/service.py`, substituir a classe `InvestmentError` e acrescentar o erro acionável:
+
+```python
+class InvestmentError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+        # `None` = o router serializa `str(e)` como sempre. Só o erro ACIONÁVEL abaixo preenche.
+        self.detail: dict | None = None
+
+
+# ── O 409 ACIONÁVEL, no MESMO formato que a Story 8.12 fixou (AC9) ───────────────────────────
+#
+# ⚠️ **A string é duplicada de `payables.service.ACAO_CADASTRAR_CONTA` DE PROPÓSITO**, e a
+# sincronia é garantida por **teste**, não por comentário:
+# `test_investments.py::test_a_acao_do_409_e_a_MESMA_string_de_payables_e_receivables` compara as
+# três constantes. Fazer `investments` importar `payables` só por causa de uma palavra seria
+# acoplamento gratuito entre dois módulos de negócio — o mesmo motivo pelo qual `receivables` já
+# a duplica em vez de importar.
+ACAO_CADASTRAR_CONTA = "cadastrar_conta"
+
+SEM_CONTA_VINCULADA_MSG = (
+    "Para registrar o rendimento o e1p precisa saber em qual conta o dinheiro entrou — é isso "
+    "que faz o movimento aparecer no seu extrato e a conferência valer alguma coisa. Vincule "
+    "esta aplicação à conta bancária dela uma vez e o rendimento segue normalmente."
+)
+
+
+class ContaNaoVinculadaError(InvestmentError):
+    """A aplicação não aponta para conta bancária nenhuma, e o rendimento precisa de uma perna.
+
+    ⚠️ **409, não 422**, e o formato é o mesmo dos outros dois módulos: a tela reconhece a
+    situação por `detail["acao"]` e abre o caminho do vínculo embutido. Um segundo valor no `acao`
+    quebraria isso **sem erro nenhum**, só deixando de funcionar.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(SEM_CONTA_VINCULADA_MSG, 409)
+        self.detail = {"acao": ACAO_CADASTRAR_CONTA, "mensagem": SEM_CONTA_VINCULADA_MSG}
+```
+
+Em `register_yield`, logo após `acc = get_account(db, account_id)`:
+
+```python
+    if not acc.bank_account_id:
+        raise ContaNaoVinculadaError()
+```
+
+Em `apps/api/app/modules/investments/router.py`, substituir `_err`:
+
+```python
+def _err(e: service.InvestmentError) -> HTTPException:
+    """`detail` estruturado quando o erro é ACIONÁVEL; string em todo o resto.
+
+    Só `ContaNaoVinculadaError` preenche `detail` — é o contrato do 409 que a 8.12 fixou (AC9) e
+    que a tela consome para oferecer o vínculo. Sem o `detail`, o front recebe uma frase e não
+    tem como saber que existe uma ação.
+    """
+    return HTTPException(status_code=e.status_code, detail=e.detail or str(e))
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -v`
+
+Expected: **PASS**. ⚠️ Vários testes antigos de `register_yield` vão **quebrar** aqui — eles criam aplicação sem vínculo. Corrija-os passando `bank_account_id` na criação (via `_aplicacao(client, headers, bank_account_id=conta["id"])`), **nunca** relaxando a guarda.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/investments/ apps/api/tests/test_investments.py
+git commit -m "feat: rendimento sem conta vinculada recusa com 409 acionável [Onda 2b-i]"
+```
+
+---
+
+### Task 4: `register_yield` gera o movimento bancário
+
+**Files:**
+- Modify: `apps/api/app/modules/investments/service.py` (`register_yield`, `_today`, validação de data futura)
+- Test: `apps/api/tests/test_investments.py`
+
+**Interfaces:**
+- Consumes: `InvestmentAccount.bank_account_id` (Task 2); `ContaNaoVinculadaError` (Task 3); `contar_rendimentos_sem_perna_bancaria` com `NOT EXISTS` (Task 1).
+- Produces: um `BankTransaction` com `source='yield'`, `origin_id=charge.id`, `status='matched'`, `amount_cents` positivo. É este movimento que a Task 1 procura.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Acrescentar em `apps/api/tests/test_investments.py`:
+
+```python
+def test_registrar_rendimento_gera_o_movimento_bancario_NASCIDO_CONCILIADO(
+    client: TestClient, headers, db: Session
+):
+    """O coração da Onda 2b-i: o rendimento passa a ter perna bancária.
+
+    **Crédito** (sinal positivo — o sinal vem da tabela de origem, `Charge` = +1, convenção
+    canônica da 5.3), `origin_id = charge.id` **sem sufixo** (perna única ⇒ o `origin_id` É o id),
+    e `status='matched'` porque movimento de origem do sistema **nasce conciliado** — ele não
+    passa pelo matcher, e é isso que a Regra da Origem compra.
+    """
+    from app.modules.bank.models import SOURCE_YIELD, BankTransaction
+
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    resp = client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    charge = db.scalars(
+        select(Charge).where(Charge.external_ref == f"investment:{app_['id']}")
+    ).one()
+    tx = db.scalars(
+        select(BankTransaction).where(BankTransaction.source == SOURCE_YIELD)
+    ).one()
+
+    assert tx.origin_id == charge.id, "perna única ⇒ o origin_id É o id, sem sufixo"
+    assert tx.bank_account_id == conta["id"]
+    assert tx.amount_cents == 48_000, "crédito: o sinal vem da tabela de origem (Charge = +1)"
+    assert tx.posted_at == date(2026, 7, 14)
+    assert tx.status == "matched", "movimento de origem do sistema NASCE conciliado"
+
+
+def test_o_rendimento_com_perna_SAI_do_termo_P3(client: TestClient, headers, db: Session):
+    """A ponta que fecha o círculo: o que a Task 1 mediu, agora produzido pelo caminho REAL.
+
+    Este teste é o que prova que a onda entrega o que a justifica — os dois lados separados
+    (o predicado e o movimento) poderiam estar corretos e não se encontrarem.
+    """
+    from app.modules.receivables.service import contar_rendimentos_sem_perna_bancaria
+
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+
+    qtd, valor = contar_rendimentos_sem_perna_bancaria(
+        db, start=date(2026, 7, 1), end=date(2026, 7, 31)
+    )
+    assert (qtd, valor) == (0, 0), "o rendimento tem perna — P3 tem de estar vazio"
+
+
+def test_rendimento_com_data_FUTURA_e_recusado(client: TestClient, headers):
+    """**A decisão que `bank/transfers.py:185` exige que a 2b tome em vez de copiar.**
+
+    A razão NÃO é a mesma da transferência. É que um rendimento que ainda não caiu não é um
+    rendimento; e, ao contrário de uma `Payable` com data futura, ele não teria para onde ir —
+    não existe estado `scheduled` para rendimento, nem superfície onde apareceria, nem caminho de
+    promoção. Aceitá-lo inventaria a quarta semântica de agendamento que o Art. IV proíbe.
+    """
+    from datetime import timedelta
+
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    # +2 dias, e não +1: com +1 a borda das 21h em UTC−3 tornaria o teste dependente da hora em
+    # que a suíte roda — exatamente a classe de flake que `hoje_do_tenant` existe para eliminar.
+    depois_de_amanha = date.today() + timedelta(days=2)
+
+    resp = client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 48_000, "date": depois_de_amanha.isoformat()},
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "ainda não caiu" in resp.json()["detail"]
+
+
+def test_registrar_rendimento_CONTINUA_sem_criar_Transaction_nem_PlatformEarning(
+    client: TestClient, headers, db: Session
+):
+    """**IV1 da Story 5.6, reafirmada e não relaxada.** A perna bancária é `bank_transactions`,
+    que é o plano do BANCO. A Carteira é o plano da PLATAFORMA, e misturar os dois é exatamente o
+    que produziu o bug de origem do Epic 8 (a Regra dos Planos).
+    """
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    antes_tx = len(db.scalars(select(Transaction)).all())
+    antes_pe = len(db.scalars(select(PlatformEarning)).all())
+
+    client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 48_000, "date": "2026-07-14"},
+        headers=headers,
+    )
+
+    assert len(db.scalars(select(Transaction)).all()) == antes_tx
+    assert len(db.scalars(select(PlatformEarning)).all()) == antes_pe
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -k "movimento_bancario or SAI_do_termo or data_FUTURA" -v`
+
+Expected: **FAIL** — `NoResultFound` no primeiro (nenhum `BankTransaction`), `(1, 48000) != (0, 0)` no segundo, 200 em vez de 422 no terceiro.
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/api/app/modules/investments/service.py`, acrescentar aos imports:
+
+```python
+from app.modules.bank import origin as bank_origin
+from app.modules.bank.models import KIND_INVESTMENT, SOURCE_YIELD
+from app.modules.settings.service import hoje_do_tenant
+```
+
+Acrescentar a âncora de hoje e a guarda de data futura, antes de `register_yield`:
+
+```python
+def _today(db: Session) -> date:
+    """A MESMA âncora de "hoje" do sistema (fuso do tenant) — nunca um segundo relógio.
+
+    `datetime.now(UTC).date()` aqui adiantaria o dia das 21h à meia-noite em UTC−3 e recusaria um
+    rendimento legítimo lançado à noite. Gate: `tests/test_fuso_do_tenant.py`.
+    """
+    return hoje_do_tenant(db)
+
+
+_DATA_FUTURA_MSG = (
+    "A data do rendimento não pode ser futura — um rendimento que ainda não caiu não é um "
+    "rendimento. Lance-o no dia em que o banco creditar."
+)
+```
+
+Substituir o corpo de `register_yield` a partir de `acc = get_account(...)`:
+
+```python
+    acc = get_account(db, account_id)
+    # A perna bancária exige saber ONDE o dinheiro entrou. Sem vínculo, 409 ACIONÁVEL — é o que
+    # põe P3 em zero por construção (ver a docstring de ContaNaoVinculadaError).
+    if not acc.bank_account_id:
+        raise ContaNaoVinculadaError()
+    if date > _today(db):
+        raise InvestmentError(_DATA_FUTURA_MSG, 422)
+    if chart_account_id:
+        _validate_financeiro_account(db, chart_account_id)
+
+    acc.accrued_yield_cents += amount_cents
+
+    # Charge sintética "já baixada": construída DIRETAMENTE (não via build_charge), NUNCA por
+    # mark_paid/build_transaction → não gera Transaction/PlatformEarning (IV1). status=paid a torna
+    # inclusive imune a um mark_paid/webhook posterior (guarda de idempotência).
+    now = datetime.now(UTC)
+    charge = Charge(
+        tenant_id=tenant_id,
+        client_id=None,  # rendimento não é de cliente nenhum
+        description=f"Rendimento de aplicação: {acc.name}",
+        kind=_YIELD_CHARGE_KIND,  # inerte (só afetaria o split, que não é acionado)
+        method=_YIELD_CHARGE_METHOD,  # inerte
+        amount_cents=amount_cents,
+        due_date=date,
+        competence_date=date,  # regime de competência (DRE, 5.3) — período do rendimento
+        paid_at=now,  # regime de caixa: já realizado
+        status=STATUS_PAID,
+        chart_account_id=chart_account_id,  # grupo FINANCEIRO (validado acima quando informado)
+        external_ref=external_ref_for(account_id),  # MARCA a origem (rendimento) + correlação
+    )
+    db.add(charge)
+    db.flush()  # o id da Charge tem default Python-side; o origin_id abaixo precisa dele
+
+    # ── A perna bancária (Onda 2b-i) ─────────────────────────────────────────────────────────
+    # Pelo MESMO `sync_origin_movement` de payables/receivables/transfers — a única função do
+    # repositório que escreve `source ∈ SOURCES_SISTEMA`. Não commita: movimento e lançamento
+    # entram na MESMA transação, e é o commit abaixo que fecha os dois.
+    #
+    # `posted_at=date` e não `paid_at::date`: o `date` é o dia em que o rendimento caiu para o
+    # dono. Usar o instante do registro erraria sempre que ele lançasse com qualquer atraso. O
+    # resíduo (competência 31/07 × crédito 01/08) é o termo 3 da decomposição da divergência —
+    # resíduo estrutural, que a banda de tolerância existe para absorver. Ele NÃO alcança o gate:
+    # o predicado de P3 pergunta *"existe perna?"*, não *"a perna caiu nesta janela?"*.
+    #
+    # ⚠️ O ramo "origem desliquidada → apaga" de `sync_origin_movement` é INALCANÇÁVEL para
+    # `source='yield'`: não existe caminho de estorno nem de exclusão de rendimento hoje (o router
+    # só expõe `register_yield`). Está escrito aqui para quem reencontrar o ramo morto na 2b-ii
+    # não achar que foi esquecimento.
+    bank_origin.sync_origin_movement(
+        db,
+        tenant_id=tenant_id,
+        actor=actor,
+        source=SOURCE_YIELD,
+        origin_id=charge.id,
+        bank_account_id=acc.bank_account_id,
+        posted_at=date,
+        amount_cents=amount_cents,  # crédito: o sinal vem da tabela de origem (Charge = +1)
+        description=f"Rendimento de aplicação: {acc.name}",
+    )
+
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="investment.register_yield", target=acc.id
+    )
+    db.commit()
+    db.refresh(acc)
+    return acc
+```
+
+Acrescentar ao final da docstring do módulo (`investments/service.py`, antes do `"""` de fecho):
+
+```
+⚠️ ONDA 2b-i: `register_yield` passou a gerar TAMBÉM um `bank_transaction` `source='yield'`, pelo
+`sync_origin_movement`. Isso **não relaxa a IV1**: `bank_transactions` é o plano do BANCO;
+`Transaction`/`PlatformEarning` são o plano da PLATAFORMA, e continuam intocados. Misturar os dois
+é a Regra dos Planos do Epic 8, e foi essa mistura que produziu o bug de origem daquele épico.
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py tests/test_bank_reconciliation_report.py tests/test_money_planes.py tests/test_invariante_do_trilho.py -v`
+
+Expected: **PASS** em todos. ⚠️ Se `test_money_planes.py` ou `test_invariante_do_trilho.py` precisarem de edição, **pare** — é sinal de que a onda passou do escopo, não de que o gate está apertado demais.
+
+- [ ] **Step 5: Matar os mutantes M3, M4 e M5**
+
+Restaure por **cópia de arquivo**:
+
+```bash
+cd apps/api && cp app/modules/investments/service.py /tmp/inv.py.bak
+```
+
+- **M3** — remova `if not acc.bank_account_id: raise ContaNaoVinculadaError()`. `test_registrar_rendimento_sem_vinculo_da_409_ACIONAVEL` deve **FALHAR**.
+- **M4** — troque `posted_at=date` por `posted_at=now.date()`. `test_registrar_rendimento_gera_o_movimento_bancario_NASCIDO_CONCILIADO` deve **FALHAR** na asserção de `posted_at`.
+- **M5** — remova a guarda `if date > _today(db)`. `test_rendimento_com_data_FUTURA_e_recusado` deve **FALHAR**.
+
+```bash
+cp /tmp/inv.py.bak app/modules/investments/service.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/investments/ apps/api/tests/test_investments.py
+git commit -m "feat: o rendimento de aplicação gera o movimento bancário [Onda 2b-i]"
+```
+
+---
+
+### Task 5: A nota de P3 nomeia a causa, não a onda
+
+**Files:**
+- Modify: `apps/api/app/modules/bank/reconciliation.py:479-514` (comentário de bloco + `_note_rendimento_sem_perna`)
+- Test: `apps/api/tests/test_bank_reconciliation_report.py:1433`
+- Test: `apps/web/src/features/financeiro/conferencia.test.ts:408,441`
+- Test: `apps/web/src/features/financeiro/ConferenciaPage.test.tsx:528`
+
+**Interfaces:**
+- Consumes: o comportamento das Tasks 3 e 4 (P3 zero por construção).
+- Produces: `_note_rendimento_sem_perna(quantidade: int, valor_cents: int) -> str` — assinatura **inalterada**; só o texto muda.
+
+⚠️ **Três asserções mudam de propósito, e isto está escrito ANTES de o arquivo ser aberto.** Ajustar asserção para fazer teste passar é a manobra que esconde regressão. Estas três mudam porque o **comportamento** mudou: depois das Tasks 3 e 4, a nota nunca mais pode prometer *"fecha na Onda 2b"*, porque a Onda 2b-i já fechou. `conferencia.test.ts:448` — que afirma que a nota de **P1/P2** *não* contém `"Onda 2b"` — permanece válida e **não se toca**.
+
+- [ ] **Step 1: Reescrever a frase**
+
+Em `apps/api/app/modules/bank/reconciliation.py`, substituir `_note_rendimento_sem_perna`:
+
+```python
+def _note_rendimento_sem_perna(quantidade: int, valor_cents: int) -> str:
+    """P3 — o termo que a Onda 2b-i fechou POR CONSTRUÇÃO, e a frase mudou junto.
+
+    Antes da 2b-i esta nota dizia *"este termo só fecha na Onda 2b"*, porque não havia nada que o
+    dono pudesse fazer. Agora há: `register_yield` recusa (409 acionável) rendimento em aplicação
+    sem conta vinculada, então todo rendimento novo nasce com perna e a população é vazia.
+
+    **A nota fica, mesmo inalcançável no caminho normal.** Se ela disparar, não é mais uma onda
+    faltando — é linha legada ou defeito, e ela precisa dizer o que FAZER. Uma frase que nomeasse
+    uma onda já entregue seria mentira dita na tela, e apagar o contador deixaria a 2b-ii (que
+    mexe justamente nesses dados) sem quem avise se eles voltarem inconsistentes.
+    """
+    plural = "s" if quantidade > 1 else ""
+    return (
+        f"{quantidade} rendimento{plural} de aplicação deste período ({_brl(valor_cents)}) ainda "
+        f"não gera{'m' if quantidade > 1 else ''} movimento bancário. A divergência abaixo "
+        "**inclui** esse valor. Vincule a aplicação à conta bancária dela para que o rendimento "
+        "passe a aparecer no extrato."
+    )
+```
+
+E no comentário de bloco acima (linhas 479-494), substituir o parágrafo *"Por que P1/P2 e P3 têm frases separadas"*:
+
+```python
+# **Por que P1/P2 e P3 continuam com frases separadas depois da Onda 2b-i:** os dois termos pedem
+# ações DIFERENTES do dono. P1/P2 pedem informar a conta em cada lançamento legado; P3 pede
+# vincular a aplicação à conta bancária dela, **uma vez**. Achatá-las numa frase só mandaria o
+# dono caçar lançamento a lançamento um termo que se resolve num clique.
+```
+
+- [ ] **Step 2: Atualizar as três asserções, com a razão escrita**
+
+Em `apps/api/tests/test_bank_reconciliation_report.py`, em `test_a1_...` (linhas 1433-1434):
+
+```python
+    assert "Onda 2b" not in nota, (
+        "a Onda 2b-i FECHOU este termo — prometer uma onda já entregue é mentira na tela"
+    )
+    assert "Vincule a aplicação" in nota, "a nota nomeia a AÇÃO, agora que existe uma"
+```
+
+Em `apps/web/src/features/financeiro/conferencia.test.ts`, linha ~408, substituir a string esperada:
+
+```ts
+      "3 rendimentos de aplicação deste período (R$ 480,00) ainda não geram movimento bancário. A divergência abaixo **inclui** esse valor. Vincule a aplicação à conta bancária dela para que o rendimento passe a aparecer no extrato.",
+```
+
+e linha ~441:
+
+```ts
+    expect(comTermos.notes[1]).toContain("Vincule a aplicação");
+```
+
+Em `apps/web/src/features/financeiro/ConferenciaPage.test.tsx`, linha ~528, substituir a continuação da string:
+
+```tsx
+    "A divergência abaixo **inclui** esse valor. Vincule a aplicação à conta bancária dela " +
+    "para que o rendimento passe a aparecer no extrato.",
+```
+
+⚠️ Confira o valor em `_brl` e a pluralização nas strings do frontend contra o que o backend produz — as duas asserções são literais completas.
+
+- [ ] **Step 3: Rodar os dois lados**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_bank_reconciliation_report.py -v`
+Expected: **PASS**
+
+Run: `pnpm --filter @e1p/web test -- --run src/features/financeiro/conferencia.test.ts src/features/financeiro/ConferenciaPage.test.tsx`
+Expected: **PASS**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/app/modules/bank/reconciliation.py apps/api/tests/test_bank_reconciliation_report.py apps/web/src/features/financeiro/conferencia.test.ts apps/web/src/features/financeiro/ConferenciaPage.test.tsx
+git commit -m "fix: a nota de P3 nomeia a ação, não uma onda já entregue [Onda 2b-i]"
+```
+
+---
+
+### Task 6: O campo de vínculo na tela da aplicação
+
+**Files:**
+- Modify: `apps/web/src/features/financeiro/investimentos.ts`
+- Modify: `apps/web/src/features/financeiro/InvestimentosPage.tsx`
+- Test: `apps/web/src/features/financeiro/investimentos.test.ts`
+
+**Interfaces:**
+- Consumes: `InvestmentAccountOut.bank_account_id` (Task 2); o 409 com `detail.acao === "cadastrar_conta"` (Task 3).
+- Produces: `rotuloDoVinculo(account: InvestmentAccount, contas: BankAccount[]): string` — puro, testável.
+
+**Por que esta task existe.** Sem ela o 409 da Task 3 é um beco: o backend pede o vínculo e não há tela onde criá-lo. Capacidade de backend sem consumidor é a classe de defeito que o item 12 do WhatsApp já pagou neste repo.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescentar em `apps/web/src/features/financeiro/investimentos.test.ts`:
+
+```ts
+describe("rotuloDoVinculo", () => {
+  const conta = { id: "c1", name: "CDB Itaú", kind: "investment", archived_at: null } as BankAccount;
+
+  it("nomeia a conta quando a aplicação está vinculada", () => {
+    const app = { id: "a1", bank_account_id: "c1" } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, [conta])).toBe("CDB Itaú");
+  });
+
+  it("diz o que FAZER quando não está vinculada — nunca só 'sem conta'", () => {
+    const app = { id: "a1", bank_account_id: null } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, [conta])).toBe("Vincular a uma conta");
+  });
+
+  it("não inventa nome quando o vínculo aponta para conta que não está na lista", () => {
+    const app = { id: "a1", bank_account_id: "sumida" } as InvestmentAccount;
+    expect(rotuloDoVinculo(app, [conta])).toBe("Vincular a uma conta");
+  });
+});
+```
+
+Acrescentar aos imports do arquivo de teste:
+
+```ts
+import { rotuloDoVinculo, type InvestmentAccount } from "./investimentos";
+import type { BankAccount } from "./contas";
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `pnpm --filter @e1p/web test -- --run src/features/financeiro/investimentos.test.ts`
+Expected: **FAIL** — `rotuloDoVinculo is not a function`.
+
+- [ ] **Step 3: Implementar o tipo e o helper**
+
+Em `apps/web/src/features/financeiro/investimentos.ts`, acrescentar o campo à interface:
+
+```ts
+export interface InvestmentAccount {
+  id: string;
+  name: string;
+  kind: string;
+  index_rate_label: string;
+  principal_cents: number;
+  accrued_yield_cents: number;
+  opened_at: string;
+  created_at: string;
+  /** A conta bancária ONDE ESTE DINHEIRO ESTÁ (Onda 2b-i). `null` = ainda não vinculada, e
+   *  nesse estado o backend recusa o rendimento com 409 acionável. */
+  bank_account_id: string | null;
+}
+```
+
+E o helper, ao final do arquivo:
+
+```ts
+import type { BankAccount } from "./contas";
+
+/**
+ * Rótulo do vínculo da aplicação com a conta bancária dela. PURO.
+ *
+ * Sem vínculo (ou com vínculo apontando para conta que sumiu da lista) devolve a AÇÃO, nunca um
+ * estado passivo tipo "sem conta": é este vínculo que o 409 do `register_yield` pede, e um rótulo
+ * que só descreve o problema deixa o dono sem saber o que fazer.
+ */
+export function rotuloDoVinculo(
+  account: InvestmentAccount,
+  contas: BankAccount[],
+): string {
+  const conta = contas.find((c) => c.id === account.bank_account_id);
+  return conta ? conta.name : "Vincular a uma conta";
+}
+```
+
+- [ ] **Step 4: Ligar na tela**
+
+Em `apps/web/src/features/financeiro/InvestimentosPage.tsx`:
+
+1. Carregar as contas de aplicação ativas em `load()`:
+
+```tsx
+const { data: bankAccounts } = await api.get<BankAccount[]>("/bank/accounts");
+setContas(bankAccounts.filter((c) => c.kind === "investment" && c.archived_at === null));
+```
+
+2. No card de cada aplicação (junto do `<Stat label="Principal" ...>`, por volta da linha 117), mostrar o vínculo:
+
+```tsx
+<Stat label="Conta bancária" value={rotuloDoVinculo(a, contas)} />
+```
+
+3. Extrair o seletor, para que `NewAccountModal` e `RegisterYieldModal` usem **o mesmo** (duas cópias divergem no primeiro ajuste):
+
+```tsx
+function SeletorDeConta({
+  contas,
+  value,
+  onChange,
+}: {
+  contas: BankAccount[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="text-slate-600">Conta bancária da aplicação</span>
+      <select
+        className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="">Escolha a conta…</option>
+        {contas.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      {contas.length === 0 && (
+        <span className="mt-1 block text-xs text-amber-700">
+          Nenhuma conta do tipo aplicação cadastrada. Cadastre-a em Contas &amp; Saldos.
+        </span>
+      )}
+    </label>
+  );
+}
+```
+
+Em `NewAccountModal`, acrescentar `const [bankAccountId, setBankAccountId] = useState("");`, renderizar `<SeletorDeConta contas={contas} value={bankAccountId} onChange={setBankAccountId} />` e incluir no `api.post`:
+
+```tsx
+        bank_account_id: bankAccountId || null,
+```
+
+4. Em `RegisterYieldModal`, tratar o 409 acionável — é ele que transforma o erro num desvio de um passo em vez de um beco:
+
+```tsx
+  const [precisaVincular, setPrecisaVincular] = useState(false);
+  const [bankAccountId, setBankAccountId] = useState("");
+
+  async function save() {
+    if (!account) return;
+    setError(null);
+    try {
+      // Se o 409 pediu o vínculo e o dono acabou de escolher a conta, vincula ANTES de
+      // reenviar — assim ele não perde o valor e a data que já digitou.
+      if (precisaVincular && bankAccountId) {
+        await api.patch(`/investments/${account.id}`, { bank_account_id: bankAccountId });
+        setPrecisaVincular(false);
+      }
+      await api.post(`/investments/${account.id}/yield`, {
+        amount_cents: Math.round(Number(amount.replace(",", ".")) * 100),
+        date,
+        chart_account_id: chartAccountId || null,
+      });
+      onSaved();
+    } catch (e) {
+      const detail = (e as AxiosError<{ detail?: { acao?: string; mensagem?: string } | string }>)
+        .response?.data?.detail;
+      if (typeof detail === "object" && detail?.acao === "cadastrar_conta") {
+        setPrecisaVincular(true);
+        setError(detail.mensagem ?? null);
+        return;
+      }
+      setError(typeof detail === "string" ? detail : "Não foi possível registrar o rendimento.");
+    }
+  }
+```
+
+e, no JSX do modal, renderizar o seletor só quando o backend o pediu:
+
+```tsx
+      {precisaVincular && (
+        <SeletorDeConta contas={contas} value={bankAccountId} onChange={setBankAccountId} />
+      )}
+```
+
+⚠️ **`contas` precisa chegar aos dois modais** — passe como prop a partir do estado carregado no Step 4.1. Não refaça o `GET /bank/accounts` dentro de cada modal.
+
+- [ ] **Step 5: Rodar**
+
+Run: `pnpm --filter @e1p/web test -- --run src/features/financeiro/`
+Expected: **PASS**
+
+Run: `pnpm --filter @e1p/web exec tsc --noEmit`
+Expected: exit 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/financeiro/
+git commit -m "feat: a tela da aplicação vincula a conta bancária dela [Onda 2b-i]"
+```
+
+---
+
+### Task 7: A entrada no CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` — seção *"Financeiro: Controle Bancário e Conferência (Epic 8)"*, após o bloco *"Onda 2 (correção) — 'tenho a conta e NÃO sei o saldo'"*
+
+**Interfaces:**
+- Consumes: tudo.
+- Produces: nada de código.
+
+**Por que é uma task e não um passo.** No e1p a entrada no `CLAUDE.md` é **AC obrigatório de toda story**, com a mesma régua do teste (`CLAUDE.md` §5, passo 4). A razão está escrita lá: documentar como último passo é documentar o que vai ser cortado — foi assim que o Epic 5 inteiro ficou invisível por um mês.
+
+- [ ] **Step 1: Escrever a entrada**
+
+Acrescentar em `CLAUDE.md`, após a seção da Story 8.21:
+
+```markdown
+### Onda 2b-i — a perna bancária do rendimento (o termo P3 fecha)
+
+> Spec: `docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento.md`
+
+**A Onda 2b foi PARTIDA EM DUAS, e o recorte é a decisão.** O §647 do PRD descreve cinco
+entregáveis; só dois tocam o gate, e o mais arriscado do épico inteiro (o backfill de
+`principal_cents` sob `FORCE RLS`) não é nenhum dos dois. **2b-i** entrega o vínculo e o
+movimento; **2b-ii** fica com o principal derivado, o backfill e o 409 de edição. Manter o
+backfill colado ao destravamento da métrica primária refaria o acoplamento que o épico já
+desfez uma vez ao separar a 2b da Onda 2.
+
+**O achado que motivou o recorte, e que teria custado a onda inteira.**
+`receivables.contar_rendimentos_sem_perna_bancaria` **não verificava se existia perna bancária** —
+nenhum join, nenhum `NOT EXISTS`. Contava todo rendimento da janela. Pré-2b isso era inofensivo,
+porque *"todos os rendimentos"* e *"os rendimentos sem perna"* eram o mesmo conjunto. Ligado o
+movimento, os dois se separam e P3 seguiria contando o que passou a ter perna: **o gate não
+abriria nem depois da onda que existe para destravá-lo**, e a nota na tela continuaria dizendo
+*"este termo só fecha na Onda 2b"* sobre uma onda já fechada. O único teste que tocava a função
+afirmava que ela era `callable` — e o membro que a mataria (um rendimento COM perna) era
+inconstruível no caminho de produção. **É a família do §2 da Onda 2 (o teste que passa e não
+prova nada), com um agravante: aqui o teste correto não podia sequer ser escrito.**
+
+- [x] **`investment_accounts.bank_account_id`** (migration `0075`) — ligação 1:1 com a
+  `bank_account` `kind='investment'`. `investment_accounts` **não** é absorvida: ela é a faceta
+  de PRODUTO (rentabilidade, indexador), a `bank_account` é onde o dinheiro está. Índice único
+  parcial com `tenant_id` na FRENTE (índice único é global e não respeita RLS — lição da 8.2).
+  **Sem `UPDATE`:** `ADD COLUMN`/`CREATE INDEX` são DDL e a RLS não os alcança. A aplicação que
+  já existia foi vinculada pelo dono, por ato, na tela.
+- [x] **`register_yield` sem vínculo recusa com 409 acionável** (`{"acao":"cadastrar_conta"}`,
+  terceira cópia da string, sincronia por teste). **É isso que põe P3 em zero POR CONSTRUÇÃO** —
+  o mesmo mecanismo pelo qual a 8.12 zerou P1. A degradação graciosa da Onda 3 (*"nada acontece,
+  nada quebra"*) foi rejeitada aqui, e a diferença é quem está na sala: o payout é disparado pelo
+  sistema, sem humano a quem perguntar; o rendimento é o dono digitando um valor agora.
+- [x] **`register_yield` gera `bank_transaction` `source='yield'`** pelo mesmo
+  `sync_origin_movement`, na mesma transação, nascido conciliado. **`SOURCE_YIELD` já estava em
+  `SOURCES_SISTEMA` desde a 0059** — como nenhuma regra do repo é escrita contra `source` solto,
+  todas já cobriam `yield` sem uma linha de mudança. **A IV1 da 5.6 NÃO foi relaxada:**
+  `bank_transactions` é o plano do BANCO, `Transaction`/`PlatformEarning` são o plano da
+  PLATAFORMA, e continuam intocados.
+- [x] **`posted_at = date` do rendimento, não o instante do registro** — e o resíduo está
+  declarado: competência 31/07 com crédito em 01/08 desloca o movimento um dia. É o **termo 3**
+  da decomposição da divergência, que a banda de tolerância existe para absorver. **A escolha só
+  é barata porque o predicado de P3 é `NOT EXISTS`:** ele pergunta *"existe perna?"*, não *"a
+  perna caiu nesta janela?"*. Se a data fosse o eixo do termo, isto seria decisão de gate.
+- [x] **Data futura: 422** — a decisão que `bank/transfers.py:185` exigia que a 2b tomasse em vez
+  de copiar. A razão **não** é a da transferência: um rendimento que ainda não caiu não é um
+  rendimento, e ele não teria para onde ir — não existe `scheduled` para rendimento, nem
+  superfície, nem caminho de promoção (Art. IV).
+- [x] **A nota de P3 deixou de nomear uma onda e passou a nomear a AÇÃO** (*"Vincule a aplicação
+  à conta bancária dela"*). Ela fica mesmo inalcançável no caminho normal: se disparar, é linha
+  legada ou defeito, e apagá-la deixaria a 2b-ii sem quem avise se os dados voltarem
+  inconsistentes.
+
+**Regra que fica (reverberar): função cujo NOME promete um filtro tem de tê-lo, mesmo quando o
+filtro é hoje redundante.** `contar_rendimentos_sem_perna_bancaria` esteve certa por coincidência
+de população durante uma onda inteira. A coincidência não deixa rastro no código, não quebra teste
+ao terminar, e o dia em que ela termina é justamente o dia em que a função vira defeito.
+
+- **Dívida:** o ramo *"origem desliquidada → apaga"* de `sync_origin_movement` é **inalcançável**
+  para `source='yield'` — não existe estorno nem exclusão de rendimento (o router só expõe
+  `register_yield`). Está na docstring para não parecer esquecimento na 2b-ii.
+- **Dívida:** **aceite visual em ~360px do campo de vínculo NÃO foi feito** — mesma dívida da
+  8.13 AC9 e da 8.21. Bloqueia release, não bloqueia merge.
+- **Dívida:** a 2b-ii continua com o único backfill do épico, e ele continua sendo o item de
+  maior risco.
+```
+
+- [ ] **Step 2: Conferir que nada acima ficou desatualizado**
+
+O §5 do bloco da Onda 2 (*"O gate NÃO abre 'depois da Onda 2'"*) diz *"Quem registra rendimento de
+aplicação precisa da **2b**"*. Continua **verdadeiro** — e agora aponta para a 2b-i. Acrescente
+`-i` ali para quem ler daqui a três meses não procurar a onda inteira.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: a Onda 2b-i entra na memória do projeto [Onda 2b-i]"
+```
+
+---
+
+## Verificação final (antes de abrir o PR)
+
+- [ ] Suíte backend inteira: `cd apps/api && .venv/Scripts/python -m pytest -q` — **em primeiro plano**
+- [ ] `ruff check apps/api` → *All checks passed!*
+- [ ] Suíte frontend inteira: `pnpm --filter @e1p/web test -- --run`
+- [ ] `pnpm --filter @e1p/web exec tsc --noEmit` → exit 0
+- [ ] `cd apps/api && .venv/Scripts/python -m alembic heads` → **um head só**, `0075`
+- [ ] Migration validada contra **Postgres real** (não só SQLite) — mesmo sem `UPDATE`, o índice
+      único parcial é a parte que o SQLite trata diferente
+- [ ] `pytest -m rls_e2e tests/test_investments_rls.py` (exige Docker) — o 404 cross-tenant do
+      vínculo. **O teste equivalente em SQLite não prova isso**
+- [ ] **PR obrigatório:** `main` é protegida (GH006), com 4 checks. Push é do `@devops`.
+
+**Não incluído de propósito, e é o que a 2b-ii carrega:** `principal_cents` derivado, o backfill
+sob `FORCE RLS`, o 409 ao editar principal, o extrato da aplicação no `InvestimentosPage`.

--- a/docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md
+++ b/docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md
@@ -1,0 +1,341 @@
+# Onda 2b-i — a perna bancária do rendimento (o termo P3 fecha)
+
+> **Data:** 2026-08-07 · **Epic:** 8 (Controle Bancário Nativo) · **Onda:** 2b, primeira metade
+> **Precede:** Onda 2b-ii (`principal_cents` derivado + backfill sob `FORCE RLS`)
+> **Referência normativa:** `docs/prd/epic-8-controle-bancario.md` §3.1.2 (pré-condição do gate),
+> §5 (roadmap), §"Onda 2b" (escopo original de cinco entregáveis)
+
+---
+
+## 1. Por que esta onda existe agora
+
+A métrica primária do Epic 8 é `|divergencia_cents|` por conta, e ela só pode ser **lida** num ciclo
+de conferência que satisfaça a pré-condição do gate (§3.1.2): não existe evento conhecido pelo e1p
+que moveu dinheiro numa conta real do dono sem ter gerado o `bank_transaction` correspondente.
+
+Quatro termos decidem isso. **P3** — rendimento de aplicação sem perna bancária — é o único que o
+dono **não consegue corrigir com trabalho nenhum**. Ele fecha na Onda 2b, e em mais lugar nenhum.
+
+A `Charge` sintética de rendimento (`investments/service.py`, Story 5.6) nasce `status=paid`,
+`external_ref="investment:<account_id>"`, e **sem** `transaction_id` e **sem** `bank_account_id` —
+ambos NULL por omissão, verificado em `apps/api/app/modules/investments/service.py:164-177`. O
+predicado de P3 é o complemento literal do `_not_investment_yield()` de P2, então **todo** rendimento
+lançado cai em P3. Enquanto P3 for não-vazio numa janela, o gate daquele ciclo não abre — nenhuma
+onda é liberada nem morta.
+
+**A decisão F-D12 (2026-07-30) segue válida e continua frágil.** Ela concluiu que a 2b não é
+pré-requisito da leitura do gate, apoiada numa medição de produção: 1 conta de investimento
+cadastrada, **0 rendimentos lançados**. O próprio PRD registra a fragilidade: *"no dia em que o
+fundador lançar o primeiro rendimento, P3 deixa de ser vazio e a leitura do gate passa a depender da
+Onda 2b — sem aviso"*. O contador continua em zero em 2026-08-07 (confirmado pelo fundador; ver
+§7, Suposição S1).
+
+**A consequência de oportunidade, e é ela que justifica o "agora":** enquanto P3 for zero, esta onda
+**não tem rendimento legado para ligar a movimento nenhum**. O backfill de `yield → bank_transaction`
+é vazio hoje e cresce a cada rendimento lançado. Essa janela não reabre.
+
+### 1.1 O que NÃO é verdade, e por que está escrito aqui
+
+A hipótese que originou este design dizia que o termo P3 **falha em silêncio**, anunciando-se ao dono
+como *"continue corrigindo lançamentos"*. **Isso é falso, e a proteção foi construída de propósito:**
+é a Story 8.16 AC7, em produção. P3 tem contador próprio e frase própria, deliberadamente separada da
+de P1/P2 (`apps/api/app/modules/bank/reconciliation.py:508-514`):
+
+> *"N rendimentos de aplicação deste período (R$ X) ainda não geram movimento bancário. A divergência
+> abaixo **inclui** esse valor. Este termo só fecha na Onda 2b — não há o que corrigir à mão."*
+
+Amarrada por teste dos dois lados, inclusive por mutação: `apps/api/tests/test_bank_reconciliation_report.py:1433`,
+`apps/web/src/features/financeiro/conferencia.test.ts:441`, e `:448` afirmando o contrário para a nota
+de P1/P2 (que **não** pode dizer "Onda 2b").
+
+Está registrado porque a spec precisa dizer o que **já** protege, senão a 2b-i o reconstrói.
+
+---
+
+## 2. O achado que muda o escopo desta onda
+
+**O contador de P3 não verifica se existe perna bancária.**
+`apps/api/app/modules/receivables/service.py:990-998`:
+
+```python
+row = db.execute(
+    select(func.count(), func.coalesce(func.sum(Charge.amount_cents), 0)).where(
+        ~_not_investment_yield(),
+        Charge.paid_at.is_not(None),
+        Charge.paid_at >= de,
+        Charge.paid_at < ate,
+    )
+).one()
+```
+
+Nenhum join, nenhum `NOT EXISTS` contra `bank_transactions`. A função se chama
+`contar_rendimentos_sem_perna_bancaria` e o nome promete um filtro que o corpo não tem.
+
+**Hoje é inofensivo, por uma razão exata:** pré-2b, nenhum rendimento tem perna, então *"todos os
+rendimentos"* e *"os rendimentos sem perna"* são o mesmo conjunto. **No dia em que a 2b ligar o
+movimento, os dois conjuntos se separam** — e P3 seguiria contando os rendimentos que agora *têm*
+perna. O gate não abriria mesmo depois da onda entregue, e a nota continuaria dizendo *"este termo só
+fecha na Onda 2b"* sobre uma onda já fechada.
+
+O único teste que toca a função (`test_bank_reconciliation_report.py:1540`) afirma que ela é
+`callable`. Nada mata essa mutação, porque o membro que a mataria — um rendimento **com** perna — é
+inconstruível antes desta onda.
+
+**Portanto a correção do predicado é entregável desta onda, não da 2b-ii.** Sem ela, os outros dois
+entregáveis não produzem o efeito que os justifica.
+
+---
+
+## 3. Escopo
+
+### 3.1 Entra
+
+| # | Entregável |
+|---|---|
+| **E1** | `investment_accounts.bank_account_id` — ligação 1:1 com a `bank_account` `kind='investment'`, **mais a superfície mínima para o dono criar o vínculo** (campo no formulário da aplicação). `investment_accounts` **não** é absorvida (é faceta de produto) |
+| **E2** | `register_yield` chama `sync_origin_movement(source='yield')` — movimento nascido conciliado, mesma transação, sem jamais tocar `mark_paid`/`build_transaction` |
+| **E3** | O predicado de P3 passa a honrar o próprio nome (`NOT EXISTS`), e a frase da nota deixa de nomear uma onda |
+
+### 3.2 Não entra — vai para a 2b-ii
+
+`principal_cents` derivado; **o backfill sob `FORCE ROW LEVEL SECURITY`** (o item de maior risco do
+épico inteiro, §"Onda 2b" do PRD); `update_account` rejeitando (409) a edição de `principal_cents`;
+extrato da aplicação no `InvestimentosPage`.
+
+**Por que partir.** Só E1 e E2 tocam o gate; o item mais arriscado do épico não é nenhum dos dois.
+O PRD já separou a 2b da Onda 2 exatamente com esse argumento — *"acoplar os dois adiaria o urgente
+pelo arriscado"*. Manter o backfill colado ao destravamento da métrica primária refaz o acoplamento
+que o épico desfez uma vez.
+
+### 3.3 Direção de import — pré-decidida, não escolhida aqui
+
+`apps/api/tests/test_money_planes.py:261` já registra que a ligação acontece *"do lado de
+`investments`, que **pode** importar `bank`"*. `bank → investments` segue proibido por dois gates
+(varredura AST + texto cru). **Esta onda não move nenhum dos dois.**
+
+`receivables → bank` também já é aresta existente (a 8.15 cria movimento pelo mesmo
+`sync_origin_movement`), então E3 não abre aresta nova.
+
+---
+
+## 4. Desenho
+
+### 4.1 E1 — a ligação 1:1
+
+**Migration `0075`** (head atual verificado: `0074_bank_opening_balance_is_known`): adiciona
+`investment_accounts.bank_account_id` nullable + índice único parcial
+(`WHERE bank_account_id IS NOT NULL`), para que duas aplicações não apontem à mesma conta bancária.
+
+> ⚠️ **A migration não executa `UPDATE` nenhum** — só `ADD COLUMN` e `CREATE INDEX`. É o que a mantém
+> **fora da armadilha do `FORCE ROW LEVEL SECURITY` da migration 0046** (`UPDATE` sem a GUC filtrado a
+> zero linhas, em silêncio, e o SQLite dos testes não pega). O backfill do épico continua sendo um só,
+> e ele é da 2b-ii.
+
+> ⚠️ **O head do alembic se reconfere no merge, não só na escrita.** Colisão de revision entre branches
+> paralelas já aconteceu neste repositório.
+
+**Validação do alvo:** a `bank_account` apontada precisa existir no tenant, ter `kind='investment'` e
+não estar arquivada. Conta arquivada → 409 reaproveitando `_CONTA_ARQUIVADA_MSG`, que já existe e já
+diz a coisa certa. Conta de outro tenant → **404** pela RLS fail-closed (`bank_service.get_account`),
+nunca 409: 409 confirmaria a existência da linha.
+
+**O vínculo da aplicação que já existe em produção é um clique do dono**, não um backfill — há uma
+conta de investimento cadastrada (§7, S2).
+
+### 4.2 E1b — `register_yield` sem vínculo: 409 acionável
+
+`register_yield` sobre uma aplicação com `bank_account_id IS NULL` responde **409** no formato
+acionável que a 8.12 fixou:
+
+```python
+detail = {"acao": ACAO_CADASTRAR_CONTA, "mensagem": SEM_CONTA_VINCULADA_MSG}
+```
+
+**A mensagem, escrita aqui para não ser inventada na implementação** (Art. IV), no molde da
+`SEM_CONTA_MSG` de `payables`:
+
+> *"Para registrar o rendimento o e1p precisa saber em qual conta o dinheiro entrou — é isso que faz
+> o movimento aparecer no seu extrato e a conferência valer alguma coisa. Vincule esta aplicação à
+> conta bancária dela uma vez e o rendimento segue normalmente."*
+
+**Por que 409 e não degradação graciosa.** Isto põe P3 em zero **por construção** — o mesmo mecanismo
+pelo qual a 8.12 zerou P1 (a coluna virou obrigatória, a população esvazia sozinha e não depende da
+disciplina de ninguém).
+
+A alternativa seria a degradação graciosa da Onda 3 (*"nada acontece, nada quebra"*). Ela é certa
+**lá** e errada **aqui**, e a diferença é quem está na sala: o payout é disparado pelo sistema, sem
+humano na tela a quem perguntar. O rendimento é o dono digitando um valor agora — existe alguém para
+quem pedir a conta, e o 409 acionável é o padrão do épico para pedir. Degradar aqui deixaria P3
+dependendo de o dono lembrar de vincular.
+
+**Custo aceito, declarado:** o dono cuja aplicação não está cadastrada como conta bancária é barrado
+de lançar rendimento até cadastrá-la. O 409 traz a ação, então é um desvio de um passo, não um beco —
+e `kind='investment'` existe desde a Onda 1, não há nada a construir para ele obedecer.
+
+**Terceira cópia de `ACAO_CADASTRAR_CONTA`.** A string já vive duplicada de propósito em `payables` e
+`receivables`, com a sincronia garantida **por teste** em vez de import
+(`receivables/service.py:97-105`). `investments` vira a terceira, e o teste de sincronia passa a
+comparar as três. Mesma decisão registrada, um membro a mais — **não** é acoplamento novo.
+
+### 4.3 E2 — o movimento
+
+```python
+sync_origin_movement(
+    db, tenant_id=tenant_id, actor=actor,
+    source=SOURCE_YIELD,
+    origin_id=charge.id,
+    bank_account_id=acc.bank_account_id,
+    posted_at=date,
+    amount_cents=amount_cents,   # crédito: o sinal vem da tabela de origem (Charge = +1)
+    description=f"Rendimento de aplicação: {acc.name}",
+)
+```
+
+Chamado **antes** do `db.commit()` que já existe em `register_yield` — `sync_origin_movement` não
+commita, então *"na MESMA transação"* se sustenta sem nada novo. Nasce `status='matched'`, pelo ramo
+*ausente → cria*. A garantia **IV1 da Story 5.6** é reafirmada e não relaxada: nunca `mark_paid`,
+nunca `build_transaction`, nenhum `Transaction`/`PlatformEarning`.
+
+`SOURCE_YIELD` **já está em `SOURCES_SISTEMA`** (`bank/models.py:161-167`). Como nenhuma regra do
+repositório é escrita contra um `source` solto — toda regra pergunta pelo conjunto —, todas elas já
+cobrem `yield` sem uma linha de mudança.
+
+**`origin_id = charge.id`, sem sufixo.** Perna única, então o `origin_id` **é** o id
+(`bank/transfers.py:18`). A idempotência vem do índice único parcial `uq_bank_transactions_origin`:
+um retry não credita duas vezes.
+
+**`posted_at = date` — a escolha com um resíduo declarado.** O `date` do rendimento é documentado como
+competência (DRE) e aqui passa a servir também de data de caixa. Fica alguma imprecisão: o dono lança
+"rendimento de julho" com competência 31/07 e o banco creditou 01/08 — o movimento cai um dia antes do
+extrato.
+
+Conviver com isso é preferível a pedir uma segunda data no formulário. A alternativa `paid_at::date`
+(o instante do registro) erra **sempre que o dono lança com qualquer atraso**, e erra mais; um segundo
+campo resolveria os dois, mas é atrito mensal num formulário onde o dono copia um número do app do
+banco, para um ganho sem consumidor. O desalinhamento de um dia é o **termo 3** da decomposição da
+divergência (*"erro de data"*), classificado no PRD como resíduo estrutural e um dos dois que a banda
+de tolerância `max(R$ 50, 0,5%)` existe para absorver.
+
+> **E — isto é o que torna a escolha barata — com E3 entregue, a data deixa de ter poder sobre o
+> gate.** O `NOT EXISTS` pergunta *"existe perna?"*, não *"a perna caiu nesta janela?"*. Se a data
+> fosse o eixo do termo, esta seria uma decisão de gate; do jeito que fica, é só de conferência.
+
+**Data futura: 422.** `bank/transfers.py:185` exige explicitamente que a 2b **decida** isto em vez de
+copiar a forma da transferência. A decisão: recusar, e a razão **não** é a mesma da transferência. É
+que um rendimento que ainda não caiu não é um rendimento; e, ao contrário de uma `Payable` com data
+futura, ele não teria para onde ir — não existe estado `scheduled` para rendimento, nem superfície
+onde apareceria, nem caminho de promoção. Aceitá-lo inventaria a quarta semântica de agendamento que
+o Art. IV proíbe.
+
+**Fora de escopo, declarado e não esquecido:** o ramo *origem desliquidada → apaga* de
+`sync_origin_movement` fica **inalcançável** para `source='yield'`, porque não existe caminho de
+estorno ou exclusão de rendimento hoje (`investments/router.py` só expõe `register_yield`). Vai na
+docstring, para quem reencontrar o ramo morto na 2b-ii não achar que foi omissão.
+
+### 4.4 E3 — o predicado de P3, e a frase da nota
+
+Acrescentar ao `where` de `contar_rendimentos_sem_perna_bancaria`:
+
+```python
+~select(BankTransaction.id).where(
+    BankTransaction.source == SOURCE_YIELD,
+    BankTransaction.origin_id == Charge.id,
+).exists()
+```
+
+**A frase da nota deixa de nomear uma onda.** Com o 409 do §4.2, todo rendimento novo nasce com perna;
+somado a P3 = 0 hoje, P3 fica **zero por construção**. A nota vira inalcançável — e a frase atual
+(*"Este termo só fecha na Onda 2b"*) seria mentira dita depois da 2b entregue.
+
+**Decisão: manter contador e nota, reescrevendo a frase para nomear a causa em vez da onda** — a
+ação passa a ser *vincular a aplicação a uma conta bancária*. Se a nota algum dia disparar, não será
+mais uma onda faltando: será linha legada ou defeito, e ela tem de dizer o que fazer. Apagar contador
+e nota é mais limpo e é a opção rejeitada, porque a 2b-ii mexe justamente nesses dados e um termo
+apagado não avisa se eles voltarem inconsistentes.
+
+---
+
+## 5. Como se prova que isto não é vácuo
+
+**O teste central:** *um rendimento COM perna não conta em P3*. Esse membro é hoje **inconstruível**,
+e é exatamente por isso que o defeito do §2 existiu — nenhum teste podia pegá-lo. Depois desta onda
+ele é construível.
+
+**Mutações que os testes têm de matar:**
+
+| # | Mutação | Teste que deve quebrar |
+|---|---|---|
+| M1 | Remover o `NOT EXISTS` de `contar_rendimentos_sem_perna_bancaria` | rendimento com perna volta a contar em P3 |
+| M2 | Trocar `source == SOURCE_YIELD` por outro `source` no `NOT EXISTS` | idem |
+| M3 | Remover o 409 de `register_yield` sem vínculo | rendimento sem perna passa a ser criável |
+| M4 | Trocar `posted_at=date` por `posted_at=paid_at::date` | movimento cai na janela errada |
+| M5 | Aceitar data futura em `register_yield` | 422 deixa de sair |
+
+**Cobertura de invariante:** `test_invariante_do_trilho.py` e `test_money_planes.py` continuam
+passando sem edição — se algum precisar de ajuste, isso é sinal de que a onda passou do escopo, não
+de que o gate estava apertado demais.
+
+**E2E RLS no Postgres real** obrigatório para o vínculo cross-tenant (404, não 409).
+
+### 5.1 Alerta de processo — três asserções mudam de propósito
+
+Três testes hoje afirmam que a nota contém `"Onda 2b"`:
+
+- `apps/api/tests/test_bank_reconciliation_report.py:1433`
+- `apps/web/src/features/financeiro/conferencia.test.ts:441`
+- `apps/web/src/features/financeiro/ConferenciaPage.test.tsx:528`
+
+A reescrita da frase (§4.4) os quebra. **Ajustar asserção para fazer teste passar é a manobra que
+esconde regressão**, então a story precisa declarar essas três mudanças **antes** de o `@dev` abrir o
+arquivo, com a razão. Sem isso, a mudança é indistinguível de um "consertando os testes".
+
+`conferencia.test.ts:448` — que afirma que a nota de P1/P2 **não** contém "Onda 2b" — permanece
+válida e **não** se toca.
+
+---
+
+## 6. Ordem de implementação
+
+**E3 é entregue em duas partes separadas na ordem** — o predicado abre a sequência, a frase da nota a
+fecha. Isso é deliberado: o predicado é a definição executável do resultado, e a frase só pode ser
+reescrita depois que o comportamento que ela descreve existir.
+
+1. **E3, parte predicado — primeiro, com o teste falhando** — o `NOT EXISTS` e o teste do
+   rendimento-com-perna. O teste não tem como passar ainda (o membro é inconstruível), o que o torna a
+   definição executável do que E1+E2 precisam produzir.
+2. **E1** — migration `0075`, coluna, índice único parcial, validação do alvo, e o campo de vínculo no
+   formulário da aplicação.
+3. **E1b** — o 409 acionável, a mensagem do §4.2, e a terceira cópia sincronizada por teste.
+4. **E2** — a chamada a `sync_origin_movement`, o 422 de data futura, e o teste de (1) passando.
+5. **E3, parte nota (§4.4)** — a frase reescrita e as três asserções do §5.1.
+
+---
+
+## 7. Suposições abertas e riscos
+
+| # | Suposição | Se for falsa |
+|---|---|---|
+| **S1** | **P3 = 0 em produção hoje** (2026-08-07). Vem de confirmação do fundador, **não** de consulta ao banco — ao contrário da medição do F-D12, que foi feita no banco. A produção foi zerada em 2026-08-05 | O desenho **não muda**. Muda o enquadramento (destravar a métrica vs. prevenir) e aparece um backfill de rendimento legado → `bank_transaction` que hoje não existe. **Medir antes de abrir a primeira story fecha isto por R$ 0** |
+| **S2** | Existe uma `bank_account` `kind='investment'` cadastrada para vincular | O dono cadastra uma; o 409 acionável já o leva lá. Não muda o desenho |
+| **S3** | O head do alembic ainda é `0074` no momento do merge | Renumerar a migration. Reconferir **no merge**, não só na escrita |
+
+**Risco residual:** nenhum código foi executado durante este design — ele é inteiramente leitura de
+código. As citações `arquivo:linha` valem para `main` @ `c46b79f`.
+
+---
+
+## 8. Rastreabilidade
+
+| Item | Origem |
+|---|---|
+| Pré-condição do gate, termos P1..P4 | PRD §3.1.2 |
+| P3 fecha na Onda 2b | PRD §3.1.2, tabela dos quatro termos |
+| Fragilidade do F-D12 | PRD §3.1.2, bloco F-D12 |
+| Escopo original de cinco entregáveis da 2b | PRD §"Onda 2b — Aplicação como conta" |
+| Backfill é o item de maior risco do épico | PRD §"Onda 2b", nota ⚠️ |
+| Nota do bloco 4 nomeia a onda (AC7) | Story 8.16; `bank/reconciliation.py:479-514` |
+| `sync_origin_movement` como ponto único de escrita | Story 8.9; PRD item 2.4 |
+| 409 acionável `cadastrar_conta` | Story 8.12 AC9; `payables/service.py:79-119` |
+| Ligação se faz do lado de `investments` | `tests/test_money_planes.py:261` |
+| "NÃO copie a forma da transferência sem decidir" | `bank/transfers.py:185` |
+| IV1 (nunca `mark_paid`/`build_transaction`) | Story 5.6 |


### PR DESCRIPTION
## O que isto destrava

A métrica primária do Epic 8 (`|divergencia_cents|` por conta) só pode ser **lida** num ciclo cuja pré-condição do gate esteja satisfeita — os quatro termos P1..P4 vazios na janela. **P3** (rendimento de aplicação sem perna bancária) é o único que o dono **não consegue corrigir com trabalho nenhum**: ele fecha na Onda 2b e em mais lugar nenhum.

A `Charge` sintética de rendimento (Story 5.6) nasce `paid` com `transaction_id` e `bank_account_id` ambos NULL, então todo rendimento lançado cai em P3. O contador em zero medido pelo F-D12 em 30/07 é o que mantinha a decisão de que a 2b não era pré-requisito — e essa decisão sempre foi frágil por depender de um contador, não de uma propriedade estrutural.

**Enquanto P3 estiver em zero, esta onda não tem rendimento legado para ligar a movimento nenhum.** O backfill de `yield → bank_transaction` é vazio hoje e cresce a cada rendimento lançado. Essa janela não reabre.

## O achado que motivou o recorte

`receivables.contar_rendimentos_sem_perna_bancaria` **não verificava se existia perna bancária** — nenhum join, nenhum `NOT EXISTS`. Contava todo rendimento da janela.

Pré-2b era inofensivo, porque *"todos os rendimentos"* e *"os sem perna"* eram o mesmo conjunto. Ligado o movimento, eles se separam e P3 seguiria contando o que passou a ter perna: **o gate não abriria nem depois da onda que existe para destravá-lo**, e a nota na tela continuaria dizendo *"este termo só fecha na Onda 2b"* sobre uma onda já fechada. O único teste que tocava a função afirmava que ela era `callable` — o membro que a mataria era inconstruível no caminho de produção.

> **Regra que fica:** função cujo NOME promete um filtro tem de tê-lo, mesmo quando o filtro é hoje redundante. Ela esteve certa **por coincidência de população** durante uma onda inteira, e a coincidência não deixa rastro no código nem quebra teste ao terminar.

## O recorte: 2b-i × 2b-ii

O §647 do PRD descreve **cinco** entregáveis para a Onda 2b. Só dois tocam o gate, e o mais arriscado do épico inteiro (o backfill de `principal_cents` sob `FORCE RLS`) não é nenhum dos dois.

**Entra:** vínculo 1:1 + o movimento + o predicado de P3 + a frase da nota + a tela.
**Fica para a 2b-ii:** `principal_cents` derivado, o backfill, o 409 de edição, o extrato na `InvestimentosPage`.

Manter o backfill colado ao destravamento da métrica primária refaria o acoplamento que o épico já desfez uma vez ao separar a 2b da Onda 2.

## Decisões que precisam de revisão

- **409 acionável, não degradação graciosa.** `register_yield` sem vínculo recusa com `{"acao":"cadastrar_conta"}`. É isso que põe P3 em zero **por construção** — mesmo mecanismo pelo qual a 8.12 zerou P1. A degradação da Onda 3 (*"nada acontece, nada quebra"*) é certa **lá** e errada **aqui**: o payout é disparado pelo sistema, sem humano na tela; o rendimento é o dono digitando um valor agora.
- **`posted_at` = data do rendimento, não o instante do registro.** O resíduo (competência 31/07 × crédito 01/08) é o **termo 3** da decomposição da divergência, que a banda de tolerância absorve. Só é barato porque o predicado de P3 é `NOT EXISTS`: ele pergunta *"existe perna?"*, não *"a perna caiu nesta janela?"*.
- **Data futura: 422.** `bank/transfers.py:185` exigia que a 2b **decidisse** em vez de copiar. A razão não é a da transferência: um rendimento que ainda não caiu não teria para onde ir — não existe `scheduled` para rendimento, nem superfície, nem promoção (Art. IV).
- **A nota de P3 deixou de nomear uma onda e passou a nomear a AÇÃO.** Prometer *"fecha na Onda 2b"* depois da 2b-i entregue seria mentira na tela. **Quatro asserções mudaram por isso** — declaradas antes, não ajustadas para passar.
- **Migration `0075` sem `UPDATE` nenhum.** `ADD COLUMN`/`CREATE INDEX` são DDL e a RLS não os alcança; a aplicação legada é vinculada pelo dono, **por ato**, na tela. `tenant_id` é a primeira coluna do índice único porque índice único é global e não respeita RLS (lição da 8.2).

## Verificação

| Item | Resultado |
|---|---|
| Suíte backend | **1927 passed**, 1 skipped (baseline 1912) |
| Suíte frontend | **57 files / 532 tests** (baseline 528) |
| `ruff check` · `tsc --noEmit` | limpos |
| `alembic heads` | `0075`, head único |
| `rls_e2e` (Postgres real, papel `e1p_app`) | **2 passed** — inclui o 404 cross-tenant do vínculo, com controle positivo |
| Mutação | **5 mutantes, 5 mortos** (M1 `NOT EXISTS`, M2 `source`, M3 guarda do 409, M4 `posted_at`, M5 data futura) |

**A IV1 da Story 5.6 não foi relaxada:** `bank_transactions` é o plano do BANCO; `Transaction`/`PlatformEarning` são o da PLATAFORMA e continuam intocados. O gate da allowlist do `sync_origin_movement` reprovou o chamador novo e ele entrou em `_CHAMADORES_PERMITIDOS` **com justificativa** — que é o que faz a revisão acontecer.

## Dívida que fica

- **Aceite visual em ~360px do campo de vínculo NÃO foi feito** — mesma dívida da 8.13 AC9 e da 8.21. Bloqueia release, não bloqueia merge.
- O ramo *"origem desliquidada → apaga"* de `sync_origin_movement` é **inalcançável** para `source='yield'` (não existe estorno de rendimento). Está na docstring para não parecer esquecimento na 2b-ii.
- A 2b-ii continua com o único backfill do épico.

## Efeito em produção, no primeiro uso

A aplicação cadastrada hoje não tem vínculo. O **primeiro rendimento pós-deploy vai receber o 409** até ela ser vinculada — é o efeito pretendido, e o modal oferece o vínculo e reenvia sem o dono redigitar valor e data.

---

Spec: `docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md`
Plano: `docs/superpowers/plans/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)