### PR TITLE
feat: o DNA da Empresa — o briefing para de falar com todo mundo do mesmo jeito [Vima V2]

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,9 +44,23 @@ paths = [
 # nunca commitado). Conferido o diff inteiro do commit antes de allowlistar (só feature +
 # testes, sem chave/token real). A fixture foi trocada num commit seguinte por um valor de
 # baixa entropia, mas o achado permanece no histórico deste commit específico. Ver PR #32.
+#
+# b5bac25: docs do plano do V2 da Vima (08/08) — o `generic-api-key` pegou uma senha de
+# FIXTURE ("senha-forte-123", entropia 3.64) dentro de um BLOCO DE CÓDIGO DE EXEMPLO no
+# plano de implementação, duas vezes. Nunca foi segredo, e nunca chegou a existir em código:
+# a fixture era INVENTADA — o payload real de `/auth/register` é outro, e o teste escrito a
+# partir dela devolvia 422. Conferido o diff inteiro antes de allowlistar: o commit toca
+# EXCLUSIVAMENTE dois arquivos de `docs/` (plano + spec), nenhum código, config ou
+# credencial. O plano foi corrigido para o payload real em 9d98647, mas o achado permanece
+# no histórico deste commit específico. Ver PR #101.
+#
+# ⚠️ Lição do achado, não do segredo: **fixture inventada em documento é dívida dupla** —
+# documenta um payload que não funciona E dispara o secret scan. Copie a fixture do teste
+# que já existe no repositório em vez de inventar uma.
 commits = [
     "b93bf6fe4e85de7e658e0eca381157623f0bdfff",
     "886f56ffcf770bf03315e12c9d9da6a8dbaaf8ba",
+    "b5bac25122f95e430ae84d301a0791a02d4c8d17",
 ]
 
 # --- Precedente documentado (NÃO ativo hoje) --------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1263,6 +1263,65 @@ O produto já gastava IA em produção e **não sabia quanto, nem por quem**: se
   ninguém e não tem como ser reconstruído. **Dívida:** `LegalDocument.input_tokens` continua
   guardando tokens na linha do documento, agora em paralelo ao ledger (não foi removido).
 
+## Vima V2: o DNA da Empresa (2026-08-08)
+
+> Spec: `docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md`
+
+O V1 entregou um briefing que fala com todo mundo do mesmo jeito: os cinco limiares de
+`absences.py` eram defaults escolhidos por nós. Um advogado que responde em dois dias e um social
+media que responde em duas horas recebiam o mesmo aviso na mesma hora.
+
+- [x] **Duas classes, e a classe é contrato mecânico, não etiqueta** (`dna/catalog.py`, 45
+  perguntas em código):
+  - **Calibração (6)** tem consumidor HOJE; responder muda o briefing de amanhã.
+  - **Retrato (39)** não tem, por definição; é guardado para o V4.
+  - ⚠️ **Duas guardas rodam no IMPORT do módulo**: Calibração exige `consome`, Retrato o proíbe;
+    e `consome` tem que apontar para chave real de `LIMIARES_PADRAO`. Sem a segunda, um typo em
+    `card_parado_dais` produz **silêncio perfeito** — grava, o `{**PADRAO, **override}` ignora a
+    chave estranha, e o dono responde para sempre sem efeito nenhum, sem erro nenhum.
+  - **São 6 de Calibração porque só existem 6 consumidores.** Qualquer número maior seria
+    invenção. `dinheiro.tolerancia_dias` parece Calibração (tem número, tem opções) e é Retrato:
+    não existe regra de Ausência sobre carência. A classe é definida pelo contrato, nunca pelo
+    formato.
+- [x] **`dinheiro_com_data_dias` separou duas regras que dividiam `prazo_vencendo_dias`** — prazo
+  da agenda e conta a pagar. Nasce com o mesmo valor `1`: refactor puro no dia do merge.
+- [x] **O núcleo do primeiro acesso NÃO é de Calibração** (é a inversão central do design).
+  *"Em quanto tempo eu te aviso que ninguém respondeu o Carlos?"* é irrespondível antes de ter
+  visto um briefing — a resposta seria um chute que vira comportamento errado com aparência de
+  configuração deliberada. Calibração vai toda por **gancho colado à ausência** que a motivou.
+- [x] **Uma pergunta por gancho por dia, no produto inteiro**, e pulada em quarentena de 7 dias
+  (`dna/cadencia.py`). O núcleo é a exceção declarada: sequência anunciada e interrupção não
+  anunciada não cansam igual.
+  - ⚠️ **A data do carimbo passa por `local_date`, não por `.date()`.** `answered_at` é
+    `timestamptz`: um dono em UTC−3 respondendo às 22h produz carimbo de 01h do dia seguinte em
+    UTC, a cota do dia não é reconhecida e ele é perguntado de novo às 22h05. Provado por
+    mutação. `app/modules/dna/` entra na varredura AST de `test_fuso_do_tenant.py`.
+- [x] **`dna/resolver.py` é a ÚNICA porta de leitura.** Nenhum outro módulo lê `dna_answers`
+  direto — é o que mantém Retrato honestamente sem consumidor até o V4, em vez de vazar por um
+  `select` esperto. Resposta órfã (opção que saiu do catálogo) cai no default em vez de derrubar
+  o briefing.
+- ⚠️ **`None` num limiar significa REGRA NÃO EXECUTADA**, não "limiar infinito" — mesma forma do
+  filtro de permissão do V1. Só `topo_sem_lead_dias` pode ser desligado, porque é a única
+  Ausência que dispara sobre o VAZIO: sem cards não há card parado, mas sem lead ela cutuca todo
+  dia, para sempre.
+- ⚠️ **`recalibrado_apos` compara `>=`, e o `>` estrito quebrava o recurso inteiro.** O caso
+  normal é o dono recalibrar HOJE, pelo gancho do briefing de hoje, cujo `reference_date` também
+  é hoje — com `>`, a limpeza do silêncio nunca acontecia no dia seguinte, que é justamente
+  quando ela precisa acontecer.
+- [x] **`Linha` do compositor ganhou `kind`** (default `""` — briefings gravados antes do V2 não
+  têm o campo, e lê-los sem default estouraria).
+- **O DNA é da EMPRESA:** `require_module("settings")` na rota inteira, o oposto do
+  `vima/router.py` (lá o recorte é por linha). É também o oposto das preferências de briefing do
+  V1, que foram para `users` por serem pessoais.
+- **O V2 não chama IA em ponto nenhum** — custo marginal zero por tenant.
+- **Dívidas:** as 45 perguntas nunca foram validadas com dono real; não há medição de ativação do
+  núcleo, então não se sabe se ele ajudou ou atrapalhou; a quarentena de 7 dias e o "uma por dia"
+  são números sem evidência; **cobrança a receber continua sem antecedência** (`_dinheiro_com_data`
+  dá aviso prévio a conta a pagar e nenhum a cobrança, que só aparece vencida — o dono é avisado
+  do que deve e surpreendido pelo que não recebeu); **validação manual em ~360px da tela do núcleo
+  e da aba não foi feita** (bloqueia release, não merge).
+
 ## 6.0 Correções importantes
 - **[CORRIGIDO 2026-08-05] O sistema inteiro passou a viver no fuso do tenant (era UTC).** O sintoma que o fundador viu foi a linha do tempo do Funil exibindo `Aguardando até 2026-08-05T11:11:32.812731+00:00` — formato de máquina e 3h adiantado. A investigação achou **três** defeitos com a mesma raiz: existia infra de fuso (`core/tz.py` + `tenant.timezone`, migration 0044) mas só 3 módulos a consumiam.
   1. **Texto para humano com UTC cru.** `funnels/engine.py` interpolava `resume_at.isoformat()` na mensagem; `contracts/service.py` montava a variável `{{DATA}}` com `datetime.now(UTC)` — um contrato criado às 22h saía datado do dia seguinte, e essa é a data que vale juridicamente.

--- a/apps/api/app/db/registry.py
+++ b/apps/api/app/db/registry.py
@@ -26,6 +26,7 @@ from app.modules.contracts.models import (  # noqa: F401
 from app.modules.cost_centers.models import CostCenter  # noqa: F401
 from app.modules.crm.models import Client, PipelineStage  # noqa: F401
 from app.modules.device_tokens.models import DeviceToken  # noqa: F401
+from app.modules.dna.models import DnaAnswer  # noqa: F401
 from app.modules.funnels.models import Funnel, FunnelRun  # noqa: F401
 from app.modules.google_calendar.models import GoogleCredential  # noqa: F401
 from app.modules.investments.models import InvestmentAccount  # noqa: F401

--- a/apps/api/app/modules/__init__.py
+++ b/apps/api/app/modules/__init__.py
@@ -16,6 +16,7 @@ from app.modules.contracts.router import router as contracts_router
 from app.modules.cost_centers.router import router as cost_centers_router
 from app.modules.crm.router import router as crm_router
 from app.modules.device_tokens.router import router as device_tokens_router
+from app.modules.dna.router import router as dna_router
 from app.modules.financial_intelligence.router import router as financial_intelligence_router
 from app.modules.funnels.router import router as funnels_router
 from app.modules.google_calendar.router import public_router as google_calendar_public_router
@@ -50,6 +51,7 @@ ALL_ROUTERS: list[APIRouter] = [
     agenda_router,
     crm_router,
     device_tokens_router,
+    dna_router,
     cockpit_router,
     platform_router,
     notifications_router,

--- a/apps/api/app/modules/dna/cadencia.py
+++ b/apps/api/app/modules/dna/cadencia.py
@@ -1,0 +1,80 @@
+"""Quando perguntar — a Regra do Silêncio do V1 aplicada a perguntar em vez de a avisar.
+
+Duas regras, e nenhuma delas é sobre CONTEÚDO:
+
+1. **Uma pergunta por gancho por dia, no produto inteiro.** Não uma por tela: uma. Um produto
+   que interroga em três telas diferentes na mesma sessão é ignorado na quarta.
+2. **Pulada fica 7 dias em quarentena.** Nunca some — continua no `/config` —, mas para de ser
+   empurrada. Sem quarentena, um "depois" acidental vira interrogatório; com quarentena
+   infinita, um toque errado perde a pergunta para sempre.
+
+**O núcleo é a exceção declarada** e não passa pela regra 1: é uma sequência anunciada, com fim
+visível, que a pessoa entrou sabendo que ia atravessar. Interrupção não anunciada e sequência
+anunciada não cansam igual — o que cansa é a primeira.
+
+⚠️ **Módulo PURO.** `hoje` e `fuso` entram por parâmetro, sempre. Quem os deriva é o router, com
+`hoje_do_tenant(db)` e `tenant_timezone(db)`. Um default que lesse o relógio aqui é exatamente
+por onde o dono no Acre passa a ser interrogado duas vezes no mesmo dia — e a regressão passaria
+meses despercebida, porque em São Paulo funciona.
+
+⚠️ **`fuso` não é decoração.** `answered_at` é `timestamptz`, e `.date()` nele devolve a data em
+UTC. Um dono em UTC−3 respondendo às 22h produz carimbo de 01h do dia SEGUINTE em UTC: comparado
+cru com `hoje`, a cota do dia não é reconhecida e ele é perguntado de novo na mesma noite. Por
+isso a data do carimbo passa por `local_date` — a mesma porta que `hoje_do_tenant` usa.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy.orm import Session
+
+from app.core.tz import local_date
+from app.modules.dna import catalog, service
+
+QUARENTENA_DIAS = 7
+GANCHO_NUCLEO = "nucleo"
+
+
+def pendente(
+    db: Session, *, gancho: str, hoje: date, fuso: str | None = None
+) -> catalog.Pergunta | None:
+    """A pergunta a fazer neste gancho hoje, ou `None` se for dia de silêncio."""
+    if gancho == GANCHO_NUCLEO:
+        faltando = faltantes(db, gancho=GANCHO_NUCLEO)
+        return faltando[0] if faltando else None
+
+    registro = service.linhas(db)
+
+    # Regra 1: qualquer registro de hoje já gastou a cota do dia.
+    if any(_dia(linha.answered_at, fuso) == hoje for linha in registro.values()):
+        return None
+
+    for pergunta in catalog.PERGUNTAS:
+        if pergunta.gancho != gancho:
+            continue
+        linha = registro.get(pergunta.key)
+        if linha is None:
+            return pergunta
+        if (
+            linha.value is None
+            and (hoje - _dia(linha.answered_at, fuso)).days >= QUARENTENA_DIAS
+        ):
+            return pergunta  # saiu da quarentena
+    return None
+
+
+def faltantes(db: Session, *, gancho: str) -> list[catalog.Pergunta]:
+    """As perguntas do gancho ainda sem RESPOSTA — puladas contam como faltantes.
+
+    Sem cadência: é o que a tela do núcleo e a aba de `/config` usam, onde a pessoa escolheu
+    estar e a interrupção não existe.
+    """
+    respondidas = set(service.respostas(db))
+    if gancho == GANCHO_NUCLEO:
+        return [catalog.POR_KEY[key] for key in catalog.NUCLEO if key not in respondidas]
+    return [p for p in catalog.PERGUNTAS if p.gancho == gancho and p.key not in respondidas]
+
+
+def _dia(quando: datetime, fuso: str | None) -> date:
+    """A data do carimbo NO FUSO DO DONO. Não deriva 'hoje' — lê o dia de um instante dado."""
+    return local_date(quando, fuso)

--- a/apps/api/app/modules/dna/catalog.py
+++ b/apps/api/app/modules/dna/catalog.py
@@ -1,0 +1,523 @@
+"""O catálogo do DNA da Empresa — as 45 perguntas, em código.
+
+Catálogo em código pelo mesmo critério de `LIMIARES_PADRAO` (vima/absences.py) e
+`MODELO_POR_TAREFA` (core/ai.py): o que precisa de gate de teste mora onde o teste alcança.
+Pergunta nova exige deploy, e isso é correto — pergunta de Calibração vem sempre junto do
+consumidor dela, que é código de qualquer forma.
+
+**As duas classes são um contrato, não uma etiqueta de organização:**
+
+- `CALIBRACAO` tem consumidor HOJE. Responder muda o briefing de amanhã.
+- `RETRATO` não tem, por definição. É guardado para o V4.
+
+A guarda abaixo roda no IMPORT do módulo. Sem ela, em seis meses alguém marca uma pergunta
+bonita como Calibração, o dono a responde acreditando ter mudado o comportamento do produto, e
+não mudou nada — um produto que finge ouvir é pior que um produto que não pergunta.
+
+Este módulo é PURO: não lê relógio, não toca no banco. Ver o gate em
+`tests/test_fuso_do_tenant.py`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+CALIBRACAO = "calibracao"
+RETRATO = "retrato"
+
+FORMATO_ESCOLHA = "escolha"
+FORMATO_MULTIPLA = "escolha_multipla"
+FORMATO_TEXTO = "texto"
+
+EIXOS = ("oferta", "cliente", "ritmo", "dinheiro", "limites")
+
+# Teto do campo aberto. Não é limite de banco (a coluna é JSON) — é o ponto em que o texto
+# deixou de ser resposta e virou documento, e o V4 vai ter que resumi-lo de qualquer forma.
+MAX_TEXTO = 2000
+
+
+class CatalogoError(ValueError):
+    """Violação do contrato das classes. Estoura no import, não em produção."""
+
+
+@dataclass(frozen=True)
+class Opcao:
+    rotulo: str              # o que o dono lê
+    valor: int | str | None  # o que o sistema guarda e consome
+
+
+@dataclass(frozen=True)
+class Pergunta:
+    key: str
+    classe: str
+    eixo: str
+    texto: str
+    formato: str
+    opcoes: tuple[Opcao, ...] = field(default_factory=tuple)
+    consome: str | None = None
+    gancho: str | None = None
+
+
+def verificar(perguntas: tuple[Pergunta, ...]) -> None:
+    """As guardas. Pública para que o teste as exercite sobre catálogo arbitrário.
+
+    Um teste que só olhasse `PERGUNTAS` provaria que o catálogo de hoje está certo, não que a
+    guarda funciona — e a guarda é o que protege o catálogo de amanhã.
+    """
+    vistas: set[str] = set()
+    for p in perguntas:
+        if p.key in vistas:
+            raise CatalogoError(f"key duplicada: {p.key}")
+        vistas.add(p.key)
+
+        if p.eixo not in EIXOS:
+            raise CatalogoError(f"{p.key}: eixo '{p.eixo}' não existe")
+        if not p.key.startswith(f"{p.eixo}."):
+            raise CatalogoError(f"{p.key} não começa com o eixo '{p.eixo}'")
+
+        if p.classe == CALIBRACAO:
+            if not p.consome:
+                raise CatalogoError(
+                    f"{p.key} é Calibração e não declara consumidor — a classe existe "
+                    "justamente para impedir pergunta sem efeito"
+                )
+            if p.consome not in LIMIARES_PADRAO:
+                raise CatalogoError(
+                    f"{p.key} consome '{p.consome}', ausente de LIMIARES_PADRAO. Um typo aqui "
+                    "grava a resposta, não consome nada e nunca falha."
+                )
+        elif p.classe == RETRATO:
+            if p.consome:
+                raise CatalogoError(f"{p.key} é Retrato e declara consumidor '{p.consome}'")
+        else:
+            raise CatalogoError(f"{p.key}: classe '{p.classe}' não existe")
+
+        if p.formato == FORMATO_ESCOLHA and len(p.opcoes) < 2:
+            raise CatalogoError(f"{p.key} é escolha com menos de duas opções")
+
+
+def _cal(key, eixo, texto, opcoes, consome, gancho) -> Pergunta:
+    return Pergunta(
+        key=key, classe=CALIBRACAO, eixo=eixo, texto=texto, formato=FORMATO_ESCOLHA,
+        opcoes=opcoes, consome=consome, gancho=gancho,
+    )
+
+
+def _esc(key, eixo, texto, opcoes, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_ESCOLHA,
+        opcoes=opcoes, gancho=gancho,
+    )
+
+
+def _mult(key, eixo, texto, opcoes, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_MULTIPLA,
+        opcoes=opcoes, gancho=gancho,
+    )
+
+
+def _txt(key, eixo, texto, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_TEXTO, gancho=gancho,
+    )
+
+
+# --- Calibração (6) --------------------------------------------------------------------
+# Cada uma existe porque há um número esperando por ela. São SEIS porque só existem seis
+# consumidores — qualquer número maior seria invenção.
+
+_CALIBRACAO: tuple[Pergunta, ...] = (
+    _cal(
+        "ritmo.resposta_horas", "ritmo",
+        "Um cliente te escreveu e ficou sem resposta. Em quanto tempo eu te aviso?",
+        (
+            Opcao("Em 4 horas", 4),
+            Opcao("No mesmo dia", 12),
+            Opcao("No dia seguinte", 24),
+            Opcao("Depois de 2 dias", 48),
+        ),
+        "sem_resposta_nossa_horas",
+        "briefing.ausencia.comercial.contato.esperando_resposta",
+    ),
+    _cal(
+        "cliente.esfria_dias", "cliente",
+        "Quantos dias sem falar com um cliente já significa que ele esfriou?",
+        (Opcao("15 dias", 15), Opcao("30 dias", 30), Opcao("60 dias", 60), Opcao("90 dias", 90)),
+        "contato_sumido_dias",
+        "briefing.ausencia.comercial.contato.sumido",
+    ),
+    _cal(
+        "ritmo.card_parado_dias", "ritmo",
+        "Uma negociação parada na mesma etapa há quanto tempo te incomoda?",
+        (Opcao("5 dias", 5), Opcao("10 dias", 10), Opcao("20 dias", 20), Opcao("30 dias", 30)),
+        "card_parado_dias",
+        "briefing.ausencia.comercial.card.parado",
+    ),
+    _cal(
+        "cliente.topo_seco_dias", "cliente",
+        "Quantos dias sem nenhum cliente novo é anormal no seu negócio?",
+        (
+            Opcao("3 dias", 3),
+            Opcao("5 dias", 5),
+            Opcao("15 dias", 15),
+            # A ÚNICA regra que pode ser desligada: é a única que dispara sobre o VAZIO. As
+            # outras cinco se calam sozinhas em quem não usa aquilo — sem cards, não há card
+            # parado. `None` = regra não executada (mesma forma do filtro de permissão do V1,
+            # que não roda a regra em vez de calcular e esconder).
+            Opcao("Não quero esse aviso", None),
+        ),
+        "topo_sem_lead_dias",
+        "briefing.ausencia.comercial.topo.sem_lead",
+    ),
+    _cal(
+        "ritmo.prazo_antecedencia_dias", "ritmo",
+        "Com quanta antecedência você quer saber de um prazo?",
+        (
+            Opcao("No próprio dia", 0),
+            Opcao("1 dia antes", 1),
+            Opcao("3 dias antes", 3),
+            Opcao("1 semana antes", 7),
+        ),
+        "prazo_vencendo_dias",
+        "briefing.ausencia.agenda.prazo.estourado",
+    ),
+    _cal(
+        "dinheiro.antecedencia_dias", "dinheiro",
+        "E de uma conta a pagar?",
+        (
+            Opcao("No próprio dia", 0),
+            Opcao("1 dia antes", 1),
+            Opcao("3 dias antes", 3),
+            Opcao("1 semana antes", 7),
+        ),
+        "dinheiro_com_data_dias",
+        "briefing.ausencia.financeiro.conta.vencendo",
+    ),
+)
+
+# --- Retrato (39) ----------------------------------------------------------------------
+# Regra de pertencimento: entra se um funcionário humano recém-contratado precisaria saber no
+# primeiro dia. "Qual seu CNPJ" não entra (é cadastro, mora em tenant_profiles).
+
+_OFERTA: tuple[Pergunta, ...] = (
+    _esc(
+        "oferta.o_que_vende", "oferta", "O que você vende?",
+        (
+            Opcao("Serviço recorrente", "servico_recorrente"),
+            Opcao("Serviço por projeto", "servico_projeto"),
+            Opcao("Produto físico", "produto_fisico"),
+            Opcao("Produto digital", "produto_digital"),
+            Opcao("Um pouco de cada", "misto"),
+        ),
+    ),
+    _txt(
+        "oferta.em_uma_frase", "oferta",
+        "Se um cliente perguntar o que você faz, o que você responde?",
+    ),
+    _esc(
+        "oferta.ticket_tipico", "oferta", "Quanto costuma custar um trabalho seu?",
+        (
+            Opcao("Até R$ 500", "ate_500"),
+            Opcao("R$ 500 a 2 mil", "500_2k"),
+            Opcao("R$ 2 mil a 10 mil", "2k_10k"),
+            Opcao("R$ 10 mil a 50 mil", "10k_50k"),
+            Opcao("Acima de R$ 50 mil", "acima_50k"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _esc(
+        "oferta.prazo_entrega", "oferta",
+        "Do 'sim' do cliente até a entrega, quanto tempo costuma passar?",
+        (
+            Opcao("No mesmo dia", "mesmo_dia"),
+            Opcao("Até uma semana", "semana"),
+            Opcao("De 2 a 4 semanas", "mes"),
+            Opcao("Mais de um mês", "mais_de_um_mes"),
+            Opcao("É contínuo, não tem fim", "continuo"),
+        ),
+    ),
+    _esc(
+        "oferta.como_cobra", "oferta", "Como você costuma cobrar?",
+        (
+            Opcao("Tudo antes", "antes"),
+            Opcao("Tudo depois", "depois"),
+            Opcao("Entrada e saldo", "entrada_saldo"),
+            Opcao("Parcelado", "parcelado"),
+            Opcao("Mensalidade", "mensalidade"),
+        ),
+    ),
+    _esc(
+        "oferta.capacidade_mes", "oferta",
+        "Quantos clientes novos você consegue atender por mês, no máximo?",
+        (
+            Opcao("1 ou 2", "1_2"),
+            Opcao("3 a 5", "3_5"),
+            Opcao("6 a 15", "6_15"),
+            Opcao("Mais de 15", "mais_15"),
+            Opcao("Não tenho teto", "sem_teto"),
+        ),
+    ),
+    _esc(
+        "oferta.proposta_formal", "oferta",
+        "Você manda proposta ou orçamento escrito antes de fechar?",
+        (
+            Opcao("Sempre", "sempre"),
+            Opcao("Na maioria das vezes", "maioria"),
+            Opcao("Raramente", "raramente"),
+            Opcao("Nunca", "nunca"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _txt("oferta.diferencial", "oferta", "Por que um cliente escolhe você e não o concorrente?"),
+    _txt("oferta.aberta", "oferta", "Algo mais que a Vima precisa saber sobre o que você vende?"),
+)
+
+_CLIENTE: tuple[Pergunta, ...] = (
+    _esc(
+        "cliente.quem_e", "cliente", "Quem compra de você?",
+        (
+            Opcao("Pessoa física", "pf"),
+            Opcao("Pequenas empresas", "pequenas"),
+            Opcao("Empresas médias e grandes", "grandes"),
+            Opcao("Órgãos públicos", "publico"),
+            Opcao("Um pouco de cada", "misto"),
+        ),
+        gancho="crm.cliente.criado",
+    ),
+    _mult(
+        "cliente.como_chega", "cliente", "Como o cliente chega até você?",
+        (
+            Opcao("Indicação", "indicacao"),
+            Opcao("Redes sociais", "social"),
+            Opcao("Busca no Google", "busca"),
+            Opcao("Anúncio pago", "ads"),
+            Opcao("Prospecção ativa", "outbound"),
+            Opcao("Passagem ou loja física", "fisico"),
+        ),
+    ),
+    _esc(
+        "cliente.decisao_tempo", "cliente",
+        "Do primeiro contato até o cliente decidir, quanto tempo costuma levar?",
+        (
+            Opcao("No mesmo dia", "mesmo_dia"),
+            Opcao("Poucos dias", "dias"),
+            Opcao("De 1 a 4 semanas", "semanas"),
+            Opcao("Mais de um mês", "meses"),
+        ),
+        gancho="crm.cliente.criado",
+    ),
+    _esc(
+        "cliente.recompra", "cliente", "O mesmo cliente costuma voltar?",
+        (
+            Opcao("É recorrente por contrato", "contrato"),
+            Opcao("Volta com frequência", "frequente"),
+            Opcao("Volta às vezes", "as_vezes"),
+            Opcao("É compra única", "unica"),
+        ),
+    ),
+    _esc(
+        "cliente.objecao", "cliente", "O que mais faz um cliente dizer não?",
+        (
+            Opcao("Preço", "preco"),
+            Opcao("Prazo", "prazo"),
+            Opcao("Falta de confiança", "confianca"),
+            Opcao("Não era o que ele procurava", "fit"),
+            Opcao("Ele some sem dizer nada", "some"),
+        ),
+    ),
+    _esc(
+        "cliente.canal_preferido", "cliente", "Por onde o cliente prefere falar com você?",
+        (
+            Opcao("WhatsApp", "whatsapp"),
+            Opcao("Telefone", "telefone"),
+            Opcao("E-mail", "email"),
+            Opcao("Presencial", "presencial"),
+            Opcao("Instagram e afins", "social"),
+        ),
+    ),
+    _txt("cliente.sinal_de_que_fecha", "cliente", "O que te faz saber que um cliente vai fechar?"),
+    _txt("cliente.aberta", "cliente", "Algo mais que a Vima precisa saber sobre seus clientes?"),
+)
+
+_RITMO: tuple[Pergunta, ...] = (
+    _mult(
+        "ritmo.dias_de_trabalho", "ritmo", "Em que dias você trabalha?",
+        (
+            Opcao("Segunda", "seg"), Opcao("Terça", "ter"), Opcao("Quarta", "qua"),
+            Opcao("Quinta", "qui"), Opcao("Sexta", "sex"), Opcao("Sábado", "sab"),
+            Opcao("Domingo", "dom"),
+        ),
+    ),
+    _esc(
+        "ritmo.janela_do_dia", "ritmo", "Que horas você costuma trabalhar?",
+        (
+            Opcao("De manhã", "manha"),
+            Opcao("Horário comercial", "comercial"),
+            Opcao("Tarde e noite", "tarde_noite"),
+            Opcao("De madrugada", "madrugada"),
+            Opcao("Varia muito", "varia"),
+        ),
+    ),
+    _esc(
+        "ritmo.pico_do_mes", "ritmo", "Tem época do mês mais cheia?",
+        (
+            Opcao("Começo", "comeco"), Opcao("Meio", "meio"),
+            Opcao("Fim", "fim"), Opcao("Não tem padrão", "sem_padrao"),
+        ),
+    ),
+    _txt("ritmo.sazonalidade", "ritmo", "E do ano? Tem mês que enche e mês que esvazia?"),
+    _esc(
+        "ritmo.o_que_trava", "ritmo", "O que mais trava o seu dia?",
+        (
+            Opcao("Atender cliente", "atender"),
+            Opcao("Fazer o trabalho em si", "executar"),
+            Opcao("Cobrar", "cobrar"),
+            Opcao("Burocracia", "burocracia"),
+            Opcao("Vender", "vender"),
+        ),
+    ),
+    _esc(
+        "ritmo.sozinho", "ritmo", "Você trabalha sozinho?",
+        (
+            Opcao("Sozinho", "sozinho"),
+            Opcao("Com ajuda pontual de freelas", "freelas"),
+            Opcao("Tenho 1 ou 2 pessoas", "pequena"),
+            Opcao("Tenho equipe", "equipe"),
+        ),
+    ),
+    _txt("ritmo.aberta", "ritmo", "Algo mais que a Vima precisa saber sobre o seu ritmo?"),
+)
+
+_DINHEIRO: tuple[Pergunta, ...] = (
+    _esc(
+        "dinheiro.atraso_reacao", "dinheiro", "Cliente atrasou o pagamento. O que você faz?",
+        (
+            Opcao("Cobro no dia seguinte", "imediato"),
+            Opcao("Espero alguns dias", "espero"),
+            Opcao("Espero ele falar", "passivo"),
+            Opcao("Evito cobrar", "evito"),
+        ),
+        gancho="receivables.cobranca.criada",
+    ),
+    # ⚠️ Parece Calibração e NÃO é: tem número e opções fechadas, mas não existe hoje regra de
+    # Ausência sobre tolerância a atraso (`dinheiro com data` olha vencimento, não carência).
+    # A classe é definida pelo contrato, nunca pelo formato. Se a regra nascer, esta pergunta
+    # migra de classe junto com ela — e a guarda cobra que o consumidor exista antes.
+    _esc(
+        "dinheiro.tolerancia_dias", "dinheiro",
+        "Quantos dias de atraso você tolera antes de agir?",
+        (
+            Opcao("1 dia", 1), Opcao("3 dias", 3), Opcao("7 dias", 7),
+            Opcao("15 dias", 15), Opcao("30 dias", 30),
+        ),
+    ),
+    _esc(
+        "dinheiro.reserva", "dinheiro", "Você tem reserva para quantos meses parados?",
+        (
+            Opcao("Nenhuma", "nenhuma"),
+            Opcao("Menos de um mês", "menos_1"),
+            Opcao("De 1 a 3 meses", "1_3"),
+            Opcao("De 3 a 6 meses", "3_6"),
+            Opcao("Mais de 6 meses", "mais_6"),
+        ),
+    ),
+    _esc(
+        "dinheiro.pro_labore", "dinheiro", "Você tira um valor fixo por mês para você?",
+        (
+            Opcao("Sim, fixo", "fixo"),
+            Opcao("Sim, variável", "variavel"),
+            Opcao("Não separo", "nao_separo"),
+        ),
+    ),
+    _txt("dinheiro.sinal_de_aperto", "dinheiro", "O que te diz que o mês vai ser apertado?"),
+    _mult(
+        "dinheiro.formas_recebimento", "dinheiro", "Como você recebe?",
+        (
+            Opcao("Pix", "pix"), Opcao("Boleto", "boleto"), Opcao("Cartão", "cartao"),
+            Opcao("Dinheiro", "dinheiro"), Opcao("Transferência", "transferencia"),
+        ),
+        gancho="receivables.cobranca.criada",
+    ),
+    _esc(
+        "dinheiro.emite_nota", "dinheiro", "Você emite nota fiscal?",
+        (
+            Opcao("Sempre", "sempre"),
+            Opcao("Quando o cliente pede", "sob_demanda"),
+            Opcao("Não emito", "nao"),
+        ),
+        gancho="payables.conta.criada",
+    ),
+    _txt("dinheiro.aberta", "dinheiro", "Algo mais que a Vima precisa saber sobre o seu dinheiro?"),
+)
+
+# O eixo mais importante e o mais fácil de esquecer: é o único que o V4 lê para decidir o que
+# NÃO fazer sozinho. Autonomia progressiva sem esta lista é um agente que descobre os limites
+# errando na frente do cliente.
+_LIMITES: tuple[Pergunta, ...] = (
+    _txt("limites.nunca_faco", "limites", "O que você nunca faz, mesmo que o cliente peça?"),
+    _mult(
+        "limites.exige_voce", "limites", "O que só pode sair com você olhando antes?",
+        (
+            Opcao("Proposta e preço", "proposta"),
+            Opcao("Mensagem para cliente", "mensagem"),
+            Opcao("Cobrança", "cobranca"),
+            Opcao("Contrato", "contrato"),
+            Opcao("Publicação", "publicacao"),
+            Opcao("Nada disso", "nada"),
+        ),
+    ),
+    _esc(
+        "limites.tom", "limites", "Como você fala com cliente?",
+        (
+            Opcao("Formal", "formal"),
+            Opcao("Cordial e direto", "cordial"),
+            Opcao("Informal e próximo", "informal"),
+            Opcao("Bem-humorado", "humorado"),
+        ),
+    ),
+    _esc(
+        "limites.desconto", "limites", "Você dá desconto?",
+        (
+            Opcao("Nunca", "nunca"),
+            Opcao("Só em caso especial", "especial"),
+            Opcao("Negocio sempre", "sempre"),
+            Opcao("Tenho tabela fixa", "tabela"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _txt("limites.recusa_cliente", "limites", "Que tipo de cliente você recusa?"),
+    _esc(
+        "limites.horario_contato", "limites", "Pode falar com cliente fora do seu horário?",
+        (
+            Opcao("Pode sempre", "sempre"),
+            Opcao("Só urgência", "urgencia"),
+            Opcao("Nunca", "nunca"),
+        ),
+        gancho="agenda.evento.criado",
+    ),
+    _txt("limites.aberta", "limites", "Algo mais que a Vima precisa saber sobre os seus limites?"),
+)
+
+PERGUNTAS: tuple[Pergunta, ...] = (
+    _CALIBRACAO + _OFERTA + _CLIENTE + _RITMO + _DINHEIRO + _LIMITES
+)
+
+# A guarda roda AGORA, no import. Falha na subida do processo, não em produção.
+verificar(PERGUNTAS)
+
+POR_KEY: dict[str, Pergunta] = {p.key: p for p in PERGUNTAS}
+
+# O núcleo do primeiro acesso. NENHUMA é de Calibração, e essa é a inversão central do design:
+# "em quanto tempo eu te aviso que ninguém respondeu o Carlos?" é impossível de responder bem
+# antes de ter visto um briefing. A resposta seria um chute que depois vira comportamento
+# errado com aparência de configuração deliberada.
+NUCLEO: tuple[str, ...] = (
+    "oferta.o_que_vende",
+    "oferta.em_uma_frase",
+    "oferta.como_cobra",
+    "oferta.ticket_tipico",
+    "cliente.como_chega",
+    "limites.nunca_faco",
+)

--- a/apps/api/app/modules/dna/models.py
+++ b/apps/api/app/modules/dna/models.py
@@ -1,0 +1,38 @@
+"""A resposta do DNA — estado atual, não história.
+
+**É upsert, não append — o oposto de `core/facts.py`, e de propósito.** Fato é história; DNA é
+estado atual. Guardar versões faria toda leitura ter que decidir qual resposta vale, e o
+histórico de quem mudou o quê já é trabalho de `core/audit.py`.
+
+`value` nulo NÃO é ausência de linha: é "o dono viu a pergunta e pulou". A distinção sustenta a
+quarentena de 7 dias em `cadencia.py` sem tabela nova.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+SOURCE_NUCLEO = "nucleo"
+SOURCE_GANCHO = "gancho"
+SOURCE_CONFIG = "config"
+
+
+class DnaAnswer(Base, TenantMixin, TimestampMixin):
+    """Uma resposta do dono sobre o próprio negócio."""
+
+    __tablename__ = "dna_answers"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    question_key: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # `int | str | list | None` — o formato é decidido pelo catálogo, e a validação acontece no
+    # serviço, contra ele. A coluna é frouxa; a porta de entrada é estreita.
+    value: Mapped[Any | None] = mapped_column(JSON, nullable=True)
+    answered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # A resposta é do TENANT, mas a autoria importa quando há sub-usuário.
+    answered_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    source: Mapped[str] = mapped_column(String(16), nullable=False)

--- a/apps/api/app/modules/dna/resolver.py
+++ b/apps/api/app/modules/dna/resolver.py
@@ -1,0 +1,76 @@
+"""A única porta de leitura do DNA.
+
+Três funções, e nada mais. Nenhum outro módulo lê `dna_answers` direto — é o que mantém a
+classe Retrato honestamente SEM consumidor até o V4, em vez de ela vazar por um `select`
+esperto em algum lugar, que é como um contrato de arquitetura morre na prática.
+
+⚠️ **Módulo PURO:** não lê relógio. `recalibrado_apos` recebe a data de comparação por
+parâmetro.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.dna import catalog
+from app.modules.dna.models import DnaAnswer
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+_CALIBRACAO_POR_KEY = {
+    p.key: p for p in catalog.PERGUNTAS if p.classe == catalog.CALIBRACAO
+}
+
+
+def limiares(db: Session) -> dict[str, int | None]:
+    """Só as respostas de Calibração, prontas para `absences.coletar(..., limiares=...)`.
+
+    Devolve **só o que foi respondido**, nunca os defaults: quem mescla é `coletar`, com
+    `{**LIMIARES_PADRAO, **override}`. Uma segunda fonte de default divergiria da primeira no
+    dia em que alguém mudasse um número em só um dos lugares.
+    """
+    fora: dict[str, int | None] = {}
+    for linha in db.scalars(select(DnaAnswer)).all():
+        pergunta = _CALIBRACAO_POR_KEY.get(linha.question_key)
+        if pergunta is None or pergunta.consome not in LIMIARES_PADRAO:
+            continue
+        # A resposta precisa continuar sendo uma das opções. Trocar o `valor` de uma opção
+        # depois de alguém responder deixa a linha órfã — e uma resposta órfã tem que cair no
+        # default, não derrubar o briefing do dia.
+        if linha.value not in {o.valor for o in pergunta.opcoes}:
+            continue
+        fora[pergunta.consome] = linha.value
+    return fora
+
+
+def retrato(db: Session) -> dict[str, Any]:
+    """O dossiê. **Sem consumidor no V2** — existe para que o V4 encontre a porta pronta."""
+    return {
+        linha.question_key: linha.value
+        for linha in db.scalars(select(DnaAnswer)).all()
+        if linha.value is not None and linha.question_key not in _CALIBRACAO_POR_KEY
+    }
+
+
+def recalibrado_apos(db: Session, quando: date) -> bool:
+    """Houve resposta de CALIBRAÇÃO depois desta data?
+
+    É o gatilho da limpeza do silêncio em `vima/service._ja_reportadas`. Só Calibração conta:
+    responder Retrato não muda comportamento nenhum, e limpar o silêncio por causa disso faria
+    o briefing repetir pendências sem motivo.
+
+    ⚠️ **A comparação é `>=`, não `>`, e o estrito quebraria o recurso inteiro.** O caso normal
+    é o dono recalibrar HOJE, pelo gancho colado à ausência do briefing de hoje — cujo
+    `reference_date` também é hoje. Com `>`, a limpeza nunca aconteceria no dia seguinte, que é
+    justamente quando ela precisa acontecer: o briefing de amanhã olha o de hoje como anterior.
+
+    O custo do `>=` é repetir uma pendência para quem respondeu ANTES de o briefing do dia sair.
+    É o erro barato: uma ausência repetida incomoda, uma calibração que não produz efeito visível
+    ensina o dono a não mexer mais em nada.
+    """
+    for linha in db.scalars(select(DnaAnswer)).all():
+        if linha.question_key in _CALIBRACAO_POR_KEY and linha.answered_at.date() >= quando:
+            return True
+    return False

--- a/apps/api/app/modules/dna/router.py
+++ b/apps/api/app/modules/dna/router.py
@@ -1,0 +1,100 @@
+"""Rotas do DNA da Empresa.
+
+⚠️ **`require_module("settings")` aqui, e não filtro no dado.** É o oposto da decisão do
+`vima/router.py`, e de propósito: lá o recorte é por LINHA (o funcionário recebe o briefing do
+que ele pode ver); aqui a superfície inteira é da empresa, então bloquear a rota é a resposta
+certa. `require_module` já dá owner-vê-tudo e lista-vazia-vê-tudo.
+
+**`hoje_do_tenant(db)` e `tenant_timezone(db)` são chamados AQUI**, e descem por parâmetro até
+`cadencia`. É o que mantém aquele módulo puro e o gate de fuso satisfeito.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.modules.dna import cadencia, catalog, service
+from app.modules.dna.schemas import PerguntaOut, PularIn, RespostaIn, to_out
+from app.modules.settings.service import hoje_do_tenant, tenant_timezone
+
+router = APIRouter(prefix="/dna", tags=["dna"])
+
+
+@router.get("/pendente", response_model=PerguntaOut | None)
+def pendente(
+    gancho: str = Query(...),
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut | None:
+    """A pergunta deste gancho hoje — ou nada, que é o caso na maioria dos dias."""
+    fuso = tenant_timezone(db)
+    achada = cadencia.pendente(
+        db, gancho=gancho, hoje=hoje_do_tenant(db), fuso=fuso
+    )
+    return to_out(achada) if achada else None
+
+
+@router.get("/faltantes", response_model=list[PerguntaOut])
+def faltantes(
+    gancho: str = Query(...),
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> list[PerguntaOut]:
+    """Sem cadência: a sequência anunciada do núcleo e a lista da aba de configurações."""
+    return [to_out(p) for p in cadencia.faltantes(db, gancho=gancho)]
+
+
+@router.get("/catalogo", response_model=list[PerguntaOut])
+def catalogo(
+    user: CurrentUser = Depends(require_module("settings")),
+) -> list[PerguntaOut]:
+    """As 45, na ordem do catálogo.
+
+    A aba de configurações é a única superfície SEM cadência — a pessoa escolheu estar ali, e
+    esconder pergunta de quem foi procurá-la é hostil.
+    """
+    return [to_out(p) for p in catalog.PERGUNTAS]
+
+
+@router.get("/respostas")
+def respostas(
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> dict[str, Any]:
+    return service.respostas(db)
+
+
+@router.put("/{key}", response_model=PerguntaOut)
+def responder(
+    key: str,
+    corpo: RespostaIn,
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut:
+    try:
+        service.responder(
+            db, tenant_id=user.tenant_id, key=key, valor=corpo.valor,
+            user_id=user.user_id, source=corpo.source,
+        )
+    except service.DnaError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    return to_out(catalog.POR_KEY[key])
+
+
+@router.post("/{key}/pular", response_model=PerguntaOut)
+def pular(
+    key: str,
+    corpo: PularIn,
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut:
+    try:
+        service.pular(
+            db, tenant_id=user.tenant_id, key=key, user_id=user.user_id, source=corpo.source
+        )
+    except service.DnaError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    return to_out(catalog.POR_KEY[key])

--- a/apps/api/app/modules/dna/schemas.py
+++ b/apps/api/app/modules/dna/schemas.py
@@ -1,0 +1,47 @@
+"""Contrato HTTP do DNA.
+
+A pergunta viaja INTEIRA para o front (texto e opções), em vez de o front ter uma cópia do
+catálogo: duas cópias divergem no primeiro ajuste de texto, e a versão errada é sempre a que o
+dono está lendo.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.modules.dna import catalog
+
+
+class OpcaoOut(BaseModel):
+    rotulo: str
+    valor: Any | None
+
+
+class PerguntaOut(BaseModel):
+    key: str
+    classe: str
+    eixo: str
+    texto: str
+    formato: str
+    opcoes: list[OpcaoOut]
+
+
+class RespostaIn(BaseModel):
+    valor: Any | None = None
+    source: str
+
+
+class PularIn(BaseModel):
+    source: str
+
+
+def to_out(pergunta: catalog.Pergunta) -> PerguntaOut:
+    return PerguntaOut(
+        key=pergunta.key,
+        classe=pergunta.classe,
+        eixo=pergunta.eixo,
+        texto=pergunta.texto,
+        formato=pergunta.formato,
+        opcoes=[OpcaoOut(rotulo=o.rotulo, valor=o.valor) for o in pergunta.opcoes],
+    )

--- a/apps/api/app/modules/dna/service.py
+++ b/apps/api/app/modules/dna/service.py
@@ -1,0 +1,112 @@
+"""Escrita e leitura crua do DNA. A validação contra o catálogo mora aqui.
+
+A coluna `value` é JSON frouxo de propósito — o formato é decidido pelo catálogo, e é aqui que
+o catálogo é cobrado. Sem esta porta estreita, o JSON vira depósito de qualquer coisa e o
+resolver quebra na leitura, longe de quem escreveu.
+
+Este módulo NÃO é puro: carimba `answered_at` com o instante. Carimbar INSTANTE é legítimo;
+derivar QUE DIA É HOJE é o que o gate de `test_fuso_do_tenant.py` proíbe — e essa derivação
+mora em `cadencia.py`, que recebe `hoje` por parâmetro.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.dna import catalog
+from app.modules.dna.models import DnaAnswer
+
+
+class DnaError(Exception):
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def responder(
+    db: Session,
+    *,
+    tenant_id: str,
+    key: str,
+    valor: Any,
+    user_id: str | None,
+    source: str,
+) -> DnaAnswer:
+    """Grava a resposta, validando contra o catálogo. Commita."""
+    pergunta = _pergunta(key)
+    _validar(pergunta, valor)
+    return _gravar(db, tenant_id=tenant_id, key=key, valor=valor, user_id=user_id, source=source)
+
+
+def pular(
+    db: Session, *, tenant_id: str, key: str, user_id: str | None, source: str
+) -> DnaAnswer:
+    """Registra que o dono viu e pulou. `value` nulo é o registro — não é linha ausente."""
+    _pergunta(key)
+    return _gravar(db, tenant_id=tenant_id, key=key, valor=None, user_id=user_id, source=source)
+
+
+def respostas(db: Session) -> dict[str, Any]:
+    """Só o que foi de fato respondido. Puladas ficam de fora."""
+    return {
+        linha.question_key: linha.value
+        for linha in db.scalars(select(DnaAnswer)).all()
+        if linha.value is not None
+    }
+
+
+def linhas(db: Session) -> dict[str, DnaAnswer]:
+    """Todas as linhas, inclusive as puladas — é o que a cadência precisa ver."""
+    return {linha.question_key: linha for linha in db.scalars(select(DnaAnswer)).all()}
+
+
+def _pergunta(key: str) -> catalog.Pergunta:
+    pergunta = catalog.POR_KEY.get(key)
+    if pergunta is None:
+        raise DnaError(f"a pergunta '{key}' não existe no catálogo", status_code=404)
+    return pergunta
+
+
+def _validar(pergunta: catalog.Pergunta, valor: Any) -> None:
+    if pergunta.formato == catalog.FORMATO_TEXTO:
+        if not isinstance(valor, str):
+            raise DnaError(f"'{pergunta.key}' espera texto")
+        if len(valor) > catalog.MAX_TEXTO:
+            raise DnaError(
+                f"texto longo demais ({len(valor)} caracteres, máximo {catalog.MAX_TEXTO})"
+            )
+        return
+
+    permitidos = {o.valor for o in pergunta.opcoes}
+
+    if pergunta.formato == catalog.FORMATO_MULTIPLA:
+        if not isinstance(valor, list):
+            raise DnaError(f"'{pergunta.key}' espera uma lista")
+        invalidos = [v for v in valor if v not in permitidos]
+        if invalidos:
+            raise DnaError(f"{invalidos} não está entre as opções de '{pergunta.key}'")
+        return
+
+    if valor not in permitidos:
+        raise DnaError(f"'{valor}' não está entre as opções de '{pergunta.key}'")
+
+
+def _gravar(
+    db: Session, *, tenant_id: str, key: str, valor: Any, user_id: str | None, source: str
+) -> DnaAnswer:
+    """Upsert por `(tenant, pergunta)` — a unique constraint da migration é o que o garante."""
+    linha = db.scalar(select(DnaAnswer).where(DnaAnswer.question_key == key))
+    if linha is None:
+        linha = DnaAnswer(tenant_id=tenant_id, question_key=key)
+        db.add(linha)
+    linha.value = valor
+    linha.answered_at = datetime.now(UTC)
+    linha.answered_by = user_id
+    linha.source = source
+    db.commit()
+    db.refresh(linha)
+    return linha

--- a/apps/api/app/modules/vima/absences.py
+++ b/apps/api/app/modules/vima/absences.py
@@ -52,6 +52,10 @@ LIMIARES_PADRAO: dict[str, int] = {
     "card_parado_dias": 10,
     "topo_sem_lead_dias": 5,
     "prazo_vencendo_dias": 1,
+    # Nasce com o MESMO valor de `prazo_vencendo_dias` porque hoje as duas regras dividem
+    # aquele número. Quem passa a lê-lo é `_dinheiro_com_data` — aqui a chave existe para que
+    # o catálogo do DNA possa apontar para ela.
+    "dinheiro_com_data_dias": 1,
 }
 
 

--- a/apps/api/app/modules/vima/absences.py
+++ b/apps/api/app/modules/vima/absences.py
@@ -166,8 +166,17 @@ def _prazos_estourados(db: Session, hoje: date, lim: dict[str, int]) -> list[Aus
 
 
 def _dinheiro_com_data(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausencia]:
-    """Conta a pagar e cobrança a receber que a data alcançou. Duas direções, uma regra."""
-    limite = hoje + timedelta(days=lim["prazo_vencendo_dias"])
+    """Conta a pagar e cobrança a receber que a data alcançou.
+
+    ⚠️ As duas direções NÃO seguem a mesma regra, apesar de morarem juntas: conta a pagar tem
+    antecedência (`due_date <= hoje + limiar`), cobrança a receber só aparece DEPOIS de vencida
+    (`due_date < hoje`, sem limiar). Um recebimento que vence amanhã não é dito por ninguém —
+    dívida registrada no spec do V2, e o motivo de a pergunta do DNA falar só de conta a pagar.
+
+    O limiar é `dinheiro_com_data_dias`, próprio, e não mais o `prazo_vencendo_dias` da agenda:
+    prazo de entrega se quer saber em cima, boleto se quer saber com folga para ter o dinheiro.
+    """
+    limite = hoje + timedelta(days=lim["dinheiro_com_data_dias"])
     fora: list[Ausencia] = []
 
     contas = db.scalars(

--- a/apps/api/app/modules/vima/absences.py
+++ b/apps/api/app/modules/vima/absences.py
@@ -96,7 +96,7 @@ def coletar(
     compatível com a data de referência —, e o serviço passa o relógio real. Como todo o resto
     deste módulo, o relógio entra por parâmetro: nada aqui dentro chama `now()`.
     """
-    lim = {**LIMIARES_PADRAO, **(limiares or {})}
+    lim: dict[str, int | None] = {**LIMIARES_PADRAO, **(limiares or {})}
     instante = agora or datetime.combine(hoje, time.max, tzinfo=UTC)
     fora: list[Ausencia] = []
 
@@ -108,7 +108,12 @@ def coletar(
         fora.extend(_silencio_nosso(db, hoje, lim, instante))
         fora.extend(_contato_sumido(db, hoje, lim))
         fora.extend(_cards_parados(db, hoje, lim))
-        fora.extend(_topo_seco(db, hoje, lim))
+        # `None` significa REGRA NÃO EXECUTADA, não "limiar infinito" — mesma forma do filtro
+        # de permissão, que não roda a regra em vez de calcular e esconder. Só topo seco pode
+        # ser desligado, porque é a única que dispara sobre o VAZIO: sem cards não há card
+        # parado, mas sem lead nenhum ela cutuca todo dia, para sempre.
+        if lim.get("topo_sem_lead_dias") is not None:
+            fora.extend(_topo_seco(db, hoje, lim))
 
     return [a for a in fora if not _ja_dita(a, ja_reportadas)]
 

--- a/apps/api/app/modules/vima/composer.py
+++ b/apps/api/app/modules/vima/composer.py
@@ -55,6 +55,10 @@ class Linha:
     secao: str  # "ACONTECEU" | "PENDENTE" | "NÚMEROS"
     module: str
     texto: str
+    # Só ausência preenche. É o que permite ao V2 colar a pergunta de calibração na linha que a
+    # motivou. O default `""` não é cosmético: **briefings gravados antes do V2 não têm este
+    # campo no payload**, e lê-los sem default estouraria na desserialização.
+    kind: str = ""
 
 
 @dataclass(frozen=True)
@@ -91,6 +95,9 @@ class _Candidata:
     # Só ausência preenche: a chave e a intensidade que alimentam a regra do silêncio.
     chave: str | None = None
     dias: int = 0
+    # Só ausência preenche. Fica SEPARADO de `chave` de propósito: aquela é composta com o
+    # `subject_id`, e fatiá-la na tela acoplaria o front ao formato dela.
+    kind: str = ""
 
 
 def compor(
@@ -117,7 +124,9 @@ def compor(
     return Payload(
         referencia=referencia,
         desde=desde,
-        linhas=[Linha(secao=c.secao, module=c.module, texto=c.texto) for c in mantidas],
+        linhas=[
+            Linha(secao=c.secao, module=c.module, texto=c.texto, kind=c.kind) for c in mantidas
+        ],
         excedente=max(0, len(ordenadas) - len(mantidas)),
         ausencias_ditas={c.chave: c.dias for c in mantidas if c.chave},
     )
@@ -138,7 +147,7 @@ def _da_ausencia(a: Any) -> _Candidata:
     return _Candidata(
         secao=SECAO_PENDENTE, module=a.module, texto=a.title,
         peso=_peso(a.kind), quando=None,
-        chave=f"{a.kind}:{a.subject_id}", dias=a.dias,
+        chave=f"{a.kind}:{a.subject_id}", dias=a.dias, kind=a.kind,
     )
 
 

--- a/apps/api/app/modules/vima/schemas.py
+++ b/apps/api/app/modules/vima/schemas.py
@@ -19,6 +19,9 @@ class LinhaOut(BaseModel):
     secao: str
     module: str
     texto: str
+    # Só ausência preenche. Default `""` porque briefings gravados ANTES do V2 não têm o campo
+    # no payload — sem ele, reler um deles quebraria a tela.
+    kind: str = ""
 
 
 class BriefingOut(BaseModel):

--- a/apps/api/app/modules/vima/service.py
+++ b/apps/api/app/modules/vima/service.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.core.facts import Fact
 from app.core.tenancy import CurrentUser
+from app.modules.dna import resolver as dna_resolver
 from app.modules.payables.models import Payable
 from app.modules.quotes.models import Quote
 from app.modules.receivables.models import Charge
@@ -59,6 +60,9 @@ def gerar_ou_ler(db: Session, *, user: CurrentUser, hoje: date | None = None) ->
         fatos=fatos,
         ausencias=absences.coletar(
             db, user=user, hoje=dia, agora=agora,
+            # O DNA da Empresa entra aqui, e só aqui. Sem resposta, o dicionário vem vazio e os
+            # defaults conservadores do V1 continuam valendo.
+            limiares=dna_resolver.limiares(db),
             ja_reportadas=_ja_reportadas(db, user=user),
         ),
         tendencias=trends.coletar(db, user=user, hoje=dia),
@@ -132,7 +136,16 @@ def _fatos_da_janela(db: Session, *, user: CurrentUser, desde: datetime) -> list
 
 
 def _ja_reportadas(db: Session, *, user: CurrentUser) -> dict[str, int]:
-    """As ausências que o briefing anterior deste usuário já disse — a regra do silêncio."""
+    """As ausências que o briefing anterior deste usuário já disse — a regra do silêncio.
+
+    ⚠️ **Recalibrar zera o registro.** Se o dono aperta "card parado" de 10 para 5 dias e o
+    briefing continua calado porque já disse aquilo ontem, a configuração parece quebrada — e a
+    próxima que ele mexer, ele não acredita.
+
+    A limpeza é GROSSA de propósito: derruba o silêncio de todas as regras, não só da que mudou.
+    Mesma linha do fator 2 da escalada, "arbitrário e deliberadamente grosso". Discriminar por
+    regra exigiria um mapa `kind`→limiar que existiria só para isto, e recalibrar é raro.
+    """
     anterior = db.scalar(
         select(Briefing)
         .where(Briefing.user_id == user.user_id)
@@ -140,6 +153,8 @@ def _ja_reportadas(db: Session, *, user: CurrentUser) -> dict[str, int]:
         .limit(1)
     )
     if anterior is None:
+        return {}
+    if dna_resolver.recalibrado_apos(db, anterior.reference_date):
         return {}
     try:
         dados = json.loads(anterior.payload)

--- a/apps/api/migrations/versions/0075_dna_answers.py
+++ b/apps/api/migrations/versions/0075_dna_answers.py
@@ -1,0 +1,66 @@
+"""DNA da Empresa — respostas do dono
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-08-08
+
+⚠️ **COLISÃO CONHECIDA, ainda não resolvida.** Existe uma `0075_investment_bank_account.py` numa
+frente paralela (branch `onda-2b-i`) que ainda NÃO mergeou. As duas nasceram de `0074` e as duas
+reivindicam a revision `0075`.
+
+**Quem mergear DEPOIS renumera** — é a única resolução possível, e ela precisa acontecer ANTES do
+merge, não depois: duas revisions com o mesmo id fazem `alembic upgrade head` escolher uma em
+silêncio, e a outra some sem erro nenhum. Reconfira com `ls migrations/versions/ | sort | tail -3`
+imediatamente antes de abrir o PR.
+
+Numerar 0076 preventivamente seria pior: a cadeia deste branch ficaria `0074 → 0076` com o elo
+faltando, impossível de rodar e impossível de testar enquanto a outra frente não mergeasse.
+
+Sem backfill: não existe resposta anterior a esta migration, então a armadilha da RLS no backfill
+(ver 0046/0066/0067/0068/0069) não se aplica. Só DDL.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0075"
+down_revision: str | None = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dna_answers",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("tenant_id", sa.String(length=36), nullable=False, index=True),
+        sa.Column("question_key", sa.String(length=64), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=True),
+        sa.Column("answered_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("answered_by", sa.String(length=36), nullable=True),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        # O upsert depende desta constraint: uma resposta por pergunta por tenant.
+        sa.UniqueConstraint("tenant_id", "question_key", name="uq_dna_answer"),
+    )
+    op.create_index("ix_dna_answers_question_key", "dna_answers", ["question_key"])
+
+    op.execute("ALTER TABLE dna_answers ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE dna_answers FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON dna_answers
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dna_answers")

--- a/apps/api/migrations/versions/0076_dna_answers.py
+++ b/apps/api/migrations/versions/0076_dna_answers.py
@@ -1,20 +1,18 @@
 """DNA da Empresa — respostas do dono
 
-Revision ID: 0075
-Revises: 0074
+Revision ID: 0076
+Revises: 0075
 Create Date: 2026-08-08
 
-⚠️ **COLISÃO CONHECIDA, ainda não resolvida.** Existe uma `0075_investment_bank_account.py` numa
-frente paralela (branch `onda-2b-i`) que ainda NÃO mergeou. As duas nasceram de `0074` e as duas
-reivindicam a revision `0075`.
+⚠️ **Nasceu como `0075` e foi RENUMERADA.** Esta migration e a `0075_investment_bank_account.py`
+(Epic 8, Onda 2b-i) foram escritas em paralelo, as duas a partir de `0074`, e as duas
+reivindicavam o mesmo id. A outra mergeou primeiro (PR #100), então esta renumerou — **quem
+mergeia depois renumera**, e antes do merge, nunca depois: duas revisions com o mesmo id fazem
+`alembic upgrade head` escolher uma em silêncio, e a outra some sem erro nenhum.
 
-**Quem mergear DEPOIS renumera** — é a única resolução possível, e ela precisa acontecer ANTES do
-merge, não depois: duas revisions com o mesmo id fazem `alembic upgrade head` escolher uma em
-silêncio, e a outra some sem erro nenhum. Reconfira com `ls migrations/versions/ | sort | tail -3`
-imediatamente antes de abrir o PR.
-
-Numerar 0076 preventivamente seria pior: a cadeia deste branch ficaria `0074 → 0076` com o elo
-faltando, impossível de rodar e impossível de testar enquanto a outra frente não mergeasse.
+Numerar `0076` preventivamente, antes de a outra mergear, teria sido pior: a cadeia deste branch
+ficaria `0074 → 0076` com o elo faltando, impossível de rodar e de testar. É a terceira vez que
+este repositório encosta nessa armadilha (ver a `0072`).
 
 Sem backfill: não existe resposta anterior a esta migration, então a armadilha da RLS no backfill
 (ver 0046/0066/0067/0068/0069) não se aplica. Só DDL.
@@ -24,8 +22,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0075"
-down_revision: str | None = "0074"
+revision: str = "0076"
+down_revision: str | None = "0075"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/api/tests/test_dna_briefing.py
+++ b/apps/api/tests/test_dna_briefing.py
@@ -1,0 +1,123 @@
+"""O DNA chegando ao briefing — a ponta que justifica a onda inteira."""
+import pytest
+from fastapi.testclient import TestClient
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio",
+    "password": "uma-senha-bem-grande",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def sem_ia(monkeypatch):
+    """O V2 não chama IA, mas o briefing chama. Fixar a narração isola o que está sendo testado."""
+    from app.core import ai
+
+    monkeypatch.setattr(
+        ai, "complete",
+        lambda **kw: type("R", (), {"text": "prosa", "input_tokens": 1, "output_tokens": 1})(),
+    )
+
+
+def test_o_tenant_novo_tem_topo_seco_e_o_dna_o_desliga(client: TestClient, headers, db):
+    """A ponta a ponta: responder muda o que o dono lê amanhã.
+
+    Topo seco é a única Ausência que dispara sobre o VAZIO — um tenant recém-criado sempre a
+    tem. É exatamente por isso que ela é a única com opção de desligamento.
+    """
+    from app.modules.dna import resolver
+    from app.modules.vima import absences
+    from app.core.tenancy import CurrentUser
+    from datetime import date
+
+    antes = client.get("/vima/briefing", headers=headers).json()
+    pendentes = [linha for linha in antes["linhas"] if linha["secao"] == "PENDENTE"]
+    assert pendentes, "o tenant novo deveria ter ao menos uma pendência"
+
+    client.put(
+        "/dna/cliente.topo_seco_dias", json={"valor": None, "source": "gancho"}, headers=headers
+    )
+
+    # O resolver passou a devolver o desligamento...
+    assert resolver.limiares(db) == {"topo_sem_lead_dias": None}
+
+    # ...e `coletar` deixa de rodar a regra.
+    tenant_id = client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+    dono = CurrentUser(
+        user_id="u1", tenant_id=tenant_id, role="owner",
+        allowed_modules=[], is_platform_admin=False,
+    )
+    ausencias = absences.coletar(
+        db, user=dono, hoje=date(2026, 8, 8), limiares=resolver.limiares(db)
+    )
+    assert not [a for a in ausencias if a.kind == "comercial.topo.sem_lead"]
+
+
+def test_o_briefing_de_hoje_nao_e_regerado(client: TestClient, headers):
+    """Idempotente por (tenant, usuário, dia): a resposta vale do PRÓXIMO em diante.
+
+    Quebrar isso para aplicar a calibração na hora custaria o que a idempotência compra — o F5
+    que relê em vez de pagar narração nova, e o dono reencontrando de tarde as palavras da manhã.
+    """
+    antes = client.get("/vima/briefing", headers=headers).json()
+    client.put(
+        "/dna/ritmo.card_parado_dias", json={"valor": 5, "source": "gancho"}, headers=headers
+    )
+    depois = client.get("/vima/briefing", headers=headers).json()
+    assert depois["id"] == antes["id"]
+    assert depois["texto"] == antes["texto"]
+
+
+def test_recalibrar_limpa_o_silencio_do_briefing_anterior(client: TestClient, headers, db):
+    """Sem isso, apertar um limiar não muda nada visível e a configuração parece quebrada."""
+    from datetime import date
+
+    from app.modules.vima import service as vima_service
+    from app.core.tenancy import CurrentUser
+
+    client.get("/vima/briefing", headers=headers)
+    tenant_id = client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+    user_id = client.get("/auth/me", headers=headers).json()["user"]["id"]
+    dono = CurrentUser(
+        user_id=user_id, tenant_id=tenant_id, role="owner",
+        allowed_modules=[], is_platform_admin=False,
+    )
+
+    # O briefing de hoje já disse as pendências dele: o silêncio está carregado.
+    assert vima_service._ja_reportadas(db, user=dono) != {}
+
+    # Recalibrar zera.
+    client.put(
+        "/dna/ritmo.card_parado_dias", json={"valor": 5, "source": "gancho"}, headers=headers
+    )
+    assert vima_service._ja_reportadas(db, user=dono) == {}
+
+
+def test_responder_RETRATO_nao_limpa_o_silencio(client: TestClient, headers, db):
+    """Retrato não muda comportamento — limpar o silêncio por causa dele seria repetição à toa."""
+    from app.modules.vima import service as vima_service
+    from app.core.tenancy import CurrentUser
+
+    client.get("/vima/briefing", headers=headers)
+    me = client.get("/auth/me", headers=headers).json()["user"]
+    dono = CurrentUser(
+        user_id=me["id"], tenant_id=me["tenant_id"], role="owner",
+        allowed_modules=[], is_platform_admin=False,
+    )
+    antes = vima_service._ja_reportadas(db, user=dono)
+    assert antes != {}
+
+    client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "misto", "source": "config"}, headers=headers
+    )
+    assert vima_service._ja_reportadas(db, user=dono) == antes

--- a/apps/api/tests/test_dna_briefing.py
+++ b/apps/api/tests/test_dna_briefing.py
@@ -1,6 +1,13 @@
 """O DNA chegando ao briefing — a ponta que justifica a onda inteira."""
+from datetime import date
+
 import pytest
 from fastapi.testclient import TestClient
+
+from app.core.tenancy import CurrentUser
+from app.modules.dna import resolver
+from app.modules.vima import absences
+from app.modules.vima import service as vima_service
 
 REGISTER = {
     "legal_name": "Vima ME",
@@ -35,11 +42,6 @@ def test_o_tenant_novo_tem_topo_seco_e_o_dna_o_desliga(client: TestClient, heade
     Topo seco é a única Ausência que dispara sobre o VAZIO — um tenant recém-criado sempre a
     tem. É exatamente por isso que ela é a única com opção de desligamento.
     """
-    from app.modules.dna import resolver
-    from app.modules.vima import absences
-    from app.core.tenancy import CurrentUser
-    from datetime import date
-
     antes = client.get("/vima/briefing", headers=headers).json()
     pendentes = [linha for linha in antes["linhas"] if linha["secao"] == "PENDENTE"]
     assert pendentes, "o tenant novo deveria ter ao menos uma pendência"
@@ -80,11 +82,6 @@ def test_o_briefing_de_hoje_nao_e_regerado(client: TestClient, headers):
 
 def test_recalibrar_limpa_o_silencio_do_briefing_anterior(client: TestClient, headers, db):
     """Sem isso, apertar um limiar não muda nada visível e a configuração parece quebrada."""
-    from datetime import date
-
-    from app.modules.vima import service as vima_service
-    from app.core.tenancy import CurrentUser
-
     client.get("/vima/briefing", headers=headers)
     tenant_id = client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
     user_id = client.get("/auth/me", headers=headers).json()["user"]["id"]
@@ -105,9 +102,6 @@ def test_recalibrar_limpa_o_silencio_do_briefing_anterior(client: TestClient, he
 
 def test_responder_RETRATO_nao_limpa_o_silencio(client: TestClient, headers, db):
     """Retrato não muda comportamento — limpar o silêncio por causa dele seria repetição à toa."""
-    from app.modules.vima import service as vima_service
-    from app.core.tenancy import CurrentUser
-
     client.get("/vima/briefing", headers=headers)
     me = client.get("/auth/me", headers=headers).json()["user"]
     dono = CurrentUser(

--- a/apps/api/tests/test_dna_cadencia.py
+++ b/apps/api/tests/test_dna_cadencia.py
@@ -1,0 +1,103 @@
+"""A cadência: uma pergunta por dia, pulada em quarentena, escolha determinística."""
+from datetime import UTC, date, datetime
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna import cadencia, catalog, service
+from app.modules.dna.models import SOURCE_GANCHO, DnaAnswer
+
+TENANT = "t1"
+HOJE = date(2026, 8, 8)
+GANCHO_CARD = "briefing.ausencia.comercial.card.parado"
+
+
+def _linha(db: Session, key: str, *, valor, quando: datetime) -> None:
+    db.add(
+        DnaAnswer(
+            tenant_id=TENANT, question_key=key, value=valor,
+            answered_at=quando, answered_by="u1", source=SOURCE_GANCHO,
+        )
+    )
+    db.commit()
+
+
+def test_devolve_a_pergunta_do_gancho_quando_nada_foi_respondido(db: Session):
+    p = cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE)
+    assert p is not None
+    assert p.key == "ritmo.card_parado_dias"
+
+
+def test_nao_devolve_pergunta_ja_respondida(db: Session):
+    _linha(db, "ritmo.card_parado_dias", valor=5,
+           quando=datetime(2026, 7, 1, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_uma_pergunta_por_dia_no_produto_inteiro(db: Session):
+    """Qualquer resposta de HOJE cala todos os ganchos — não é uma por tela, é uma."""
+    _linha(db, "oferta.o_que_vende", valor="misto",
+           quando=datetime(2026, 8, 8, 9, 0, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_resposta_das_22h_em_sao_paulo_gasta_a_cota_DAQUELE_dia(db: Session):
+    """`answered_at` é timestamptz: 22h de 08/08 em UTC−3 é 01h de 09/08 em UTC.
+
+    Lida crua, a data do carimbo seria 09/08 e a cota de 08/08 pareceria intacta — o dono
+    responderia às 22h e seria perguntado de novo às 22h05. É a mesma classe de bug que a
+    correção de fuso de 2026-08-05 eliminou do sistema inteiro.
+    """
+    _linha(db, "oferta.o_que_vende", valor="misto",
+           quando=datetime(2026, 8, 9, 1, 0, tzinfo=UTC))
+    assert cadencia.pendente(
+        db, gancho=GANCHO_CARD, hoje=HOJE, fuso="America/Sao_Paulo"
+    ) is None
+    # E o mesmo instante, num tenant que de fato vive em UTC, é amanhã: a cota de hoje sobrou.
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE, fuso="UTC") is not None
+
+
+def test_resposta_de_ontem_nao_cala_hoje(db: Session):
+    _linha(db, "oferta.o_que_vende", valor="misto",
+           quando=datetime(2026, 8, 7, 23, 0, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is not None
+
+
+def test_pulada_fica_em_quarentena_por_7_dias(db: Session):
+    _linha(db, "ritmo.card_parado_dias", valor=None,
+           quando=datetime(2026, 8, 5, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_pulada_volta_depois_da_quarentena(db: Session):
+    """Some por uma semana, não para sempre: um 'depois' acidental não pode perder a pergunta."""
+    _linha(db, "ritmo.card_parado_dias", valor=None,
+           quando=datetime(2026, 7, 20, tzinfo=UTC))
+    p = cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE)
+    assert p is not None and p.key == "ritmo.card_parado_dias"
+
+
+def test_escolha_e_deterministica_pela_ordem_do_catalogo(db: Session):
+    """Duas elegíveis no mesmo gancho: vence a primeira do catálogo, sempre a mesma."""
+    gancho = "quotes.orcamento.criado"
+    primeira = cadencia.pendente(db, gancho=gancho, hoje=HOJE)
+    assert primeira is not None
+    assert primeira.key == "oferta.ticket_tipico"
+    assert cadencia.pendente(db, gancho=gancho, hoje=HOJE).key == primeira.key
+
+
+def test_gancho_desconhecido_devolve_nada(db: Session):
+    assert cadencia.pendente(db, gancho="tela.inventada", hoje=HOJE) is None
+
+
+def test_nucleo_devolve_as_seis_na_ordem_declarada(db: Session):
+    faltando = cadencia.faltantes(db, gancho=cadencia.GANCHO_NUCLEO)
+    assert [p.key for p in faltando] == list(catalog.NUCLEO)
+
+
+def test_nucleo_encolhe_conforme_responde(db: Session):
+    """O núcleo é sequência anunciada: não obedece ao 'uma por dia' e some item a item."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source="nucleo")
+    faltando = cadencia.faltantes(db, gancho=cadencia.GANCHO_NUCLEO)
+    assert "oferta.o_que_vende" not in [p.key for p in faltando]
+    assert len(faltando) == 5

--- a/apps/api/tests/test_dna_catalog.py
+++ b/apps/api/tests/test_dna_catalog.py
@@ -1,0 +1,109 @@
+"""O catálogo do DNA: as duas guardas que dão sentido às classes.
+
+Estes testes são o contrato. Sem eles, "Calibração" vira rótulo decorativo e o produto passa a
+fingir que ouviu.
+"""
+import pytest
+
+from app.modules.dna import catalog
+from app.modules.dna.catalog import (
+    CALIBRACAO,
+    FORMATO_ESCOLHA,
+    NUCLEO,
+    PERGUNTAS,
+    POR_KEY,
+    RETRATO,
+    CatalogoError,
+    Opcao,
+    Pergunta,
+)
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+
+def test_calibracao_exige_consome_e_retrato_proibe():
+    for p in PERGUNTAS:
+        if p.classe == CALIBRACAO:
+            assert p.consome, f"{p.key} é Calibração e não declara consumidor"
+        else:
+            assert p.consome is None, f"{p.key} é Retrato e declara consumidor"
+
+
+def test_consome_aponta_para_limiar_que_existe():
+    """Um typo aqui produz silêncio perfeito: grava, não consome, não erra."""
+    for p in PERGUNTAS:
+        if p.consome:
+            assert p.consome in LIMIARES_PADRAO, (
+                f"{p.key} consome '{p.consome}', que não existe em LIMIARES_PADRAO"
+            )
+
+
+def test_todo_limiar_tem_pergunta():
+    """O outro lado: um limiar sem pergunta é um número que ninguém pode calibrar."""
+    cobertos = {p.consome for p in PERGUNTAS if p.consome}
+    assert cobertos == set(LIMIARES_PADRAO)
+
+
+def test_key_unica_e_prefixada_pelo_eixo():
+    vistas = set()
+    for p in PERGUNTAS:
+        assert p.key not in vistas, f"key duplicada: {p.key}"
+        vistas.add(p.key)
+        assert p.key.startswith(f"{p.eixo}."), (
+            f"{p.key} não começa com o eixo '{p.eixo}' — é a lição de facts.kind"
+        )
+
+
+def test_pergunta_de_escolha_tem_ao_menos_duas_opcoes():
+    for p in PERGUNTAS:
+        if p.formato == FORMATO_ESCOLHA:
+            assert len(p.opcoes) >= 2, f"{p.key} é escolha com {len(p.opcoes)} opção(ões)"
+
+
+def test_o_catalogo_tem_45_perguntas_sendo_6_de_calibracao():
+    assert len(PERGUNTAS) == 45
+    assert sum(1 for p in PERGUNTAS if p.classe == CALIBRACAO) == 6
+
+
+def test_nucleo_aponta_para_perguntas_que_existem_e_nenhuma_e_calibracao():
+    """'Em quanto tempo eu te aviso?' é irrespondível antes de ter visto um briefing."""
+    assert len(NUCLEO) == 6
+    for key in NUCLEO:
+        assert key in POR_KEY, f"núcleo cita {key}, que não está no catálogo"
+        assert POR_KEY[key].classe == RETRATO
+
+
+def test_toda_calibracao_tem_gancho_de_ausencia():
+    for p in PERGUNTAS:
+        if p.classe == CALIBRACAO:
+            assert p.gancho and p.gancho.startswith("briefing.ausencia."), (
+                f"{p.key} é Calibração e precisa vir colada à ausência que a motivou"
+            )
+
+
+def test_a_guarda_recusa_calibracao_sem_consumidor():
+    """A guarda precisa ser executável sobre um catálogo arbitrário, não só sobre o real."""
+    with pytest.raises(CatalogoError, match="consumidor"):
+        catalog.verificar(
+            (
+                Pergunta(
+                    key="ritmo.qualquer", classe=CALIBRACAO, eixo="ritmo",
+                    texto="?", formato=FORMATO_ESCOLHA,
+                    opcoes=(Opcao("a", 1), Opcao("b", 2)),
+                ),
+            )
+        )
+
+
+def test_a_guarda_recusa_consome_inexistente():
+    with pytest.raises(CatalogoError, match="LIMIARES_PADRAO"):
+        catalog.verificar(
+            (
+                Pergunta(
+                    key="ritmo.qualquer", classe=CALIBRACAO, eixo="ritmo",
+                    texto="?", formato=FORMATO_ESCOLHA,
+                    opcoes=(Opcao("a", 1), Opcao("b", 2)),
+                    consome="card_parado_dais",  # typo de propósito
+                    gancho="briefing.ausencia.comercial.card.parado",
+                ),
+            )
+        )

--- a/apps/api/tests/test_dna_models.py
+++ b/apps/api/tests/test_dna_models.py
@@ -1,0 +1,43 @@
+"""A linha de resposta do DNA: upsert por (tenant, pergunta), e nulo significa 'pulei'."""
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna.models import SOURCE_CONFIG, DnaAnswer
+
+
+def test_grava_e_le(db: Session):
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="oferta.o_que_vende", value="servico_projeto",
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    linha = db.query(DnaAnswer).one()
+    assert linha.value == "servico_projeto"
+    assert linha.id  # uuid gerado pelo default
+
+
+def test_valor_nulo_e_estado_valido_e_significa_pulada(db: Session):
+    """'Pulei' precisa ser distinguível de 'nunca me perguntaram', sem tabela nova."""
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="limites.nunca_faco", value=None,
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    linha = db.query(DnaAnswer).one()
+    assert linha.value is None
+
+
+def test_valor_aceita_lista_para_escolha_multipla(db: Session):
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="cliente.como_chega", value=["indicacao", "busca"],
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    assert db.query(DnaAnswer).one().value == ["indicacao", "busca"]

--- a/apps/api/tests/test_dna_resolver.py
+++ b/apps/api/tests/test_dna_resolver.py
@@ -1,0 +1,71 @@
+"""O resolver é a ÚNICA porta de leitura do DNA."""
+from datetime import UTC, date, datetime
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna import resolver, service
+from app.modules.dna.models import SOURCE_CONFIG, DnaAnswer
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+TENANT = "t1"
+
+
+def test_sem_resposta_devolve_dicionario_vazio(db: Session):
+    """Vazio, não os defaults: quem mescla é `coletar`, e duas fontes de default divergem."""
+    assert resolver.limiares(db) == {}
+
+
+def test_calibracao_respondida_vira_limiar(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {"card_parado_dias": 5}
+
+
+def test_retrato_nunca_entra_nos_limiares(db: Session):
+    """O contrato das classes vive ou morre aqui."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {}
+    assert resolver.retrato(db) == {"oferta.o_que_vende": "misto"}
+
+
+def test_calibracao_nunca_entra_no_retrato(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.retrato(db) == {}
+
+
+def test_desligar_topo_seco_vira_none_e_nao_some(db: Session):
+    """`None` = regra não executada. Sumir do dicionário faria o default de 5 dias voltar."""
+    service.responder(db, tenant_id=TENANT, key="cliente.topo_seco_dias", valor=None,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {"topo_sem_lead_dias": None}
+
+
+def test_valor_que_saiu_do_catalogo_cai_no_default(db: Session):
+    """Trocar o `valor` de uma opção deixa resposta órfã. Ela não pode derrubar o briefing."""
+    db.add(
+        DnaAnswer(
+            tenant_id=TENANT, question_key="ritmo.card_parado_dias", value=999,
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    assert "card_parado_dias" not in resolver.limiares(db)
+
+
+def test_toda_chave_devolvida_existe_em_limiares_padrao(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert set(resolver.limiares(db)) <= set(LIMIARES_PADRAO)
+
+
+def test_recalibrado_apos_olha_so_calibracao(db: Session):
+    """Responder Retrato não pode limpar o silêncio — nada no comportamento mudou."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.recalibrado_apos(db, date(2026, 1, 1)) is False
+
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.recalibrado_apos(db, date(2026, 1, 1)) is True

--- a/apps/api/tests/test_dna_router.py
+++ b/apps/api/tests/test_dna_router.py
@@ -1,0 +1,118 @@
+"""O contrato HTTP do DNA — incluindo quem NÃO pode responder."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.security import create_access_token
+
+REGISTER = {
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio",
+    "password": "uma-senha-bem-grande",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+@pytest.fixture()
+def headers_sub_crm(tenant_id: str) -> dict[str, str]:
+    """Sub-usuário só de CRM: vê o briefing, mas o DNA é da EMPRESA e não é dele."""
+    token = create_access_token(
+        {
+            "sub": "sub-crm",
+            "tenant_id": tenant_id,
+            "role": "member",
+            "allowed_modules": ["comercial"],
+        }
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_nucleo_devolve_as_seis(client: TestClient, headers):
+    corpo = client.get("/dna/faltantes", params={"gancho": "nucleo"}, headers=headers).json()
+    assert len(corpo) == 6
+    assert corpo[0]["key"] == "oferta.o_que_vende"
+    assert corpo[0]["opcoes"][0]["rotulo"] == "Serviço recorrente"
+
+
+def test_responder_e_ler_de_volta(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "servico_projeto", "source": "nucleo"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert client.get("/dna/respostas", headers=headers).json()["oferta.o_que_vende"] == (
+        "servico_projeto"
+    )
+
+
+def test_valor_invalido_devolve_400(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "telepatia", "source": "config"},
+        headers=headers,
+    )
+    assert r.status_code == 400
+
+
+def test_chave_inexistente_devolve_404(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.inventada", json={"valor": "x", "source": "config"}, headers=headers
+    )
+    assert r.status_code == 404
+
+
+def test_pular_registra_sem_responder(client: TestClient, headers):
+    assert client.post(
+        "/dna/limites.nunca_faco/pular", json={"source": "gancho"}, headers=headers
+    ).status_code == 200
+    assert "limites.nunca_faco" not in client.get("/dna/respostas", headers=headers).json()
+
+
+def test_pendente_por_gancho(client: TestClient, headers):
+    corpo = client.get(
+        "/dna/pendente",
+        params={"gancho": "briefing.ausencia.comercial.card.parado"},
+        headers=headers,
+    ).json()
+    assert corpo["key"] == "ritmo.card_parado_dias"
+
+
+def test_dia_de_silencio_devolve_nulo(client: TestClient, headers):
+    """Respondeu uma hoje: o gancho se cala até amanhã."""
+    client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "misto", "source": "nucleo"}, headers=headers
+    )
+    corpo = client.get(
+        "/dna/pendente",
+        params={"gancho": "briefing.ausencia.comercial.card.parado"},
+        headers=headers,
+    ).json()
+    assert corpo is None
+
+
+def test_catalogo_devolve_as_45(client: TestClient, headers):
+    """A aba de configurações é a única superfície SEM cadência."""
+    corpo = client.get("/dna/catalogo", headers=headers).json()
+    assert len(corpo) == 45
+
+
+def test_sub_usuario_sem_settings_nao_alcanca_o_dna(client: TestClient, headers_sub_crm):
+    """O DNA é da EMPRESA. Um sub-usuário recalibrando o negócio seria surpresa ruim."""
+    assert client.get(
+        "/dna/pendente", params={"gancho": "nucleo"}, headers=headers_sub_crm
+    ).status_code == 403
+    assert client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "misto", "source": "config"},
+        headers=headers_sub_crm,
+    ).status_code == 403

--- a/apps/api/tests/test_dna_service.py
+++ b/apps/api/tests/test_dna_service.py
@@ -1,0 +1,134 @@
+"""A porta de escrita do DNA: valida contra o catálogo, faz upsert, e pular é gravar nulo."""
+import pytest
+from sqlalchemy.orm import Session
+
+from app.modules.dna import service
+from app.modules.dna.models import SOURCE_CONFIG, SOURCE_GANCHO, DnaAnswer
+
+TENANT = "t1"
+
+
+def test_responder_grava_e_commita(db: Session):
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="servico_projeto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    linha = db.query(DnaAnswer).one()
+    assert linha.value == "servico_projeto"
+    assert linha.answered_by == "u1"
+
+
+def test_responder_de_novo_faz_upsert_e_nao_cria_segunda_linha(db: Session):
+    """DNA é estado atual, não história — duas linhas fariam toda leitura ter que escolher."""
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="servico_projeto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="produto_digital",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).count() == 1
+    assert db.query(DnaAnswer).one().value == "produto_digital"
+
+
+def test_chave_desconhecida_e_recusada(db: Session):
+    with pytest.raises(service.DnaError, match="não existe"):
+        service.responder(
+            db, tenant_id=TENANT, key="oferta.inventada", valor="x",
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_valor_fora_das_opcoes_e_recusado(db: Session):
+    """Sem isso o JSON vira depósito e o resolver quebra na leitura, longe de quem escreveu."""
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="oferta.o_que_vende", valor="nao_existe",
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_escolha_multipla_aceita_lista_e_recusa_item_invalido(db: Session):
+    service.responder(
+        db, tenant_id=TENANT, key="cliente.como_chega", valor=["indicacao", "busca"],
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).one().value == ["indicacao", "busca"]
+
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="cliente.como_chega", valor=["indicacao", "telepatia"],
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_texto_longo_demais_e_recusado(db: Session):
+    with pytest.raises(service.DnaError, match="longo"):
+        service.responder(
+            db, tenant_id=TENANT, key="limites.nunca_faco", valor="x" * 2001,
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_calibracao_aceita_none_so_onde_a_opcao_existe(db: Session):
+    """Topo seco pode ser desligado; as outras cinco não têm opção de desligamento."""
+    service.responder(
+        db, tenant_id=TENANT, key="cliente.topo_seco_dias", valor=None,
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).one().value is None
+
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=None,
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_pular_grava_linha_com_valor_nulo(db: Session):
+    service.pular(
+        db, tenant_id=TENANT, key="limites.nunca_faco", user_id="u1", source=SOURCE_GANCHO,
+    )
+    linha = db.query(DnaAnswer).one()
+    assert linha.value is None
+    assert linha.source == SOURCE_GANCHO
+
+
+def test_respostas_ignora_puladas_mas_linhas_as_inclui(db: Session):
+    """A distinção que sustenta a quarentena: 'pulei' não é resposta, mas é registro."""
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    service.pular(db, tenant_id=TENANT, key="limites.nunca_faco", user_id="u1",
+                  source=SOURCE_CONFIG)
+
+    assert service.respostas(db) == {"oferta.o_que_vende": "misto"}
+    assert set(service.linhas(db)) == {"oferta.o_que_vende", "limites.nunca_faco"}
+
+
+def test_responder_nao_emite_fato(db: Session):
+    """O feed do briefing é sobre o NEGÓCIO, não sobre a configuração do produto.
+
+    Um "você respondeu uma pergunta" no resumo de amanhã seria ruído auto-referente. A trilha de
+    quem mudou o quê é trabalho de `core/audit.py`.
+    """
+    from app.core.facts import Fact
+
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(Fact).count() == 0
+
+
+def test_pular_e_depois_responder_vira_resposta(db: Session):
+    service.pular(db, tenant_id=TENANT, key="oferta.o_que_vende", user_id="u1",
+                  source=SOURCE_GANCHO)
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).count() == 1
+    assert service.respostas(db) == {"oferta.o_que_vende": "misto"}

--- a/apps/api/tests/test_fuso_do_tenant.py
+++ b/apps/api/tests/test_fuso_do_tenant.py
@@ -240,3 +240,41 @@ def test_o_gate_da_vima_tem_o_que_varrer():
     arquivos = {p.name for p in VIMA_DIR.glob("*.py")}
     assert VIMA_PUROS <= arquivos
     assert "service.py" in arquivos  # o membro que PODE ler instante, e não pode derivar "hoje"
+
+
+# ── O mesmo gate, aplicado ao módulo `dna` ──────────────────────────────────────────────
+#
+# A cadência do DNA é por DIA ("uma pergunta por dia", "pulada em quarentena de 7 dias"). Em
+# UTC−3, derivar esse dia do relógio do servidor interroga o dono duas vezes na mesma noite —
+# e a regressão passaria meses despercebida, porque em São Paulo funciona.
+
+DNA_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules" / "dna"
+
+# Puros por contrato: recebem `hoje` (e `fuso`) por parâmetro e não podem tocar no relógio nem
+# para instante. `service.py` PODE carimbar instante (`answered_at`) e não pode derivar "hoje".
+DNA_PUROS = {"catalog.py", "cadencia.py", "resolver.py"}
+
+
+@pytest.mark.parametrize("caminho", sorted(DNA_DIR.glob("*.py")), ids=lambda p: p.name)
+def test_dna_nunca_deriva_hoje_do_relogio_do_servidor(caminho: pathlib.Path):
+    arvore = ast.parse(caminho.read_text(encoding="utf-8"))
+    puro = caminho.name in DNA_PUROS
+
+    for forma, no in _chamadas_de_relogio(arvore):
+        if forma in {"today", "utcnow"} or _vira_data(arvore, no):
+            pytest.fail(
+                f"{caminho.name}:{no.lineno} deriva 'hoje' do relógio do servidor. "
+                "A cadência do DNA é por DIA — em UTC−3 isso interroga o dono duas vezes."
+            )
+        if puro:
+            pytest.fail(
+                f"{caminho.name}:{no.lineno} lê o relógio, e este módulo é PURO: "
+                "`hoje` entra por parâmetro, e quem o deriva é o router."
+            )
+
+
+def test_o_gate_do_dna_tem_o_que_varrer():
+    """A instanciação obrigatória: um conjunto vazio passaria calado para sempre."""
+    arquivos = {p.name for p in DNA_DIR.glob("*.py")}
+    assert DNA_PUROS <= arquivos
+    assert "service.py" in arquivos

--- a/apps/api/tests/test_investments.py
+++ b/apps/api/tests/test_investments.py
@@ -23,6 +23,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
 from app.modules.agenda.models import AgendaEvent
 from app.modules.financial_intelligence import dre as dre_service
 from app.modules.receivables.models import STATUS_PAID, Charge
@@ -597,12 +598,17 @@ def test_o_rendimento_com_perna_SAI_do_termo_P3(client: TestClient, headers, db:
     segunda armadilha — a janela é aberta em ±1 dia porque `date.today()` é a data LOCAL da
     máquina enquanto `paid_at` é `now(UTC)`: às 22h em UTC−3 as duas já são dias diferentes, e uma
     janela de um dia só perderia o rendimento pela borda, silenciosamente.
+
+    ⚠️ **`hoje` é o do TENANT, não o da máquina** — e alargar a janela não bastava. O `POST` abaixo
+    manda `date=hoje`, e a API valida contra `hoje_do_tenant`: num runner em UTC, às 22h de São
+    Paulo, `date.today()` já é amanhã e o rendimento é recusado com 422 antes de a janela importar.
+    Foi assim que este teste ficou vermelho no CI de 01:02 UTC e verde no de 09:19.
     """
     from datetime import timedelta
 
     from app.modules.receivables.service import contar_rendimentos_sem_perna_bancaria
 
-    hoje = date.today()
+    hoje = tenant_today(DEFAULT_TENANT_TIMEZONE)
     de, ate = hoje - timedelta(days=1), hoje + timedelta(days=1)
     conta = _conta_bancaria(client, headers)
     acc = _investment(client, headers, bank_account_id=conta["id"])
@@ -678,7 +684,9 @@ def test_rendimento_de_HOJE_e_aceito(client: TestClient, headers):
 
     r = client.post(
         f"/investments/{acc['id']}/yield",
-        json={"amount_cents": 1_000, "date": date.today().isoformat()},
+        # O "hoje" do TENANT, não o da máquina: num runner em UTC, `date.today()` às 22h de São
+        # Paulo já é amanhã, e a guarda de data futura recusa com 422 o rendimento do próprio dia.
+        json={"amount_cents": 1_000, "date": tenant_today(DEFAULT_TENANT_TIMEZONE).isoformat()},
         headers=headers,
     )
     assert r.status_code == 200, r.text

--- a/apps/api/tests/test_vima_absences.py
+++ b/apps/api/tests/test_vima_absences.py
@@ -208,3 +208,20 @@ def test_conta_a_pagar_usa_o_limiar_proprio_e_nao_o_do_prazo(db: Session, usuari
         limiares={"prazo_vencendo_dias": 0, "dinheiro_com_data_dias": 7},
     )
     assert [a for a in longo if a.kind == "financeiro.conta.vencendo"]
+
+
+def test_topo_seco_desligado_nao_roda_a_regra(db: Session, usuario_owner):
+    """`None` = regra NÃO EXECUTADA, não "limiar infinito".
+
+    É a mesma forma do filtro de permissão do V1: não roda em vez de calcular e esconder. Se o
+    `None` chegasse a `timedelta(days=...)`, o briefing estouraria com TypeError para todo dono
+    que desligasse o aviso — e desligar é justamente o que a única pergunta com essa opção
+    oferece.
+    """
+    ligado = coletar(db, user=usuario_owner, hoje=HOJE)
+    assert [a for a in ligado if a.kind == "comercial.topo.sem_lead"]
+
+    desligado = coletar(
+        db, user=usuario_owner, hoje=HOJE, limiares={"topo_sem_lead_dias": None}
+    )
+    assert not [a for a in desligado if a.kind == "comercial.topo.sem_lead"]

--- a/apps/api/tests/test_vima_absences.py
+++ b/apps/api/tests/test_vima_absences.py
@@ -179,3 +179,32 @@ def test_ausencia_reincide_quando_escala(db, usuario_owner, card_parado_ha_12_di
         ja_reportadas={**briefing_de_ontem_com_o_card, "comercial.card.parado:c1": 3},
     )
     assert any(a.kind == "comercial.card.parado" for a in ausencias)
+
+
+def test_conta_a_pagar_usa_o_limiar_proprio_e_nao_o_do_prazo(db: Session, usuario_owner):
+    """Prazo de entrega se quer saber em cima; boleto, com folga para ter o dinheiro.
+
+    Um número só para as duas coisas é a fusão que o DNA torna insustentável ao perguntar em
+    voz alta.
+    """
+    db.add(
+        Payable(
+            tenant_id=TENANT, description="Aluguel", amount_cents=250_000,
+            due_date=date(2026, 8, 11), status=STATUS_OPEN,
+        )
+    )
+    db.commit()
+
+    # Antecedência curta: a conta de daqui a 5 dias ainda não é notícia.
+    curto = coletar(
+        db, user=usuario_owner, hoje=HOJE,
+        limiares={"prazo_vencendo_dias": 7, "dinheiro_com_data_dias": 1},
+    )
+    assert not [a for a in curto if a.kind == "financeiro.conta.vencendo"]
+
+    # Antecedência longa: agora é.
+    longo = coletar(
+        db, user=usuario_owner, hoje=HOJE,
+        limiares={"prazo_vencendo_dias": 0, "dinheiro_com_data_dias": 7},
+    )
+    assert [a for a in longo if a.kind == "financeiro.conta.vencendo"]

--- a/apps/api/tests/test_vima_briefing.py
+++ b/apps/api/tests/test_vima_briefing.py
@@ -117,3 +117,11 @@ def test_dia_sem_nada_devolve_briefing_vazio_e_nao_falha(client: TestClient, hea
     corpo = client.get("/vima/briefing", headers=headers).json()
     assert corpo["vazio"] is True
     assert corpo["texto"]
+
+
+def test_a_linha_de_ausencia_carrega_o_kind(client: TestClient, headers):
+    """Sem o kind na linha, a pergunta de calibração do DNA não tem como se colar à ausência."""
+    corpo = client.get("/vima/briefing", headers=headers).json()
+    pendentes = [linha for linha in corpo["linhas"] if linha["secao"] == "PENDENTE"]
+    assert pendentes, "o tenant novo deveria ter ao menos uma pendência"
+    assert pendentes[0]["kind"], "a linha de pendência não trouxe o kind"

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -43,6 +43,7 @@ import ProdutosPage from "../features/produtos/ProdutosPage";
 import PageBuilderPage from "../features/sites/PageBuilderPage";
 import PublicPage from "../features/sites/PublicPage";
 import SitesPage from "../features/sites/SitesPage";
+import NucleoPage from "../features/dna/NucleoPage";
 import BriefingPage from "../features/vima/BriefingPage";
 import EntradaDoDia from "../features/vima/EntradaDoDia";
 import IdleWarningModal from "../components/IdleWarningModal";
@@ -125,6 +126,9 @@ export default function App() {
             largura que o polegar já disputa. A saída fica na própria tela.
           */}
           <Route path="/vima" element={<BriefingPage />} />
+          {/* O núcleo do DNA mora aqui pelo mesmo motivo do briefing: é porta de entrada, não
+              uma página do produto — sem shell, sem menu, desenhado para 360px. */}
+          <Route path="/dna/nucleo" element={<NucleoPage />} />
           <Route path="/compartilhar" element={<CompartilharPage />} />
           <Route path="/comprovante/:id" element={<ComprovantePage />} />
         </Route>

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage, getGoogleStatus } from "../../lib/api";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import { formatDateTime, formatDay, formatTime, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
@@ -122,6 +123,7 @@ export default function AgendaPage() {
 
   return (
     <div className="space-y-4">
+      <GanchoDaVima gancho="agenda.evento.criado" />
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <button onClick={() => nav(-1)} className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100">

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -5,6 +5,7 @@ import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage, publicApi } from "../../lib/api";
 import { pluralize } from "../../lib/pluralize";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
 import { type BankAccount, hojeISO } from "../financeiro/contas";
@@ -145,6 +146,8 @@ export default function CobrancasPage() {
           Financeiro.
         </p>
       </div>
+
+      <GanchoDaVima gancho="receivables.cobranca.criada" />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="A vencer" value={brl(summary.open_cents)} hint={`${summary.open_count} ${pluralize(summary.open_count, "cobrança", "cobranças")}`} tone="text-blue-700" />

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -1,25 +1,32 @@
 import type { TenantProfile } from "@e1p/shared-types";
-import { Building2, Check, Filter, MessageCircle, Workflow } from "lucide-react";
+import { Building2, Check, Filter, MessageCircle, Sparkles, Workflow } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatTime } from "../../lib/datetime";
 import { applyBrandTheme } from "../../lib/theme";
 import { useFuso } from "../../store/auth";
 import CanaisTab from "./CanaisTab";
+import EmpresaDnaTab from "./EmpresaDnaTab";
 import EmpresaTab from "./EmpresaTab";
 import IntegracoesTab from "./IntegracoesTab";
 import VendasTab from "./VendasTab";
 
-type Tab = "empresa" | "canais" | "integracoes" | "vendas";
+type Tab = "empresa" | "dna" | "canais" | "integracoes" | "vendas";
 
 const TABS: { key: Tab; label: string; icon: typeof Building2 }[] = [
   { key: "empresa", label: "Empresa", icon: Building2 },
+  { key: "dna", label: "A sua empresa", icon: Sparkles },
   { key: "canais", label: "Canais", icon: MessageCircle },
   { key: "integracoes", label: "Integrações", icon: Workflow },
   { key: "vendas", label: "Vendas", icon: Filter },
 ];
 
-/** Abas cujo conteúdo edita o perfil do tenant — só nelas o botão Salvar faz sentido. */
+/**
+ * Abas cujo conteúdo edita o perfil do tenant — só nelas o botão Salvar faz sentido.
+ *
+ * A aba `dna` NÃO entra aqui: ela salva sozinha, pergunta a pergunta, e um "Salvar" pairando
+ * sobre ela sugeriria que há algo pendente quando não há.
+ */
 const PERFIL_TABS: Tab[] = ["empresa", "vendas"];
 
 export default function ConfiguracoesPage() {
@@ -101,6 +108,7 @@ export default function ConfiguracoesPage() {
       </div>
 
       {tab === "empresa" && <EmpresaTab p={p} set={set} />}
+      {tab === "dna" && <EmpresaDnaTab />}
       {tab === "canais" && <CanaisTab />}
       {tab === "integracoes" && <IntegracoesTab />}
       {tab === "vendas" && (

--- a/apps/web/src/features/config/EmpresaDnaTab.test.tsx
+++ b/apps/web/src/features/config/EmpresaDnaTab.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import EmpresaDnaTab from "./EmpresaDnaTab";
+
+const CATALOGO = vi.hoisted(() => [
+  {
+    key: "oferta.o_que_vende",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você vende?",
+    formato: "escolha",
+    opcoes: [
+      { rotulo: "Serviço por projeto", valor: "servico_projeto" },
+      { rotulo: "Produto digital", valor: "produto_digital" },
+    ],
+  },
+  {
+    key: "limites.nunca_faco",
+    classe: "retrato",
+    eixo: "limites",
+    texto: "O que você nunca faz?",
+    formato: "texto",
+    opcoes: [],
+  },
+]);
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), put: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+function mockar(respostas: Record<string, unknown>) {
+  vi.mocked(api.get).mockImplementation((url: string) =>
+    Promise.resolve({ data: url === "/dna/catalogo" ? CATALOGO : respostas } as never),
+  );
+}
+
+describe("EmpresaDnaTab", () => {
+  it("agrupa por eixo e mostra quantas faltam", async () => {
+    mockar({ "oferta.o_que_vende": "servico_projeto" });
+    render(<EmpresaDnaTab />);
+
+    await waitFor(() => expect(screen.getByText("Oferta")).toBeInTheDocument());
+    expect(screen.getByText("Limites")).toBeInTheDocument();
+    expect(screen.getByText(/1 de 2 respondidas/i)).toBeInTheDocument();
+  });
+
+  it("mostra o RÓTULO da resposta, não o valor interno", async () => {
+    mockar({ "oferta.o_que_vende": "servico_projeto" });
+    render(<EmpresaDnaTab />);
+
+    await waitFor(() => expect(screen.getByText("Serviço por projeto")).toBeInTheDocument());
+    expect(screen.queryByText("servico_projeto")).not.toBeInTheDocument();
+  });
+
+  it("a não respondida aparece como pergunta aberta", async () => {
+    mockar({ "oferta.o_que_vende": "servico_projeto" });
+    render(<EmpresaDnaTab />);
+
+    await waitFor(() => expect(screen.getByText("O que você nunca faz?")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /salvar/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/config/EmpresaDnaTab.tsx
+++ b/apps/web/src/features/config/EmpresaDnaTab.tsx
@@ -1,0 +1,102 @@
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "../dna/PerguntaDaVima";
+
+const EIXOS: { key: DnaPergunta["eixo"]; titulo: string; descricao: string }[] = [
+  { key: "oferta", titulo: "Oferta", descricao: "O que você vende e como cobra" },
+  { key: "cliente", titulo: "Cliente", descricao: "Quem compra e como chega até você" },
+  { key: "ritmo", titulo: "Ritmo", descricao: "Como é a sua semana" },
+  { key: "dinheiro", titulo: "Dinheiro", descricao: "Como você recebe e reage a atraso" },
+  { key: "limites", titulo: "Limites", descricao: "O que você nunca faz" },
+];
+
+/**
+ * A saída para quem quiser sentar e responder tudo de uma vez.
+ *
+ * **É a única superfície SEM cadência.** A regra de uma pergunta por dia existe para proteger de
+ * interrupção; aqui a pessoa foi procurar, e esconder pergunta de quem foi atrás dela seria
+ * hostil. Tudo editável a qualquer momento — inclusive o que já foi respondido.
+ */
+export default function EmpresaDnaTab() {
+  const [catalogo, setCatalogo] = useState<DnaPergunta[]>([]);
+  const [respostas, setRespostas] = useState<Record<string, unknown>>({});
+  const [reabertas, setReabertas] = useState<string[]>([]);
+
+  const carregar = useCallback(async () => {
+    const [{ data: perguntas }, { data: dadas }] = await Promise.all([
+      api.get<DnaPergunta[]>("/dna/catalogo"),
+      api.get<Record<string, unknown>>("/dna/respostas"),
+    ]);
+    setCatalogo(perguntas);
+    setRespostas(dadas);
+    setReabertas([]);
+  }, []);
+
+  useEffect(() => {
+    carregar();
+  }, [carregar]);
+
+  if (catalogo.length === 0) {
+    return <p className="text-sm text-neutral-400">Carregando…</p>;
+  }
+
+  const respondidas = catalogo.filter((p) => p.key in respostas).length;
+
+  return (
+    <div className="space-y-8">
+      <p className="text-sm text-neutral-500">
+        {respondidas} de {catalogo.length} respondidas. Não precisa responder tudo de uma vez — a
+        Vima pergunta aos poucos, no momento em que cada resposta faz sentido.
+      </p>
+
+      {EIXOS.map((eixo) => {
+        const doEixo = catalogo.filter((p) => p.eixo === eixo.key);
+        if (doEixo.length === 0) return null;
+        return (
+          <section key={eixo.key} className="space-y-3">
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-800">{eixo.titulo}</h2>
+              <p className="text-xs text-neutral-500">{eixo.descricao}</p>
+            </div>
+            {doEixo.map((p) => (
+              <div key={p.key}>
+                {p.key in respostas && !reabertas.includes(p.key) ? (
+                  <div className="rounded-xl border border-neutral-200 bg-neutral-50 p-4">
+                    <p className="text-sm text-neutral-600">{p.texto}</p>
+                    <p className="mt-1 text-sm font-medium text-neutral-800">
+                      {rotulo(p, respostas[p.key])}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setReabertas([...reabertas, p.key])}
+                      className="mt-2 text-xs text-neutral-400 underline"
+                    >
+                      Mudar
+                    </button>
+                  </div>
+                ) : (
+                  <PerguntaDaVima
+                    pergunta={p}
+                    source="config"
+                    onPronto={carregar}
+                    onPular={carregar}
+                  />
+                )}
+              </div>
+            ))}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Mostra o RÓTULO que o dono escolheu, não o valor interno que o sistema guarda. */
+function rotulo(pergunta: DnaPergunta, valor: unknown): string {
+  if (pergunta.formato === "texto") return String(valor);
+  const lista = Array.isArray(valor) ? valor : [valor];
+  return lista
+    .map((v) => pergunta.opcoes.find((o) => o.valor === v)?.rotulo ?? String(v))
+    .join(", ");
+}

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatDateShort } from "../../lib/datetime";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import { useFuso } from "../../store/auth";
 
@@ -60,6 +61,8 @@ export default function CrmPage() {
         <h1 className="text-2xl font-bold text-neutral-800">Funil de clientes</h1>
         <p className="text-xs text-neutral-400">Arraste os cards entre as colunas.</p>
       </div>
+
+      <GanchoDaVima gancho="crm.cliente.criado" />
 
       {loading ? (
         <p className="text-sm text-neutral-400">Carregando...</p>

--- a/apps/web/src/features/dna/GanchoDaVima.test.tsx
+++ b/apps/web/src/features/dna/GanchoDaVima.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import GanchoDaVima from "./GanchoDaVima";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), put: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+const PERGUNTA = {
+  key: "ritmo.card_parado_dias",
+  classe: "calibracao",
+  eixo: "ritmo",
+  texto: "Há quanto tempo te incomoda?",
+  formato: "escolha",
+  opcoes: [
+    { rotulo: "5 dias", valor: 5 },
+    { rotulo: "10 dias", valor: 10 },
+  ],
+};
+
+describe("GanchoDaVima", () => {
+  it("não renderiza nada quando não há pergunta para hoje", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: null });
+    const { container } = render(
+      <GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />,
+    );
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("some depois de responder, sem recarregar a tela", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: PERGUNTA });
+    vi.mocked(api.put).mockResolvedValue({ data: {} });
+
+    render(<GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />);
+    await waitFor(() =>
+      expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "5 dias" }));
+    await waitFor(() =>
+      expect(screen.queryByText("Há quanto tempo te incomoda?")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("erro na busca não derruba a tela hospedeira", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("403"));
+    const { container } = render(<GanchoDaVima gancho="qualquer" />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/apps/web/src/features/dna/GanchoDaVima.tsx
+++ b/apps/web/src/features/dna/GanchoDaVima.tsx
@@ -1,0 +1,46 @@
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+/**
+ * A pergunta do DNA colada ao contexto que a torna óbvia.
+ *
+ * **Falha em silêncio, sempre.** Um 403 (sub-usuário sem `settings`) ou uma rede ruim não podem
+ * derrubar a tela hospedeira — o DNA é acessório em toda superfície onde aparece. Erro aqui
+ * significa "não pergunta hoje", nunca "quebra o briefing".
+ *
+ * A cadência inteira mora no servidor (`dna/cadencia.py`): uma pergunta por dia no produto
+ * inteiro, pulada em quarentena de 7 dias. O componente só mostra o que lhe deram.
+ */
+export default function GanchoDaVima({ gancho }: { gancho: string }) {
+  const [pergunta, setPergunta] = useState<DnaPergunta | null>(null);
+
+  useEffect(() => {
+    let vivo = true;
+    api
+      .get<DnaPergunta | null>("/dna/pendente", { params: { gancho } })
+      .then(({ data }) => {
+        if (vivo) setPergunta(data ?? null);
+      })
+      .catch(() => {
+        if (vivo) setPergunta(null);
+      });
+    return () => {
+      vivo = false;
+    };
+  }, [gancho]);
+
+  if (!pergunta) return null;
+
+  return (
+    <div className="mt-2">
+      <PerguntaDaVima
+        pergunta={pergunta}
+        source="gancho"
+        onPronto={() => setPergunta(null)}
+        onPular={() => setPergunta(null)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/dna/NucleoPage.test.tsx
+++ b/apps/web/src/features/dna/NucleoPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import NucleoPage from "./NucleoPage";
+
+// `vi.hoisted` porque a fábrica do `vi.mock` sobe para o topo do arquivo e não enxergaria um
+// `const` comum declarado aqui.
+const PERGUNTAS = vi.hoisted(() => [
+  {
+    key: "oferta.o_que_vende",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você vende?",
+    formato: "escolha",
+    opcoes: [
+      { rotulo: "Serviço por projeto", valor: "servico_projeto" },
+      { rotulo: "Produto digital", valor: "produto_digital" },
+    ],
+  },
+  {
+    key: "oferta.em_uma_frase",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você responde?",
+    formato: "texto",
+    opcoes: [],
+  },
+]);
+
+vi.mock("../../lib/api", () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: PERGUNTAS }),
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+describe("NucleoPage", () => {
+  it("mostra uma pergunta por vez, com o progresso visível", async () => {
+    render(
+      <MemoryRouter>
+        <NucleoPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("O que você vende?")).toBeInTheDocument());
+    expect(screen.queryByText("O que você responde?")).not.toBeInTheDocument();
+    expect(screen.getByText("1 de 2")).toBeInTheDocument();
+  });
+
+  it("oferece sair da sequência inteira — não é um beco", async () => {
+    render(
+      <MemoryRouter>
+        <NucleoPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /pular por enquanto/i })).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/src/features/dna/NucleoPage.tsx
+++ b/apps/web/src/features/dna/NucleoPage.tsx
@@ -1,0 +1,95 @@
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+/** Marca de "o núcleo já foi decidido NESTE aparelho". Espelha `CHAVE_ENTRADA` do briefing. */
+export const CHAVE_NUCLEO = "e1p_dna_nucleo";
+
+/**
+ * As seis perguntas do primeiro acesso.
+ *
+ * **Nenhuma é de Calibração, e essa é a inversão central do design.** "Em quanto tempo eu te
+ * aviso que ninguém respondeu o Carlos?" é impossível de responder bem antes de ter visto um
+ * briefing — a resposta seria um chute que depois vira comportamento errado com aparência de
+ * configuração deliberada. Calibração vem por gancho, colada à ausência que a motivou.
+ *
+ * **É sequência anunciada, não interrogatório:** fim visível ("2 de 6") e saída em um toque. Por
+ * isso é a exceção declarada à regra de uma pergunta por dia — o que cansa é a interrupção não
+ * anunciada, não a sequência que a pessoa entrou sabendo que ia atravessar.
+ */
+export default function NucleoPage() {
+  const navegar = useNavigate();
+  const [perguntas, setPerguntas] = useState<DnaPergunta[] | null>(null);
+  const [i, setI] = useState(0);
+
+  useEffect(() => {
+    let vivo = true;
+    api
+      .get<DnaPergunta[]>("/dna/faltantes", { params: { gancho: "nucleo" } })
+      .then(({ data }) => {
+        if (vivo) setPerguntas(data ?? []);
+      })
+      .catch(() => {
+        // 403 (sub-usuário sem `settings`) ou rede ruim: o núcleo não pode trancar a entrada.
+        if (vivo) sair();
+      });
+    return () => {
+      vivo = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function sair() {
+    try {
+      localStorage.setItem(CHAVE_NUCLEO, "1");
+    } catch {
+      // Sem a marca, a entrada volta a perguntar ao servidor — mais lento, correto.
+    }
+    navegar("/", { replace: true });
+  }
+
+  function avancar() {
+    if (perguntas && i + 1 < perguntas.length) setI(i + 1);
+    else sair();
+  }
+
+  if (!perguntas) {
+    return <div className="py-10 text-center text-sm text-neutral-400">Um instante…</div>;
+  }
+  if (perguntas.length === 0) {
+    sair();
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 p-4">
+      <div>
+        <p className="text-sm text-neutral-500">
+          {i + 1} de {perguntas.length}
+        </p>
+        <h1 className="text-xl font-bold text-neutral-800">Me conta do seu negócio</h1>
+        <p className="mt-1 text-sm text-neutral-500">
+          Leva menos de dois minutos e é o que faz o resumo diário falar a sua língua.
+        </p>
+      </div>
+
+      <PerguntaDaVima
+        key={perguntas[i].key}
+        pergunta={perguntas[i]}
+        source="nucleo"
+        onPronto={avancar}
+        onPular={avancar}
+      />
+
+      <button
+        type="button"
+        onClick={sair}
+        className="w-full text-center text-xs text-neutral-400 underline"
+      >
+        Pular por enquanto
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/dna/PerguntaDaVima.test.tsx
+++ b/apps/web/src/features/dna/PerguntaDaVima.test.tsx
@@ -1,0 +1,72 @@
+import type { DnaPergunta } from "@e1p/shared-types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+vi.mock("../../lib/api", () => ({
+  api: {
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+const ESCOLHA: DnaPergunta = {
+  key: "ritmo.card_parado_dias",
+  classe: "calibracao",
+  eixo: "ritmo",
+  texto: "Uma negociação parada há quanto tempo te incomoda?",
+  formato: "escolha",
+  opcoes: [
+    { rotulo: "5 dias", valor: 5 },
+    { rotulo: "10 dias", valor: 10 },
+  ],
+};
+
+const TEXTO: DnaPergunta = {
+  key: "limites.nunca_faco",
+  classe: "retrato",
+  eixo: "limites",
+  texto: "O que você nunca faz?",
+  formato: "texto",
+  opcoes: [],
+};
+
+describe("PerguntaDaVima", () => {
+  it("responde uma escolha em um toque", async () => {
+    const onPronto = vi.fn();
+    render(<PerguntaDaVima pergunta={ESCOLHA} source="gancho" onPronto={onPronto} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "5 dias" }));
+
+    await waitFor(() => expect(onPronto).toHaveBeenCalled());
+    expect(api.put).toHaveBeenCalledWith("/dna/ritmo.card_parado_dias", {
+      valor: 5,
+      source: "gancho",
+    });
+  });
+
+  it("avisa que Calibração vale a partir de amanhã", () => {
+    render(<PerguntaDaVima pergunta={ESCOLHA} source="gancho" onPronto={vi.fn()} />);
+    expect(screen.getByText(/a partir de amanhã/i)).toBeInTheDocument();
+  });
+
+  it("avisa que Retrato fica guardado, sem prometer efeito", () => {
+    render(<PerguntaDaVima pergunta={TEXTO} source="config" onPronto={vi.fn()} />);
+    expect(screen.getByText(/guardad/i)).toBeInTheDocument();
+    expect(screen.queryByText(/a partir de amanhã/i)).not.toBeInTheDocument();
+  });
+
+  it("pular chama a rota de pular e não a de responder", async () => {
+    const onPular = vi.fn();
+    render(
+      <PerguntaDaVima pergunta={TEXTO} source="gancho" onPronto={vi.fn()} onPular={onPular} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /depois/i }));
+
+    await waitFor(() => expect(onPular).toHaveBeenCalled());
+    expect(api.post).toHaveBeenCalledWith("/dna/limites.nunca_faco/pular", { source: "gancho" });
+  });
+});

--- a/apps/web/src/features/dna/PerguntaDaVima.tsx
+++ b/apps/web/src/features/dna/PerguntaDaVima.tsx
@@ -1,0 +1,147 @@
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+type Props = {
+  pergunta: DnaPergunta;
+  source: "nucleo" | "gancho" | "config";
+  onPronto: () => void;
+  onPular?: () => void;
+};
+
+/**
+ * A pergunta do DNA, em um único componente para todas as superfícies (núcleo, gancho, config).
+ *
+ * **A tela DIZ o que cada classe faz.** Calibração vale a partir de amanhã — o briefing de hoje
+ * é idempotente e já foi narrado, e mentir sobre isso custa mais que explicar. Retrato é
+ * guardado, e prometer efeito imediato a ele seria exatamente o erro que as duas classes
+ * existem para impedir: um produto que finge ouvir é pior que um que não pergunta.
+ *
+ * Desenhado para 360px: opções são blocos de largura inteira, não uma linha de pílulas.
+ */
+export default function PerguntaDaVima({ pergunta, source, onPronto, onPular }: Props) {
+  const [texto, setTexto] = useState("");
+  const [marcadas, setMarcadas] = useState<(string | number | null)[]>([]);
+  const [salvando, setSalvando] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  async function responder(valor: unknown) {
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.put(`/dna/${pergunta.key}`, { valor, source });
+      onPronto();
+    } catch (e) {
+      setErro(apiErrorMessage(e));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function pular() {
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.post(`/dna/${pergunta.key}/pular`, { source });
+      (onPular ?? onPronto)();
+    } catch (e) {
+      setErro(apiErrorMessage(e));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-4">
+      <p className="text-base font-medium text-neutral-800">{pergunta.texto}</p>
+      <p className="mt-1 text-xs text-neutral-500">
+        {pergunta.classe === "calibracao"
+          ? "Isso muda o seu resumo a partir de amanhã."
+          : "Fica guardado para a Vima te conhecer melhor."}
+      </p>
+
+      {pergunta.formato === "escolha" && (
+        <div className="mt-3 space-y-2">
+          {pergunta.opcoes.map((o) => (
+            <button
+              key={o.rotulo}
+              type="button"
+              disabled={salvando}
+              onClick={() => responder(o.valor)}
+              className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-left text-sm text-neutral-700 hover:border-neutral-400 disabled:opacity-50"
+            >
+              {o.rotulo}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {pergunta.formato === "escolha_multipla" && (
+        <div className="mt-3 space-y-2">
+          {pergunta.opcoes.map((o) => {
+            const ativa = marcadas.includes(o.valor);
+            return (
+              <button
+                key={o.rotulo}
+                type="button"
+                disabled={salvando}
+                onClick={() =>
+                  setMarcadas(
+                    ativa ? marcadas.filter((v) => v !== o.valor) : [...marcadas, o.valor],
+                  )
+                }
+                className={`w-full rounded-lg border px-4 py-3 text-left text-sm disabled:opacity-50 ${
+                  ativa
+                    ? "border-neutral-800 bg-neutral-800 text-white"
+                    : "border-neutral-200 text-neutral-700 hover:border-neutral-400"
+                }`}
+              >
+                {o.rotulo}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            disabled={salvando || marcadas.length === 0}
+            onClick={() => responder(marcadas)}
+            className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-sm font-medium text-white disabled:opacity-40"
+          >
+            Confirmar
+          </button>
+        </div>
+      )}
+
+      {pergunta.formato === "texto" && (
+        <div className="mt-3 space-y-2">
+          <textarea
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            className="w-full rounded-lg border border-neutral-200 p-3 text-sm text-neutral-700"
+            placeholder="Escreva do seu jeito"
+          />
+          <button
+            type="button"
+            disabled={salvando || texto.trim() === ""}
+            onClick={() => responder(texto.trim())}
+            className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-sm font-medium text-white disabled:opacity-40"
+          >
+            Salvar
+          </button>
+        </div>
+      )}
+
+      {erro && <p className="mt-2 text-xs text-red-600">{erro}</p>}
+
+      <button
+        type="button"
+        disabled={salvando}
+        onClick={pular}
+        className="mt-3 text-xs text-neutral-400 underline disabled:opacity-50"
+      >
+        Responder depois
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/orcamentos/OrcamentosPage.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.tsx
@@ -2,6 +2,7 @@ import type { Quote, QuotesSummary } from "@e1p/shared-types";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../../lib/api";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -48,6 +49,8 @@ export default function OrcamentosPage() {
         <p className="text-sm text-neutral-500">Página / Orçamentos</p>
         <h1 className="text-2xl font-bold text-neutral-800">Orçamentos</h1>
       </div>
+
+      <GanchoDaVima gancho="quotes.orcamento.criado" />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="Rascunhos" value={String(summary.draft_count)} tone="text-neutral-700" />

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
 import type { CostCenter } from "../financeiro/costCenters";
@@ -164,6 +165,8 @@ export default function PagarPage() {
         <p className="text-sm text-neutral-500">Página / Contas a Pagar</p>
         <h1 className="text-2xl font-bold text-neutral-800">Despesas</h1>
       </div>
+
+      <GanchoDaVima gancho="payables.conta.criada" />
 
       {inbox.length > 0 && (
         <Link

--- a/apps/web/src/features/vima/BriefingPage.tsx
+++ b/apps/web/src/features/vima/BriefingPage.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatTime } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
+import GanchoDaVima from "../dna/GanchoDaVima";
 import PreferenciasSection from "./PreferenciasSection";
 
 /**
@@ -141,6 +142,11 @@ const TITULO_DA_SECAO: Record<string, string> = {
 // ação; número por último, porque é contexto e não notícia.
 const ORDEM = ["PENDENTE", "ACONTECEU", "NÚMEROS"];
 
+/** O `kind` da primeira pendência com um — é nele que a pergunta de calibração se ancora. */
+function primeiroKind(linhas: BriefingLinha[]): string | null {
+  return linhas.find((l) => l.secao === "PENDENTE" && l.kind)?.kind ?? null;
+}
+
 function Secoes({ linhas, excedente }: { linhas: BriefingLinha[]; excedente: number }) {
   const presentes = ORDEM.filter((s) => linhas.some((l) => l.secao === s));
   if (presentes.length === 0) return null;
@@ -163,6 +169,13 @@ function Secoes({ linhas, excedente }: { linhas: BriefingLinha[]; excedente: num
                 </li>
               ))}
           </ul>
+          {/* A pergunta de calibração vem colada à PRIMEIRA pendência da seção, e só ali: é o
+              único instante em que "esse é o tempo certo para você?" é óbvia. O componente
+              decide sozinho se aparece — a cadência mora no servidor. Linhas gravadas antes do
+              V2 não têm `kind`, e sem ele não há gancho. */}
+          {secao === "PENDENTE" && primeiroKind(linhas) && (
+            <GanchoDaVima gancho={`briefing.ausencia.${primeiroKind(linhas)}`} />
+          )}
         </section>
       ))}
       {excedente > 0 && (

--- a/apps/web/src/features/vima/EntradaDoDia.tsx
+++ b/apps/web/src/features/vima/EntradaDoDia.tsx
@@ -16,7 +16,15 @@ import { useFuso } from "../../store/auth";
  */
 export const CHAVE_ENTRADA = "e1p_briefing_dia";
 
-type Decisao = "perguntando" | "vima" | "cockpit";
+/**
+ * Marca de "o núcleo do DNA já foi decidido NESTE aparelho" — respondido ou pulado, tanto faz.
+ *
+ * Não carrega data, ao contrário de `CHAVE_ENTRADA`: o núcleo é de uma vez na vida, não de uma
+ * vez por dia.
+ */
+export const CHAVE_NUCLEO = "e1p_dna_nucleo";
+
+type Decisao = "perguntando" | "nucleo" | "vima" | "cockpit";
 
 /**
  * Decide qual é a porta de entrada do dia.
@@ -38,16 +46,46 @@ export default function EntradaDoDia({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (decisao !== "perguntando") return;
     let vivo = true;
-    api
-      .get<Briefing>("/vima/briefing")
-      .then(({ data }) => {
-        if (!vivo) return;
-        gravarMarca(hoje);
-        setDecisao(data?.read_at ? "cockpit" : "vima");
-      })
-      .catch(() => {
-        if (vivo) setDecisao("cockpit");
-      });
+
+    function decidirPeloBriefing() {
+      api
+        .get<Briefing>("/vima/briefing")
+        .then(({ data }) => {
+          if (!vivo) return;
+          gravarMarca(hoje);
+          setDecisao(data?.read_at ? "cockpit" : "vima");
+        })
+        .catch(() => {
+          if (vivo) setDecisao("cockpit");
+        });
+    }
+
+    // O núcleo do DNA vem ANTES do briefing, e só no primeiro acesso: um dono que nunca
+    // respondeu nada recebe um briefing que fala com todo mundo do mesmo jeito. Perguntar
+    // primeiro é o que faz a leitura dele já nascer calibrada — de amanhã em diante.
+    if (lerMarcaNucleo() === null) {
+      api
+        .get<unknown[]>("/dna/faltantes", { params: { gancho: "nucleo" } })
+        .then(({ data }) => {
+          if (!vivo) return;
+          if (data?.length) {
+            setDecisao("nucleo");
+            return;
+          }
+          gravarMarcaNucleo();
+          decidirPeloBriefing();
+        })
+        // 403 = sub-usuário sem `settings`. O DNA é da empresa e não é dele: segue para o
+        // briefing normalmente, sem nunca ver a pergunta.
+        .catch(() => {
+          if (vivo) decidirPeloBriefing();
+        });
+      return () => {
+        vivo = false;
+      };
+    }
+
+    decidirPeloBriefing();
     return () => {
       vivo = false;
     };
@@ -56,8 +94,25 @@ export default function EntradaDoDia({ children }: { children: ReactNode }) {
   if (decisao === "perguntando") {
     return <div className="py-10 text-center text-sm text-neutral-400">Um instante…</div>;
   }
+  if (decisao === "nucleo") return <Navigate to="/dna/nucleo" replace />;
   if (decisao === "vima") return <Navigate to="/vima" replace />;
   return <>{children}</>;
+}
+
+function lerMarcaNucleo(): string | null {
+  try {
+    return localStorage.getItem(CHAVE_NUCLEO);
+  } catch {
+    return null;
+  }
+}
+
+function gravarMarcaNucleo(): void {
+  try {
+    localStorage.setItem(CHAVE_NUCLEO, "1");
+  } catch {
+    // Sem a marca, a entrada consulta o servidor toda visita — mais lento, correto.
+  }
 }
 
 /** `localStorage` pode lançar (modo privativo do Safari, cota) — e isso não pode derrubar a app. */

--- a/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
+++ b/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
@@ -1,0 +1,3336 @@
+# Vima V2 — DNA da Empresa · Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar ao e1p um retrato do negócio declarado pelo dono, que calibra o comportamento do briefing hoje e serve de contexto aos funcionários virtuais no V4.
+
+**Architecture:** Um catálogo de 45 perguntas em código (`dna/catalog.py`), dividido em duas classes com contrato verificado no import: Calibração (6, cada uma com consumidor real em `LIMIARES_PADRAO`) e Retrato (39, guardadas sem consumidor até o V4). As respostas vão para uma tabela `dna_answers` em upsert, e um resolver é a única porta de leitura — `limiares(db)` entra em `absences.coletar`, `retrato(db)` fica esperando o V4. A captura é progressiva: um núcleo de 6 no primeiro acesso e o resto por ganchos declarados, com cadência de uma pergunta por dia.
+
+**Tech Stack:** FastAPI · SQLAlchemy 2 · Alembic · PostgreSQL 16 (RLS `FORCE`) · React 18 + Vite + TypeScript + Tailwind · Vitest + Testing Library · pytest
+
+**Spec:** [`docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md`](../specs/2026-08-08-vima-dna-da-empresa-design.md)
+
+**Branch:** `feat/vima-dna-da-empresa`, worktree `.claude/worktrees/vima-dna` (criada de `origin/main`, head `c46b79f`)
+
+---
+
+## Global Constraints
+
+Valem para **toda** tarefa deste plano.
+
+- **Isolamento de tenant é RLS, não filtro manual.** Nenhuma query nova adiciona `WHERE tenant_id`. `DnaAnswer` herda `TenantMixin` e a migration dá `ENABLE` + `FORCE ROW LEVEL SECURITY` + policy `tenant_isolation`.
+- **"Hoje" é `hoje_do_tenant(db)`** de `app.modules.settings.service`. `datetime.now(UTC).date()` / `date.today()` em lógica de negócio é regressão declarada neste repositório. **Neste plano, só o router chama `hoje_do_tenant`** — `cadencia.py` recebe `hoje` por parâmetro.
+- **`app/modules/dna/` entra na varredura AST** de `tests/test_fuso_do_tenant.py` (Task 7). `catalog.py`, `resolver.py` e `cadencia.py` são PUROS: não podem ler o relógio nem para instante.
+- **Texto para humano nunca usa `isoformat()`.** Backend: `format_datetime_br` / `format_date_br` de `app.core.tz`. Frontend: `lib/datetime.ts`.
+- **O V2 não chama IA em ponto nenhum.** Nada de `core/ai.py`, nada de `anonymizer`, nenhuma linha em `ai_usage`.
+- **A migration é a `0076`.** ⚠️ A `0075` **já está tomada** por `0075_investment_bank_account.py`, de uma frente paralela (worktree `onda-2b-i`) que ainda não mergeou. **Reconfira o head com `ls apps/api/migrations/versions/ | tail -3` a cada merge de `main`, não só agora** — é a lição já paga pela `0072`, cujo plano dizia `0071`.
+- **Só DDL, sem backfill.** Não existe resposta anterior a esta migration, então a armadilha da RLS no backfill (INSERT ... SELECT que grava zero linhas em silêncio) não se aplica.
+- **Idioma:** domínio, docstrings e comentários em PT-BR; identificadores em inglês quando já for a convenção do arquivo.
+- **Commits:** Conventional Commits. `main` é protegida — todo trabalho vai por PR.
+- **Rodar antes de considerar concluído:** `cd apps/api && pytest` e `pnpm --filter @e1p/web test`. Não confie em `scripts/check.sh` isoladamente — ele mascara falha de frontend com `|| true` no vitest (dívida registrada).
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `apps/api/app/modules/dna/__init__.py` | **Criar.** Vazio. |
+| `apps/api/app/modules/dna/catalog.py` | **Criar.** `Pergunta`, `Opcao`, as 45, `NUCLEO`, e as guardas que rodam no import. PURO. |
+| `apps/api/app/modules/dna/models.py` | **Criar.** `DnaAnswer`. |
+| `apps/api/app/modules/dna/service.py` | **Criar.** `responder`, `pular`, `respostas`. Escreve — pode carimbar instante. |
+| `apps/api/app/modules/dna/cadencia.py` | **Criar.** `pendente(db, *, gancho, hoje)`. PURO: `hoje` entra por parâmetro. |
+| `apps/api/app/modules/dna/resolver.py` | **Criar.** `limiares(db)` e `retrato(db)`. A única porta de leitura. PURO. |
+| `apps/api/app/modules/dna/schemas.py` | **Criar.** Contrato HTTP. |
+| `apps/api/app/modules/dna/router.py` | **Criar.** `GET /dna/pendente`, `GET /dna/respostas`, `PUT /dna/{key}`, `POST /dna/{key}/pular`. |
+| `apps/api/migrations/versions/0076_dna_answers.py` | **Criar.** Tabela + RLS. |
+| `apps/api/app/db/registry.py` | **Modificar.** Importar `DnaAnswer`. |
+| `apps/api/app/modules/__init__.py` | **Modificar.** Registrar `dna_router`. |
+| `apps/api/app/modules/vima/absences.py` | **Modificar.** `dinheiro_com_data_dias` separado de `prazo_vencendo_dias`. |
+| `apps/api/app/modules/vima/service.py` | **Modificar.** Passa `limiares=resolver.limiares(db)`; `_ja_reportadas` respeita recalibração. |
+| `apps/api/tests/test_fuso_do_tenant.py` | **Modificar.** Varredura AST sobre `app/modules/dna/`. |
+| `packages/shared-types/src/index.ts` | **Modificar.** `DnaPergunta`, `DnaOpcao`, `DnaPendente`. |
+| `apps/web/src/features/dna/PerguntaDaVima.tsx` | **Criar.** O componente único de pergunta, usado por todos os ganchos. |
+| `apps/web/src/features/dna/GanchoDaVima.tsx` | **Criar.** Busca a pendente do gancho e renderiza (ou nada). |
+| `apps/web/src/features/dna/NucleoPage.tsx` | **Criar.** As 6 do núcleo em sequência, pulável. |
+| `apps/web/src/features/dna/EmpresaDnaTab.tsx` | **Criar.** A aba "A sua empresa" com os cinco eixos. |
+| `apps/web/src/features/vima/EntradaDoDia.tsx` | **Modificar.** Terceiro estado: `nucleo`. |
+| `apps/web/src/features/vima/BriefingPage.tsx` | **Modificar.** Gancho colado à linha de ausência. |
+| `apps/web/src/features/config/ConfiguracoesPage.tsx` | **Modificar.** Quinta aba. |
+| `apps/web/src/app/App.tsx` | **Modificar.** Rota `/dna/nucleo`. |
+
+---
+
+## Ondas
+
+| Onda | Entregável | Tarefas |
+|---|---|---|
+| **1** | O DNA existe e é respondível pela API. Nada visível mudou. | 1–5 |
+| **2** | **O DNA muda o briefing.** Limiar separado, resolver ligado, silêncio limpo ao recalibrar. | 6–7 |
+| **3** | O núcleo de 6 no primeiro acesso. | 8–9 |
+| **4** | Os ganchos: Calibração colada à ausência + ganchos de contexto. | 10–11 |
+| **5** | A aba "A sua empresa" em `/config`. | 12 |
+
+Pode-se parar depois de qualquer onda com software funcionando.
+
+---
+
+# ONDA 1 — O registro do DNA nasce
+
+### Task 1: `dna/catalog.py` — as 45 perguntas e as duas guardas
+
+**Files:**
+- Create: `apps/api/app/modules/dna/__init__.py` (vazio)
+- Create: `apps/api/app/modules/dna/catalog.py`
+- Test: `apps/api/tests/test_dna_catalog.py`
+
+**Interfaces:**
+- Consumes: nada (módulo puro, sem imports do projeto)
+- Produces: `Opcao(rotulo: str, valor: int | str | None)`, `Pergunta(key, classe, eixo, texto, formato, opcoes, consome, gancho)`, `CatalogoError`, constantes `CALIBRACAO = "calibracao"` / `RETRATO = "retrato"`, `FORMATO_ESCOLHA = "escolha"` / `FORMATO_MULTIPLA = "escolha_multipla"` / `FORMATO_TEXTO = "texto"`, `PERGUNTAS: tuple[Pergunta, ...]` (45 itens), `POR_KEY: dict[str, Pergunta]`, `NUCLEO: tuple[str, ...]` (6 keys), `EIXOS: tuple[str, ...]`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```python
+# apps/api/tests/test_dna_catalog.py
+"""O catálogo do DNA: as duas guardas que dão sentido às classes.
+
+Estes testes são o contrato. Sem eles, "Calibração" vira rótulo decorativo e o produto passa a
+fingir que ouviu.
+"""
+import pytest
+
+from app.modules.dna import catalog
+from app.modules.dna.catalog import (
+    CALIBRACAO,
+    FORMATO_ESCOLHA,
+    NUCLEO,
+    PERGUNTAS,
+    POR_KEY,
+    RETRATO,
+    CatalogoError,
+    Opcao,
+    Pergunta,
+)
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+
+def test_calibracao_exige_consome_e_retrato_proibe():
+    for p in PERGUNTAS:
+        if p.classe == CALIBRACAO:
+            assert p.consome, f"{p.key} é Calibração e não declara consumidor"
+        else:
+            assert p.consome is None, f"{p.key} é Retrato e declara consumidor"
+
+
+def test_consome_aponta_para_limiar_que_existe():
+    """Um typo aqui produz silêncio perfeito: grava, não consome, não erra."""
+    for p in PERGUNTAS:
+        if p.consome:
+            assert p.consome in LIMIARES_PADRAO, (
+                f"{p.key} consome '{p.consome}', que não existe em LIMIARES_PADRAO"
+            )
+
+
+def test_todo_limiar_tem_pergunta():
+    """O outro lado: um limiar sem pergunta é um número que ninguém pode calibrar."""
+    cobertos = {p.consome for p in PERGUNTAS if p.consome}
+    assert cobertos == set(LIMIARES_PADRAO)
+
+
+def test_key_unica_e_prefixada_pelo_eixo():
+    vistas = set()
+    for p in PERGUNTAS:
+        assert p.key not in vistas, f"key duplicada: {p.key}"
+        vistas.add(p.key)
+        assert p.key.startswith(f"{p.eixo}."), (
+            f"{p.key} não começa com o eixo '{p.eixo}' — é a lição de facts.kind"
+        )
+
+
+def test_pergunta_de_escolha_tem_ao_menos_duas_opcoes():
+    for p in PERGUNTAS:
+        if p.formato == FORMATO_ESCOLHA:
+            assert len(p.opcoes) >= 2, f"{p.key} é escolha com {len(p.opcoes)} opção(ões)"
+
+
+def test_o_catalogo_tem_45_perguntas_sendo_6_de_calibracao():
+    assert len(PERGUNTAS) == 45
+    assert sum(1 for p in PERGUNTAS if p.classe == CALIBRACAO) == 6
+
+
+def test_nucleo_aponta_para_perguntas_que_existem_e_nenhuma_e_calibracao():
+    """'Em quanto tempo eu te aviso?' é irrespondível antes de ter visto um briefing."""
+    assert len(NUCLEO) == 6
+    for key in NUCLEO:
+        assert key in POR_KEY, f"núcleo cita {key}, que não está no catálogo"
+        assert POR_KEY[key].classe == RETRATO
+
+
+def test_toda_calibracao_tem_gancho_de_ausencia():
+    for p in PERGUNTAS:
+        if p.classe == CALIBRACAO:
+            assert p.gancho and p.gancho.startswith("briefing.ausencia."), (
+                f"{p.key} é Calibração e precisa vir colada à ausência que a motivou"
+            )
+
+
+def test_a_guarda_recusa_calibracao_sem_consumidor():
+    """A guarda precisa ser executável sobre um catálogo arbitrário, não só sobre o real."""
+    with pytest.raises(CatalogoError, match="consumidor"):
+        catalog.verificar(
+            (
+                Pergunta(
+                    key="ritmo.qualquer", classe=CALIBRACAO, eixo="ritmo",
+                    texto="?", formato=FORMATO_ESCOLHA,
+                    opcoes=(Opcao("a", 1), Opcao("b", 2)),
+                ),
+            )
+        )
+
+
+def test_a_guarda_recusa_consome_inexistente():
+    with pytest.raises(CatalogoError, match="LIMIARES_PADRAO"):
+        catalog.verificar(
+            (
+                Pergunta(
+                    key="ritmo.qualquer", classe=CALIBRACAO, eixo="ritmo",
+                    texto="?", formato=FORMATO_ESCOLHA,
+                    opcoes=(Opcao("a", 1), Opcao("b", 2)),
+                    consome="card_parado_dais",  # typo de propósito
+                    gancho="briefing.ausencia.comercial.card.parado",
+                ),
+            )
+        )
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_catalog.py -v`
+Expected: FAIL com `ModuleNotFoundError: No module named 'app.modules.dna'`
+
+- [ ] **Step 3: Criar o pacote**
+
+```bash
+mkdir -p apps/api/app/modules/dna && touch apps/api/app/modules/dna/__init__.py
+```
+
+- [ ] **Step 4: Escrever o catálogo**
+
+Criar `apps/api/app/modules/dna/catalog.py`:
+
+```python
+"""O catálogo do DNA da Empresa — as 45 perguntas, em código.
+
+Catálogo em código pelo mesmo critério de `LIMIARES_PADRAO` (vima/absences.py) e
+`MODELO_POR_TAREFA` (core/ai.py): o que precisa de gate de teste mora onde o teste alcança.
+Pergunta nova exige deploy, e isso é correto — pergunta de Calibração vem sempre junto do
+consumidor dela, que é código de qualquer forma.
+
+**As duas classes são um contrato, não uma etiqueta de organização:**
+
+- `CALIBRACAO` tem consumidor HOJE. Responder muda o briefing de amanhã.
+- `RETRATO` não tem, por definição. É guardado para o V4.
+
+A guarda abaixo roda no IMPORT do módulo. Sem ela, em seis meses alguém marca uma pergunta
+bonita como Calibração, o dono a responde acreditando ter mudado o comportamento do produto, e
+não mudou nada — um produto que finge ouvir é pior que um produto que não pergunta.
+
+Este módulo é PURO: não lê relógio, não toca no banco. Ver o gate em
+`tests/test_fuso_do_tenant.py`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+CALIBRACAO = "calibracao"
+RETRATO = "retrato"
+
+FORMATO_ESCOLHA = "escolha"
+FORMATO_MULTIPLA = "escolha_multipla"
+FORMATO_TEXTO = "texto"
+
+EIXOS = ("oferta", "cliente", "ritmo", "dinheiro", "limites")
+
+# Teto do campo aberto. Não é limite de banco (a coluna é JSON) — é o ponto em que o texto
+# deixou de ser resposta e virou documento, e o V4 vai ter que resumi-lo de qualquer forma.
+MAX_TEXTO = 2000
+
+
+class CatalogoError(ValueError):
+    """Violação do contrato das classes. Estoura no import, não em produção."""
+
+
+@dataclass(frozen=True)
+class Opcao:
+    rotulo: str          # o que o dono lê
+    valor: int | str | None  # o que o sistema guarda e consome
+
+
+@dataclass(frozen=True)
+class Pergunta:
+    key: str
+    classe: str
+    eixo: str
+    texto: str
+    formato: str
+    opcoes: tuple[Opcao, ...] = field(default_factory=tuple)
+    consome: str | None = None
+    gancho: str | None = None
+
+
+def verificar(perguntas: tuple[Pergunta, ...]) -> None:
+    """As guardas. Pública para que o teste as exercite sobre catálogo arbitrário.
+
+    Um teste que só olhasse `PERGUNTAS` provaria que o catálogo de hoje está certo, não que a
+    guarda funciona — e a guarda é o que protege o catálogo de amanhã.
+    """
+    vistas: set[str] = set()
+    for p in perguntas:
+        if p.key in vistas:
+            raise CatalogoError(f"key duplicada: {p.key}")
+        vistas.add(p.key)
+
+        if p.eixo not in EIXOS:
+            raise CatalogoError(f"{p.key}: eixo '{p.eixo}' não existe")
+        if not p.key.startswith(f"{p.eixo}."):
+            raise CatalogoError(f"{p.key} não começa com o eixo '{p.eixo}'")
+
+        if p.classe == CALIBRACAO:
+            if not p.consome:
+                raise CatalogoError(
+                    f"{p.key} é Calibração e não declara consumidor — a classe existe "
+                    "justamente para impedir pergunta sem efeito"
+                )
+            if p.consome not in LIMIARES_PADRAO:
+                raise CatalogoError(
+                    f"{p.key} consome '{p.consome}', ausente de LIMIARES_PADRAO. Um typo aqui "
+                    "grava a resposta, não consome nada e nunca falha."
+                )
+        elif p.classe == RETRATO:
+            if p.consome:
+                raise CatalogoError(f"{p.key} é Retrato e declara consumidor '{p.consome}'")
+        else:
+            raise CatalogoError(f"{p.key}: classe '{p.classe}' não existe")
+
+        if p.formato == FORMATO_ESCOLHA and len(p.opcoes) < 2:
+            raise CatalogoError(f"{p.key} é escolha com menos de duas opções")
+
+
+def _cal(key, eixo, texto, opcoes, consome, gancho) -> Pergunta:
+    return Pergunta(
+        key=key, classe=CALIBRACAO, eixo=eixo, texto=texto, formato=FORMATO_ESCOLHA,
+        opcoes=opcoes, consome=consome, gancho=gancho,
+    )
+
+
+def _esc(key, eixo, texto, opcoes, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_ESCOLHA,
+        opcoes=opcoes, gancho=gancho,
+    )
+
+
+def _mult(key, eixo, texto, opcoes, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_MULTIPLA,
+        opcoes=opcoes, gancho=gancho,
+    )
+
+
+def _txt(key, eixo, texto, gancho=None) -> Pergunta:
+    return Pergunta(
+        key=key, classe=RETRATO, eixo=eixo, texto=texto, formato=FORMATO_TEXTO, gancho=gancho,
+    )
+
+
+# --- Calibração (6) --------------------------------------------------------------------
+# Cada uma existe porque há um número esperando por ela. São SEIS porque só existem seis
+# consumidores — qualquer número maior seria invenção.
+
+_CALIBRACAO: tuple[Pergunta, ...] = (
+    _cal(
+        "ritmo.resposta_horas", "ritmo",
+        "Um cliente te escreveu e ficou sem resposta. Em quanto tempo eu te aviso?",
+        (
+            Opcao("Em 4 horas", 4),
+            Opcao("No mesmo dia", 12),
+            Opcao("No dia seguinte", 24),
+            Opcao("Depois de 2 dias", 48),
+        ),
+        "sem_resposta_nossa_horas",
+        "briefing.ausencia.comercial.contato.esperando_resposta",
+    ),
+    _cal(
+        "cliente.esfria_dias", "cliente",
+        "Quantos dias sem falar com um cliente já significa que ele esfriou?",
+        (Opcao("15 dias", 15), Opcao("30 dias", 30), Opcao("60 dias", 60), Opcao("90 dias", 90)),
+        "contato_sumido_dias",
+        "briefing.ausencia.comercial.contato.sumido",
+    ),
+    _cal(
+        "ritmo.card_parado_dias", "ritmo",
+        "Uma negociação parada na mesma etapa há quanto tempo te incomoda?",
+        (Opcao("5 dias", 5), Opcao("10 dias", 10), Opcao("20 dias", 20), Opcao("30 dias", 30)),
+        "card_parado_dias",
+        "briefing.ausencia.comercial.card.parado",
+    ),
+    _cal(
+        "cliente.topo_seco_dias", "cliente",
+        "Quantos dias sem nenhum cliente novo é anormal no seu negócio?",
+        (
+            Opcao("3 dias", 3),
+            Opcao("5 dias", 5),
+            Opcao("15 dias", 15),
+            # A ÚNICA regra que pode ser desligada: é a única que dispara sobre o VAZIO. As
+            # outras cinco se calam sozinhas em quem não usa aquilo — sem cards, não há card
+            # parado. `None` = regra não executada (mesma forma do filtro de permissão do V1,
+            # que não roda a regra em vez de calcular e esconder).
+            Opcao("Não quero esse aviso", None),
+        ),
+        "topo_sem_lead_dias",
+        "briefing.ausencia.comercial.topo.sem_lead",
+    ),
+    _cal(
+        "ritmo.prazo_antecedencia_dias", "ritmo",
+        "Com quanta antecedência você quer saber de um prazo?",
+        (
+            Opcao("No próprio dia", 0),
+            Opcao("1 dia antes", 1),
+            Opcao("3 dias antes", 3),
+            Opcao("1 semana antes", 7),
+        ),
+        "prazo_vencendo_dias",
+        "briefing.ausencia.agenda.prazo.estourado",
+    ),
+    _cal(
+        "dinheiro.antecedencia_dias", "dinheiro",
+        "E de uma conta a pagar?",
+        (
+            Opcao("No próprio dia", 0),
+            Opcao("1 dia antes", 1),
+            Opcao("3 dias antes", 3),
+            Opcao("1 semana antes", 7),
+        ),
+        "dinheiro_com_data_dias",
+        "briefing.ausencia.financeiro.conta.vencendo",
+    ),
+)
+
+# --- Retrato (39) ----------------------------------------------------------------------
+# Regra de pertencimento: entra se um funcionário humano recém-contratado precisaria saber no
+# primeiro dia. "Qual seu CNPJ" não entra (é cadastro, mora em tenant_profiles).
+
+_OFERTA: tuple[Pergunta, ...] = (
+    _esc(
+        "oferta.o_que_vende", "oferta", "O que você vende?",
+        (
+            Opcao("Serviço recorrente", "servico_recorrente"),
+            Opcao("Serviço por projeto", "servico_projeto"),
+            Opcao("Produto físico", "produto_fisico"),
+            Opcao("Produto digital", "produto_digital"),
+            Opcao("Um pouco de cada", "misto"),
+        ),
+    ),
+    _txt(
+        "oferta.em_uma_frase", "oferta",
+        "Se um cliente perguntar o que você faz, o que você responde?",
+    ),
+    _esc(
+        "oferta.ticket_tipico", "oferta", "Quanto costuma custar um trabalho seu?",
+        (
+            Opcao("Até R$ 500", "ate_500"),
+            Opcao("R$ 500 a 2 mil", "500_2k"),
+            Opcao("R$ 2 mil a 10 mil", "2k_10k"),
+            Opcao("R$ 10 mil a 50 mil", "10k_50k"),
+            Opcao("Acima de R$ 50 mil", "acima_50k"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _esc(
+        "oferta.prazo_entrega", "oferta",
+        "Do 'sim' do cliente até a entrega, quanto tempo costuma passar?",
+        (
+            Opcao("No mesmo dia", "mesmo_dia"),
+            Opcao("Até uma semana", "semana"),
+            Opcao("De 2 a 4 semanas", "mes"),
+            Opcao("Mais de um mês", "mais_de_um_mes"),
+            Opcao("É contínuo, não tem fim", "continuo"),
+        ),
+    ),
+    _esc(
+        "oferta.como_cobra", "oferta", "Como você costuma cobrar?",
+        (
+            Opcao("Tudo antes", "antes"),
+            Opcao("Tudo depois", "depois"),
+            Opcao("Entrada e saldo", "entrada_saldo"),
+            Opcao("Parcelado", "parcelado"),
+            Opcao("Mensalidade", "mensalidade"),
+        ),
+    ),
+    _esc(
+        "oferta.capacidade_mes", "oferta",
+        "Quantos clientes novos você consegue atender por mês, no máximo?",
+        (
+            Opcao("1 ou 2", "1_2"),
+            Opcao("3 a 5", "3_5"),
+            Opcao("6 a 15", "6_15"),
+            Opcao("Mais de 15", "mais_15"),
+            Opcao("Não tenho teto", "sem_teto"),
+        ),
+    ),
+    _esc(
+        "oferta.proposta_formal", "oferta",
+        "Você manda proposta ou orçamento escrito antes de fechar?",
+        (
+            Opcao("Sempre", "sempre"),
+            Opcao("Na maioria das vezes", "maioria"),
+            Opcao("Raramente", "raramente"),
+            Opcao("Nunca", "nunca"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _txt("oferta.diferencial", "oferta", "Por que um cliente escolhe você e não o concorrente?"),
+    _txt("oferta.aberta", "oferta", "Algo mais que a Vima precisa saber sobre o que você vende?"),
+)
+
+_CLIENTE: tuple[Pergunta, ...] = (
+    _esc(
+        "cliente.quem_e", "cliente", "Quem compra de você?",
+        (
+            Opcao("Pessoa física", "pf"),
+            Opcao("Pequenas empresas", "pequenas"),
+            Opcao("Empresas médias e grandes", "grandes"),
+            Opcao("Órgãos públicos", "publico"),
+            Opcao("Um pouco de cada", "misto"),
+        ),
+        gancho="crm.cliente.criado",
+    ),
+    _mult(
+        "cliente.como_chega", "cliente", "Como o cliente chega até você?",
+        (
+            Opcao("Indicação", "indicacao"),
+            Opcao("Redes sociais", "social"),
+            Opcao("Busca no Google", "busca"),
+            Opcao("Anúncio pago", "ads"),
+            Opcao("Prospecção ativa", "outbound"),
+            Opcao("Passagem ou loja física", "fisico"),
+        ),
+    ),
+    _esc(
+        "cliente.decisao_tempo", "cliente",
+        "Do primeiro contato até o cliente decidir, quanto tempo costuma levar?",
+        (
+            Opcao("No mesmo dia", "mesmo_dia"),
+            Opcao("Poucos dias", "dias"),
+            Opcao("De 1 a 4 semanas", "semanas"),
+            Opcao("Mais de um mês", "meses"),
+        ),
+        gancho="crm.cliente.criado",
+    ),
+    _esc(
+        "cliente.recompra", "cliente", "O mesmo cliente costuma voltar?",
+        (
+            Opcao("É recorrente por contrato", "contrato"),
+            Opcao("Volta com frequência", "frequente"),
+            Opcao("Volta às vezes", "as_vezes"),
+            Opcao("É compra única", "unica"),
+        ),
+    ),
+    _esc(
+        "cliente.objecao", "cliente", "O que mais faz um cliente dizer não?",
+        (
+            Opcao("Preço", "preco"),
+            Opcao("Prazo", "prazo"),
+            Opcao("Falta de confiança", "confianca"),
+            Opcao("Não era o que ele procurava", "fit"),
+            Opcao("Ele some sem dizer nada", "some"),
+        ),
+    ),
+    _esc(
+        "cliente.canal_preferido", "cliente", "Por onde o cliente prefere falar com você?",
+        (
+            Opcao("WhatsApp", "whatsapp"),
+            Opcao("Telefone", "telefone"),
+            Opcao("E-mail", "email"),
+            Opcao("Presencial", "presencial"),
+            Opcao("Instagram e afins", "social"),
+        ),
+    ),
+    _txt("cliente.sinal_de_que_fecha", "cliente", "O que te faz saber que um cliente vai fechar?"),
+    _txt("cliente.aberta", "cliente", "Algo mais que a Vima precisa saber sobre seus clientes?"),
+)
+
+_RITMO: tuple[Pergunta, ...] = (
+    _mult(
+        "ritmo.dias_de_trabalho", "ritmo", "Em que dias você trabalha?",
+        (
+            Opcao("Segunda", "seg"), Opcao("Terça", "ter"), Opcao("Quarta", "qua"),
+            Opcao("Quinta", "qui"), Opcao("Sexta", "sex"), Opcao("Sábado", "sab"),
+            Opcao("Domingo", "dom"),
+        ),
+    ),
+    _esc(
+        "ritmo.janela_do_dia", "ritmo", "Que horas você costuma trabalhar?",
+        (
+            Opcao("De manhã", "manha"),
+            Opcao("Horário comercial", "comercial"),
+            Opcao("Tarde e noite", "tarde_noite"),
+            Opcao("De madrugada", "madrugada"),
+            Opcao("Varia muito", "varia"),
+        ),
+    ),
+    _esc(
+        "ritmo.pico_do_mes", "ritmo", "Tem época do mês mais cheia?",
+        (
+            Opcao("Começo", "comeco"), Opcao("Meio", "meio"),
+            Opcao("Fim", "fim"), Opcao("Não tem padrão", "sem_padrao"),
+        ),
+    ),
+    _txt("ritmo.sazonalidade", "ritmo", "E do ano? Tem mês que enche e mês que esvazia?"),
+    _esc(
+        "ritmo.o_que_trava", "ritmo", "O que mais trava o seu dia?",
+        (
+            Opcao("Atender cliente", "atender"),
+            Opcao("Fazer o trabalho em si", "executar"),
+            Opcao("Cobrar", "cobrar"),
+            Opcao("Burocracia", "burocracia"),
+            Opcao("Vender", "vender"),
+        ),
+    ),
+    _esc(
+        "ritmo.sozinho", "ritmo", "Você trabalha sozinho?",
+        (
+            Opcao("Sozinho", "sozinho"),
+            Opcao("Com ajuda pontual de freelas", "freelas"),
+            Opcao("Tenho 1 ou 2 pessoas", "pequena"),
+            Opcao("Tenho equipe", "equipe"),
+        ),
+    ),
+    _txt("ritmo.aberta", "ritmo", "Algo mais que a Vima precisa saber sobre o seu ritmo?"),
+)
+
+_DINHEIRO: tuple[Pergunta, ...] = (
+    _esc(
+        "dinheiro.atraso_reacao", "dinheiro", "Cliente atrasou o pagamento. O que você faz?",
+        (
+            Opcao("Cobro no dia seguinte", "imediato"),
+            Opcao("Espero alguns dias", "espero"),
+            Opcao("Espero ele falar", "passivo"),
+            Opcao("Evito cobrar", "evito"),
+        ),
+        gancho="receivables.cobranca.criada",
+    ),
+    # ⚠️ Parece Calibração e NÃO é: tem número e opções fechadas, mas não existe hoje regra de
+    # Ausência sobre tolerância a atraso (`dinheiro com data` olha vencimento, não carência).
+    # A classe é definida pelo contrato, nunca pelo formato. Se a regra nascer, esta pergunta
+    # migra de classe junto com ela — e a guarda cobra que o consumidor exista antes.
+    _esc(
+        "dinheiro.tolerancia_dias", "dinheiro",
+        "Quantos dias de atraso você tolera antes de agir?",
+        (
+            Opcao("1 dia", 1), Opcao("3 dias", 3), Opcao("7 dias", 7),
+            Opcao("15 dias", 15), Opcao("30 dias", 30),
+        ),
+    ),
+    _esc(
+        "dinheiro.reserva", "dinheiro", "Você tem reserva para quantos meses parados?",
+        (
+            Opcao("Nenhuma", "nenhuma"),
+            Opcao("Menos de um mês", "menos_1"),
+            Opcao("De 1 a 3 meses", "1_3"),
+            Opcao("De 3 a 6 meses", "3_6"),
+            Opcao("Mais de 6 meses", "mais_6"),
+        ),
+    ),
+    _esc(
+        "dinheiro.pro_labore", "dinheiro", "Você tira um valor fixo por mês para você?",
+        (
+            Opcao("Sim, fixo", "fixo"),
+            Opcao("Sim, variável", "variavel"),
+            Opcao("Não separo", "nao_separo"),
+        ),
+    ),
+    _txt("dinheiro.sinal_de_aperto", "dinheiro", "O que te diz que o mês vai ser apertado?"),
+    _mult(
+        "dinheiro.formas_recebimento", "dinheiro", "Como você recebe?",
+        (
+            Opcao("Pix", "pix"), Opcao("Boleto", "boleto"), Opcao("Cartão", "cartao"),
+            Opcao("Dinheiro", "dinheiro"), Opcao("Transferência", "transferencia"),
+        ),
+        gancho="receivables.cobranca.criada",
+    ),
+    _esc(
+        "dinheiro.emite_nota", "dinheiro", "Você emite nota fiscal?",
+        (
+            Opcao("Sempre", "sempre"),
+            Opcao("Quando o cliente pede", "sob_demanda"),
+            Opcao("Não emito", "nao"),
+        ),
+        gancho="payables.conta.criada",
+    ),
+    _txt("dinheiro.aberta", "dinheiro", "Algo mais que a Vima precisa saber sobre o seu dinheiro?"),
+)
+
+# O eixo mais importante e o mais fácil de esquecer: é o único que o V4 lê para decidir o que
+# NÃO fazer sozinho. Autonomia progressiva sem esta lista é um agente que descobre os limites
+# errando na frente do cliente.
+_LIMITES: tuple[Pergunta, ...] = (
+    _txt("limites.nunca_faco", "limites", "O que você nunca faz, mesmo que o cliente peça?"),
+    _mult(
+        "limites.exige_voce", "limites", "O que só pode sair com você olhando antes?",
+        (
+            Opcao("Proposta e preço", "proposta"),
+            Opcao("Mensagem para cliente", "mensagem"),
+            Opcao("Cobrança", "cobranca"),
+            Opcao("Contrato", "contrato"),
+            Opcao("Publicação", "publicacao"),
+            Opcao("Nada disso", "nada"),
+        ),
+    ),
+    _esc(
+        "limites.tom", "limites", "Como você fala com cliente?",
+        (
+            Opcao("Formal", "formal"),
+            Opcao("Cordial e direto", "cordial"),
+            Opcao("Informal e próximo", "informal"),
+            Opcao("Bem-humorado", "humorado"),
+        ),
+    ),
+    _esc(
+        "limites.desconto", "limites", "Você dá desconto?",
+        (
+            Opcao("Nunca", "nunca"),
+            Opcao("Só em caso especial", "especial"),
+            Opcao("Negocio sempre", "sempre"),
+            Opcao("Tenho tabela fixa", "tabela"),
+        ),
+        gancho="quotes.orcamento.criado",
+    ),
+    _txt("limites.recusa_cliente", "limites", "Que tipo de cliente você recusa?"),
+    _esc(
+        "limites.horario_contato", "limites", "Pode falar com cliente fora do seu horário?",
+        (
+            Opcao("Pode sempre", "sempre"),
+            Opcao("Só urgência", "urgencia"),
+            Opcao("Nunca", "nunca"),
+        ),
+        gancho="agenda.evento.criado",
+    ),
+    _txt("limites.aberta", "limites", "Algo mais que a Vima precisa saber sobre os seus limites?"),
+)
+
+PERGUNTAS: tuple[Pergunta, ...] = (
+    _CALIBRACAO + _OFERTA + _CLIENTE + _RITMO + _DINHEIRO + _LIMITES
+)
+
+# A guarda roda AGORA, no import. Falha na subida do processo, não em produção.
+verificar(PERGUNTAS)
+
+POR_KEY: dict[str, Pergunta] = {p.key: p for p in PERGUNTAS}
+
+# O núcleo do primeiro acesso. NENHUMA é de Calibração, e essa é a inversão central do design:
+# "em quanto tempo eu te aviso que ninguém respondeu o Carlos?" é impossível de responder bem
+# antes de ter visto um briefing. A resposta seria um chute que depois vira comportamento
+# errado com aparência de configuração deliberada.
+NUCLEO: tuple[str, ...] = (
+    "oferta.o_que_vende",
+    "oferta.em_uma_frase",
+    "oferta.como_cobra",
+    "oferta.ticket_tipico",
+    "cliente.como_chega",
+    "limites.nunca_faco",
+)
+```
+
+- [ ] **Step 5: Rodar os testes**
+
+Run: `cd apps/api && pytest tests/test_dna_catalog.py -v`
+Expected: PASS, **exceto** `test_consome_aponta_para_limiar_que_existe` e `test_todo_limiar_tem_pergunta`, que falham porque `dinheiro_com_data_dias` ainda não existe em `LIMIARES_PADRAO` — ele nasce na Task 6.
+
+- [ ] **Step 6: Antecipar só a chave do limiar**
+
+O catálogo depende de uma chave que a Onda 2 vai usar. Adicionar **apenas a chave** agora, com o mesmo valor que `prazo_vencendo_dias` tem hoje, mantém a Task 1 verde sem mudar comportamento nenhum (nada lê essa chave ainda — a leitura entra na Task 6).
+
+Modificar `apps/api/app/modules/vima/absences.py`, no dicionário `LIMIARES_PADRAO`:
+
+```python
+LIMIARES_PADRAO: dict[str, int] = {
+    "sem_resposta_nossa_horas": 24,
+    "contato_sumido_dias": 30,
+    "card_parado_dias": 10,
+    "topo_sem_lead_dias": 5,
+    "prazo_vencendo_dias": 1,
+    # Nasce com o MESMO valor de `prazo_vencendo_dias` porque hoje as duas regras dividem
+    # aquele número. Quem passa a lê-lo é a Task 6 — aqui a chave só existe para o catálogo do
+    # DNA poder apontar para ela.
+    "dinheiro_com_data_dias": 1,
+}
+```
+
+- [ ] **Step 7: Rodar a suíte inteira**
+
+Run: `cd apps/api && pytest tests/test_dna_catalog.py tests/test_vima_absences.py -v`
+Expected: PASS em tudo. `test_vima_absences.py` não muda de comportamento — a chave nova não é lida por ninguém.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/dna/ apps/api/tests/test_dna_catalog.py apps/api/app/modules/vima/absences.py
+git commit -m "feat: o catálogo do DNA da Empresa e as duas guardas de classe [V2]"
+```
+
+---
+
+### Task 2: `DnaAnswer` e a migration 0076
+
+**Files:**
+- Create: `apps/api/app/modules/dna/models.py`
+- Create: `apps/api/migrations/versions/0076_dna_answers.py`
+- Modify: `apps/api/app/db/registry.py`
+- Test: `apps/api/tests/test_dna_models.py`
+
+**Interfaces:**
+- Consumes: `app.db.base.Base`, `TenantMixin`, `TimestampMixin`, `_uuid`
+- Produces: `DnaAnswer` com campos `id`, `tenant_id`, `question_key`, `value` (JSON, nulo), `answered_at` (datetime), `answered_by` (str | None), `source` (str); constantes `SOURCE_NUCLEO = "nucleo"`, `SOURCE_GANCHO = "gancho"`, `SOURCE_CONFIG = "config"`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```python
+# apps/api/tests/test_dna_models.py
+"""A linha de resposta do DNA: upsert por (tenant, pergunta), e nulo significa 'pulei'."""
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna.models import SOURCE_CONFIG, DnaAnswer
+
+
+def test_grava_e_le(db: Session):
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="oferta.o_que_vende", value="servico_projeto",
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    linha = db.query(DnaAnswer).one()
+    assert linha.value == "servico_projeto"
+    assert linha.id  # uuid gerado pelo default
+
+
+def test_valor_nulo_e_estado_valido_e_significa_pulada(db: Session):
+    """'Pulei' precisa ser distinguível de 'nunca me perguntaram', sem tabela nova."""
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="limites.nunca_faco", value=None,
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    linha = db.query(DnaAnswer).one()
+    assert linha.value is None
+
+
+def test_valor_aceita_lista_para_escolha_multipla(db: Session):
+    db.add(
+        DnaAnswer(
+            tenant_id="t1", question_key="cliente.como_chega", value=["indicacao", "busca"],
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    assert db.query(DnaAnswer).one().value == ["indicacao", "busca"]
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_models.py -v`
+Expected: FAIL com `ModuleNotFoundError: No module named 'app.modules.dna.models'`
+
+- [ ] **Step 3: Escrever o modelo**
+
+Criar `apps/api/app/modules/dna/models.py`:
+
+```python
+"""A resposta do DNA — estado atual, não história.
+
+**É upsert, não append — o oposto de `core/facts.py`, e de propósito.** Fato é história; DNA é
+estado atual. Guardar versões faria toda leitura ter que decidir qual resposta vale, e o
+histórico de quem mudou o quê já é trabalho de `core/audit.py`.
+
+`value` nulo NÃO é ausência de linha: é "o dono viu a pergunta e pulou". A distinção sustenta a
+quarentena de 7 dias em `cadencia.py` sem tabela nova.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
+
+SOURCE_NUCLEO = "nucleo"
+SOURCE_GANCHO = "gancho"
+SOURCE_CONFIG = "config"
+
+
+class DnaAnswer(Base, TenantMixin, TimestampMixin):
+    """Uma resposta do dono sobre o próprio negócio."""
+
+    __tablename__ = "dna_answers"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    question_key: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # `int | str | list | None` — o formato é decidido pelo catálogo, e a validação acontece no
+    # serviço, contra ele. A coluna é frouxa; a porta de entrada é estreita.
+    value: Mapped[Any | None] = mapped_column(JSON, nullable=True)
+    answered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # A resposta é do TENANT, mas a autoria importa quando há sub-usuário.
+    answered_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    source: Mapped[str] = mapped_column(String(16), nullable=False)
+```
+
+- [ ] **Step 4: Registrar no metadata**
+
+Modificar `apps/api/app/db/registry.py`, na lista de imports em ordem alfabética (entre `device_tokens` e `funnels`):
+
+```python
+from app.modules.dna.models import DnaAnswer  # noqa: F401
+```
+
+- [ ] **Step 5: Rodar o teste**
+
+Run: `cd apps/api && pytest tests/test_dna_models.py -v`
+Expected: PASS (3 testes)
+
+- [ ] **Step 6: Conferir o head do Alembic antes de escrever a migration**
+
+Run: `ls apps/api/migrations/versions/ | sort | tail -3`
+Expected: a maior revision é `0075_investment_bank_account.py`. **Se for maior que 0075, use o número seguinte ao que apareceu e ajuste `down_revision`** — a frente paralela pode ter avançado.
+
+- [ ] **Step 7: Escrever a migration**
+
+Criar `apps/api/migrations/versions/0076_dna_answers.py`:
+
+```python
+"""DNA da Empresa — respostas do dono
+
+Revision ID: 0076
+Revises: 0075
+Create Date: 2026-08-08
+
+⚠️ A `0075` já estava tomada por `investment_bank_account`, de uma frente paralela — mesma
+armadilha que a `0072` documentou. Duas revisions com o mesmo id fazem o `alembic upgrade head`
+escolher uma em silêncio.
+
+Sem backfill: não existe resposta anterior a esta migration, então a armadilha da RLS no
+backfill (ver 0046/0066/0067/0068/0069) não se aplica. Só DDL.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0076"
+down_revision: str | None = "0075"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dna_answers",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("tenant_id", sa.String(length=36), nullable=False, index=True),
+        sa.Column("question_key", sa.String(length=64), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=True),
+        sa.Column("answered_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("answered_by", sa.String(length=36), nullable=True),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        # O upsert depende desta constraint: uma resposta por pergunta por tenant.
+        sa.UniqueConstraint("tenant_id", "question_key", name="uq_dna_answer"),
+    )
+    op.create_index("ix_dna_answers_question_key", "dna_answers", ["question_key"])
+
+    op.execute("ALTER TABLE dna_answers ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE dna_answers FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON dna_answers
+            USING (tenant_id = current_setting('app.current_tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dna_answers")
+```
+
+- [ ] **Step 8: Verificar que a migration sobe e desce**
+
+Run: `cd apps/api && alembic upgrade head && alembic downgrade -1 && alembic upgrade head`
+Expected: três comandos sem erro. Se o banco local não estiver de pé, subir com `docker compose up -d db` na raiz (porta 5433 no host — ver `docker-compose.yml`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/app/modules/dna/models.py apps/api/migrations/versions/0076_dna_answers.py apps/api/app/db/registry.py apps/api/tests/test_dna_models.py
+git commit -m "feat: tabela dna_answers com RLS [V2]"
+```
+
+---
+
+### Task 3: `dna/service.py` — responder, pular e ler, validando contra o catálogo
+
+**Files:**
+- Create: `apps/api/app/modules/dna/service.py`
+- Test: `apps/api/tests/test_dna_service.py`
+
+**Interfaces:**
+- Consumes: `catalog.POR_KEY`, `catalog.FORMATO_*`, `catalog.MAX_TEXTO`, `DnaAnswer`, `SOURCE_*`
+- Produces: `DnaError(message, status_code)`, `responder(db, *, tenant_id, key, valor, user_id, source) -> DnaAnswer`, `pular(db, *, tenant_id, key, user_id, source) -> DnaAnswer`, `respostas(db) -> dict[str, Any]` (só as respondidas — `value` não nulo), `linhas(db) -> dict[str, DnaAnswer]` (todas, inclusive as puladas)
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```python
+# apps/api/tests/test_dna_service.py
+"""A porta de escrita do DNA: valida contra o catálogo, faz upsert, e pular é gravar nulo."""
+import pytest
+from sqlalchemy.orm import Session
+
+from app.modules.dna import service
+from app.modules.dna.models import SOURCE_CONFIG, SOURCE_GANCHO, DnaAnswer
+
+TENANT = "t1"
+
+
+def test_responder_grava_e_commita(db: Session):
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="servico_projeto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    linha = db.query(DnaAnswer).one()
+    assert linha.value == "servico_projeto"
+    assert linha.answered_by == "u1"
+
+
+def test_responder_de_novo_faz_upsert_e_nao_cria_segunda_linha(db: Session):
+    """DNA é estado atual, não história — duas linhas fariam toda leitura ter que escolher."""
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="servico_projeto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="produto_digital",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).count() == 1
+    assert db.query(DnaAnswer).one().value == "produto_digital"
+
+
+def test_chave_desconhecida_e_recusada(db: Session):
+    with pytest.raises(service.DnaError, match="não existe"):
+        service.responder(
+            db, tenant_id=TENANT, key="oferta.inventada", valor="x",
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_valor_fora_das_opcoes_e_recusado(db: Session):
+    """Sem isso o JSON vira depósito e o resolver quebra na leitura, longe de quem escreveu."""
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="oferta.o_que_vende", valor="nao_existe",
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_escolha_multipla_aceita_lista_e_recusa_item_invalido(db: Session):
+    service.responder(
+        db, tenant_id=TENANT, key="cliente.como_chega", valor=["indicacao", "busca"],
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).one().value == ["indicacao", "busca"]
+
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="cliente.como_chega", valor=["indicacao", "telepatia"],
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_texto_longo_demais_e_recusado(db: Session):
+    with pytest.raises(service.DnaError, match="longo"):
+        service.responder(
+            db, tenant_id=TENANT, key="limites.nunca_faco", valor="x" * 2001,
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_calibracao_aceita_none_so_onde_a_opcao_existe(db: Session):
+    """Topo seco pode ser desligado; as outras cinco não têm opção de desligamento."""
+    service.responder(
+        db, tenant_id=TENANT, key="cliente.topo_seco_dias", valor=None,
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).one().value is None
+
+    with pytest.raises(service.DnaError, match="opções"):
+        service.responder(
+            db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=None,
+            user_id="u1", source=SOURCE_CONFIG,
+        )
+
+
+def test_pular_grava_linha_com_valor_nulo(db: Session):
+    service.pular(
+        db, tenant_id=TENANT, key="limites.nunca_faco", user_id="u1", source=SOURCE_GANCHO,
+    )
+    linha = db.query(DnaAnswer).one()
+    assert linha.value is None
+    assert linha.source == SOURCE_GANCHO
+
+
+def test_respostas_ignora_puladas_mas_linhas_as_inclui(db: Session):
+    """A distinção que sustenta a quarentena: 'pulei' não é resposta, mas é registro."""
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    service.pular(db, tenant_id=TENANT, key="limites.nunca_faco", user_id="u1",
+                  source=SOURCE_CONFIG)
+
+    assert service.respostas(db) == {"oferta.o_que_vende": "misto"}
+    assert set(service.linhas(db)) == {"oferta.o_que_vende", "limites.nunca_faco"}
+
+
+def test_responder_nao_emite_fato(db: Session):
+    """O feed do briefing é sobre o NEGÓCIO, não sobre a configuração do produto.
+
+    Um "você respondeu uma pergunta" no resumo de amanhã seria ruído auto-referente. A trilha de
+    quem mudou o quê é trabalho de `core/audit.py`.
+    """
+    from app.core.facts import Fact
+
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(Fact).count() == 0
+
+
+def test_pular_e_depois_responder_vira_resposta(db: Session):
+    service.pular(db, tenant_id=TENANT, key="oferta.o_que_vende", user_id="u1",
+                  source=SOURCE_GANCHO)
+    service.responder(
+        db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+        user_id="u1", source=SOURCE_CONFIG,
+    )
+    assert db.query(DnaAnswer).count() == 1
+    assert service.respostas(db) == {"oferta.o_que_vende": "misto"}
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_service.py -v`
+Expected: FAIL com `ModuleNotFoundError: No module named 'app.modules.dna.service'`
+
+- [ ] **Step 3: Escrever o serviço**
+
+Criar `apps/api/app/modules/dna/service.py`:
+
+```python
+"""Escrita e leitura crua do DNA. A validação contra o catálogo mora aqui.
+
+A coluna `value` é JSON frouxo de propósito — o formato é decidido pelo catálogo, e é aqui que
+o catálogo é cobrado. Sem esta porta estreita, o JSON vira depósito de qualquer coisa e o
+resolver quebra na leitura, longe de quem escreveu.
+
+Este módulo NÃO é puro: carimba `answered_at` com o instante. Carimbar INSTANTE é legítimo;
+derivar QUE DIA É HOJE é o que o gate de `test_fuso_do_tenant.py` proíbe — e essa derivação
+mora em `cadencia.py`, que recebe `hoje` por parâmetro.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.dna import catalog
+from app.modules.dna.models import DnaAnswer
+
+
+class DnaError(Exception):
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def responder(
+    db: Session,
+    *,
+    tenant_id: str,
+    key: str,
+    valor: Any,
+    user_id: str | None,
+    source: str,
+) -> DnaAnswer:
+    """Grava a resposta, validando contra o catálogo. Commita."""
+    pergunta = _pergunta(key)
+    _validar(pergunta, valor)
+    return _gravar(db, tenant_id=tenant_id, key=key, valor=valor, user_id=user_id, source=source)
+
+
+def pular(
+    db: Session, *, tenant_id: str, key: str, user_id: str | None, source: str
+) -> DnaAnswer:
+    """Registra que o dono viu e pulou. `value` nulo é o registro — não é linha ausente."""
+    _pergunta(key)
+    return _gravar(db, tenant_id=tenant_id, key=key, valor=None, user_id=user_id, source=source)
+
+
+def respostas(db: Session) -> dict[str, Any]:
+    """Só o que foi de fato respondido. Puladas ficam de fora."""
+    return {
+        linha.question_key: linha.value
+        for linha in db.scalars(select(DnaAnswer)).all()
+        if linha.value is not None
+    }
+
+
+def linhas(db: Session) -> dict[str, DnaAnswer]:
+    """Todas as linhas, inclusive as puladas — é o que a cadência precisa ver."""
+    return {linha.question_key: linha for linha in db.scalars(select(DnaAnswer)).all()}
+
+
+def _pergunta(key: str) -> catalog.Pergunta:
+    pergunta = catalog.POR_KEY.get(key)
+    if pergunta is None:
+        raise DnaError(f"a pergunta '{key}' não existe no catálogo", status_code=404)
+    return pergunta
+
+
+def _validar(pergunta: catalog.Pergunta, valor: Any) -> None:
+    if pergunta.formato == catalog.FORMATO_TEXTO:
+        if not isinstance(valor, str):
+            raise DnaError(f"'{pergunta.key}' espera texto")
+        if len(valor) > catalog.MAX_TEXTO:
+            raise DnaError(
+                f"texto longo demais ({len(valor)} caracteres, máximo {catalog.MAX_TEXTO})"
+            )
+        return
+
+    permitidos = {o.valor for o in pergunta.opcoes}
+
+    if pergunta.formato == catalog.FORMATO_MULTIPLA:
+        if not isinstance(valor, list):
+            raise DnaError(f"'{pergunta.key}' espera uma lista")
+        invalidos = [v for v in valor if v not in permitidos]
+        if invalidos:
+            raise DnaError(f"{invalidos} não está entre as opções de '{pergunta.key}'")
+        return
+
+    if valor not in permitidos:
+        raise DnaError(f"'{valor}' não está entre as opções de '{pergunta.key}'")
+
+
+def _gravar(
+    db: Session, *, tenant_id: str, key: str, valor: Any, user_id: str | None, source: str
+) -> DnaAnswer:
+    """Upsert por `(tenant, pergunta)` — a unique constraint da 0076 é o que o garante."""
+    linha = db.scalar(select(DnaAnswer).where(DnaAnswer.question_key == key))
+    if linha is None:
+        linha = DnaAnswer(tenant_id=tenant_id, question_key=key)
+        db.add(linha)
+    linha.value = valor
+    linha.answered_at = datetime.now(UTC)
+    linha.answered_by = user_id
+    linha.source = source
+    db.commit()
+    db.refresh(linha)
+    return linha
+```
+
+- [ ] **Step 4: Rodar os testes**
+
+Run: `cd apps/api && pytest tests/test_dna_service.py -v`
+Expected: PASS (10 testes)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/dna/service.py apps/api/tests/test_dna_service.py
+git commit -m "feat: escrita do DNA validada contra o catálogo [V2]"
+```
+
+---
+
+### Task 4: `dna/cadencia.py` — uma pergunta por dia, quarentena de 7 dias
+
+**Files:**
+- Create: `apps/api/app/modules/dna/cadencia.py`
+- Test: `apps/api/tests/test_dna_cadencia.py`
+
+**Interfaces:**
+- Consumes: `catalog.PERGUNTAS`, `catalog.NUCLEO`, `service.linhas`
+- Produces: `QUARENTENA_DIAS = 7`, `GANCHO_NUCLEO = "nucleo"`, `pendente(db, *, gancho, hoje) -> catalog.Pergunta | None`, `faltantes(db) -> list[catalog.Pergunta]`
+
+**⚠️ Este módulo é PURO.** `hoje` entra por parâmetro; ele nunca chama `now()`, `today()` nem `hoje_do_tenant`. O gate da Task 7 cobra isso.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```python
+# apps/api/tests/test_dna_cadencia.py
+"""A cadência: uma pergunta por dia, pulada em quarentena, escolha determinística."""
+from datetime import UTC, date, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna import cadencia, catalog, service
+from app.modules.dna.models import SOURCE_GANCHO, DnaAnswer
+
+TENANT = "t1"
+HOJE = date(2026, 8, 8)
+GANCHO_CARD = "briefing.ausencia.comercial.card.parado"
+
+
+def _linha(db: Session, key: str, *, valor, quando: datetime) -> None:
+    db.add(
+        DnaAnswer(
+            tenant_id=TENANT, question_key=key, value=valor,
+            answered_at=quando, answered_by="u1", source=SOURCE_GANCHO,
+        )
+    )
+    db.commit()
+
+
+def test_devolve_a_pergunta_do_gancho_quando_nada_foi_respondido(db: Session):
+    p = cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE)
+    assert p is not None
+    assert p.key == "ritmo.card_parado_dias"
+
+
+def test_nao_devolve_pergunta_ja_respondida(db: Session):
+    _linha(db, "ritmo.card_parado_dias", valor=5,
+           quando=datetime(2026, 7, 1, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_uma_pergunta_por_dia_no_produto_inteiro(db: Session):
+    """Qualquer resposta de HOJE cala todos os ganchos — não é uma por tela, é uma."""
+    _linha(db, "oferta.o_que_vende", valor="misto",
+           quando=datetime(2026, 8, 8, 9, 0, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_resposta_de_ontem_nao_cala_hoje(db: Session):
+    _linha(db, "oferta.o_que_vende", valor="misto",
+           quando=datetime(2026, 8, 7, 23, 0, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is not None
+
+
+def test_pulada_fica_em_quarentena_por_7_dias(db: Session):
+    _linha(db, "ritmo.card_parado_dias", valor=None,
+           quando=datetime(2026, 8, 5, tzinfo=UTC))
+    assert cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE) is None
+
+
+def test_pulada_volta_depois_da_quarentena(db: Session):
+    """Some por uma semana, não para sempre: um 'depois' acidental não pode perder a pergunta."""
+    _linha(db, "ritmo.card_parado_dias", valor=None,
+           quando=datetime(2026, 7, 20, tzinfo=UTC))
+    p = cadencia.pendente(db, gancho=GANCHO_CARD, hoje=HOJE)
+    assert p is not None and p.key == "ritmo.card_parado_dias"
+
+
+def test_escolha_e_deterministica_pela_ordem_do_catalogo(db: Session):
+    """Duas elegíveis no mesmo gancho: vence a primeira do catálogo, sempre a mesma."""
+    gancho = "quotes.orcamento.criado"
+    primeira = cadencia.pendente(db, gancho=gancho, hoje=HOJE)
+    assert primeira is not None
+    assert primeira.key == "oferta.ticket_tipico"
+    assert cadencia.pendente(db, gancho=gancho, hoje=HOJE).key == primeira.key
+
+
+def test_gancho_desconhecido_devolve_nada(db: Session):
+    assert cadencia.pendente(db, gancho="tela.inventada", hoje=HOJE) is None
+
+
+def test_nucleo_devolve_as_seis_na_ordem_declarada(db: Session):
+    faltando = cadencia.faltantes(db, gancho=cadencia.GANCHO_NUCLEO)
+    assert [p.key for p in faltando] == list(catalog.NUCLEO)
+
+
+def test_nucleo_encolhe_conforme_responde(db: Session):
+    """O núcleo é sequência anunciada: não obedece ao 'uma por dia' e some item a item."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source="nucleo")
+    faltando = cadencia.faltantes(db, gancho=cadencia.GANCHO_NUCLEO)
+    assert "oferta.o_que_vende" not in [p.key for p in faltando]
+    assert len(faltando) == 5
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_cadencia.py -v`
+Expected: FAIL com `ModuleNotFoundError: No module named 'app.modules.dna.cadencia'`
+
+- [ ] **Step 3: Escrever a cadência**
+
+Criar `apps/api/app/modules/dna/cadencia.py`:
+
+```python
+"""Quando perguntar — a Regra do Silêncio do V1 aplicada a perguntar em vez de a avisar.
+
+Duas regras, e nenhuma delas é sobre CONTEÚDO:
+
+1. **Uma pergunta por gancho por dia, no produto inteiro.** Não uma por tela: uma. Um produto
+   que interroga em três telas diferentes na mesma sessão é ignorado na quarta.
+2. **Pulada fica 7 dias em quarentena.** Nunca some — continua no `/config` —, mas para de ser
+   empurrada. Sem quarentena, um "depois" acidental vira interrogatório; com quarentena
+   infinita, um toque errado perde a pergunta para sempre.
+
+**O núcleo é a exceção declarada** e não passa por aqui: é uma sequência anunciada, com fim
+visível, que a pessoa entrou sabendo que ia atravessar. Interrupção não anunciada e sequência
+anunciada não cansam igual — o que cansa é a primeira.
+
+⚠️ **Módulo PURO.** `hoje` entra por parâmetro, sempre. Quem o deriva é o router, com
+`hoje_do_tenant(db)`. Um default que lesse o relógio aqui é exatamente por onde o dono no Acre
+passa a ser interrogado duas vezes no mesmo dia — e a regressão passaria meses despercebida,
+porque em São Paulo funciona.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna import catalog, service
+
+QUARENTENA_DIAS = 7
+GANCHO_NUCLEO = "nucleo"
+
+
+def pendente(db: Session, *, gancho: str, hoje: date) -> catalog.Pergunta | None:
+    """A pergunta a fazer neste gancho hoje, ou `None` se for dia de silêncio."""
+    if gancho == GANCHO_NUCLEO:
+        faltando = faltantes(db, gancho=GANCHO_NUCLEO)
+        return faltando[0] if faltando else None
+
+    registro = service.linhas(db)
+
+    # Regra 1: qualquer registro de hoje já gastou a cota do dia.
+    if any(_dia(linha.answered_at) == hoje for linha in registro.values()):
+        return None
+
+    for pergunta in catalog.PERGUNTAS:
+        if pergunta.gancho != gancho:
+            continue
+        linha = registro.get(pergunta.key)
+        if linha is None:
+            return pergunta
+        if linha.value is None and (hoje - _dia(linha.answered_at)).days >= QUARENTENA_DIAS:
+            return pergunta  # saiu da quarentena
+    return None
+
+
+def faltantes(db: Session, *, gancho: str) -> list[catalog.Pergunta]:
+    """As perguntas do gancho ainda sem RESPOSTA — puladas contam como faltantes.
+
+    Sem cadência: é o que a tela do núcleo e a aba de `/config` usam, onde a pessoa escolheu
+    estar e a interrupção não existe.
+    """
+    respondidas = set(service.respostas(db))
+    if gancho == GANCHO_NUCLEO:
+        return [
+            catalog.POR_KEY[key] for key in catalog.NUCLEO if key not in respondidas
+        ]
+    return [
+        p for p in catalog.PERGUNTAS if p.gancho == gancho and p.key not in respondidas
+    ]
+
+
+def _dia(quando) -> date:
+    """A data do carimbo. Não deriva 'hoje' — lê o dia de um instante que já existe."""
+    return quando.date()
+```
+
+- [ ] **Step 4: Rodar os testes**
+
+Run: `cd apps/api && pytest tests/test_dna_cadencia.py -v`
+Expected: PASS (10 testes)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/dna/cadencia.py apps/api/tests/test_dna_cadencia.py
+git commit -m "feat: cadência do DNA — uma por dia, pulada em quarentena [V2]"
+```
+
+---
+
+### Task 5: `dna/router.py` — o contrato HTTP
+
+**Files:**
+- Create: `apps/api/app/modules/dna/schemas.py`
+- Create: `apps/api/app/modules/dna/router.py`
+- Modify: `apps/api/app/modules/__init__.py`
+- Test: `apps/api/tests/test_dna_router.py`
+
+**Interfaces:**
+- Consumes: `cadencia.pendente`, `cadencia.faltantes`, `cadencia.GANCHO_NUCLEO`, `service.responder`, `service.pular`, `service.respostas`, `service.DnaError`, `hoje_do_tenant`, `require_module`, `get_tenant_db`, `get_current_user`
+- Produces: rotas `GET /dna/pendente?gancho=`, `GET /dna/faltantes?gancho=`, `GET /dna/respostas`, `PUT /dna/{key}`, `POST /dna/{key}/pular`; schemas `OpcaoOut`, `PerguntaOut`, `RespostaIn`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```python
+# apps/api/tests/test_dna_router.py
+"""O contrato HTTP do DNA — incluindo quem NÃO pode responder."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.security import create_access_token
+
+REGISTER = {
+    "email": "dono@exemplo.com",
+    "password": "senha-forte-123",
+    "tenant_name": "Estúdio de Uma Pessoa",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, headers: dict[str, str]) -> str:
+    return client.get("/auth/me", headers=headers).json()["user"]["tenant_id"]
+
+
+@pytest.fixture()
+def headers_sub_crm(tenant_id: str) -> dict[str, str]:
+    """Sub-usuário só de CRM: vê o briefing, mas o DNA é da EMPRESA e não é dele."""
+    token = create_access_token(
+        {
+            "sub": "sub-crm",
+            "tenant_id": tenant_id,
+            "role": "member",
+            "allowed_modules": ["comercial"],
+        }
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_nucleo_devolve_as_seis(client: TestClient, headers):
+    corpo = client.get("/dna/faltantes", params={"gancho": "nucleo"}, headers=headers).json()
+    assert len(corpo) == 6
+    assert corpo[0]["key"] == "oferta.o_que_vende"
+    assert corpo[0]["opcoes"][0]["rotulo"] == "Serviço recorrente"
+
+
+def test_responder_e_ler_de_volta(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "servico_projeto", "source": "nucleo"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert client.get("/dna/respostas", headers=headers).json()["oferta.o_que_vende"] == (
+        "servico_projeto"
+    )
+
+
+def test_valor_invalido_devolve_400(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "telepatia", "source": "config"},
+        headers=headers,
+    )
+    assert r.status_code == 400
+
+
+def test_chave_inexistente_devolve_404(client: TestClient, headers):
+    r = client.put(
+        "/dna/oferta.inventada", json={"valor": "x", "source": "config"}, headers=headers
+    )
+    assert r.status_code == 404
+
+
+def test_pular_registra_sem_responder(client: TestClient, headers):
+    assert client.post(
+        "/dna/limites.nunca_faco/pular", json={"source": "gancho"}, headers=headers
+    ).status_code == 200
+    assert "limites.nunca_faco" not in client.get("/dna/respostas", headers=headers).json()
+
+
+def test_pendente_por_gancho(client: TestClient, headers):
+    corpo = client.get(
+        "/dna/pendente",
+        params={"gancho": "briefing.ausencia.comercial.card.parado"},
+        headers=headers,
+    ).json()
+    assert corpo["key"] == "ritmo.card_parado_dias"
+
+
+def test_dia_de_silencio_devolve_nulo(client: TestClient, headers):
+    """Respondeu uma hoje: o gancho se cala até amanhã."""
+    client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "misto", "source": "nucleo"}, headers=headers
+    )
+    corpo = client.get(
+        "/dna/pendente",
+        params={"gancho": "briefing.ausencia.comercial.card.parado"},
+        headers=headers,
+    ).json()
+    assert corpo is None
+
+
+def test_sub_usuario_sem_settings_nao_alcanca_o_dna(client: TestClient, headers_sub_crm):
+    """O DNA é da EMPRESA. Um sub-usuário recalibrando o negócio seria surpresa ruim."""
+    assert client.get(
+        "/dna/pendente", params={"gancho": "nucleo"}, headers=headers_sub_crm
+    ).status_code == 403
+    assert client.put(
+        "/dna/oferta.o_que_vende", json={"valor": "misto", "source": "config"},
+        headers=headers_sub_crm,
+    ).status_code == 403
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_router.py -v`
+Expected: FAIL — todas as rotas devolvem 404, porque o router não existe.
+
+- [ ] **Step 3: Escrever os schemas**
+
+Criar `apps/api/app/modules/dna/schemas.py`:
+
+```python
+"""Contrato HTTP do DNA.
+
+A pergunta viaja INTEIRA para o front (texto e opções), em vez de o front ter uma cópia do
+catálogo: duas cópias divergem no primeiro ajuste de texto, e a versão errada é sempre a que o
+dono está lendo.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.modules.dna import catalog
+
+
+class OpcaoOut(BaseModel):
+    rotulo: str
+    valor: Any | None
+
+
+class PerguntaOut(BaseModel):
+    key: str
+    classe: str
+    eixo: str
+    texto: str
+    formato: str
+    opcoes: list[OpcaoOut]
+
+
+class RespostaIn(BaseModel):
+    valor: Any | None = None
+    source: str
+
+
+class PularIn(BaseModel):
+    source: str
+
+
+def to_out(pergunta: catalog.Pergunta) -> PerguntaOut:
+    return PerguntaOut(
+        key=pergunta.key,
+        classe=pergunta.classe,
+        eixo=pergunta.eixo,
+        texto=pergunta.texto,
+        formato=pergunta.formato,
+        opcoes=[OpcaoOut(rotulo=o.rotulo, valor=o.valor) for o in pergunta.opcoes],
+    )
+```
+
+- [ ] **Step 4: Escrever o router**
+
+Criar `apps/api/app/modules/dna/router.py`:
+
+```python
+"""Rotas do DNA da Empresa.
+
+⚠️ **`require_module("settings")` aqui, e não filtro no dado.** É o oposto da decisão do
+`vima/router.py`, e de propósito: lá o recorte é por LINHA (o funcionário recebe o briefing do
+que ele pode ver); aqui a superfície inteira é da empresa, então bloquear a rota é a resposta
+certa. `require_module` já dá owner-vê-tudo e lista-vazia-vê-tudo.
+
+**`hoje_do_tenant(db)` é chamado AQUI**, e a data desce por parâmetro até `cadencia`. É o que
+mantém aquele módulo puro e o gate de fuso satisfeito.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.modules.dna import cadencia, catalog, service
+from app.modules.dna.schemas import PerguntaOut, PularIn, RespostaIn, to_out
+from app.modules.settings.service import hoje_do_tenant
+
+router = APIRouter(prefix="/dna", tags=["dna"])
+
+
+@router.get("/pendente", response_model=PerguntaOut | None)
+def pendente(
+    gancho: str = Query(...),
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut | None:
+    """A pergunta deste gancho hoje — ou nada, que é o caso na maioria dos dias."""
+    achada = cadencia.pendente(db, gancho=gancho, hoje=hoje_do_tenant(db))
+    return to_out(achada) if achada else None
+
+
+@router.get("/faltantes", response_model=list[PerguntaOut])
+def faltantes(
+    gancho: str = Query(...),
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> list[PerguntaOut]:
+    """Sem cadência: a sequência anunciada do núcleo e a lista da aba de configurações."""
+    return [to_out(p) for p in cadencia.faltantes(db, gancho=gancho)]
+
+
+@router.get("/respostas")
+def respostas(
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> dict[str, Any]:
+    return service.respostas(db)
+
+
+@router.put("/{key}", response_model=PerguntaOut)
+def responder(
+    key: str,
+    corpo: RespostaIn,
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut:
+    try:
+        service.responder(
+            db, tenant_id=user.tenant_id, key=key, valor=corpo.valor,
+            user_id=user.user_id, source=corpo.source,
+        )
+    except service.DnaError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    return to_out(catalog.POR_KEY[key])
+
+
+@router.post("/{key}/pular", response_model=PerguntaOut)
+def pular(
+    key: str,
+    corpo: PularIn,
+    user: CurrentUser = Depends(require_module("settings")),
+    db: Session = Depends(get_tenant_db),
+) -> PerguntaOut:
+    try:
+        service.pular(
+            db, tenant_id=user.tenant_id, key=key, user_id=user.user_id, source=corpo.source
+        )
+    except service.DnaError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    return to_out(catalog.POR_KEY[key])
+```
+
+- [ ] **Step 5: Registrar o router**
+
+Modificar `apps/api/app/modules/__init__.py`: adicionar o import junto aos outros (ordem alfabética) e a entrada em `ALL_ROUTERS`:
+
+```python
+from app.modules.dna.router import router as dna_router
+```
+
+```python
+ALL_ROUTERS: list[APIRouter] = [
+    # ... entradas existentes ...
+    dna_router,
+]
+```
+
+- [ ] **Step 6: Rodar os testes**
+
+Run: `cd apps/api && pytest tests/test_dna_router.py -v`
+Expected: PASS (8 testes)
+
+- [ ] **Step 7: Rodar a suíte inteira da Onda 1**
+
+Run: `cd apps/api && pytest`
+Expected: PASS. Nenhum teste existente muda — a Onda 1 não altera comportamento nenhum.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/dna/ apps/api/app/modules/__init__.py apps/api/tests/test_dna_router.py
+git commit -m "feat: rotas do DNA da Empresa, restritas a quem configura a empresa [V2]"
+```
+
+---
+
+# ONDA 2 — O DNA muda o briefing
+
+### Task 6: `dinheiro_com_data_dias` deixa de dividir número com o prazo da agenda
+
+**Files:**
+- Modify: `apps/api/app/modules/vima/absences.py:166`
+- Test: `apps/api/tests/test_vima_absences.py`
+
+**Interfaces:**
+- Consumes: `LIMIARES_PADRAO["dinheiro_com_data_dias"]` (a chave nasceu na Task 1)
+- Produces: nenhuma assinatura nova — `_dinheiro_com_data` passa a ler a chave própria
+
+**Refactor puro no dia do merge:** a chave nasce com `1`, idêntico ao `prazo_vencendo_dias` de hoje. Nenhum comportamento muda enquanto ninguém responde.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescentar a `apps/api/tests/test_vima_absences.py`:
+
+```python
+def test_conta_a_pagar_usa_o_limiar_proprio_e_nao_o_do_prazo(db: Session, dono):
+    """Prazo de entrega se quer saber em cima; boleto, com folga para ter o dinheiro.
+
+    Um número só para as duas coisas é a fusão que o DNA torna insustentável ao perguntar em
+    voz alta.
+    """
+    hoje = date(2026, 8, 8)
+    db.add(
+        Payable(
+            tenant_id=TENANT_ID, description="Aluguel", amount_cents=250000,
+            due_date=hoje + timedelta(days=5), status=PAYABLE_ABERTA,
+        )
+    )
+    db.commit()
+
+    # Antecedência curta: a conta de daqui a 5 dias ainda não é notícia.
+    curto = absences.coletar(
+        db, user=dono, hoje=hoje,
+        limiares={"prazo_vencendo_dias": 7, "dinheiro_com_data_dias": 1},
+    )
+    assert not [a for a in curto if a.kind == "financeiro.conta.vencendo"]
+
+    # Antecedência longa: agora é.
+    longo = absences.coletar(
+        db, user=dono, hoje=hoje,
+        limiares={"prazo_vencendo_dias": 0, "dinheiro_com_data_dias": 7},
+    )
+    assert [a for a in longo if a.kind == "financeiro.conta.vencendo"]
+```
+
+> **Nota para quem implementa:** o arquivo de teste já tem fixtures de tenant e usuário — reutilize as existentes (`TENANT_ID`, a fixture do dono) em vez de criar novas. Abra o arquivo e siga o padrão dos testes vizinhos para os imports de `Payable`/`PAYABLE_ABERTA`.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_vima_absences.py -k limiar_proprio -v`
+Expected: FAIL — a conta aparece no caso "curto", porque a regra ainda lê `prazo_vencendo_dias`.
+
+- [ ] **Step 3: Trocar a chave lida**
+
+Modificar `apps/api/app/modules/vima/absences.py`, dentro de `_dinheiro_com_data`, na linha do `limite`:
+
+```python
+def _dinheiro_com_data(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausencia]:
+    """Conta a pagar e cobrança a receber que a data alcançou.
+
+    ⚠️ As duas direções NÃO seguem a mesma regra, apesar de morarem juntas: conta a pagar tem
+    antecedência (`due_date <= hoje + limiar`), cobrança a receber só aparece DEPOIS de vencida
+    (`due_date < hoje`, sem limiar). Um recebimento que vence amanhã não é dito por ninguém —
+    dívida registrada no spec do V2, e o motivo de a pergunta do DNA falar só de conta a pagar.
+    """
+    limite = hoje + timedelta(days=lim["dinheiro_com_data_dias"])
+```
+
+- [ ] **Step 4: Rodar os testes**
+
+Run: `cd apps/api && pytest tests/test_vima_absences.py -v`
+Expected: PASS, inclusive os testes antigos — o default `1` preserva o comportamento anterior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/vima/absences.py apps/api/tests/test_vima_absences.py
+git commit -m "refactor: conta a pagar ganha limiar próprio, separado do prazo da agenda [V2]"
+```
+
+---
+
+### Task 7: O resolver liga o DNA ao briefing, e recalibrar limpa o silêncio
+
+**Files:**
+- Create: `apps/api/app/modules/dna/resolver.py`
+- Modify: `apps/api/app/modules/vima/service.py` (a chamada a `absences.coletar` e `_ja_reportadas`)
+- Modify: `apps/api/tests/test_fuso_do_tenant.py`
+- Test: `apps/api/tests/test_dna_resolver.py`, `apps/api/tests/test_dna_briefing.py`
+
+**Interfaces:**
+- Consumes: `service.respostas`, `catalog.PERGUNTAS`, `LIMIARES_PADRAO`, `DnaAnswer`
+- Produces: `limiares(db) -> dict[str, int | None]`, `retrato(db) -> dict[str, Any]`, `recalibrado_apos(db, quando: date) -> bool`
+
+- [ ] **Step 1: Escrever os testes do resolver**
+
+```python
+# apps/api/tests/test_dna_resolver.py
+"""O resolver é a ÚNICA porta de leitura do DNA."""
+from datetime import UTC, date, datetime
+
+from sqlalchemy.orm import Session
+
+from app.modules.dna import resolver, service
+from app.modules.dna.models import SOURCE_CONFIG, DnaAnswer
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+TENANT = "t1"
+
+
+def test_sem_resposta_devolve_dicionario_vazio(db: Session):
+    """Vazio, não os defaults: quem mescla é `coletar`, e duas fontes de default divergem."""
+    assert resolver.limiares(db) == {}
+
+
+def test_calibracao_respondida_vira_limiar(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {"card_parado_dias": 5}
+
+
+def test_retrato_nunca_entra_nos_limiares(db: Session):
+    """O contrato das classes vive ou morre aqui."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {}
+    assert resolver.retrato(db) == {"oferta.o_que_vende": "misto"}
+
+
+def test_calibracao_nunca_entra_no_retrato(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.retrato(db) == {}
+
+
+def test_desligar_topo_seco_vira_none_e_nao_some(db: Session):
+    """`None` = regra não executada. Sumir do dicionário faria o default de 5 dias voltar."""
+    service.responder(db, tenant_id=TENANT, key="cliente.topo_seco_dias", valor=None,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.limiares(db) == {"topo_sem_lead_dias": None}
+
+
+def test_valor_que_saiu_do_catalogo_cai_no_default(db: Session):
+    """Trocar o `valor` de uma opção deixa resposta órfã. Ela não pode derrubar o briefing."""
+    db.add(
+        DnaAnswer(
+            tenant_id=TENANT, question_key="ritmo.card_parado_dias", value=999,
+            answered_at=datetime.now(UTC), answered_by="u1", source=SOURCE_CONFIG,
+        )
+    )
+    db.commit()
+    assert "card_parado_dias" not in resolver.limiares(db)
+
+
+def test_toda_chave_devolvida_existe_em_limiares_padrao(db: Session):
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert set(resolver.limiares(db)) <= set(LIMIARES_PADRAO)
+
+
+def test_recalibrado_apos_olha_so_calibracao(db: Session):
+    """Responder Retrato não pode limpar o silêncio — nada no comportamento mudou."""
+    service.responder(db, tenant_id=TENANT, key="oferta.o_que_vende", valor="misto",
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.recalibrado_apos(db, date(2026, 1, 1)) is False
+
+    service.responder(db, tenant_id=TENANT, key="ritmo.card_parado_dias", valor=5,
+                      user_id="u1", source=SOURCE_CONFIG)
+    assert resolver.recalibrado_apos(db, date(2026, 1, 1)) is True
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && pytest tests/test_dna_resolver.py -v`
+Expected: FAIL com `ModuleNotFoundError: No module named 'app.modules.dna.resolver'`
+
+- [ ] **Step 3: Escrever o resolver**
+
+Criar `apps/api/app/modules/dna/resolver.py`:
+
+```python
+"""A única porta de leitura do DNA.
+
+Duas funções, e nada mais. Nenhum outro módulo lê `dna_answers` direto — é o que mantém a
+classe Retrato honestamente SEM consumidor até o V4, em vez de ela vazar por um `select`
+esperto em algum lugar, que é como um contrato de arquitetura morre na prática.
+
+⚠️ **Módulo PURO:** não lê relógio. `recalibrado_apos` recebe a data de comparação por
+parâmetro.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.dna import catalog
+from app.modules.dna.models import DnaAnswer
+from app.modules.vima.absences import LIMIARES_PADRAO
+
+_CALIBRACAO_POR_KEY = {
+    p.key: p for p in catalog.PERGUNTAS if p.classe == catalog.CALIBRACAO
+}
+
+
+def limiares(db: Session) -> dict[str, int | None]:
+    """Só as respostas de Calibração, prontas para `absences.coletar(..., limiares=...)`.
+
+    Devolve **só o que foi respondido**, nunca os defaults: quem mescla é `coletar`, com
+    `{**LIMIARES_PADRAO, **override}`. Uma segunda fonte de default divergiria da primeira no
+    dia em que alguém mudasse um número em só um dos lugares.
+    """
+    fora: dict[str, int | None] = {}
+    for linha in db.scalars(select(DnaAnswer)).all():
+        pergunta = _CALIBRACAO_POR_KEY.get(linha.question_key)
+        if pergunta is None or pergunta.consome not in LIMIARES_PADRAO:
+            continue
+        # A resposta precisa continuar sendo uma das opções. Trocar o `valor` de uma opção
+        # depois de alguém responder deixa a linha órfã — e uma resposta órfã tem que cair no
+        # default, não derrubar o briefing do dia.
+        if linha.value not in {o.valor for o in pergunta.opcoes}:
+            continue
+        fora[pergunta.consome] = linha.value
+    return fora
+
+
+def retrato(db: Session) -> dict[str, Any]:
+    """O dossiê. **Sem consumidor no V2** — existe para que o V4 encontre a porta pronta."""
+    return {
+        linha.question_key: linha.value
+        for linha in db.scalars(select(DnaAnswer)).all()
+        if linha.value is not None and linha.question_key not in _CALIBRACAO_POR_KEY
+    }
+
+
+def recalibrado_apos(db: Session, quando: date) -> bool:
+    """Houve resposta de CALIBRAÇÃO depois desta data?
+
+    É o gatilho da limpeza do silêncio em `vima/service._ja_reportadas`. Só Calibração conta:
+    responder Retrato não muda comportamento nenhum, e limpar o silêncio por causa disso faria
+    o briefing repetir pendências sem motivo.
+    """
+    for linha in db.scalars(select(DnaAnswer)).all():
+        if linha.question_key in _CALIBRACAO_POR_KEY and linha.answered_at.date() > quando:
+            return True
+    return False
+```
+
+- [ ] **Step 4: Rodar os testes do resolver**
+
+Run: `cd apps/api && pytest tests/test_dna_resolver.py -v`
+Expected: PASS (8 testes)
+
+- [ ] **Step 5: Escrever os testes de integração com o briefing**
+
+```python
+# apps/api/tests/test_dna_briefing.py
+"""O DNA chegando ao briefing — a ponta que justifica a onda inteira."""
+import pytest
+from fastapi.testclient import TestClient
+
+REGISTER = {
+    "email": "dono@exemplo.com",
+    "password": "senha-forte-123",
+    "tenant_name": "Estúdio de Uma Pessoa",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_desligar_topo_seco_cala_a_ausencia_no_briefing(client: TestClient, headers, monkeypatch):
+    """A ponta a ponta: responder muda o que o dono lê amanhã."""
+    from app.core import ai
+
+    monkeypatch.setattr(
+        ai, "complete",
+        lambda **kw: type("R", (), {"text": "prosa", "input_tokens": 1, "output_tokens": 1})(),
+    )
+
+    antes = client.get("/vima/briefing", headers=headers).json()
+    assert any("lead" in linha["texto"].lower() or "cliente novo" in linha["texto"].lower()
+               for linha in antes["linhas"]), "o tenant novo deveria ter topo seco"
+
+    client.put(
+        "/dna/cliente.topo_seco_dias", json={"valor": None, "source": "gancho"}, headers=headers
+    )
+
+    # O briefing de HOJE não é regerado (idempotente por dia) — a resposta vale de amanhã.
+    depois = client.get("/vima/briefing", headers=headers).json()
+    assert depois["id"] == antes["id"]
+```
+
+> **Nota para quem implementa:** este teste depende de o tenant recém-criado disparar
+> `comercial.topo.sem_lead`. Confirme rodando `pytest tests/test_vima_briefing.py -v` primeiro e
+> olhando o payload de `test_dia_sem_nada_devolve_briefing_vazio_e_nao_falha`. Se o tenant novo
+> **não** disparar aquela ausência, ajuste a asserção do `antes` para a ausência que ele de fato
+> produz e mantenha o resto do teste — o que se está provando é que a resposta chega ao
+> `coletar` e que o briefing do dia não é regerado.
+
+- [ ] **Step 6: Ligar o resolver no serviço da Vima**
+
+Modificar `apps/api/app/modules/vima/service.py`, na chamada a `absences.coletar` dentro de `gerar_ou_ler`:
+
+```python
+        ausencias=absences.coletar(
+            db, user=user, hoje=dia, agora=agora,
+            limiares=dna_resolver.limiares(db),
+            ja_reportadas=_ja_reportadas(db, user=user),
+        ),
+```
+
+E o import, junto aos outros:
+
+```python
+from app.modules.dna import resolver as dna_resolver
+```
+
+- [ ] **Step 7: Limpar o silêncio quando o dono recalibra**
+
+Modificar `_ja_reportadas` em `apps/api/app/modules/vima/service.py`:
+
+```python
+def _ja_reportadas(db: Session, *, user: CurrentUser) -> dict[str, int]:
+    """As ausências que o briefing anterior deste usuário já disse — a regra do silêncio.
+
+    ⚠️ **Recalibrar zera o registro.** Se o dono aperta "card parado" de 10 para 5 dias e o
+    briefing continua calado porque já disse aquilo ontem, a configuração parece quebrada — e a
+    próxima que ele mexer, ele não acredita.
+
+    A limpeza é GROSSA de propósito: derruba o silêncio de todas as regras, não só da que
+    mudou. Mesma linha do fator 2 da escalada, "arbitrário e deliberadamente grosso".
+    Discriminar por regra exigiria um mapa `kind`→limiar que existiria só para isto, e
+    recalibrar é raro.
+    """
+    anterior = db.scalar(
+        select(Briefing)
+        .where(Briefing.user_id == user.user_id)
+        .order_by(Briefing.reference_date.desc())
+        .limit(1)
+    )
+    if anterior is None:
+        return {}
+    if dna_resolver.recalibrado_apos(db, anterior.reference_date):
+        return {}
+    try:
+        dados = json.loads(anterior.payload)
+    except (TypeError, ValueError):  # payload corrompido não pode calar o briefing de hoje
+        return {}
+    return {str(k): int(v) for k, v in (dados.get("ausencias_ditas") or {}).items()}
+```
+
+- [ ] **Step 8: Estender o gate de fuso ao módulo `dna`**
+
+Modificar `apps/api/tests/test_fuso_do_tenant.py`, depois do bloco da Vima:
+
+```python
+DNA_DIR = pathlib.Path(__file__).resolve().parents[1] / "app" / "modules" / "dna"
+
+# Puros por contrato: recebem `hoje` por parâmetro e não podem tocar no relógio nem para
+# instante. `service.py` PODE carimbar instante (`answered_at`) e não pode derivar "hoje".
+DNA_PUROS = {"catalog.py", "cadencia.py", "resolver.py"}
+
+
+@pytest.mark.parametrize("caminho", sorted(DNA_DIR.glob("*.py")), ids=lambda p: p.name)
+def test_dna_nunca_deriva_hoje_do_relogio_do_servidor(caminho: pathlib.Path):
+    arvore = ast.parse(caminho.read_text(encoding="utf-8"))
+    puro = caminho.name in DNA_PUROS
+
+    for forma, no in _chamadas_de_relogio(arvore):
+        if forma in {"today", "utcnow"} or _vira_data(arvore, no):
+            pytest.fail(
+                f"{caminho.name}:{no.lineno} deriva 'hoje' do relógio do servidor. "
+                "A cadência do DNA é por DIA — em UTC−3 isso interroga o dono duas vezes."
+            )
+        if puro:
+            pytest.fail(
+                f"{caminho.name}:{no.lineno} lê o relógio, e este módulo é PURO: "
+                "`hoje` entra por parâmetro, e quem o deriva é o router."
+            )
+
+
+def test_o_gate_do_dna_tem_o_que_varrer():
+    """A instanciação obrigatória: um conjunto vazio passaria calado para sempre."""
+    arquivos = {p.name for p in DNA_DIR.glob("*.py")}
+    assert DNA_PUROS <= arquivos
+    assert "service.py" in arquivos
+```
+
+- [ ] **Step 9: Rodar a suíte inteira do backend**
+
+Run: `cd apps/api && pytest`
+Expected: PASS. Se `test_dna_briefing.py` falhar na asserção do `antes`, siga a nota do Step 5.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/app/modules/dna/resolver.py apps/api/app/modules/vima/service.py apps/api/tests/test_dna_resolver.py apps/api/tests/test_dna_briefing.py apps/api/tests/test_fuso_do_tenant.py
+git commit -m "feat: o DNA calibra o briefing, e recalibrar limpa a regra do silêncio [V2]"
+```
+
+---
+
+# ONDA 3 — O núcleo no primeiro acesso
+
+### Task 8: Tipos compartilhados e o componente único de pergunta
+
+**Files:**
+- Modify: `packages/shared-types/src/index.ts`
+- Create: `apps/web/src/features/dna/PerguntaDaVima.tsx`
+- Test: `apps/web/src/features/dna/PerguntaDaVima.test.tsx`
+
+**Interfaces:**
+- Consumes: `api` de `../../lib/api`
+- Produces: tipos `DnaOpcao`, `DnaPergunta`; componente `PerguntaDaVima({ pergunta, source, onPronto, onPular })` — `onPronto` dispara depois do PUT, `onPular` depois do POST de pular
+
+- [ ] **Step 1: Acrescentar os tipos**
+
+Modificar `packages/shared-types/src/index.ts`, ao lado das interfaces `Briefing`:
+
+```typescript
+export interface DnaOpcao {
+  rotulo: string;
+  valor: string | number | null;
+}
+
+/** Uma pergunta do DNA da Empresa. Viaja INTEIRA do backend — o front não tem cópia do
+ *  catálogo, porque duas cópias divergem no primeiro ajuste de texto. */
+export interface DnaPergunta {
+  key: string;
+  /** "calibracao" muda o briefing de amanhã; "retrato" é guardado para depois. A tela DIZ
+   *  isso — prometer efeito imediato ao Retrato seria o erro que as classes existem para
+   *  impedir. */
+  classe: "calibracao" | "retrato";
+  eixo: "oferta" | "cliente" | "ritmo" | "dinheiro" | "limites";
+  texto: string;
+  formato: "escolha" | "escolha_multipla" | "texto";
+  opcoes: DnaOpcao[];
+}
+```
+
+- [ ] **Step 2: Escrever o teste que falha**
+
+```tsx
+// apps/web/src/features/dna/PerguntaDaVima.test.tsx
+import type { DnaPergunta } from "@e1p/shared-types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+vi.mock("../../lib/api", () => ({
+  api: { put: vi.fn().mockResolvedValue({ data: {} }), post: vi.fn().mockResolvedValue({ data: {} }) },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+const ESCOLHA: DnaPergunta = {
+  key: "ritmo.card_parado_dias",
+  classe: "calibracao",
+  eixo: "ritmo",
+  texto: "Uma negociação parada há quanto tempo te incomoda?",
+  formato: "escolha",
+  opcoes: [
+    { rotulo: "5 dias", valor: 5 },
+    { rotulo: "10 dias", valor: 10 },
+  ],
+};
+
+const TEXTO: DnaPergunta = {
+  key: "limites.nunca_faco",
+  classe: "retrato",
+  eixo: "limites",
+  texto: "O que você nunca faz?",
+  formato: "texto",
+  opcoes: [],
+};
+
+describe("PerguntaDaVima", () => {
+  it("responde uma escolha em um toque", async () => {
+    const onPronto = vi.fn();
+    render(<PerguntaDaVima pergunta={ESCOLHA} source="gancho" onPronto={onPronto} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "5 dias" }));
+
+    await waitFor(() => expect(onPronto).toHaveBeenCalled());
+    expect(api.put).toHaveBeenCalledWith("/dna/ritmo.card_parado_dias", {
+      valor: 5,
+      source: "gancho",
+    });
+  });
+
+  it("avisa que Calibração vale a partir de amanhã", () => {
+    render(<PerguntaDaVima pergunta={ESCOLHA} source="gancho" onPronto={vi.fn()} />);
+    expect(screen.getByText(/a partir de amanhã/i)).toBeInTheDocument();
+  });
+
+  it("avisa que Retrato fica guardado, sem prometer efeito", () => {
+    render(<PerguntaDaVima pergunta={TEXTO} source="config" onPronto={vi.fn()} />);
+    expect(screen.getByText(/guardad/i)).toBeInTheDocument();
+    expect(screen.queryByText(/a partir de amanhã/i)).not.toBeInTheDocument();
+  });
+
+  it("pular chama a rota de pular e não a de responder", async () => {
+    const onPular = vi.fn();
+    render(
+      <PerguntaDaVima pergunta={TEXTO} source="gancho" onPronto={vi.fn()} onPular={onPular} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /depois/i }));
+
+    await waitFor(() => expect(onPular).toHaveBeenCalled());
+    expect(api.post).toHaveBeenCalledWith("/dna/limites.nunca_faco/pular", { source: "gancho" });
+  });
+});
+```
+
+- [ ] **Step 3: Rodar e ver falhar**
+
+Run: `pnpm --filter @e1p/web test -- PerguntaDaVima`
+Expected: FAIL — o módulo `./PerguntaDaVima` não existe.
+
+- [ ] **Step 4: Escrever o componente**
+
+Criar `apps/web/src/features/dna/PerguntaDaVima.tsx`:
+
+```tsx
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useState } from "react";
+import { api, apiErrorMessage } from "../../lib/api";
+
+type Props = {
+  pergunta: DnaPergunta;
+  source: "nucleo" | "gancho" | "config";
+  onPronto: () => void;
+  onPular?: () => void;
+};
+
+/**
+ * A pergunta do DNA, em um único componente para todas as superfícies (núcleo, gancho, config).
+ *
+ * **A tela DIZ o que cada classe faz.** Calibração vale a partir de amanhã — o briefing de hoje
+ * é idempotente e já foi narrado, e mentir sobre isso custa mais que explicar. Retrato é
+ * guardado, e prometer efeito imediato a ele seria exatamente o erro que as duas classes
+ * existem para impedir: um produto que finge ouvir é pior que um que não pergunta.
+ *
+ * Desenhado para 360px: opções são blocos de largura inteira, não uma linha de pílulas.
+ */
+export default function PerguntaDaVima({ pergunta, source, onPronto, onPular }: Props) {
+  const [texto, setTexto] = useState("");
+  const [marcadas, setMarcadas] = useState<(string | number | null)[]>([]);
+  const [salvando, setSalvando] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  async function responder(valor: unknown) {
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.put(`/dna/${pergunta.key}`, { valor, source });
+      onPronto();
+    } catch (e) {
+      setErro(apiErrorMessage(e));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function pular() {
+    setSalvando(true);
+    setErro(null);
+    try {
+      await api.post(`/dna/${pergunta.key}/pular`, { source });
+      (onPular ?? onPronto)();
+    } catch (e) {
+      setErro(apiErrorMessage(e));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-4">
+      <p className="text-base font-medium text-neutral-800">{pergunta.texto}</p>
+      <p className="mt-1 text-xs text-neutral-500">
+        {pergunta.classe === "calibracao"
+          ? "Isso muda o seu resumo a partir de amanhã."
+          : "Fica guardado para a Vima te conhecer melhor."}
+      </p>
+
+      {pergunta.formato === "escolha" && (
+        <div className="mt-3 space-y-2">
+          {pergunta.opcoes.map((o) => (
+            <button
+              key={o.rotulo}
+              type="button"
+              disabled={salvando}
+              onClick={() => responder(o.valor)}
+              className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-left text-sm text-neutral-700 hover:border-neutral-400 disabled:opacity-50"
+            >
+              {o.rotulo}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {pergunta.formato === "escolha_multipla" && (
+        <div className="mt-3 space-y-2">
+          {pergunta.opcoes.map((o) => {
+            const ativa = marcadas.includes(o.valor);
+            return (
+              <button
+                key={o.rotulo}
+                type="button"
+                disabled={salvando}
+                onClick={() =>
+                  setMarcadas(ativa ? marcadas.filter((v) => v !== o.valor) : [...marcadas, o.valor])
+                }
+                className={`w-full rounded-lg border px-4 py-3 text-left text-sm disabled:opacity-50 ${
+                  ativa
+                    ? "border-neutral-800 bg-neutral-800 text-white"
+                    : "border-neutral-200 text-neutral-700 hover:border-neutral-400"
+                }`}
+              >
+                {o.rotulo}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            disabled={salvando || marcadas.length === 0}
+            onClick={() => responder(marcadas)}
+            className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-sm font-medium text-white disabled:opacity-40"
+          >
+            Confirmar
+          </button>
+        </div>
+      )}
+
+      {pergunta.formato === "texto" && (
+        <div className="mt-3 space-y-2">
+          <textarea
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            className="w-full rounded-lg border border-neutral-200 p-3 text-sm text-neutral-700"
+            placeholder="Escreva do seu jeito"
+          />
+          <button
+            type="button"
+            disabled={salvando || texto.trim() === ""}
+            onClick={() => responder(texto.trim())}
+            className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-sm font-medium text-white disabled:opacity-40"
+          >
+            Salvar
+          </button>
+        </div>
+      )}
+
+      {erro && <p className="mt-2 text-xs text-red-600">{erro}</p>}
+
+      <button
+        type="button"
+        disabled={salvando}
+        onClick={pular}
+        className="mt-3 text-xs text-neutral-400 underline disabled:opacity-50"
+      >
+        Responder depois
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Rodar os testes**
+
+Run: `pnpm --filter @e1p/web test -- PerguntaDaVima`
+Expected: PASS (4 testes)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared-types/src/index.ts apps/web/src/features/dna/
+git commit -m "feat: o componente único de pergunta do DNA, com o rótulo honesto por classe [V2]"
+```
+
+---
+
+### Task 9: O núcleo de 6 no primeiro acesso
+
+**Files:**
+- Create: `apps/web/src/features/dna/NucleoPage.tsx`
+- Modify: `apps/web/src/features/vima/EntradaDoDia.tsx`
+- Modify: `apps/web/src/app/App.tsx`
+- Test: `apps/web/src/features/dna/NucleoPage.test.tsx`, `apps/web/src/features/vima/EntradaDoDia.test.tsx`
+
+**Interfaces:**
+- Consumes: `PerguntaDaVima`, `api`, `GET /dna/faltantes?gancho=nucleo`
+- Produces: rota `/dna/nucleo`; `EntradaDoDia` ganha o estado `"nucleo"` e a chave `CHAVE_NUCLEO`
+
+- [ ] **Step 1: Escrever o teste do NucleoPage**
+
+```tsx
+// apps/web/src/features/dna/NucleoPage.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import NucleoPage from "./NucleoPage";
+
+const PERGUNTAS = [
+  {
+    key: "oferta.o_que_vende",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você vende?",
+    formato: "escolha",
+    opcoes: [{ rotulo: "Serviço por projeto", valor: "servico_projeto" }],
+  },
+  {
+    key: "oferta.em_uma_frase",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você responde?",
+    formato: "texto",
+    opcoes: [],
+  },
+];
+
+vi.mock("../../lib/api", () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: PERGUNTAS }),
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+describe("NucleoPage", () => {
+  it("mostra uma pergunta por vez, com o progresso visível", async () => {
+    render(
+      <MemoryRouter>
+        <NucleoPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("O que você vende?")).toBeInTheDocument());
+    expect(screen.queryByText("O que você responde?")).not.toBeInTheDocument();
+    expect(screen.getByText("1 de 2")).toBeInTheDocument();
+  });
+
+  it("oferece sair da sequência inteira — não é um beco", async () => {
+    render(
+      <MemoryRouter>
+        <NucleoPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /pular por enquanto/i })).toBeInTheDocument(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `pnpm --filter @e1p/web test -- NucleoPage`
+Expected: FAIL — o módulo não existe.
+
+- [ ] **Step 3: Escrever a página**
+
+Criar `apps/web/src/features/dna/NucleoPage.tsx`:
+
+```tsx
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+/** Marca de "o núcleo já foi decidido NESTE aparelho". Espelha `CHAVE_ENTRADA` do briefing. */
+export const CHAVE_NUCLEO = "e1p_dna_nucleo";
+
+/**
+ * As seis perguntas do primeiro acesso.
+ *
+ * **Nenhuma é de Calibração, e essa é a inversão central do design.** "Em quanto tempo eu te
+ * aviso que ninguém respondeu o Carlos?" é impossível de responder bem antes de ter visto um
+ * briefing — a resposta seria um chute que depois vira comportamento errado com aparência de
+ * configuração deliberada. Calibração vem por gancho, colada à ausência que a motivou.
+ *
+ * **É sequência anunciada, não interrogatório:** fim visível ("2 de 6") e saída em um toque. Por
+ * isso é a exceção declarada à regra de uma pergunta por dia — o que cansa é a interrupção não
+ * anunciada, não a sequência que a pessoa entrou sabendo que ia atravessar.
+ */
+export default function NucleoPage() {
+  const navegar = useNavigate();
+  const [perguntas, setPerguntas] = useState<DnaPergunta[] | null>(null);
+  const [i, setI] = useState(0);
+
+  useEffect(() => {
+    api
+      .get<DnaPergunta[]>("/dna/faltantes", { params: { gancho: "nucleo" } })
+      .then(({ data }) => setPerguntas(data))
+      .catch(() => sair());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function sair() {
+    try {
+      localStorage.setItem(CHAVE_NUCLEO, "1");
+    } catch {
+      // Sem a marca, a entrada volta a perguntar ao servidor — mais lento, correto.
+    }
+    navegar("/", { replace: true });
+  }
+
+  function avancar() {
+    if (perguntas && i + 1 < perguntas.length) setI(i + 1);
+    else sair();
+  }
+
+  if (!perguntas) {
+    return <div className="py-10 text-center text-sm text-neutral-400">Um instante…</div>;
+  }
+  if (perguntas.length === 0) {
+    sair();
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 p-4">
+      <div>
+        <p className="text-sm text-neutral-500">
+          {i + 1} de {perguntas.length}
+        </p>
+        <h1 className="text-xl font-bold text-neutral-800">Me conta do seu negócio</h1>
+        <p className="mt-1 text-sm text-neutral-500">
+          Leva menos de dois minutos e é o que faz o resumo diário falar a sua língua.
+        </p>
+      </div>
+
+      <PerguntaDaVima
+        key={perguntas[i].key}
+        pergunta={perguntas[i]}
+        source="nucleo"
+        onPronto={avancar}
+        onPular={avancar}
+      />
+
+      <button
+        type="button"
+        onClick={sair}
+        className="w-full text-center text-xs text-neutral-400 underline"
+      >
+        Pular por enquanto
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Rodar o teste da página**
+
+Run: `pnpm --filter @e1p/web test -- NucleoPage`
+Expected: PASS (2 testes)
+
+- [ ] **Step 5: Escrever o teste da nova decisão de entrada**
+
+Acrescentar a `apps/web/src/features/vima/EntradaDoDia.test.tsx` — siga o padrão dos testes já existentes no arquivo para mockar `api` e `useFuso`:
+
+```tsx
+it("manda ao núcleo no primeiro acesso, antes do briefing", async () => {
+  localStorage.clear();
+  // `api.get` responde: /dna/faltantes → 6 perguntas; /vima/briefing → não lido
+  render(
+    <MemoryRouter>
+      <EntradaDoDia>
+        <div>cockpit</div>
+      </EntradaDoDia>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.queryByText("cockpit")).not.toBeInTheDocument());
+});
+
+it("não volta ao núcleo depois de ele ter sido decidido neste aparelho", async () => {
+  localStorage.setItem("e1p_dna_nucleo", "1");
+  // briefing já lido → cockpit
+  render(
+    <MemoryRouter>
+      <EntradaDoDia>
+        <div>cockpit</div>
+      </EntradaDoDia>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("cockpit")).toBeInTheDocument());
+});
+```
+
+- [ ] **Step 6: Acrescentar o terceiro estado à entrada**
+
+Modificar `apps/web/src/features/vima/EntradaDoDia.tsx`:
+
+```tsx
+type Decisao = "perguntando" | "nucleo" | "vima" | "cockpit";
+```
+
+No `useEffect`, antes da chamada ao briefing:
+
+```tsx
+    // O núcleo vem ANTES do briefing, e só no primeiro acesso: um dono que nunca respondeu nada
+    // recebe um briefing que fala com todo mundo do mesmo jeito. Perguntar primeiro é o que
+    // torna a primeira leitura dele já calibrada — de amanhã em diante.
+    if (lerMarcaNucleo() === null) {
+      api
+        .get<unknown[]>("/dna/faltantes", { params: { gancho: "nucleo" } })
+        .then(({ data }) => {
+          if (!vivo) return;
+          if (data.length > 0) {
+            setDecisao("nucleo");
+            return;
+          }
+          gravarMarcaNucleo();
+          decidirPeloBriefing();
+        })
+        // 403 = sub-usuário sem `settings`. O DNA é da empresa e não é dele: segue para o
+        // briefing normalmente, sem nunca ver a pergunta.
+        .catch(() => decidirPeloBriefing());
+      return;
+    }
+    decidirPeloBriefing();
+```
+
+E, junto às funções de marca já existentes:
+
+```tsx
+export const CHAVE_NUCLEO = "e1p_dna_nucleo";
+
+function lerMarcaNucleo(): string | null {
+  try {
+    return localStorage.getItem(CHAVE_NUCLEO);
+  } catch {
+    return null;
+  }
+}
+
+function gravarMarcaNucleo(): void {
+  try {
+    localStorage.setItem(CHAVE_NUCLEO, "1");
+  } catch {
+    // Sem a marca, a entrada consulta o servidor toda visita — mais lento, correto.
+  }
+}
+```
+
+E o novo destino:
+
+```tsx
+  if (decisao === "nucleo") return <Navigate to="/dna/nucleo" replace />;
+```
+
+> **Nota para quem implementa:** o `useEffect` atual tem a chamada ao briefing inline. Extraia
+> aquele trecho para uma função local `decidirPeloBriefing()` dentro do efeito, preservando o
+> `gravarMarca(hoje)` e o `catch` que cai no cockpit. Não mude o comportamento existente — só
+> ganhe um caminho antes dele.
+
+- [ ] **Step 7: Registrar a rota**
+
+Modificar `apps/web/src/app/App.tsx`, ao lado da rota `/vima`:
+
+```tsx
+import NucleoPage from "../features/dna/NucleoPage";
+```
+
+```tsx
+          <Route path="/dna/nucleo" element={<NucleoPage />} />
+```
+
+> A rota fica no mesmo bloco de `/vima` — dentro do `ProtectedBareLayout`, sem o shell do app.
+> O núcleo é porta de entrada, não uma página do produto.
+
+- [ ] **Step 8: Rodar a suíte do front**
+
+Run: `pnpm --filter @e1p/web test`
+Expected: PASS. Nenhum teste existente de `EntradaDoDia` pode quebrar — o caminho novo só roda quando a marca do núcleo está ausente.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web/src/features/dna/ apps/web/src/features/vima/EntradaDoDia.tsx apps/web/src/app/App.tsx
+git commit -m "feat: o núcleo de seis perguntas no primeiro acesso [V2]"
+```
+
+---
+
+# ONDA 4 — Os ganchos
+
+### Task 10: `GanchoDaVima` e a Calibração colada à ausência
+
+**Files:**
+- Create: `apps/web/src/features/dna/GanchoDaVima.tsx`
+- Modify: `apps/web/src/features/vima/BriefingPage.tsx`
+- Test: `apps/web/src/features/dna/GanchoDaVima.test.tsx`
+
+**Interfaces:**
+- Consumes: `PerguntaDaVima`, `GET /dna/pendente?gancho=`
+- Produces: `GanchoDaVima({ gancho })` — renderiza a pergunta pendente daquele gancho, ou `null`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```tsx
+// apps/web/src/features/dna/GanchoDaVima.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import GanchoDaVima from "./GanchoDaVima";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), put: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+describe("GanchoDaVima", () => {
+  it("não renderiza nada quando não há pergunta para hoje", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: null });
+    const { container } = render(<GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("some depois de responder, sem recarregar a tela", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: {
+        key: "ritmo.card_parado_dias",
+        classe: "calibracao",
+        eixo: "ritmo",
+        texto: "Há quanto tempo te incomoda?",
+        formato: "escolha",
+        opcoes: [{ rotulo: "5 dias", valor: 5 }],
+      },
+    });
+    vi.mocked(api.put).mockResolvedValue({ data: {} });
+
+    render(<GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />);
+    await waitFor(() => expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument());
+
+    screen.getByRole("button", { name: "5 dias" }).click();
+    await waitFor(() =>
+      expect(screen.queryByText("Há quanto tempo te incomoda?")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("erro na busca não derruba a tela hospedeira", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("403"));
+    const { container } = render(<GanchoDaVima gancho="qualquer" />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `pnpm --filter @e1p/web test -- GanchoDaVima`
+Expected: FAIL — o módulo não existe.
+
+- [ ] **Step 3: Escrever o componente**
+
+Criar `apps/web/src/features/dna/GanchoDaVima.tsx`:
+
+```tsx
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "./PerguntaDaVima";
+
+/**
+ * A pergunta do DNA colada ao contexto que a torna óbvia.
+ *
+ * **Falha em silêncio, sempre.** Um 403 (sub-usuário sem `settings`) ou uma rede ruim não podem
+ * derrubar a tela hospedeira — o DNA é acessório em toda superfície onde aparece. Erro aqui
+ * significa "não pergunta hoje", nunca "quebra o briefing".
+ *
+ * A cadência inteira mora no servidor (`dna/cadencia.py`): uma pergunta por dia no produto
+ * inteiro, pulada em quarentena de 7 dias. O componente só mostra o que lhe deram.
+ */
+export default function GanchoDaVima({ gancho }: { gancho: string }) {
+  const [pergunta, setPergunta] = useState<DnaPergunta | null>(null);
+
+  useEffect(() => {
+    let vivo = true;
+    api
+      .get<DnaPergunta | null>("/dna/pendente", { params: { gancho } })
+      .then(({ data }) => {
+        if (vivo) setPergunta(data ?? null);
+      })
+      .catch(() => {
+        if (vivo) setPergunta(null);
+      });
+    return () => {
+      vivo = false;
+    };
+  }, [gancho]);
+
+  if (!pergunta) return null;
+
+  return (
+    <div className="mt-2">
+      <PerguntaDaVima
+        pergunta={pergunta}
+        source="gancho"
+        onPronto={() => setPergunta(null)}
+        onPular={() => setPergunta(null)}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Rodar os testes**
+
+Run: `pnpm --filter @e1p/web test -- GanchoDaVima`
+Expected: PASS (3 testes)
+
+- [ ] **Step 5: Colar o gancho na linha de ausência do briefing**
+
+Modificar `apps/web/src/features/vima/BriefingPage.tsx`. Abra o arquivo e encontre onde as
+`linhas` do briefing são renderizadas. Depois da **primeira** linha cuja `secao` é a de
+pendências, inserir:
+
+```tsx
+{primeiraAusencia && <GanchoDaVima gancho={`briefing.ausencia.${primeiraAusencia.kind}`} />}
+```
+
+**O `kind` não viaja hoje — é preciso fazê-lo viajar.** `Linha` (composer.py:86) carrega só
+`secao`, `module` e `texto`; o `kind` existe apenas dentro de `Candidato.chave`, no formato
+`"{kind}:{subject_id}"`. São quatro edições, nesta ordem:
+
+**(a)** Teste primeiro, em `apps/api/tests/test_vima_briefing.py`:
+
+```python
+def test_a_linha_de_ausencia_carrega_o_kind(client: TestClient, headers):
+    """Sem o kind na linha, a pergunta do DNA não tem como se colar à ausência certa."""
+    corpo = client.get("/vima/briefing", headers=headers).json()
+    pendentes = [linha for linha in corpo["linhas"] if linha["secao"] == "PENDENTE"]
+    assert pendentes, "o tenant novo deveria ter ao menos uma pendência"
+    assert pendentes[0]["kind"], "a linha de pendência não trouxe o kind"
+```
+
+**(b)** `apps/api/app/modules/vima/composer.py` — acrescentar o campo a `Candidato` (junto de
+`chave` e `dias`, que já são "só ausência preenche"):
+
+```python
+    # Só ausência preenche: a chave e a intensidade que alimentam a regra do silêncio.
+    chave: str | None = None
+    dias: int = 0
+    # Só ausência preenche: é o que permite ao V2 colar a pergunta de calibração na linha que a
+    # motivou. Fica separado de `chave` de propósito — aquela é uma chave composta com
+    # `subject_id`, e fatiá-la no front acoplaria a tela ao formato dela.
+    kind: str = ""
+```
+
+a `Linha`:
+
+```python
+class Linha(BaseModel):
+    secao: str
+    module: str
+    texto: str
+    kind: str = ""
+```
+
+em `_da_ausencia`, passar `kind=a.kind` junto de `chave=` e `dias=`, e na construção do payload
+(linha 120):
+
+```python
+        linhas=[
+            Linha(secao=c.secao, module=c.module, texto=c.texto, kind=c.kind) for c in mantidas
+        ],
+```
+
+> **Nota:** `Linha` pode ser dataclass em vez de `BaseModel` — abra o arquivo e siga o que
+> estiver lá. O default `""` é obrigatório em qualquer um dos dois: **briefings já gravados não
+> têm `kind` no payload**, e ler um deles sem default estoura na desserialização.
+
+**(c)** `apps/api/app/modules/vima/schemas.py` — `LinhaOut` ganha `kind: str = ""`. `to_out` já
+faz `LinhaOut(**linha)`, então nada mais muda ali.
+
+**(d)** `packages/shared-types/src/index.ts` — `BriefingLinha` ganha `kind: string`.
+
+- [ ] **Step 6: Rodar as duas suítes**
+
+Run: `cd apps/api && pytest tests/test_vima_briefing.py -v && cd ../.. && pnpm --filter @e1p/web test`
+Expected: PASS nas duas.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/dna/GanchoDaVima.tsx apps/web/src/features/dna/GanchoDaVima.test.tsx apps/web/src/features/vima/BriefingPage.tsx apps/api/app/modules/vima/schemas.py packages/shared-types/src/index.ts apps/api/tests/test_vima_briefing.py
+git commit -m "feat: a Calibração chega colada à ausência que a motivou [V2]"
+```
+
+---
+
+### Task 11: Os ganchos de contexto
+
+**Files:**
+- Modify: `apps/web/src/features/crm/` (a tela que lista contatos, depois de criar um)
+- Modify: `apps/web/src/features/receivables/`, `apps/web/src/features/quotes/`, `apps/web/src/features/payables/`, `apps/web/src/features/agenda/`
+- Test: nenhum novo — `GanchoDaVima` já está coberto
+
+**Interfaces:**
+- Consumes: `GanchoDaVima`
+
+Os cinco ganchos declarados no catálogo, cada um numa tela onde a resposta é óbvia:
+
+| Gancho | Tela | Perguntas que ele serve |
+|---|---|---|
+| `crm.cliente.criado` | lista de contatos do CRM | `cliente.quem_e`, `cliente.decisao_tempo` |
+| `receivables.cobranca.criada` | lista de cobranças | `dinheiro.atraso_reacao`, `dinheiro.formas_recebimento` |
+| `quotes.orcamento.criado` | lista de orçamentos | `oferta.ticket_tipico`, `oferta.proposta_formal`, `limites.desconto` |
+| `payables.conta.criada` | lista de contas a pagar | `dinheiro.emite_nota` |
+| `agenda.evento.criado` | agenda | `limites.horario_contato` |
+
+- [ ] **Step 1: Localizar as cinco telas**
+
+Run: `ls apps/web/src/features/crm apps/web/src/features/receivables apps/web/src/features/quotes apps/web/src/features/payables apps/web/src/features/agenda`
+Anote o componente de LISTA de cada módulo (o que a rota do menu abre).
+
+- [ ] **Step 2: Inserir o gancho em cada uma**
+
+Em cada tela, logo **abaixo do cabeçalho e acima da lista**, inserir:
+
+```tsx
+<GanchoDaVima gancho="crm.cliente.criado" />
+```
+
+(trocando o valor pelo gancho da tabela acima). O import:
+
+```tsx
+import GanchoDaVima from "../dna/GanchoDaVima";
+```
+
+**Só isso.** O componente já decide sozinho se aparece — a cadência inteira mora no servidor, e
+uma tela sem pergunta do dia renderiza `null`.
+
+- [ ] **Step 3: Rodar a suíte do front**
+
+Run: `pnpm --filter @e1p/web test`
+Expected: PASS. Se algum teste de lista quebrar por causa do `api.get` não mockado para
+`/dna/pendente`, adicione o mock devolvendo `{ data: null }` — é o caminho de "sem pergunta
+hoje", que é o normal.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/features/
+git commit -m "feat: os cinco ganchos de contexto do DNA [V2]"
+```
+
+---
+
+# ONDA 5 — A aba "A sua empresa"
+
+### Task 12: Os cinco eixos em `/config`
+
+**Files:**
+- Create: `apps/web/src/features/config/EmpresaDnaTab.tsx`
+- Modify: `apps/web/src/features/config/ConfiguracoesPage.tsx`
+- Test: `apps/web/src/features/config/EmpresaDnaTab.test.tsx`
+
+**Interfaces:**
+- Consumes: `PerguntaDaVima`, `GET /dna/faltantes?gancho=<eixo>` não serve aqui — use `GET /dna/respostas` + o catálogo completo
+- Produces: `EmpresaDnaTab()`; nova aba `"dna"` em `ConfiguracoesPage`
+
+> **Ajuste necessário no backend:** a aba precisa listar **todas** as 45 com o que já foi
+> respondido. Acrescentar a `apps/api/app/modules/dna/router.py`:
+>
+> ```python
+> @router.get("/catalogo", response_model=list[PerguntaOut])
+> def catalogo(
+>     user: CurrentUser = Depends(require_module("settings")),
+> ) -> list[PerguntaOut]:
+>     """As 45, na ordem do catálogo. A aba de configurações é a única superfície SEM cadência —
+>     a pessoa escolheu estar ali, e esconder pergunta de quem foi procurá-la é hostil."""
+>     return [to_out(p) for p in catalog.PERGUNTAS]
+> ```
+>
+> `catalog` já está importado no router desde a Task 5 — nenhum import novo. Escreva o teste em
+> `tests/test_dna_router.py` afirmando `len(resposta) == 45` antes de implementar.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```tsx
+// apps/web/src/features/config/EmpresaDnaTab.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import EmpresaDnaTab from "./EmpresaDnaTab";
+
+const CATALOGO = [
+  {
+    key: "oferta.o_que_vende",
+    classe: "retrato",
+    eixo: "oferta",
+    texto: "O que você vende?",
+    formato: "escolha",
+    opcoes: [{ rotulo: "Serviço por projeto", valor: "servico_projeto" }],
+  },
+  {
+    key: "limites.nunca_faco",
+    classe: "retrato",
+    eixo: "limites",
+    texto: "O que você nunca faz?",
+    formato: "texto",
+    opcoes: [],
+  },
+];
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), put: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+describe("EmpresaDnaTab", () => {
+  it("agrupa por eixo e mostra quantas faltam", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) =>
+      Promise.resolve({
+        data: url === "/dna/catalogo" ? CATALOGO : { "oferta.o_que_vende": "servico_projeto" },
+      }),
+    );
+
+    render(<EmpresaDnaTab />);
+
+    await waitFor(() => expect(screen.getByText("Oferta")).toBeInTheDocument());
+    expect(screen.getByText("Limites")).toBeInTheDocument();
+    expect(screen.getByText(/1 de 2 respondidas/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `pnpm --filter @e1p/web test -- EmpresaDnaTab`
+Expected: FAIL — o módulo não existe.
+
+- [ ] **Step 3: Escrever a aba**
+
+Criar `apps/web/src/features/config/EmpresaDnaTab.tsx`:
+
+```tsx
+import type { DnaPergunta } from "@e1p/shared-types";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import PerguntaDaVima from "../dna/PerguntaDaVima";
+
+const EIXOS: { key: DnaPergunta["eixo"]; titulo: string; descricao: string }[] = [
+  { key: "oferta", titulo: "Oferta", descricao: "O que você vende e como cobra" },
+  { key: "cliente", titulo: "Cliente", descricao: "Quem compra e como chega até você" },
+  { key: "ritmo", titulo: "Ritmo", descricao: "Como é a sua semana" },
+  { key: "dinheiro", titulo: "Dinheiro", descricao: "Como você recebe e reage a atraso" },
+  { key: "limites", titulo: "Limites", descricao: "O que você nunca faz" },
+];
+
+/**
+ * A saída para quem quiser sentar e responder tudo de uma vez.
+ *
+ * **É a única superfície SEM cadência.** A regra de uma pergunta por dia existe para proteger
+ * de interrupção; aqui a pessoa foi procurar, e esconder pergunta de quem foi atrás dela seria
+ * hostil. Tudo editável a qualquer momento — inclusive o que já foi respondido.
+ */
+export default function EmpresaDnaTab() {
+  const [catalogo, setCatalogo] = useState<DnaPergunta[]>([]);
+  const [respostas, setRespostas] = useState<Record<string, unknown>>({});
+
+  const carregar = useCallback(async () => {
+    const [{ data: perguntas }, { data: dadas }] = await Promise.all([
+      api.get<DnaPergunta[]>("/dna/catalogo"),
+      api.get<Record<string, unknown>>("/dna/respostas"),
+    ]);
+    setCatalogo(perguntas);
+    setRespostas(dadas);
+  }, []);
+
+  useEffect(() => {
+    carregar();
+  }, [carregar]);
+
+  if (catalogo.length === 0) {
+    return <p className="text-sm text-neutral-400">Carregando…</p>;
+  }
+
+  const respondidas = catalogo.filter((p) => p.key in respostas).length;
+
+  return (
+    <div className="space-y-8">
+      <p className="text-sm text-neutral-500">
+        {respondidas} de {catalogo.length} respondidas. Não precisa responder tudo de uma vez — a
+        Vima pergunta aos poucos, no momento em que cada resposta faz sentido.
+      </p>
+
+      {EIXOS.map((eixo) => {
+        const doEixo = catalogo.filter((p) => p.eixo === eixo.key);
+        if (doEixo.length === 0) return null;
+        return (
+          <section key={eixo.key} className="space-y-3">
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-800">{eixo.titulo}</h2>
+              <p className="text-xs text-neutral-500">{eixo.descricao}</p>
+            </div>
+            {doEixo.map((p) => (
+              <div key={p.key}>
+                {p.key in respostas ? (
+                  <div className="rounded-xl border border-neutral-200 bg-neutral-50 p-4">
+                    <p className="text-sm text-neutral-600">{p.texto}</p>
+                    <p className="mt-1 text-sm font-medium text-neutral-800">
+                      {rotulo(p, respostas[p.key])}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const resto = { ...respostas };
+                        delete resto[p.key];
+                        setRespostas(resto);
+                      }}
+                      className="mt-2 text-xs text-neutral-400 underline"
+                    >
+                      Mudar
+                    </button>
+                  </div>
+                ) : (
+                  <PerguntaDaVima
+                    pergunta={p}
+                    source="config"
+                    onPronto={carregar}
+                    onPular={carregar}
+                  />
+                )}
+              </div>
+            ))}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Mostra o RÓTULO que o dono escolheu, não o valor interno que o sistema guarda. */
+function rotulo(pergunta: DnaPergunta, valor: unknown): string {
+  if (pergunta.formato === "texto") return String(valor);
+  const lista = Array.isArray(valor) ? valor : [valor];
+  return lista
+    .map((v) => pergunta.opcoes.find((o) => o.valor === v)?.rotulo ?? String(v))
+    .join(", ");
+}
+```
+
+- [ ] **Step 4: Registrar a aba**
+
+Modificar `apps/web/src/features/config/ConfiguracoesPage.tsx`:
+
+```tsx
+import { Building2, Check, Filter, MessageCircle, Sparkles, Workflow } from "lucide-react";
+import EmpresaDnaTab from "./EmpresaDnaTab";
+```
+
+```tsx
+type Tab = "empresa" | "dna" | "canais" | "integracoes" | "vendas";
+
+const TABS: { key: Tab; label: string; icon: typeof Building2 }[] = [
+  { key: "empresa", label: "Empresa", icon: Building2 },
+  { key: "dna", label: "A sua empresa", icon: Sparkles },
+  { key: "canais", label: "Canais", icon: MessageCircle },
+  { key: "integracoes", label: "Integrações", icon: Workflow },
+  { key: "vendas", label: "Vendas", icon: Filter },
+];
+```
+
+E no corpo, junto às outras abas:
+
+```tsx
+        {tab === "dna" && <EmpresaDnaTab />}
+```
+
+> **Atenção:** `PERFIL_TABS` continua `["empresa", "vendas"]`. A aba do DNA **não** entra ali —
+> ela salva sozinha, pergunta a pergunta, e o botão "Salvar" do perfil não tem o que fazer com
+> ela.
+
+- [ ] **Step 5: Rodar as duas suítes**
+
+Run: `cd apps/api && pytest && cd ../.. && pnpm --filter @e1p/web test`
+Expected: PASS nas duas.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/config/ apps/api/app/modules/dna/router.py apps/api/tests/test_dna_router.py
+git commit -m "feat: a aba 'A sua empresa' com os cinco eixos do DNA [V2]"
+```
+
+---
+
+## Fechamento
+
+- [ ] **Rodar tudo, uma última vez**
+
+Run: `cd apps/api && pytest && cd ../.. && pnpm --filter @e1p/web test && pnpm --filter @e1p/web build`
+Expected: PASS nos três.
+
+- [ ] **Reconferir o head do Alembic**
+
+Run: `ls apps/api/migrations/versions/ | sort | tail -3`
+Se a frente paralela mergeou uma `0076` enquanto isto era construído, renumerar para `0077` e
+ajustar `down_revision`. **É a terceira vez que este repositório paga essa lição** — 0072, 0076,
+e a próxima.
+
+- [ ] **Validação manual em ~360px**
+
+Abrir `/dna/nucleo` e a aba "A sua empresa" em 360px de largura e conferir que nenhum bloco
+estoura. **Bloqueia release, não bloqueia merge** — mesmo padrão das telas de Contas & Saldos,
+Conversas e do briefing. `toContain("flex-wrap")` não prova layout: meça.
+
+- [ ] **Registrar no `CLAUDE.md`**
+
+Acrescentar a seção do V2 seguindo o formato das seções da Vima já existentes: o que mudou, as
+duas guardas de classe, a inversão do núcleo, a limpeza do silêncio ao recalibrar, e as dívidas
+(cobrança sem antecedência, sem medição de ativação, 45 perguntas não validadas com dono real).
+
+- [ ] **Abrir o PR**
+
+```bash
+git push -u origin feat/vima-dna-da-empresa
+```
+
+⚠️ `git push` é **exclusivo do @devops** neste repositório. Delegue.

--- a/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
+++ b/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
@@ -27,7 +27,9 @@ Valem para **toda** tarefa deste plano.
 - **Só DDL, sem backfill.** Não existe resposta anterior a esta migration, então a armadilha da RLS no backfill (INSERT ... SELECT que grava zero linhas em silêncio) não se aplica.
 - **Idioma:** domínio, docstrings e comentários em PT-BR; identificadores em inglês quando já for a convenção do arquivo.
 - **Commits:** Conventional Commits. `main` é protegida — todo trabalho vai por PR.
-- **Rodar antes de considerar concluído:** `cd apps/api && pytest` e `pnpm --filter @e1p/web test`. Não confie em `scripts/check.sh` isoladamente — ele mascara falha de frontend com `|| true` no vitest (dívida registrada).
+- **Rodar antes de considerar concluído — os TRÊS:** `cd apps/api && ruff check .`, `cd apps/api && pytest` e `pnpm --filter @e1p/web test`.
+  - ⚠️ **O `ruff` é gate de CI** (`ci.yml:47` roda `ruff check . && pytest` dentro da imagem de produção) e é o mais fácil de esquecer, porque não é teste. Esquecê-lo custou uma rodada vermelha neste PR: imports dentro de função em `test_dna_briefing.py` deram `I001` + `F401`.
+  - Não confie em `scripts/check.sh` isoladamente — ele mascara falha de frontend com `|| true` no vitest (dívida registrada). **Mas note que é ele quem roda o `ruff` (linha 14):** desconfiar do script inteiro é o caminho direto para pular o lint.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
+++ b/docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md
@@ -1505,10 +1505,16 @@ from fastapi.testclient import TestClient
 
 from app.core.security import create_access_token
 
+# O payload real de `/auth/register` — copiado de `tests/test_vima_briefing.py`, não inventado.
+# Um payload adivinhado aqui devolve 422 e todas as fixtures do arquivo morrem com KeyError
+# em `["access_token"]`, longe da causa.
 REGISTER = {
-    "email": "dono@exemplo.com",
-    "password": "senha-forte-123",
-    "tenant_name": "Estúdio de Uma Pessoa",
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio",
+    "password": "uma-senha-bem-grande",
 }
 
 
@@ -2062,10 +2068,16 @@ Expected: PASS (8 testes)
 import pytest
 from fastapi.testclient import TestClient
 
+# O payload real de `/auth/register` — copiado de `tests/test_vima_briefing.py`, não inventado.
+# Um payload adivinhado aqui devolve 422 e todas as fixtures do arquivo morrem com KeyError
+# em `["access_token"]`, longe da causa.
 REGISTER = {
-    "email": "dono@exemplo.com",
-    "password": "senha-forte-123",
-    "tenant_name": "Estúdio de Uma Pessoa",
+    "legal_name": "Vima ME",
+    "document": "11444777000161",
+    "slug": "vimame",
+    "email": "vima@example.com",
+    "name": "Flávio",
+    "password": "uma-senha-bem-grande",
 }
 
 

--- a/docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md
+++ b/docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md
@@ -1,0 +1,495 @@
+# Vima — DNA da Empresa
+
+**Data:** 2026-08-08
+**Status:** Aprovado (design)
+**Escopo:** V2 da visão Vima
+**Módulos afetados:** `dna` (novo), `vima` (consumo dos limiares), `auth`/`settings` (permissão), `apps/web` (núcleo na entrada, ganchos, nova aba em `/config`)
+**Depende de:** V0 (Registro de Fatos) e V1 (Briefing), ambos em `main` — PRs #85, #87, #90
+
+---
+
+## Problema
+
+O V1 entregou um briefing que fala com todo mundo do mesmo jeito.
+
+As cinco famílias de Ausência têm um número cada — 24 horas sem resposta, 30 dias sem falar com
+o cliente, 10 dias parado na etapa — e esses números são
+[defaults conservadores escolhidos por nós](../specs/2026-08-06-vima-registro-de-fatos-e-briefing-design.md),
+não pelo dono. A docstring de [`absences.py`](../../../apps/api/app/modules/vima/absences.py)
+já registra a dívida em voz alta:
+
+> Os limiares são injetáveis porque o V2 (DNA da Empresa) vai substituí-los: "você gosta de
+> responder rápido?" é literalmente o limiar de `contato.esperando_resposta`.
+
+Um advogado que responde em dois dias e um social media que responde em duas horas recebem hoje
+o mesmo aviso, na mesma hora. Para um, o briefing grita cedo demais; para o outro, avisa quando
+já era tarde. **Pela assimetria de credibilidade que o V1 estabeleceu — um aviso errado custa
+mais caro que um aviso ausente — o default conservador é a decisão certa enquanto não se sabe.
+O V2 é o momento de passar a saber.**
+
+Há um segundo problema, maior e mais adiante. O V4 (Motor de Contexto + Autonomia Progressiva)
+depende de V0 **e V2**, e a razão é que um agente que age em nome do dono precisa saber o que o
+dono **nunca faz**. Hoje esse conhecimento não existe em lugar nenhum do sistema. Descobri-lo
+por tentativa e erro significa errar na frente do cliente.
+
+---
+
+## Objetivo
+
+Um retrato do negócio, **declarado pelo dono**, que calibra o comportamento da Vima hoje e serve
+de contexto aos funcionários virtuais amanhã — capturado sem nunca virar um portão de quinze
+minutos na porta de entrada do produto.
+
+### A escolha estruturante: duas classes, declaradas e verificadas
+
+Toda pergunta pertence a uma de duas classes, e a classe não é um rótulo de organização — é um
+contrato mecânico:
+
+| Classe | Tem consumidor **hoje**? | Efeito de responder |
+|---|---|---|
+| **Calibração** | Sim, obrigatoriamente | Muda o comportamento do briefing no dia seguinte |
+| **Retrato** | Não, por definição | É guardado. Nada muda até o V4 |
+
+O contrato existe porque a alternativa é conhecida e ruim: sem ele, em seis meses alguém marca
+uma pergunta bonita como Calibração, o dono a responde acreditando ter mudado o comportamento
+do produto, e não mudou nada. **Um produto que finge ouvir é pior que um produto que não
+pergunta.** As duas guardas que sustentam o contrato estão em [Guardas do catálogo](#guardas-do-catálogo).
+
+Uma consequência desconfortável e aceita: **Calibração são apenas 6 perguntas**, porque só
+existem seis consumidores. Qualquer número maior seria invenção — e o Artigo IV da Constitution
+proíbe.
+
+---
+
+## O modelo de dados
+
+### O catálogo é código
+
+As perguntas vivem em `apps/api/app/modules/dna/catalog.py` como dados imutáveis em Python.
+É o mesmo padrão já estabelecido no repositório por `LIMIARES_PADRAO` (`vima/absences.py`) e
+`MODELO_POR_TAREFA` (`core/ai.py`): catálogo em código, com gate de teste.
+
+```python
+@dataclass(frozen=True)
+class Opcao:
+    rotulo: str            # o que o dono lê
+    valor: int | str | None  # o que o sistema guarda e consome
+
+@dataclass(frozen=True)
+class Pergunta:
+    key: str                          # "ritmo.resposta_horas"
+    classe: str                       # CALIBRACAO | RETRATO
+    eixo: str                         # oferta | cliente | ritmo | dinheiro | limites
+    texto: str
+    formato: str                      # escolha | escolha_multipla | texto
+    opcoes: tuple[Opcao, ...] = ()
+    consome: str | None = None        # chave de LIMIARES_PADRAO
+    gancho: str | None = None         # onde a pergunta aparece sozinha
+```
+
+**Pergunta nova exige deploy, e isso é correto.** Pergunta nova de Calibração vem sempre junto
+do consumidor dela, que é código de qualquer forma. Pergunta nova de Retrato não tem urgência
+que justifique um editor de catálogo em banco — e um catálogo editável por tenant faria o
+dossiê do V4 ter formato diferente em cada empresa, que é exatamente o que ele não pode ter.
+
+### Guardas do catálogo
+
+Duas verificações rodam no **import do módulo** — falham na subida do processo, não em
+produção. É o mesmo espírito das duas invariantes de `facts.record`, que estouram a transação
+de propósito:
+
+1. **`CALIBRACAO` exige `consome`; `RETRATO` proíbe.** É a guarda que dá sentido à classe.
+2. **`consome` precisa apontar para uma chave existente em `LIMIARES_PADRAO`.** Sem ela, um
+   typo em `"card_parado_dais"` produz um silêncio perfeito: a resposta grava, o resolver monta
+   o dicionário, `coletar` faz `{**LIMIARES_PADRAO, **override}`, e a chave estranha é
+   simplesmente ignorada. O dono responderia e nada aconteceria — para sempre, sem erro nenhum,
+   sem teste quebrando.
+
+Uma terceira, de higiene: **`key` única** e **`key` começa com o `eixo`**, pela mesma razão que
+`facts.record` exige que `kind` comece com `module` — trinta perguntas produzindo
+`resposta_horas` e `ritmo.resposta_horas` convivendo é o custo de não verificar.
+
+### A tabela `dna_answers`
+
+| Coluna | Tipo | Nota |
+|---|---|---|
+| `id` | String(36) | |
+| `tenant_id` | String(36) | `TenantMixin`, RLS `ENABLE` + `FORCE`, policy `tenant_isolation` |
+| `question_key` | String(64) | |
+| `value` | JSON, nulo | **Nulo = pulada.** Não é o mesmo que linha ausente |
+| `answered_at` | timestamptz | |
+| `answered_by` | String(36), nulo | id do usuário |
+| `source` | String(16) | `nucleo` \| `gancho` \| `config` |
+
+Único por `(tenant_id, question_key)`.
+
+**É upsert, não append — o oposto de `facts`, e de propósito.** Fato é história; DNA é estado
+atual. Guardar versões faria toda leitura ter que decidir qual resposta vale, e o histórico de
+quem mudou o quê já é trabalho de [`core/audit.py`](../../../apps/api/app/core/audit.py), que
+existe e é o lugar certo.
+
+**`value` nulo distingue "pulei" de "nunca me perguntaram"** sem tabela nova. É o que sustenta a
+quarentena de 7 dias descrita em [Cadência](#cadência-as-duas-regras-de-silêncio).
+
+**A escrita valida contra o catálogo.** Chave desconhecida → 422. Valor fora de `opcoes` para
+formato `escolha` → 422. Texto acima de 2.000 caracteres → 422. Sem isso o `value` JSON vira
+depósito de qualquer coisa e o resolver quebra na leitura, longe de quem escreveu.
+
+### O V2 não chama IA
+
+Em nenhum ponto. Nem para redigir pergunta, nem para interpretar o texto livre dos campos
+abertos — que são guardados crus até o V4. Isso mantém `core/ai.py`, o ledger `ai_usage` e o
+anonimizador inteiramente fora do escopo, e é o que torna o V2 barato de operar: custo marginal
+zero por tenant.
+
+---
+
+## O catálogo — as 45 perguntas
+
+Formato `escolha` salva o `valor` da opção escolhida; `escolha_multipla` salva uma lista;
+`texto` salva string.
+
+### Calibração (6)
+
+Cada uma existe porque há um número esperando por ela. O valor em **negrito** é o default de
+hoje, preservado quando ninguém responde.
+
+| `key` | Texto | Opções (`rotulo` → `valor`) | `consome` |
+|---|---|---|---|
+| `ritmo.resposta_horas` | "Um cliente te escreveu e ficou sem resposta. Em quanto tempo eu te aviso?" | Em 4 horas → 4 · No mesmo dia → 12 · **No dia seguinte → 24** · Depois de 2 dias → 48 | `sem_resposta_nossa_horas` |
+| `cliente.esfria_dias` | "Quantos dias sem falar com um cliente já significa que ele esfriou?" | 15 · **30** · 60 · 90 | `contato_sumido_dias` |
+| `ritmo.card_parado_dias` | "Uma negociação parada na mesma etapa há quanto tempo te incomoda?" | 5 · **10** · 20 · 30 | `card_parado_dias` |
+| `cliente.topo_seco_dias` | "Quantos dias sem nenhum cliente novo é anormal no seu negócio?" | 3 · **5** · 15 · Não quero esse aviso → `null` | `topo_sem_lead_dias` |
+| `ritmo.prazo_antecedencia_dias` | "Com quanta antecedência você quer saber de um **prazo**?" | No próprio dia → 0 · **1 dia antes → 1** · 3 dias antes → 3 · 1 semana antes → 7 | `prazo_vencendo_dias` |
+| `dinheiro.antecedencia_dias` | "E de uma **conta a pagar**?" | No próprio dia → 0 · **1 dia antes → 1** · 3 dias antes → 3 · 1 semana antes → 7 | `dinheiro_com_data_dias` (novo) |
+
+#### `dinheiro_com_data_dias` é chave nova, e por quê
+
+Hoje `prazo_vencendo_dias` governa **duas regras diferentes**: prazo da agenda
+(`absences.py:132`) e conta a pagar chegando ao vencimento (`absences.py:166`). São
+antecedências distintas na cabeça de qualquer dono — prazo de entrega se quer saber em cima,
+boleto se quer saber com folga para ter o dinheiro. Perguntar em voz alta é o momento em que a
+fusão fica insustentável.
+
+A separação nasce com valor `1`, idêntico ao de hoje: **é refactor puro no dia do merge**,
+comportamento inalterado enquanto ninguém responde.
+
+#### A pergunta fala só de conta a PAGAR, e isso não é descuido
+
+`_dinheiro_com_data` trata duas direções com regras diferentes, apesar da docstring dizer *"duas
+direções, uma regra"*: contas a pagar usam `due_date <= hoje + limiar` (têm antecedência),
+cobranças a receber usam `due_date < hoje` (**só aparecem depois de vencidas, sem limiar
+nenhum**). Um recebimento que vence amanhã não é dito por ninguém.
+
+A assimetria é do V1 e **fica registrada como dívida, não é consertada aqui** — dar antecedência
+a cobrança é decisão de produto sobre o que o briefing anuncia, não sobre como ele é calibrado.
+Perguntar "e de uma conta a receber?" antes de existir a regra criaria uma resposta gravada que
+não consome nada: exatamente o que as duas classes existem para impedir.
+
+#### "Não quero esse aviso" existe em exatamente uma pergunta
+
+Só `cliente.topo_seco_dias` oferece desligamento, e a razão é estrutural. As outras cinco regras
+disparam sobre **coisa que existe** — sem cards, não há card parado; sem cobrança, não há
+cobrança vencendo —, então elas se calam sozinhas em quem não usa aquilo. Topo seco dispara
+sobre o **vazio**: um negócio sem entrada inbound é cutucado todo dia, para sempre. É a dívida
+já registrada no `CLAUDE.md` (*"a única Ausência que lê o log, então enquanto o registro for
+novo ela dispara por falta de histórico e não por falta de lead"*), e o desligamento explícito
+é o conserto honesto dela.
+
+**Mecanicamente, `null` significa regra não executada** — não "regra executada com limiar
+infinito". É a mesma forma do filtro de permissão do V1, que não roda a regra em vez de calcular
+e esconder o resultado, eliminando a classe inteira de bug em que o dado proibido vaza por
+esquecimento no filtro de saída.
+
+### Retrato (39)
+
+A regra de pertencimento é dura, e ela é o que impede o catálogo de inchar:
+
+> **Entra se um funcionário humano recém-contratado precisaria saber no primeiro dia.**
+
+O que não passa nesse teste não entra. "Qual seu CNPJ" não entra — é dado cadastral e já mora em
+`tenant_profiles`. "Qual sua cor favorita" não entra. "O que você nunca faz" entra.
+
+#### Eixo Oferta (9)
+
+| `key` | Texto | Formato / Opções |
+|---|---|---|
+| `oferta.o_que_vende` | "O que você vende?" | escolha: Serviço recorrente · Serviço por projeto · Produto físico · Produto digital · Um pouco de cada |
+| `oferta.em_uma_frase` | "Se um cliente perguntar o que você faz, o que você responde?" | texto |
+| `oferta.ticket_tipico` | "Quanto costuma custar um trabalho seu?" | escolha: Até R$ 500 · R$ 500 a 2 mil · R$ 2 mil a 10 mil · R$ 10 mil a 50 mil · Acima de R$ 50 mil |
+| `oferta.prazo_entrega` | "Do 'sim' do cliente até a entrega, quanto tempo costuma passar?" | escolha: No mesmo dia · Até uma semana · De 2 a 4 semanas · Mais de um mês · É contínuo, não tem fim |
+| `oferta.como_cobra` | "Como você costuma cobrar?" | escolha: Tudo antes · Tudo depois · Entrada e saldo · Parcelado · Mensalidade |
+| `oferta.capacidade_mes` | "Quantos clientes novos você consegue atender por mês, no máximo?" | escolha: 1 ou 2 · 3 a 5 · 6 a 15 · Mais de 15 · Não tenho teto |
+| `oferta.proposta_formal` | "Você manda proposta ou orçamento escrito antes de fechar?" | escolha: Sempre · Na maioria das vezes · Raramente · Nunca |
+| `oferta.diferencial` | "Por que um cliente escolhe você e não o concorrente?" | texto |
+| `oferta.aberta` | "Algo mais que a Vima precisa saber sobre o que você vende?" | texto |
+
+#### Eixo Cliente (8)
+
+| `key` | Texto | Formato / Opções |
+|---|---|---|
+| `cliente.quem_e` | "Quem compra de você?" | escolha: Pessoa física · Pequenas empresas · Empresas médias e grandes · Órgãos públicos · Um pouco de cada |
+| `cliente.como_chega` | "Como o cliente chega até você?" | escolha_multipla: Indicação · Redes sociais · Busca no Google · Anúncio pago · Prospecção ativa · Passagem ou loja física |
+| `cliente.decisao_tempo` | "Do primeiro contato até o cliente decidir, quanto tempo costuma levar?" | escolha: No mesmo dia · Poucos dias · De 1 a 4 semanas · Mais de um mês |
+| `cliente.recompra` | "O mesmo cliente costuma voltar?" | escolha: É recorrente por contrato · Volta com frequência · Volta às vezes · É compra única |
+| `cliente.objecao` | "O que mais faz um cliente dizer não?" | escolha: Preço · Prazo · Falta de confiança · Não era o que ele procurava · Ele some sem dizer nada |
+| `cliente.canal_preferido` | "Por onde o cliente prefere falar com você?" | escolha: WhatsApp · Telefone · E-mail · Presencial · Instagram e afins |
+| `cliente.sinal_de_que_fecha` | "O que te faz saber que um cliente vai fechar?" | texto |
+| `cliente.aberta` | "Algo mais que a Vima precisa saber sobre seus clientes?" | texto |
+
+#### Eixo Ritmo (7)
+
+| `key` | Texto | Formato / Opções |
+|---|---|---|
+| `ritmo.dias_de_trabalho` | "Em que dias você trabalha?" | escolha_multipla: Segunda · Terça · Quarta · Quinta · Sexta · Sábado · Domingo |
+| `ritmo.janela_do_dia` | "Que horas você costuma trabalhar?" | escolha: De manhã · Horário comercial · Tarde e noite · De madrugada · Varia muito |
+| `ritmo.pico_do_mes` | "Tem época do mês mais cheia?" | escolha: Começo · Meio · Fim · Não tem padrão |
+| `ritmo.sazonalidade` | "E do ano? Tem mês que enche e mês que esvazia?" | texto |
+| `ritmo.o_que_trava` | "O que mais trava o seu dia?" | escolha: Atender cliente · Fazer o trabalho em si · Cobrar · Burocracia · Vender |
+| `ritmo.sozinho` | "Você trabalha sozinho?" | escolha: Sozinho · Com ajuda pontual de freelas · Tenho 1 ou 2 pessoas · Tenho equipe |
+| `ritmo.aberta` | "Algo mais que a Vima precisa saber sobre o seu ritmo?" | texto |
+
+#### Eixo Dinheiro (8)
+
+| `key` | Texto | Formato / Opções |
+|---|---|---|
+| `dinheiro.atraso_reacao` | "Cliente atrasou o pagamento. O que você faz?" | escolha: Cobro no dia seguinte · Espero alguns dias · Espero ele falar · Evito cobrar |
+| `dinheiro.tolerancia_dias` | "Quantos dias de atraso você tolera antes de agir?" | escolha: 1 · 3 · 7 · 15 · 30 |
+| `dinheiro.reserva` | "Você tem reserva para quantos meses parados?" | escolha: Nenhuma · Menos de um mês · De 1 a 3 meses · De 3 a 6 meses · Mais de 6 meses |
+| `dinheiro.pro_labore` | "Você tira um valor fixo por mês para você?" | escolha: Sim, fixo · Sim, variável · Não separo |
+| `dinheiro.sinal_de_aperto` | "O que te diz que o mês vai ser apertado?" | texto |
+| `dinheiro.formas_recebimento` | "Como você recebe?" | escolha_multipla: Pix · Boleto · Cartão · Dinheiro · Transferência |
+| `dinheiro.emite_nota` | "Você emite nota fiscal?" | escolha: Sempre · Quando o cliente pede · Não emito |
+| `dinheiro.aberta` | "Algo mais que a Vima precisa saber sobre o seu dinheiro?" | texto |
+
+> **`dinheiro.tolerancia_dias` parece Calibração e não é.** Tem número e tem opções fechadas,
+> mas **não existe hoje regra de Ausência sobre tolerância a atraso** — `dinheiro com data` olha
+> vencimento, não carência. Sem consumidor, é Retrato: a classe é definida pelo contrato, nunca
+> pelo formato. Se algum dia nascer a regra, esta pergunta migra de classe junto com ela, e a
+> guarda do catálogo cobra que o consumidor exista antes.
+
+#### Eixo Limites (7)
+
+**É o eixo mais importante e o mais fácil de esquecer.** É o único que o V4 lê para decidir o
+que **não** fazer sozinho. Uma autonomia progressiva sem esta lista é um agente que descobre os
+limites errando na frente do cliente.
+
+| `key` | Texto | Formato / Opções |
+|---|---|---|
+| `limites.nunca_faco` | "O que você nunca faz, mesmo que o cliente peça?" | texto |
+| `limites.exige_voce` | "O que só pode sair com você olhando antes?" | escolha_multipla: Proposta e preço · Mensagem para cliente · Cobrança · Contrato · Publicação · Nada disso |
+| `limites.tom` | "Como você fala com cliente?" | escolha: Formal · Cordial e direto · Informal e próximo · Bem-humorado |
+| `limites.desconto` | "Você dá desconto?" | escolha: Nunca · Só em caso especial · Negocio sempre · Tenho tabela fixa |
+| `limites.recusa_cliente` | "Que tipo de cliente você recusa?" | texto |
+| `limites.horario_contato` | "Pode falar com cliente fora do seu horário?" | escolha: Pode sempre · Só urgência · Nunca |
+| `limites.aberta` | "Algo mais que a Vima precisa saber sobre os seus limites?" | texto |
+
+**Total: 6 + 9 + 8 + 7 + 8 + 7 = 45.**
+
+---
+
+## As superfícies
+
+### O núcleo não é de Calibração
+
+Esta é a inversão central do design, e a razão é forte: *"em quanto tempo eu te aviso que
+ninguém respondeu o Carlos?"* é impossível de responder bem antes de ter visto um briefing.
+Perguntada no primeiro acesso, a resposta é um chute — que depois vira comportamento errado com
+aparência de configuração deliberada, e o dono não tem como saber que foi ele quem pediu aquilo.
+
+**Núcleo — 6 perguntas, no primeiro acesso, gancho `nucleo`:**
+
+`oferta.o_que_vende` · `oferta.em_uma_frase` · `oferta.como_cobra` · `oferta.ticket_tipico` ·
+`cliente.como_chega` · `limites.nunca_faco`
+
+São respondíveis em cerca de noventa segundos por quem acabou de entrar e nunca viu o produto, e
+são as que fazem o sistema parecer dele. **São puláveis** — "responder depois" é um botão, não
+um beco. Roda em `EntradaDoDia`, que já é o lugar onde a porta do dia é decidida, como um
+terceiro estado antes de `vima` e `cockpit`.
+
+### Calibração vai toda por gancho, colada à ausência que a motivou
+
+Na primeira vez que o briefing diz *"o Carlos está sem resposta há 24 horas"*, logo abaixo
+daquela linha aparece *"esse é o tempo certo para você?"* com as quatro opções. A pergunta chega
+no único instante em que ela é óbvia, e o efeito aparece no briefing do dia seguinte.
+
+O gancho é `briefing.ausencia.<kind>`, com os `kind` que já existem em `absences.py`:
+
+| Pergunta | Gancho |
+|---|---|
+| `ritmo.resposta_horas` | `briefing.ausencia.comercial.contato.esperando_resposta` |
+| `cliente.esfria_dias` | `briefing.ausencia.comercial.contato.sumido` |
+| `ritmo.card_parado_dias` | `briefing.ausencia.comercial.card.parado` |
+| `cliente.topo_seco_dias` | `briefing.ausencia.comercial.topo.sem_lead` |
+| `ritmo.prazo_antecedencia_dias` | `briefing.ausencia.agenda.prazo.estourado` |
+| `dinheiro.antecedencia_dias` | `briefing.ausencia.financeiro.conta.vencendo` |
+
+`financeiro.cobranca.vencida` não recebe pergunta porque **não tem limiar** — ela dispara sobre
+o que já venceu, sem antecedência (ver a dívida registrada acima).
+
+### Retrato restante
+
+Ganchos de contexto declarados no catálogo, disparados depois da ação correspondente:
+`crm.cliente.criado`, `receivables.cobranca.criada`, `quotes.orcamento.criado`,
+`payables.conta.criada`, `agenda.evento.criado`.
+
+E a aba nova **"A sua empresa"** em `/config` — que acabou de virar abas no PR #86 e tem o lugar
+pronto — com os cinco eixos, o que já foi respondido e o que falta, tudo editável a qualquer
+momento. É a saída para quem quiser sentar e responder as 45 de uma vez, sem que isso tenha
+sido imposto a ninguém.
+
+### Cadência: as duas regras de silêncio
+
+1. **No máximo uma pergunta por gancho por dia, no produto inteiro.** Não uma por tela: uma. Um
+   produto que interroga em três telas diferentes na mesma sessão é ignorado na quarta. É a
+   Regra do Silêncio do V1 aplicada a perguntar em vez de a avisar.
+
+   **O núcleo é a exceção declarada**, e as seis perguntas dele não contam para esse limite: ele
+   é uma sequência anunciada, com fim visível, que a pessoa entrou sabendo que ia atravessar (e
+   podendo pular). Interrupção não anunciada e sequência anunciada são coisas diferentes — o que
+   cansa é a primeira. Consequência mecânica: no dia do primeiro acesso o gancho fica calado,
+   porque o núcleo já usou a cota.
+2. **Pergunta pulada não reaparece por 7 dias.** Nunca some — continua no `/config` —, mas para
+   de ser empurrada. Sem isso, um "depois" acidental vira interrogatório; com quarentena
+   infinita, um toque errado perde a pergunta para sempre.
+
+**As duas são derivação de *que dia é hoje*, então saem de `hoje_do_tenant(db)`.** O módulo `dna`
+entra na varredura AST de `tests/test_fuso_do_tenant.py`, junto com `app/modules/vima/`. Sem
+isso, o dono no Acre é interrogado duas vezes no mesmo dia — e a regressão passaria despercebida
+por meses, porque em São Paulo funciona.
+
+**A escolha entre várias elegíveis é determinística:** a Calibração colada ao gancho vence;
+empatando, a primeira não respondida na ordem do catálogo. Nada de sorteio — teste que depende
+de aleatoriedade não prova nada.
+
+---
+
+## Consumo
+
+### O resolver é a única porta
+
+`apps/api/app/modules/dna/resolver.py` expõe duas funções e nada mais:
+
+- `limiares(db) -> dict[str, int | None]` — montado **só** das respostas de Calibração, pronto
+  para entrar em `absences.coletar(..., limiares=...)`. `vima/service.py` passa a chamá-lo; hoje
+  ele não passa nada e o default vale para todos.
+- `retrato(db) -> dict[str, Any]` — as respostas de Retrato, **sem consumidor no V2**. Existe
+  para que o V4 encontre a porta pronta.
+
+**Nenhum outro módulo lê `dna_answers` direto.** É o que mantém a classe Retrato honestamente
+sem consumidor, em vez de ela vazar por um `select` esperto em algum lugar — que é como um
+contrato de arquitetura morre na prática.
+
+### Mudar um limiar limpa o registro de silêncio
+
+Se o dono aperta "card parado" de 10 para 5 dias e o briefing continua calado porque já disse
+aquilo ontem, a configuração parece quebrada — e a próxima que ele mexer, ele não acredita.
+
+`_ja_reportadas` (em `vima/service.py`) devolve `{}` quando existe resposta de **Calibração**
+gravada depois da `reference_date` do briefing anterior. Isso limpa o silêncio de **todas** as
+regras, não só da que mudou. É grosso de propósito, na mesma linha do fator 2 da escalada, que o
+próprio código chama de *"arbitrário e deliberadamente grosso"*: recalibrar é raro, e
+discriminar por regra exigiria um mapa `kind`→limiar que existiria só para essa finalidade.
+
+### O briefing de hoje não é regerado
+
+Ele é idempotente por `(tenant, usuário, dia)` e já foi narrado e possivelmente enviado por
+WhatsApp. A resposta vale do próximo em diante, e **a tela diz isso** ("vale a partir de
+amanhã"). Dizer é mais barato que quebrar a idempotência — que é o que faz o F5 reler em vez de
+pagar narração nova, e o que faz o dono reencontrar de tarde as mesmas palavras da manhã.
+
+---
+
+## Permissão
+
+O DNA é **da empresa**, não da pessoa. Núcleo e ganchos só aparecem para `owner` ou para quem
+tem o módulo `settings` — a mesma decisão de `require_module` (owner vê tudo; lista vazia vê
+tudo). Um sub-usuário só de CRM vê o briefing normalmente, sem a pergunta embaixo da ausência.
+
+É deliberadamente o **oposto** das preferências de briefing do V1, que foram para `users`
+justamente por serem pessoais (telefone e horário diferem entre dois usuários do mesmo tenant).
+Aqui, um sub-usuário recalibrando o negócio inteiro seria surpresa ruim para o dono.
+
+**Responder não emite fato.** O feed do briefing é sobre o negócio, não sobre a configuração do
+produto — e a trilha de quem mudou o quê é trabalho de `core/audit.py`.
+
+---
+
+## Gates
+
+| Gate | O que quebra sem ele |
+|---|---|
+| `CALIBRACAO` tem `consome`, `RETRATO` não tem | A classe vira rótulo decorativo e o produto finge ouvir |
+| `consome` aponta para chave real de `LIMIARES_PADRAO` | Typo produz silêncio perfeito: grava, não consome, não erra |
+| `key` única e prefixada pelo `eixo` | Vocabulário divergente em seis meses (lição de `facts.kind`) |
+| Toda pergunta de `escolha` tem ao menos 2 `opcoes` | Pergunta impossível de responder chega ao dono |
+| Varredura AST de `app/modules/dna/` em `test_fuso_do_tenant.py` | Cadência em UTC cru: dois interrogatórios no mesmo dia fora de SP |
+| Resposta fora de `opcoes` → 422 | `value` JSON vira depósito e o resolver quebra na leitura |
+| `limiares()` devolve só Calibração | Retrato ganha consumidor por acidente e o contrato morre |
+| Default preservado quando não há resposta | Tenant que não respondeu muda de comportamento sem ter pedido |
+
+---
+
+## Ondas
+
+| Onda | Entregável | Dá para parar aqui? |
+|---|---|---|
+| **1** | `dna/catalog.py` com as 45 e as guardas · migration `dna_answers` (RLS `FORCE`) · rotas `GET /dna/pendente`, `PUT /dna/{key}`, `POST /dna/{key}/pular` · validação | Sim — nada visível mudou |
+| **2** | `dna/resolver.py` ligado em `absences` via `vima/service.py` · `dinheiro_com_data_dias` separado de `prazo_vencendo_dias` · limpeza do silêncio | Sim — **o DNA já muda o briefing**, respondendo pela API |
+| **3** | Núcleo de 6 no primeiro acesso, em `EntradaDoDia`, pulável, 360px | Sim |
+| **4** | Ganchos: Calibração colada à ausência no briefing + ganchos de contexto | Sim |
+| **5** | Aba "A sua empresa" em `/config`, os cinco eixos, tudo editável | Fim do V2 |
+
+Cada onda termina com software funcionando, como as cinco do V1.
+
+---
+
+## Riscos e dívidas conhecidas
+
+**As 45 perguntas são um chute educado.** Nenhuma foi validada com um dono real de empresa de
+uma pessoa. A estrutura (duas classes, cinco eixos, catálogo em código) aguenta troca de
+pergunta sem migration — trocar texto e opções é editar um arquivo Python —, mas **trocar o
+`valor` de uma opção depois que alguém respondeu deixa a resposta gravada apontando para um
+valor que não existe mais**. O resolver precisa ignorar valor desconhecido e cair no default,
+com log, em vez de estourar.
+
+**Calibração são 6 e a expectativa de "50 perguntas" era outra.** Quem ler o roadmap e depois o
+produto vai achar que faltou. Não faltou: 39 das 45 são Retrato e só rendem no V4. O risco real
+é o dono responder 45 perguntas e sentir que 39 não fizeram nada — **a tela precisa dizer, em
+cada pergunta de Retrato, que ela está sendo guardada para depois.** Prometer efeito imediato
+seria repetir exatamente o erro que as duas classes existem para impedir.
+
+**O núcleo tem custo de ativação real.** Seis perguntas antes do primeiro uso, mesmo puláveis,
+mesmo em noventa segundos, são seis telas entre a pessoa e o produto. Não há medição de
+ativação no e1p hoje para saber se doeu — e essa é a dívida: o V2 não vem com forma de descobrir
+se o núcleo ajudou ou atrapalhou.
+
+**A quarentena de 7 dias e o "uma por dia" são números sem evidência**, escolhidos pelo mesmo
+critério conservador dos limiares do V1: errar para menos incomoda menos que errar para mais.
+
+**O V4 vai querer o dossiê em formato de prompt, e o V2 entrega dicionário.** A tradução — que
+frases descrevem uma empresa a partir de 39 respostas — é trabalho do V4 e não foi feita aqui.
+O risco é o V4 descobrir que precisava de perguntas diferentes.
+
+**Cobrança a receber continua sem antecedência.** Descoberto ao escrever este spec e não
+consertado aqui: `_dinheiro_com_data` dá aviso prévio a conta a pagar e nenhum a cobrança, que
+só aparece depois de vencida. O dono é avisado do que deve e surpreendido pelo que não recebeu.
+É dívida do V1, e a pergunta correspondente do DNA só pode existir depois da regra.
+
+**Sem histórico de respostas.** Se o dono mudar "esfria em 30 dias" para 60, não há registro de
+que um dia foi 30 além do `core/audit.py`. Uma análise futura do tipo "donos apertam ou afrouxam
+com o tempo?" não é respondível.
+
+---
+
+## Fora de escopo
+
+| Fora | Vai para |
+|---|---|
+| Observar comportamento para sugerir resposta (*"notamos que você responde em ~4h"*) | V2.5 |
+| Qualquer uso de IA — redigir, interpretar texto livre, inferir | V4 |
+| O dossiê ser efetivamente **consumido** (no V2 é guardado e mais nada) | V4 |
+| DNA por usuário (é do tenant, sempre) | — |
+| Histórico de versões das respostas | — |
+| Editor de catálogo por tenant | — |
+| Medição de ativação do núcleo | dívida de analytics |

--- a/docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md
+++ b/docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md
@@ -131,9 +131,10 @@ existe e é o lugar certo.
 **`value` nulo distingue "pulei" de "nunca me perguntaram"** sem tabela nova. É o que sustenta a
 quarentena de 7 dias descrita em [Cadência](#cadência-as-duas-regras-de-silêncio).
 
-**A escrita valida contra o catálogo.** Chave desconhecida → 422. Valor fora de `opcoes` para
-formato `escolha` → 422. Texto acima de 2.000 caracteres → 422. Sem isso o `value` JSON vira
-depósito de qualquer coisa e o resolver quebra na leitura, longe de quem escreveu.
+**A escrita valida contra o catálogo.** Chave desconhecida → **404** (a pergunta não existe como
+recurso). Valor fora de `opcoes` → **400**. Texto acima de 2.000 caracteres → **400**. Sem isso o
+`value` JSON vira depósito de qualquer coisa e o resolver quebra na leitura, longe de quem
+escreveu.
 
 ### O V2 não chama IA
 
@@ -424,7 +425,8 @@ produto — e a trilha de quem mudou o quê é trabalho de `core/audit.py`.
 | `key` única e prefixada pelo `eixo` | Vocabulário divergente em seis meses (lição de `facts.kind`) |
 | Toda pergunta de `escolha` tem ao menos 2 `opcoes` | Pergunta impossível de responder chega ao dono |
 | Varredura AST de `app/modules/dna/` em `test_fuso_do_tenant.py` | Cadência em UTC cru: dois interrogatórios no mesmo dia fora de SP |
-| Resposta fora de `opcoes` → 422 | `value` JSON vira depósito e o resolver quebra na leitura |
+| Resposta fora de `opcoes` → 400 | `value` JSON vira depósito e o resolver quebra na leitura |
+| Resposta órfã (opção que saiu do catálogo) cai no default | Um ajuste de catálogo derruba o briefing de quem já tinha respondido |
 | `limiares()` devolve só Calibração | Retrato ganha consumidor por acidente e o contrato morre |
 | Default preservado quando não há resposta | Tenant que não respondeu muda de comportamento sem ter pedido |
 
@@ -434,7 +436,7 @@ produto — e a trilha de quem mudou o quê é trabalho de `core/audit.py`.
 
 | Onda | Entregável | Dá para parar aqui? |
 |---|---|---|
-| **1** | `dna/catalog.py` com as 45 e as guardas · migration `dna_answers` (RLS `FORCE`) · rotas `GET /dna/pendente`, `PUT /dna/{key}`, `POST /dna/{key}/pular` · validação | Sim — nada visível mudou |
+| **1** | `dna/catalog.py` com as 45 e as guardas · migration `dna_answers` (RLS `FORCE`) · rotas `GET /dna/pendente` (com cadência), `GET /dna/faltantes` (sem), `GET /dna/respostas`, `PUT /dna/{key}`, `POST /dna/{key}/pular` · validação | Sim — nada visível mudou |
 | **2** | `dna/resolver.py` ligado em `absences` via `vima/service.py` · `dinheiro_com_data_dias` separado de `prazo_vencendo_dias` · limpeza do silêncio | Sim — **o DNA já muda o briefing**, respondendo pela API |
 | **3** | Núcleo de 6 no primeiro acesso, em `EntradaDoDia`, pulável, 360px | Sim |
 | **4** | Ganchos: Calibração colada à ausência no briefing + ganchos de contexto | Sim |

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1103,6 +1103,12 @@ export interface BriefingLinha {
   secao: "PENDENTE" | "ACONTECEU" | "NÚMEROS";
   module: string;
   texto: string;
+  /**
+   * O `kind` da ausência que gerou a linha — é o que permite colar a pergunta de calibração do
+   * DNA na linha que a motivou. Vazio em linhas que não são ausência e em briefings gravados
+   * ANTES do V2, cujo payload não tinha o campo.
+   */
+  kind: string;
 }
 
 export interface Briefing {
@@ -1118,6 +1124,28 @@ export interface Briefing {
   linhas: BriefingLinha[];
   read_at: string | null;
   created_at: string;
+}
+
+export interface DnaOpcao {
+  rotulo: string;
+  valor: string | number | null;
+}
+
+/**
+ * Uma pergunta do DNA da Empresa. Viaja INTEIRA do backend — o front não tem cópia do catálogo,
+ * porque duas cópias divergem no primeiro ajuste de texto e a errada é sempre a que o dono lê.
+ */
+export interface DnaPergunta {
+  key: string;
+  /**
+   * `calibracao` muda o briefing de amanhã; `retrato` é guardado para o V4. A tela DIZ isso —
+   * prometer efeito imediato ao Retrato seria o erro que as duas classes existem para impedir.
+   */
+  classe: "calibracao" | "retrato";
+  eixo: "oferta" | "cliente" | "ritmo" | "dinheiro" | "limites";
+  texto: string;
+  formato: "escolha" | "escolha_multipla" | "texto";
+  opcoes: DnaOpcao[];
 }
 
 /**


### PR DESCRIPTION
## Vima V2 — o DNA da Empresa

O V1 entregou um briefing que fala com todo mundo do mesmo jeito: os cinco limiares de `absences.py` eram defaults escolhidos por nós, não pelo dono. Um advogado que responde em dois dias e um social media que responde em duas horas recebiam o mesmo aviso, na mesma hora — para um o briefing gritava cedo demais, para o outro avisava quando já era tarde.

Este PR faz o dono declarar o próprio negócio, e o briefing passar a falar a língua dele.

> Spec: `docs/superpowers/specs/2026-08-08-vima-dna-da-empresa-design.md`
> Plano: `docs/superpowers/plans/2026-08-08-vima-dna-da-empresa.md`

---

### A escolha estruturante: duas classes verificadas mecanicamente

| Classe | Tem consumidor hoje? | Efeito de responder |
|---|---|---|
| **Calibração** (6) | Sim, obrigatoriamente | Muda o briefing de amanhã |
| **Retrato** (39) | Não, por definição | É guardado para o V4 |

Duas guardas rodam **no import do módulo** — falham na subida do processo, não em produção:

1. Calibração exige `consome`; Retrato o proíbe.
2. `consome` precisa apontar para chave real de `LIMIARES_PADRAO`.

A segunda existe porque a alternativa é um **silêncio perfeito**: um typo em `card_parado_dais` grava a resposta, o `{**PADRAO, **override}` ignora a chave estranha, e o dono responde para sempre sem efeito nenhum — sem erro, sem teste quebrando. Um produto que finge ouvir é pior que um que não pergunta.

**São 6 de Calibração porque só existem 6 consumidores.** Qualquer número maior seria invenção (Artigo IV). `dinheiro.tolerancia_dias` parece Calibração — tem número, tem opções fechadas — e é Retrato: não existe regra de Ausência sobre carência. A classe é definida pelo contrato, nunca pelo formato.

### O núcleo do primeiro acesso NÃO é de Calibração

É a inversão central do design. *"Em quanto tempo eu te aviso que ninguém respondeu o Carlos?"* é irrespondível antes de ter visto um briefing — a resposta seria um chute que depois vira comportamento errado com aparência de configuração deliberada. O núcleo são 6 perguntas de Retrato, puláveis, em ~90s; a Calibração vem por **gancho colado à ausência que a motivou**, no único instante em que a pergunta é óbvia.

### Cadência

Uma pergunta por gancho por dia, no produto inteiro. Pulada em quarentena de 7 dias. O núcleo é a exceção declarada — sequência anunciada e interrupção não anunciada não cansam igual.

---

## Ondas

| Onda | Entrega |
|---|---|
| 1 | `dna/catalog.py` (45 perguntas + guardas), `dna_answers` com RLS `FORCE`, rotas |
| 2 | Resolver ligado em `absences`; `dinheiro_com_data_dias` separado; silêncio limpo ao recalibrar |
| 3 | Núcleo de 6 em `EntradaDoDia` |
| 4 | Ganchos: Calibração colada à ausência + 5 ganchos de contexto |
| 5 | Aba "A sua empresa" em `/config` |

## Três defeitos encontrados durante a execução

Nenhum seria pego por teste unitário — todos apareceram no teste ponta a ponta ou por mutação.

1. **O `None` de "não quero esse aviso" estourava o briefing inteiro.** Chegava em `timedelta(days=None)`. O spec especificava "regra não executada" e nenhuma tarefa do plano implementava isso — lacuna do plano, não do spec.
2. **`recalibrado_apos` com `>` estrito quebrava o recurso por completo.** O dono recalibra HOJE, pelo gancho do briefing de hoje, cujo `reference_date` também é hoje — a limpeza do silêncio nunca chegava ao dia seguinte, que é justamente quando precisa acontecer.
3. **Bug de fuso na cadência.** `answered_at` é `timestamptz`, e `.date()` nele devolve a data em UTC: um dono em UTC−3 respondendo às 22h produzia carimbo do dia seguinte, a cota do dia não era reconhecida e ele seria perguntado de novo às 22h05. Corrigido com `local_date` e **provado por mutação**. `app/modules/dna/` entrou na varredura AST de `test_fuso_do_tenant.py`.

## Migration: renumerada de 0075 para 0076

Esta migration e a `0075_investment_bank_account.py` (#100) foram escritas em paralelo, ambas a partir de `0074`, ambas reivindicando o mesmo id. A #100 mergeou primeiro, então esta renumerou — **quem mergeia depois renumera**, antes do merge e nunca depois: duas revisions com o mesmo id fazem `alembic upgrade head` escolher uma em silêncio. É a terceira vez que o repositório encosta nessa armadilha (ver a `0072`).

`origin/main` já está mergeado neste branch e a cadeia `0074 → 0075 → 0076` foi verificada do zero contra Postgres, com `DROP SCHEMA` antes.

## Verificação

| Gate | Resultado |
|---|---|
| `pytest` (pós-merge) | **1995 passando**, 1 skip, 0 falhas |
| `pnpm --filter @e1p/web test` | **544 passando**, 61 arquivos |
| `pnpm --filter @e1p/web build` | compila limpo |
| `alembic upgrade head` | cadeia completa do zero contra Postgres |
| RLS de `dna_answers` | `relrowsecurity` e `relforcerowsecurity` = `t`, policy `tenant_isolation` |

## Escopo e dívidas

**O V2 não chama IA em ponto nenhum** — nem para redigir, nem para interpretar texto livre. Custo marginal zero por tenant.

- ⚠️ **Validação manual em ~360px** da tela do núcleo e da aba nova **não foi feita** — bloqueia release, não bloqueia merge (mesmo padrão de Contas & Saldos, Conversas e do briefing).
- As 45 perguntas nunca foram validadas com dono real. Trocar texto e opções é editar um arquivo Python; resposta órfã (opção que saiu do catálogo) cai no default em vez de derrubar o briefing.
- Sem medição de ativação do núcleo — não há como saber se ele ajudou ou atrapalhou.
- **Cobrança a receber continua sem antecedência**: `_dinheiro_com_data` avisa antes sobre conta a pagar e nada sobre cobrança, que só aparece depois de vencida. O dono é avisado do que deve e surpreendido pelo que não recebeu. Dívida do V1, registrada e não consertada aqui — é decisão sobre o que o briefing anuncia, não sobre como ele é calibrado.
- A quarentena de 7 dias e o "uma por dia" são números sem evidência, conservadores pelo mesmo critério dos limiares do V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
