### PR TITLE
feat: o principal da aplicação passa a ser calculado, e o backfill do épico deixa de existir [Epic 8, Onda 2b-ii]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -919,8 +919,123 @@ onda já fechada. O único teste que tocava a função afirmava que ela era `cal
   `register_yield`). Está na docstring para não parecer esquecimento na 2b-ii.
 - **Dívida:** **aceite visual em ~360px do campo de vínculo NÃO foi feito** — mesma dívida da 8.13
   AC9 e da 8.21. Bloqueia release, não bloqueia merge.
-- **Dívida:** a 2b-ii continua com o único backfill do épico, e ele continua sendo o item de maior
-  risco.
+- **Dívida:** ~~a 2b-ii continua com o único backfill do épico, e ele continua sendo o item de
+  maior risco.~~ **FECHADA na 2b-ii (2026-08-08): o backfill não foi mitigado, deixou de
+  existir.** Ver a seção da Onda 2b-ii, logo abaixo.
+
+### Onda 2b-ii — o principal deixa de ser digitado (e o backfill deixa de existir)
+
+> Spec: `docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md`
+
+**A onda que era "o item de maior risco do épico inteiro" NÃO TEM MIGRATION.** Todo documento
+anterior a ela a descrevia como a onda do backfill — o único `UPDATE` sobre dado existente do
+épico, sob a armadilha do `FORCE RLS` (`UPDATE` filtrado a zero linhas **em silêncio**, que o
+SQLite dos testes não pega). Duas coisas o dissolveram: a **2b-i já executou os passos 1-2 do
+design-mãe §6.2 por ato do dono** (coluna via DDL puro, vínculo pela tela), e
+`investment_accounts` está **vazia em produção** (confirmado pelo fundador). Os passos 3-4 não
+tinham sobre o que rodar.
+
+> **A regra que fica (reverberar): quando um backfill existe para reconstruir histórico que um
+> ATO DO DONO reconstrói melhor, o backfill é o caminho pior.** Ele escreve sem testemunha, num
+> regime onde o fracasso é silencioso. Trocar escrita retroativa por *auditoria + ato* foi a
+> manobra da 2b-i; esta é a segunda aplicação, e agora é padrão.
+
+- [x] **`principal = opening_balance_cents + Σ movimentos com `source <> 'yield'`.** O saldo de
+  abertura entra, e **isso não estava no design-mãe §6.2**: é o dinheiro que já estava aplicado no
+  dia do cadastro, principal que nunca teve movimento. Sem ele, uma conta cadastrada com R$ 10.000
+  mostraria principal **zero** — número errado com aparência de fato, a família que a Onda 0 existe
+  para não repetir. O recorte de `source` impede a dupla contagem: o rendimento já é
+  `accrued_yield_cents` e, desde a 2b-i, também é `bank_transaction`.
+- [x] **`exclude_sources` entrou em `_movements_sums`, não numa query nova.** A docstring dela já
+  dizia por quê: duas cópias da fórmula divergiriam, e o sintoma seria um saldo que muda conforme a
+  tela que o pede. `bank.service.movement_sums` é a porta pública fina — existe porque `investments`
+  precisava dela e importar um símbolo `_` de outro módulo é acesso que ninguém encontra depois.
+- [x] **Saldo de abertura desconhecido ⇒ principal `None`, nunca zero.** Reusa
+  `origem_do_saldo_derivado` (Story 8.21) em vez de recomparar `opening_balance_is_known` — foi
+  exatamente essa recomparação duplicada que a 8.21 pagou para eliminar. Zero seria a afirmação
+  *"você não tem nada aplicado"*, falsa e indistinguível de um saldo genuinamente zerado.
+- [x] **A coluna `principal_cents` está CONGELADA** — sem leitor, sem escritor, com gate AST e
+  **controle positivo**. Terceiro uso do padrão (`attachments.data`, `tenant_profiles.timezone`).
+  **Eram NOVE leitores**, levantados por `grep` **antes de a spec fechar** e não durante a
+  implementação — a lição da 0073, onde três consumidores não apareceram na investigação inicial.
+  Drop numa migration posterior.
+  - ⚠️ **O gate proíbe `<conta>.principal_cents` e PERMITE `data.principal_cents`**, e a assimetria
+    tem teste próprio: ler o campo do **request** é como a recusa 409 sabe que alguém tentou editar.
+    Quem "endurecer" o gate acrescentando `data` à lista torna a guarda inalcançável e devolve a
+    edição do principal — com o gate verde o tempo todo.
+- [x] **O DÉCIMO leitor não estava no inventário, e não era do módulo: o Diagnóstico.** A regra 4
+  do motor (`engine._investment_signals`, Story 5.6) só avalia quando `period_rentability_pct` não
+  é `None` — e essa fração agora depende do principal DERIVADO. Aplicação sem conta vinculada
+  deixou de produzir o sinal 🟡 "sem rendimento no período". O inventário do §4.2.1 da spec buscou
+  por `principal_cents` e o achou em nove lugares; este décimo **não menciona a coluna** — consome
+  a rentabilidade, dois saltos adiante. Quem o pegou foram dois testes de `financial_intelligence`,
+  não o grep.
+  - ⚠️ **Um deles era o `rls_e2e` do vazamento de PII cross-tenant**, e o modo de falha é o pior
+    possível: sem conta vinculada, nenhum sinal cita nome de aplicação, e o teste passaria **verde
+    por vacuidade** — sem exercitar o vetor que ele existe para exercitar. A fixture agora semeia a
+    `bank_account` junto e continua gravando a coluna congelada de propósito, provando que **não é
+    ela** que aparece.
+  - **Regra que fica: um grep pelo NOME do dado acha os leitores diretos, e para nos leitores que
+    o consomem transformado.** Quem congela uma coluna precisa perguntar também *"quem consome o
+    que se calcula a partir dela?"* — aqui a resposta estava a dois saltos e em outro módulo.
+- [x] **O leitor que quase passou: `_pct` DIVIDE pelo principal.** Com `None` levantaria
+  `TypeError`; com **negativo** devolveria um percentual de sinal invertido — plausível na tela, e
+  errado. Agora protege os três casos (`None`, zero, negativo). *"Quanto rendeu percentualmente o
+  que você não aplicou?"* não é pergunta com resposta menor: é pergunta sem resposta.
+- [x] **Editar o principal: 409, e ele é o OPOSTO do 409 da 2b-i.** Aquele era caminho normal e por
+  isso a tela oferecia a saída no próprio modal. Este é **inalcançável pela tela** (o campo saiu do
+  formulário): se disparar, é integração antiga ou defeito. Por isso **não** tem `detail["acao"]` —
+  um `acao` sem modal do outro lado é contrato com ninguém. A guarda do `create` é sobre o **valor**
+  (`if data.principal_cents:`) e a do `update` sobre a **presença** (`is not None`), porque o
+  default do schema é `0` num e `None` no outro; a assimetria é deliberada e cada metade tem teste.
+- [x] **REQ-25 cumprido na LEITURA, não na escrita — desvio declarado.** O resgate bruto (principal
+  + rendimento embutido, que é como o banco credita) deixa o principal negativo. Recusar o resgate
+  exigiria `bank/transfers.py` consultar `investments`, que o gate
+  `test_bank_transfers_nao_importa_investments` proíbe — e recusaria um fato que **já aconteceu no
+  banco**, o inverso do princípio da Onda 0. A tela nomeia a diferença e a ação, e **não adivinha o
+  valor** (Artigo IV): o sistema sabe que faltam R$ 500 e não os lança sozinho.
+- [x] **`app/scripts/investment_audit.py` — sem `--fix`, e a ausência é a decisão.** Com uma flag de
+  correção, alguém a rodaria no deploy sem ler a saída e o `UPDATE` voltaria pela porta dos fundos.
+  Imprime **quantos tenants varreu**: `0 aplicações em 0 tenants` e `0 em 7` são resultados
+  diferentes, e o primeiro é defeito do próprio script (a lição da sondagem de `phone_key`, onde a
+  RLS devolveu zero linhas sem erro e o silêncio quase virou aprovação). Principal `None` **não** é
+  divergência: é ausência de comparação, e marcá-la mandaria o dono caçar um erro que não existe.
+- [x] **O extrato da aplicação é a SEGUNDA superfície sobre o mesmo razão, de propósito** (decisão
+  do fundador). A primeira é "Ver movimentos" em Contas & Saldos — a conta de aplicação é uma
+  `bank_account` como qualquer outra. **A garantia contra divergência virou estrutural em vez de
+  documental:** `contas.ROTA_MOVIMENTOS` é uma constante com dois consumidores, e um gate por
+  `import.meta.glob` reprova a string literal em qualquer das duas telas (com controle positivo
+  próprio, senão um glob que deixasse de casar tornaria o gate vacuamente verde).
+
+- [x] **O aceite em ~360px FOI FEITO, com screenshot — e achou um defeito na primeira medição.**
+  Depois de três dívidas abertas na fila (8.13 AC9, 8.21, 2b-i) e três PRs de campo pagos (#56,
+  #58, #89), esta onda mediu antes de mergear. **O extrato nasceu como `<table>` de 3 colunas com
+  `min-w-[20rem]` dentro de `overflow-x-auto`, e em 360px a coluna de VALOR nascia fora da vista:
+  a tela mostrava `R$ 3.` no lugar de `R$ 3.000,00`.** Virou lista (`<ul>`): data e descrição
+  empilhadas à esquerda num bloco `min-w-0`, valor à direita com `whitespace-nowrap`.
+  > **A lição do PR #58 era "role, não corte" (`overflow-x-auto` em vez de `overflow-hidden`), e
+  > ela funcionou — não houve corte silencioso. A desta onda é mais funda: em 360px uma tabela de
+  > 3 colunas não cabe, e a saída não é fazer a rolagem funcionar melhor, é não precisar dela.**
+  > Num extrato o valor é *a* informação, e informação que exige rolagem lateral para existir é
+  > informação que o dono não lê. **Nenhuma asserção de classe CSS pegaria isto** — o `overflow-x`
+  > estava correto, o `flex-wrap` estava correto, e a tela estava errada.
+- ⚠️ **Achado PRÉ-EXISTENTE, fora do escopo desta onda e não corrigido aqui:** em 360px o
+  `document.scrollWidth` da tela de Investimentos é **375px** — a página inteira rola 15px na
+  horizontal. Medido idêntico **com e sem** o extrato (logo não é desta onda), e ausente em
+  Contas & Saldos (345px). O culpado é o `ChevronDown` do menu do usuário em
+  `app/AppShell.tsx:209`. Fica registrado com a medição, e **não** foi corrigido junto: misturar
+  correção de defeito existente com regra nova no mesmo diff tira do gate a capacidade de julgar
+  qual mudança quebrou o quê — mesmo argumento que manteve SIG-001 fora da 8.16 e separou 8.19
+  de 8.20.
+
+- **Dívida:** `packages/shared-types/src/generated.ts` tem `principal_cents` em quatro lugares e
+  segue defasado desde o PR #45, sem check de drift no CI. Dívida do épico, não desta onda.
+- **Dívida:** REQ-26 (cotização e liquidação em datas diferentes) segue não implementado —
+  declarado fora de escopo, não esquecido.
+- **Dívida:** o `DROP COLUMN principal_cents` é migration posterior, depois de um ciclo.
+- **Dívida:** o estouro horizontal de 15px do `AppShell` (acima) — vale para **todas** as telas,
+  não só esta.
 
 
 ## WhatsApp Evolution: em produção de verdade (deploy 2026-08-04)

--- a/apps/api/app/modules/bank/service.py
+++ b/apps/api/app/modules/bank/service.py
@@ -561,6 +561,7 @@ def _movements_sums(
     until: date | None = None,
     since: date | None = None,
     sign: int | None = None,
+    exclude_sources: frozenset[str] = frozenset(),
 ) -> dict[str, int]:
     """Σ dos movimentos de cada conta, em **UMA** query. `{bank_account_id: centavos}`.
 
@@ -577,6 +578,7 @@ def _movements_sums(
           AND (:until IS NULL OR posted_at <= :until)    -- `until` é DATE e INCLUSIVO
           AND (:since IS NULL OR posted_at >  :since)    -- `since` é DATE e EXCLUSIVO (8.14)
           AND (:sign  IS NULL OR sinal(amount_cents) = :sign)
+          AND (:exclude_sources vazio OR source NOT IN :exclude_sources)  -- Onda 2b-ii
           AND status <> 'ignored'                        -- AC5: ignorar TIRA do saldo
 
     ⚠️ **O filtro `status <> 'ignored'` mora AQUI, dentro do saldo** — é contrato para as Stories
@@ -598,6 +600,13 @@ def _movements_sums(
     `sign` é `+1` (só entradas), `-1` (só saídas) ou `None` (líquido, o comportamento do saldo).
     Nunca `0`: `_validate_amount` recusa movimento de valor zero, então esse conjunto é vazio por
     construção e aceitá-lo seria oferecer um filtro que nunca soma nada.
+
+    ⚠️ **[Onda 2b-ii] `exclude_sources` existe para que o principal derivado NÃO seja uma segunda
+    fórmula.** O principal de uma aplicação é a soma dos movimentos da conta dela **menos os de
+    rendimento** (que já são contados por `accrued_yield_cents`). Escrever essa soma noutro lugar
+    duplicaria o piso `posted_at > opening_date` e o `status <> 'ignored'`, e o dia em que um dos
+    dois fosse corrigido só de um lado o principal passaria a divergir do saldo por um motivo que
+    ninguém acharia. Default vazio: todo chamador anterior a esta onda segue idêntico.
 
     A cláusula de conta é um `OR` de pares `(conta, opening_date)` em vez de um `IN (...)` porque
     cada conta tem a **sua** data de corte. Ainda é uma query só — a alternativa (`GROUP BY` com
@@ -635,6 +644,8 @@ def _movements_sums(
             stmt = stmt.where(BankTransaction.amount_cents > 0)
         else:
             stmt = stmt.where(BankTransaction.amount_cents < 0)
+    if exclude_sources:
+        stmt = stmt.where(BankTransaction.source.notin_(exclude_sources))
     return {account_id: int(total or 0) for account_id, total in db.execute(stmt).all()}
 
 
@@ -645,6 +656,31 @@ def _movements_sum(db: Session, *, account: BankAccount, until: date | None = No
     a assinatura é privada e a 8.2 explicitamente autorizou mudá-la para evitar a releitura.
     """
     return _movements_sums(db, accounts=[account], until=until).get(account.id, 0)
+
+
+def movement_sums(
+    db: Session,
+    *,
+    accounts: Sequence[BankAccount],
+    until: date | None = None,
+    exclude_sources: frozenset[str] = frozenset(),
+) -> dict[str, int]:
+    """A porta PÚBLICA da soma de movimentos — `{bank_account_id: centavos}`.
+
+    Fina de propósito: delega para `_movements_sums`, que continua sendo a **única** implementação
+    da fórmula. Ela existe porque `investments` precisa da soma com `exclude_sources` (Onda 2b-ii) e
+    importar um símbolo `_` de outro módulo é o tipo de acesso que ninguém encontra depois — e que o
+    `dedup-checker` não consegue julgar.
+
+    `until=None` significa **hoje**, como em `derived_balance` (Story 8.10). Conta sem movimento não
+    aparece no dicionário; use `.get(id, 0)`.
+    """
+    return _movements_sums(
+        db,
+        accounts=accounts,
+        until=resolve_until(until, _today(db)),
+        exclude_sources=exclude_sources,
+    )
 
 
 def derived_balance(db: Session, *, bank_account_id: str, until: date | None = None) -> int:

--- a/apps/api/app/modules/investments/router.py
+++ b/apps/api/app/modules/investments/router.py
@@ -22,13 +22,18 @@ router = APIRouter(prefix="/investments", tags=["investments"])
 _guard = require_module("investments")
 
 
-def _out(a: InvestmentAccount) -> InvestmentAccountOut:
+def _out(a: InvestmentAccount, principal_cents: int | None) -> InvestmentAccountOut:
+    """O principal vem de FORA (Onda 2b-ii) — `a.principal_cents` está congelado.
+
+    O parâmetro é **obrigatório de propósito**: um default que lesse a coluna seria exatamente o
+    caminho por onde o valor digitado voltaria a vencer, e nada quebraria para avisar.
+    """
     return InvestmentAccountOut(
         id=a.id,
         name=a.name,
         kind=a.kind,
         index_rate_label=a.index_rate_label,
-        principal_cents=a.principal_cents,
+        principal_cents=principal_cents,
         accrued_yield_cents=a.accrued_yield_cents,
         opened_at=a.opened_at,
         bank_account_id=a.bank_account_id,
@@ -51,7 +56,11 @@ def list_accounts(
     _user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> list[InvestmentAccountOut]:
-    return [_out(a) for a in service.list_accounts(db)]
+    contas = service.list_accounts(db)
+    # Lote de propósito: UMA query para N aplicações. `principal_derivado` num laço seria o
+    # N+1 que `_movements_sums` existe para evitar um nível abaixo.
+    principais = service.principais_derivados(db, contas)
+    return [_out(a, principais[a.id]) for a in contas]
 
 
 @router.post("", response_model=InvestmentAccountOut, status_code=201)
@@ -65,7 +74,7 @@ def create_account(
         acc = service.create_account(db, tenant_id=user.tenant_id, actor=user.user_id, data=data)
     except service.InvestmentError as e:
         raise _err(e) from e
-    return _out(acc)
+    return _out(acc, service.principal_derivado(db, acc))
 
 
 @router.patch("/{account_id}", response_model=InvestmentAccountOut)
@@ -81,7 +90,7 @@ def update_account(
         )
     except service.InvestmentError as e:
         raise _err(e) from e
-    return _out(acc)
+    return _out(acc, service.principal_derivado(db, acc))
 
 
 @router.post("/{account_id}/yield", response_model=InvestmentAccountOut)
@@ -103,7 +112,7 @@ def register_yield(
         )
     except service.InvestmentError as e:
         raise _err(e) from e
-    return _out(acc)
+    return _out(acc, service.principal_derivado(db, acc))
 
 
 @router.get("/{account_id}/rentability", response_model=RentabilityOut)

--- a/apps/api/app/modules/investments/schemas.py
+++ b/apps/api/app/modules/investments/schemas.py
@@ -79,7 +79,11 @@ class InvestmentAccountOut(BaseModel):
     name: str
     kind: str
     index_rate_label: str
-    principal_cents: int
+    # Onda 2b-ii: CALCULADO dos movimentos da conta bancária vinculada, não mais a coluna.
+    # `None` = inafirmável (sem vínculo, ou saldo de abertura declarado desconhecido — Story 8.21).
+    # **`None` não é zero:** zero seria a afirmação "você não tem nada aplicado". Pode ser NEGATIVO
+    # (resgate bruto que levou rendimento ainda não lançado junto) — e não é clampado.
+    principal_cents: int | None
     accrued_yield_cents: int
     opened_at: date
     bank_account_id: str | None
@@ -88,12 +92,13 @@ class InvestmentAccountOut(BaseModel):
 
 class RentabilityOut(BaseModel):
     account_id: str
-    principal_cents: int
+    principal_cents: int | None  # Onda 2b-ii — ver InvestmentAccountOut
     accrued_yield_cents: int
-    # Rentabilidade TOTAL (rendimento acumulado / principal). None se principal == 0 (evita ÷0).
+    # Rentabilidade TOTAL (rendimento acumulado / principal). `None` quando o principal é `None`,
+    # zero ou NEGATIVO — ver `service._pct`.
     total_rentability_pct: float | None
     # Rentabilidade do PERÍODO (soma dos rendimentos com competência no intervalo / principal).
-    # None se principal == 0. start/end None = período aberto (todo o histórico).
+    # Mesmas três condições de `None`. start/end None = período aberto (todo o histórico).
     period_rentability_pct: float | None
     period_yield_cents: int
     start: date | None

--- a/apps/api/app/modules/investments/service.py
+++ b/apps/api/app/modules/investments/service.py
@@ -115,6 +115,36 @@ class ContaNaoVinculadaError(InvestmentError):
         self.detail = {"acao": ACAO_CADASTRAR_CONTA, "mensagem": SEM_CONTA_VINCULADA_MSG}
 
 
+_PRINCIPAL_DERIVADO_MSG = (
+    "O valor aplicado agora é calculado pelos movimentos da conta. Para mudar quanto está "
+    "aplicado, registre a transferência que você fez de verdade — da conta corrente para a "
+    "aplicação (aporte) ou da aplicação para a corrente (resgate)."
+)
+
+_PRINCIPAL_NO_CADASTRO_MSG = (
+    "No cadastro, o valor já aplicado é o saldo de abertura da conta bancária da aplicação — é "
+    "lá que ele é informado, uma vez."
+)
+
+
+class PrincipalNaoEditavelError(InvestmentError):
+    """O principal é derivado (Onda 2b-ii) e não se edita.
+
+    ⚠️ **`detail` fica em texto, sem `{"acao": ...}` — e a ausência é a decisão.** O 409 acionável
+    da 8.12/2b-i existe porque a tela reconhece a situação e oferece a saída ali mesmo. Este 409 é
+    **inalcançável pela tela** (o campo saiu do formulário): quem o recebe é uma integração antiga
+    ou um defeito. Um `acao` sem modal do outro lado seria um contrato com ninguém, e convidaria a
+    próxima pessoa a construir o modal que não deve existir.
+
+    A ação que a mensagem manda fazer **existe hoje**: `investment_in`/`investment_out` são
+    `TRANSFER_KINDS` desde a Onda 2, e a tela de transferência está em `ContasSaldosPage`. Recusar
+    apontando para uma ação inexistente é o defeito que esta classe existe para não cometer.
+    """
+
+    def __init__(self, mensagem: str) -> None:
+        super().__init__(mensagem, 409)
+
+
 def get_account(db: Session, account_id: str) -> InvestmentAccount:
     acc = db.get(InvestmentAccount, account_id)
     if acc is None:
@@ -126,6 +156,10 @@ def get_account(db: Session, account_id: str) -> InvestmentAccount:
 def create_account(
     db: Session, *, tenant_id: str, actor: str, data: InvestmentAccountCreate
 ) -> InvestmentAccount:
+    # Onda 2b-ii. `principal_cents` tem default `0` no schema, então a guarda é sobre o VALOR e não
+    # sobre a presença: `is not None` recusaria todo cadastro que simplesmente não manda o campo.
+    if data.principal_cents:
+        raise PrincipalNaoEditavelError(_PRINCIPAL_NO_CADASTRO_MSG)
     if data.bank_account_id:
         _validate_bank_account(db, data.bank_account_id)
     acc = InvestmentAccount(
@@ -133,7 +167,7 @@ def create_account(
         name=data.name,
         kind=data.kind,
         index_rate_label=data.index_rate_label,
-        principal_cents=data.principal_cents,
+        # `principal_cents` NÃO é escrito: a coluna está congelada e nasce no default `0` do model.
         accrued_yield_cents=0,
         opened_at=data.opened_at,
         bank_account_id=data.bank_account_id,
@@ -158,7 +192,10 @@ def update_account(
     if data.index_rate_label is not None:
         acc.index_rate_label = data.index_rate_label
     if data.principal_cents is not None:
-        acc.principal_cents = data.principal_cents
+        # Onda 2b-ii. Aqui `is not None` É a guarda certa: no `Update` o default é `None` e
+        # significa "não altera" — o oposto exato do `Create`, cujo default é `0`. A assimetria é
+        # deliberada, e cada metade tem o seu teste.
+        raise PrincipalNaoEditavelError(_PRINCIPAL_DERIVADO_MSG)
     if data.bank_account_id is not None:
         # Onda 2b-i: é por aqui que a aplicação LEGADA é vinculada — ato do dono, não backfill.
         _validate_bank_account(db, data.bank_account_id)
@@ -406,9 +443,23 @@ def register_yield(
     return acc
 
 
-def _pct(numerator: int, principal_cents: int) -> float | None:
-    """Rentabilidade (fração) protegendo divisão por zero: principal 0 → None (AC3)."""
-    if principal_cents == 0:
+def _pct(numerator: int, principal_cents: int | None) -> float | None:
+    """Rentabilidade (fração), ou `None` quando a pergunta não tem sentido.
+
+    Três casos sem número, e o terceiro é o que a Onda 2b-ii acrescentou:
+
+    - **`None`** — o principal é inafirmável (sem vínculo, ou saldo de abertura desconhecido).
+      Dividir levantaria `TypeError`.
+    - **zero** — divisão por zero, protegida desde a 5.6 (AC3).
+    - **negativo** — resgate bruto que levou rendimento ainda não lançado junto. Dividir devolveria
+      um percentual de **sinal invertido**: plausível na tela, e errado. *"Quanto rendeu
+      percentualmente o que você não aplicou?"* não é uma pergunta com resposta menor — é uma
+      pergunta sem resposta.
+
+    O `None` já é renderizado como "—" pela tela desde a 5.6 (`investimentos.ts::formatPct`): a
+    superfície existe e não precisa ser inventada.
+    """
+    if principal_cents is None or principal_cents <= 0:
         return None
     return numerator / principal_cents
 
@@ -433,12 +484,15 @@ def rentability(
         stmt = stmt.where(Charge.competence_date <= end)
     period_yield = int(db.scalar(stmt) or 0)
 
+    # Onda 2b-ii: o principal vem dos MOVIMENTOS, nunca mais da coluna (que está congelada).
+    principal = principal_derivado(db, acc)
+
     return {
         "account_id": acc.id,
-        "principal_cents": acc.principal_cents,
+        "principal_cents": principal,
         "accrued_yield_cents": acc.accrued_yield_cents,
-        "total_rentability_pct": _pct(acc.accrued_yield_cents, acc.principal_cents),
-        "period_rentability_pct": _pct(period_yield, acc.principal_cents),
+        "total_rentability_pct": _pct(acc.accrued_yield_cents, principal),
+        "period_rentability_pct": _pct(period_yield, principal),
         "period_yield_cents": period_yield,
         "start": start,
         "end": end,

--- a/apps/api/app/modules/investments/service.py
+++ b/apps/api/app/modules/investments/service.py
@@ -45,12 +45,14 @@ A perna existe porque rendimento **move dinheiro numa conta real do dono** — e
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, date, datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import audit
+from app.core.money_planes import ORIGEM_INDISPONIVEL
 from app.modules.bank import origin as bank_origin
 from app.modules.bank import service as bank_service
 from app.modules.bank.models import KIND_INVESTMENT, SOURCE_YIELD
@@ -169,6 +171,80 @@ def update_account(
 
 def list_accounts(db: Session) -> list[InvestmentAccount]:
     return list(db.scalars(select(InvestmentAccount).order_by(InvestmentAccount.name)).all())
+
+
+# ── O principal DERIVADO (Onda 2b-ii) ─────────────────────────────────────────────────────────
+
+
+def principais_derivados(
+    db: Session, accs: Sequence[InvestmentAccount]
+) -> dict[str, int | None]:
+    """O principal CALCULADO de cada aplicação — `{investment_account_id: centavos | None}`.
+
+        principal = opening_balance_cents da conta de aplicação
+                  + Σ movimentos daquela conta com `source <> 'yield'`
+
+    Os três termos, e por que cada um está aqui:
+
+    **(a) O saldo de abertura entra.** É o dinheiro que já estava aplicado no dia do cadastro —
+    principal que nunca teve movimento. Somar só os movimentos daria R$ 0,00 numa conta com
+    R$ 10.000 aplicados: um número errado com aparência de fato.
+
+    **(b) `source <> 'yield'` impede a dupla contagem.** O rendimento já é contado por
+    `accrued_yield_cents` e, desde a Onda 2b-i, também gera `bank_transaction`. Sem o recorte, cada
+    rendimento entraria duas vezes no saldo da aplicação.
+
+    **(c) O piso `posted_at > opening_date` e o teto `<= hoje` não são escolha desta função** — vêm
+    de `_movements_sums`, a única soma de movimentos do repositório. Um aporte agendado para o mês
+    que vem não é principal aplicado hoje.
+
+    ⚠️ **`None` NÃO é zero, e a distinção é o ponto.** Devolvemos `None` em dois casos — aplicação
+    sem vínculo, e conta cujo saldo de abertura o dono declarou **não saber** (Story 8.21,
+    `origem_do_saldo_derivado`). Zero seria a afirmação *"você não tem nada aplicado"*, falsa e
+    indistinguível de um saldo genuinamente zerado. É o princípio da Onda 0 e da 8.21: suprimir a
+    afirmação, nunca o número.
+
+    ⚠️ **A procedência é lida de `bank_service.origem_do_saldo_derivado`, nunca recomparada aqui.**
+    A Story 8.21 pagou exatamente esse preço: a mesma decisão escrita duas vezes no `router.py`
+    fazia a mesma conta responder coisas diferentes por portas diferentes.
+
+    O principal **pode ser negativo** (resgate bruto que levou rendimento ainda não lançado junto).
+    Não é clampado: quem o nomeia é a tela, e clampar seria esconder.
+    """
+    vinculadas = {a.bank_account_id for a in accs if a.bank_account_id}
+    if not vinculadas:
+        return {a.id: None for a in accs}
+
+    # `include_archived=True`: uma aplicação encerrada continua tendo um principal histórico, e
+    # arquivar a conta não apaga o que passou por ela. Esconder aqui daria `None` (= "não sei")
+    # para algo que o sistema sabe perfeitamente.
+    contas = {
+        c.id: c
+        for c in bank_service.list_accounts(db, include_archived=True)
+        if c.id in vinculadas
+    }
+    somas = bank_service.movement_sums(
+        db, accounts=list(contas.values()), exclude_sources=frozenset({SOURCE_YIELD})
+    )
+
+    resultado: dict[str, int | None] = {}
+    for a in accs:
+        conta = contas.get(a.bank_account_id) if a.bank_account_id else None
+        if conta is None or bank_service.origem_do_saldo_derivado(conta) == ORIGEM_INDISPONIVEL:
+            resultado[a.id] = None
+            continue
+        resultado[a.id] = conta.opening_balance_cents + somas.get(conta.id, 0)
+    return resultado
+
+
+def principal_derivado(db: Session, acc: InvestmentAccount) -> int | None:
+    """O principal de UMA aplicação. Delega para `principais_derivados` — ver a fórmula lá.
+
+    Uma implementação, dois usos: duas cópias da fórmula divergiriam no dia em que uma delas
+    ganhasse uma condição, e o sintoma seria um principal que muda conforme a tela que o pede —
+    exatamente o que `_movements_sum`/`_movements_sums` já evitam um nível abaixo.
+    """
+    return principais_derivados(db, [acc])[acc.id]
 
 
 def _validate_financeiro_account(db: Session, chart_account_id: str) -> None:

--- a/apps/api/app/scripts/investment_audit.py
+++ b/apps/api/app/scripts/investment_audit.py
@@ -1,0 +1,114 @@
+"""Confere o principal das aplicações: o que a coluna congelada diz × o que os movimentos dizem.
+
+    docker compose exec api python -m app.scripts.investment_audit
+
+**Não existe `--fix`, e a ausência é a decisão.** A Onda 2b-ii substituiu o backfill do design-mãe
+§6.2 — o único `UPDATE` sobre dado existente do épico, exposto à armadilha do `FORCE ROW LEVEL
+SECURITY` (o `UPDATE` filtrado a zero linhas **em silêncio**, que o SQLite dos testes não pega) —
+por *auditoria + ato do dono*. Uma flag de correção reintroduziria exatamente o que a onda existe
+para não fazer, e alguém a rodaria no deploy sem ler a saída.
+
+O que fazer com uma divergência: **o dono corrige por ato na tela** — declarando o saldo de abertura
+da conta de aplicação, ou registrando o aporte que faltou como transferência. É o mesmo mecanismo
+pelo qual a Onda 2b-i vinculou a aplicação legada, já validado em campo.
+
+⚠️ **Isolamento:** itera a tabela GLOBAL `tenants` e abre `tenant_session` por tenant (RLS fixada),
+mesmo padrão de `merge_duplicate_clients` e `migrate_attachments_to_s3`. Uma consulta em tabela com
+RLS **sem** tenant devolve zero linhas **sem erro** — foi assim que a sondagem de `phone_key` em
+produção quase virou um "está tudo limpo" falso. Por isso a saída imprime **quantos tenants foram
+varridos**: `0 aplicações em 0 tenants` e `0 aplicações em 7 tenants` são resultados diferentes, e o
+primeiro é um defeito deste script, não um banco limpo.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db, tenant_session
+from app.modules.auth.models import Tenant
+from app.modules.investments import service as inv_service
+
+logger = logging.getLogger("e1p.investment_audit")
+
+
+def auditar(db: Session) -> list[dict]:
+    """Uma linha por aplicação do tenant da sessão. **Só lê.**
+
+    `coluna_cents` lê `principal_cents` de propósito — é o único lugar do repositório autorizado a
+    fazê-lo, e é por isso que este arquivo vive em `app/scripts/` e não em `app/modules/`: o gate
+    `test_investments_principal_gate.py` varre só os módulos.
+    """
+    contas = inv_service.list_accounts(db)
+    derivados = inv_service.principais_derivados(db, contas)
+    linhas: list[dict] = []
+    for a in contas:
+        derivado = derivados[a.id]
+        linhas.append(
+            {
+                "id": a.id,
+                "name": a.name,
+                "coluna_cents": a.principal_cents,
+                "derivado_cents": derivado,
+                # `None` (inafirmável) NÃO é divergência: é ausência de comparação. Tratá-lo como
+                # divergente mandaria o dono caçar um erro que não existe — o modo de falha que o
+                # épico chama de "pior do que ficar calado".
+                "diverge": derivado is not None and derivado != a.principal_cents,
+            }
+        )
+    return linhas
+
+
+def _tenant_ids() -> list[str]:
+    gen = get_db()
+    db = next(gen)
+    try:
+        return [t.id for t in db.scalars(select(Tenant)).all()]
+    finally:
+        gen.close()
+
+
+def _reais(cents: int | None) -> str:
+    if cents is None:
+        return "não sei"
+    inteiro, centavos = divmod(abs(cents), 100)
+    sinal = "-" if cents < 0 else ""
+    return f"{sinal}R$ {inteiro:,}".replace(",", ".") + f",{centavos:02d}"
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info("=== Auditoria do principal das aplicações (Onda 2b-ii) — SÓ LEITURA ===")
+
+    tenants = _tenant_ids()
+    total = divergentes = 0
+    for tenant_id in tenants:
+        with tenant_session(tenant_id) as db:
+            for linha in auditar(db):
+                total += 1
+                if not linha["diverge"]:
+                    continue
+                divergentes += 1
+                logger.info("")
+                logger.info("  %s (tenant %s)", linha["name"], tenant_id)
+                logger.info("    principal na coluna : %s", _reais(linha["coluna_cents"]))
+                logger.info("    principal calculado : %s", _reais(linha["derivado_cents"]))
+                logger.info(
+                    "    -> declare o saldo de abertura da conta de aplicação, ou registre o "
+                    "aporte que faltou como transferência"
+                )
+
+    logger.info("")
+    logger.info(
+        "%d aplicação(ões) em %d tenant(s); %d com divergência.", total, len(tenants), divergentes
+    )
+    if not tenants:
+        logger.warning(
+            "NENHUM tenant varrido — isto é um defeito deste script, não um banco limpo."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/tests/test_bank_corte_de_data.py
+++ b/apps/api/tests/test_bank_corte_de_data.py
@@ -46,6 +46,7 @@ from app.modules.bank.models import (
     KIND_CHECKING,
     KIND_INVESTMENT,
     SOURCE_MANUAL,
+    SOURCE_YIELD,
     STATUS_IGNORED,
     STATUS_UNMATCHED,
     BankTransaction,
@@ -114,6 +115,7 @@ def _plantar(
     amount_cents: int,
     posted_at: date,
     status: str = STATUS_UNMATCHED,
+    source: str = SOURCE_MANUAL,
 ) -> BankTransaction:
     """Monta o movimento **direto pelo model**, contornando `_validate_posted_at` de propósito.
 
@@ -130,8 +132,8 @@ def _plantar(
         amount_cents=amount_cents,
         raw_description="Agendado (plantado pelo teste, como a 8.14 fará)",
         user_description="",
-        dedup_hash=f"plantado-{account_id}-{posted_at.isoformat()}-{amount_cents}",
-        source=SOURCE_MANUAL,
+        dedup_hash=f"plantado-{account_id}-{posted_at.isoformat()}-{amount_cents}-{source}",
+        source=source,
         status=status,
     )
     db.add(tx)
@@ -656,3 +658,43 @@ def test_IV8_os_dois_totais_da_tela_nao_incluem_o_agendado(
     # "Total em contas" (soma de tudo) e "Disponível como caixa" (exclui aplicação), ambos limpos.
     assert sum(saldos.values()) == OPENING_CENTS + 900_00
     assert saldos["Corrente"] == OPENING_CENTS
+
+
+# ── Onda 2b-ii — o recorte por origem, de que o principal derivado depende ────────────────────
+
+
+def test_movement_sums_exclui_a_origem_pedida(
+    client: TestClient, db: Session, headers, tenant_id: str
+):
+    """`exclude_sources` tira uma origem da soma sem tocar nas outras (Onda 2b-ii).
+
+    É o recorte de que o principal derivado depende: o rendimento já é contado por
+    `accrued_yield_cents` e, desde a Onda 2b-i, também gera `bank_transaction` — sem este filtro
+    ele entraria DUAS vezes no saldo da aplicação.
+
+    ⚠️ **Dois `assert`, e é de propósito.** Com só o caso do rendimento excluído, ignorar
+    `exclude_sources` por completo ainda passaria: é o mutante `>` → `>=` da Onda 2, que sobreviveu
+    a 58 testes por faltar o caso do outro lado. O primeiro `assert` é o outro lado.
+    """
+    conta = _conta(client, headers, kind=KIND_INVESTMENT, opening_balance_cents=0)
+    hoje = _hoje()
+
+    _plantar(db, tenant_id=tenant_id, account_id=conta["id"], amount_cents=15_00, posted_at=hoje)
+    _plantar(
+        db,
+        tenant_id=tenant_id,
+        account_id=conta["id"],
+        amount_cents=100_00,
+        posted_at=hoje,
+        source=SOURCE_YIELD,
+    )
+
+    acc = service.get_account(db, conta["id"])
+
+    sem_recorte = service.movement_sums(db, accounts=[acc])
+    assert sem_recorte.get(acc.id) == 115_00, "sem recorte, os dois movimentos entram"
+
+    sem_rendimento = service.movement_sums(
+        db, accounts=[acc], exclude_sources=frozenset({SOURCE_YIELD})
+    )
+    assert sem_rendimento.get(acc.id) == 15_00, "o rendimento saiu; o manual FICOU"

--- a/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
+++ b/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
@@ -372,10 +372,31 @@ def test_diagnostico_continua_emitindo_os_sinais_das_outras_origens(
 ) -> None:
     """A completude entrou SEM apagar as demais regras: o sinal 🟡 de investimento (5.6) continua
     lá, ao lado do de completude, e a narrativa continua sendo montada normalmente."""
+    # ⚠️ **Onda 2b-ii: o principal vem do SALDO DE ABERTURA da conta de aplicação**, e não mais de
+    # `principal_cents` no payload (que agora responde 409). O que este teste precisa continua
+    # sendo o mesmo — uma aplicação com principal > 0, sem a qual `period_rentability_pct` é `None`
+    # e a regra 4 do motor não avalia nada (`engine._investment_signals`). Mudou onde o valor é
+    # informado, que é a mudança inteira daquela onda.
+    conta_aplicacao = client.post(
+        "/bank/accounts",
+        json={
+            "name": "CDB Reserva (conta)",
+            "kind": "investment",
+            "opening_balance_cents": 100_000,
+            "opening_balance_is_known": True,
+            "opening_date": START.isoformat(),
+        },
+        headers=headers,
+    )
+    assert conta_aplicacao.status_code == 201, conta_aplicacao.text
+
     r = client.post(
         "/investments",
-        json={"name": "CDB Reserva", "principal_cents": 100_000,
-              "opened_at": START.isoformat()},
+        json={
+            "name": "CDB Reserva",
+            "opened_at": START.isoformat(),
+            "bank_account_id": conta_aplicacao.json()["id"],
+        },
         headers=headers,
     )
     assert r.status_code == 201, r.text

--- a/apps/api/tests/test_financial_intelligence_diagnostics_rls.py
+++ b/apps/api/tests/test_financial_intelligence_diagnostics_rls.py
@@ -66,7 +66,17 @@ def _run_migrations_as_app(app_url: str) -> None:
 
 def _seed_investment(app_url: str, tenant_id: str, *, name: str, principal: int) -> None:
     """Uma aplicação com principal > 0 e sem rendimento → gera o sinal 🟡 'sem rendimento no
-    período', cuja explicação cita o NOME da aplicação (o vetor de vazamento que testamos)."""
+    período', cuja explicação cita o NOME da aplicação (o vetor de vazamento que testamos).
+
+    ⚠️ **Onda 2b-ii: o principal vem da CONTA BANCÁRIA vinculada**, então esta fixture semeia as
+    duas linhas — a `bank_account` `kind='investment'` com `opening_balance_cents = principal`, e a
+    `investment_accounts` apontando para ela. Semear só a segunda deixaria o principal derivado em
+    `None`, `period_rentability_pct` em `None`, e a regra 4 do motor não avaliaria nada: o teste
+    ficaria **verde por vacuidade**, sem nenhum sinal citando nome de aplicação — ou seja, sem o
+    vetor de vazamento que ele existe para exercitar. A coluna `principal_cents` continua sendo
+    escrita aqui **de propósito**: é o valor congelado, e o teste prova que ele NÃO é o que aparece.
+    """
+    from app.modules.bank.models import KIND_INVESTMENT, BankAccount
     from app.modules.investments.models import InvestmentAccount
 
     engine = create_engine(app_url, poolclass=NullPool)
@@ -80,10 +90,20 @@ def _seed_investment(app_url: str, tenant_id: str, *, name: str, principal: int)
             # só libera o savepoint — a txn externa (com o seed) é revertida no close. Mesmo
             # padrão da produção em app/db/session.py::tenant_session.
             session = Session(bind=conn)
+            conta = BankAccount(
+                tenant_id=tenant_id,
+                name=f"{name} (conta)",
+                kind=KIND_INVESTMENT,
+                opening_balance_cents=principal,
+                opening_balance_is_known=True,
+                opening_date=date(2026, 6, 1),
+            )
+            session.add(conta)
+            session.flush()  # o id tem default Python-side; sem isto o vínculo nasceria vazio
             session.add(
                 InvestmentAccount(
                     tenant_id=tenant_id, name=name, principal_cents=principal,
-                    opened_at=date(2026, 6, 1),
+                    opened_at=date(2026, 6, 1), bank_account_id=conta.id,
                 )
             )
             session.commit()

--- a/apps/api/tests/test_financial_intelligence_narrator.py
+++ b/apps/api/tests/test_financial_intelligence_narrator.py
@@ -163,9 +163,29 @@ def test_signals_identical_with_and_without_ai(
     """O CORAÇÃO da Story 5.8: os sinais determinísticos são idênticos byte-a-byte com e sem IA —
     a IA só troca o texto da NARRATIVA, jamais um número/sinal."""
     # Semeia uma aplicação com principal > 0 e sem rendimento → sinal 🟡 determinístico e estável.
+    #
+    # ⚠️ **Onda 2b-ii: o principal vem do SALDO DE ABERTURA da conta de aplicação.** Sem a conta,
+    # o principal derivado é `None`, `period_rentability_pct` é `None`, e a regra 4 do motor não
+    # avalia nada — o teste ficaria verde **sem o sinal que ele existe para comparar**.
+    conta = client.post(
+        "/bank/accounts",
+        json={
+            "name": "CDB Reserva (conta)",
+            "kind": "investment",
+            "opening_balance_cents": 100000,
+            "opening_balance_is_known": True,
+            "opening_date": "2026-06-01",
+        },
+        headers=headers,
+    )
+    assert conta.status_code == 201, conta.text
     r = client.post(
         "/investments",
-        json={"name": "CDB Reserva", "principal_cents": 100000, "opened_at": "2026-06-01"},
+        json={
+            "name": "CDB Reserva",
+            "opened_at": "2026-06-01",
+            "bank_account_id": conta.json()["id"],
+        },
         headers=headers,
     )
     assert r.status_code == 201, r.text

--- a/apps/api/tests/test_invariante_do_trilho.py
+++ b/apps/api/tests/test_invariante_do_trilho.py
@@ -179,7 +179,12 @@ def _cenario_completo(client: TestClient, headers, tenant_id: str, conta: dict) 
         json={
             "name": "CDB Itaú",
             "kind": "investment",
-            "opening_balance_cents": 0,
+            # Onda 2b-ii: o principal da aplicação é DERIVADO, e o valor já aplicado entra por
+            # aqui — o saldo de abertura da conta. O payload de `/investments` recusa
+            # `principal_cents` com 409 desde então. O que este arquivo prova (a Invariante do
+            # Trilho) não depende do número; ele fica em 1.000.000 só para o cenário continuar
+            # sendo o mesmo de antes, e não um caso degenerado com zero aplicado.
+            "opening_balance_cents": 1_000_000,
             "opening_balance_is_known": True,
             "opening_date": ABERTURA.isoformat(),
         },
@@ -191,7 +196,6 @@ def _cenario_completo(client: TestClient, headers, tenant_id: str, conta: dict) 
         json={
             "name": "CDB Banco X",
             "kind": "CDB",
-            "principal_cents": 1_000_000,
             "opened_at": ABERTURA.isoformat(),
             "bank_account_id": conta_aplicacao.json()["id"],
         },

--- a/apps/api/tests/test_investment_audit_rls.py
+++ b/apps/api/tests/test_investment_audit_rls.py
@@ -1,0 +1,182 @@
+"""O script de auditoria do principal, no Postgres REAL e sob RLS (Onda 2b-ii).
+
+**Por que este teste existe, e por que ele não podia ser em SQLite.** A Onda 2b-ii trocou o backfill
+do design-mãe §6.2 — o único `UPDATE` sobre dado existente do épico — por *auditoria + ato do dono*.
+Trocar escrita por leitura só é seguro se a leitura de fato **enxergar**: uma consulta em tabela com
+`FORCE ROW LEVEL SECURITY` **sem** a GUC de tenant devolve **zero linhas, sem erro**, e o silêncio
+fica indistinguível de "está tudo certo". Foi assim que a sondagem de `phone_key` em produção quase
+virou um "está tudo limpo" falso.
+
+Os testes SQLite de `auditar()` (em `test_investments_principal.py`) provam a aritmética da
+comparação e nada mais — **RLS não é exercida lá** (ver `conftest.py`). O que se prova aqui é a
+outra metade, que é a que pode falhar em silêncio:
+
+1. `_tenant_ids()` enxerga a tabela GLOBAL `tenants` (ela não tem RLS — mesma exceção de `users`);
+2. `auditar()` dentro de `tenant_session` vê as aplicações **daquele** tenant;
+3. e **não** vê as do outro (se visse, o script reportaria divergência de terceiro);
+4. sem GUC, a leitura é **fail-closed** — zero linhas, que é exatamente o resultado que o script
+   nunca pode confundir com aprovação, e por isso `main()` imprime a contagem de tenants varridos.
+
+Módulo marcado `rls_e2e`: NÃO roda no `pytest -q` (suíte SQLite), só no job `cross-tenant-rls` do CI
+ou manualmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+
+_API_DIR = Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original_url
+
+
+def _seed(app_url: str, *, slug: str, aplicacao: str, abertura: int, coluna: int) -> str:
+    """Um tenant com uma aplicação vinculada a uma conta de aplicação. Devolve o `tenant_id`.
+
+    `abertura` vira o principal DERIVADO (é o saldo de abertura da conta); `coluna` é gravado em
+    `principal_cents`, a coluna congelada. Os dois são diferentes de propósito: é a divergência que
+    o script existe para reportar.
+    """
+    from app.modules.auth.models import Tenant
+    from app.modules.bank.models import KIND_INVESTMENT, BankAccount
+    from app.modules.investments.models import InvestmentAccount
+
+    tenant_id = str(uuid4())
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()  # fixa a GUC (escopo de sessão) e encerra a txn — ver a nota do
+            # test_financial_intelligence_diagnostics_rls sobre o SAVEPOINT.
+            session = Session(bind=conn)
+            session.add(
+                Tenant(id=tenant_id, slug=slug, legal_name=slug, document=f"{slug}-doc")
+            )
+            conta = BankAccount(
+                tenant_id=tenant_id,
+                name=f"{aplicacao} (conta)",
+                kind=KIND_INVESTMENT,
+                opening_balance_cents=abertura,
+                opening_balance_is_known=True,
+                opening_date=date(2026, 1, 1),
+            )
+            session.add(conta)
+            session.flush()  # o id tem default Python-side
+            session.add(
+                InvestmentAccount(
+                    tenant_id=tenant_id,
+                    name=aplicacao,
+                    principal_cents=coluna,
+                    opened_at=date(2026, 1, 1),
+                    bank_account_id=conta.id,
+                )
+            )
+            session.commit()
+            session.close()
+    finally:
+        engine.dispose()
+    return tenant_id
+
+
+def _auditar_como(app_url: str, tenant_id: str | None) -> list[dict]:
+    from app.scripts.investment_audit import auditar
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            if tenant_id is not None:
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                    {"tid": tenant_id},
+                )
+            session = Session(bind=conn)
+            linhas = auditar(session)
+            session.close()
+            return linhas
+    finally:
+        engine.dispose()
+
+
+def test_a_auditoria_enxerga_o_proprio_tenant_e_nao_o_vizinho() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        a = _seed(app_url, slug="tenant-a", aplicacao="CDB-DO-A", abertura=10_000_00, coluna=777_77)
+        b = _seed(app_url, slug="tenant-b", aplicacao="CDB-DO-B", abertura=20_000_00, coluna=0)
+
+        # (1) e (2) — o tenant A vê a aplicação dele, com a divergência real
+        linhas_a = _auditar_como(app_url, a)
+        assert [linha["name"] for linha in linhas_a] == ["CDB-DO-A"]
+        assert linhas_a[0]["coluna_cents"] == 777_77
+        assert linhas_a[0]["derivado_cents"] == 10_000_00, (
+            "o principal derivado veio do saldo de abertura da conta, sob RLS real"
+        )
+        assert linhas_a[0]["diverge"] is True
+
+        # (3) — e não vê a do vizinho. Se visse, o script mandaria o dono de A caçar um lançamento
+        # que é de B, que é o modo de falha que o épico chama de "pior do que ficar calado".
+        assert "CDB-DO-B" not in {linha["name"] for linha in linhas_a}
+
+        linhas_b = _auditar_como(app_url, b)
+        assert [linha["name"] for linha in linhas_b] == ["CDB-DO-B"]
+        assert "CDB-DO-A" not in {linha["name"] for linha in linhas_b}
+
+        # (4) — sem GUC: ZERO linhas, sem erro. **É este silêncio que o `main()` do script não pode
+        # confundir com aprovação**, e é por isso que ele imprime a contagem de tenants varridos.
+        assert _auditar_como(app_url, None) == []

--- a/apps/api/tests/test_investments.py
+++ b/apps/api/tests/test_investments.py
@@ -58,7 +58,13 @@ def _account(client: TestClient, headers, grupo: str, categoria: str) -> str:
 
 
 def _conta_bancaria(
-    client: TestClient, headers, *, name="CDB Itaú", kind="investment", opening_date="2026-01-01"
+    client: TestClient,
+    headers,
+    *,
+    name="CDB Itaú",
+    kind="investment",
+    opening_date="2026-01-01",
+    opening_balance_cents=0,
 ) -> dict:
     """A `bank_account` ONDE O DINHEIRO DA APLICAÇÃO ESTÁ (Onda 2b-i).
 
@@ -71,7 +77,7 @@ def _conta_bancaria(
             "name": name,
             "kind": kind,
             "number": "",
-            "opening_balance_cents": 0,
+            "opening_balance_cents": opening_balance_cents,
             "opening_balance_is_known": True,
             "opening_date": opening_date,
         },
@@ -100,14 +106,19 @@ def _investment(
     Cada aplicação ganha a SUA conta: o índice único `(tenant_id, bank_account_id)` é 1:1.
     """
     if bank_account_id == "auto":
-        bank_account_id = _conta_bancaria(client, headers, name=f"Conta {name}")["id"]
+        # ⚠️ **Onda 2b-ii: `principal` vira o SALDO DE ABERTURA da conta bancária**, e não mais
+        # o campo `principal_cents` da aplicação — que agora é derivado e cuja edição é 409.
+        # A intenção de cada call site ("esta aplicação tem X aplicados") sobrevive intacta; o
+        # que mudou é ONDE o valor é informado, que é a mudança inteira desta onda.
+        bank_account_id = _conta_bancaria(
+            client, headers, name=f"Conta {name}", opening_balance_cents=principal
+        )["id"]
     r = client.post(
         "/investments",
         json={
             "name": name,
             "kind": "CDB",
             "index_rate_label": "CDI 110%",
-            "principal_cents": principal,
             "opened_at": opened,
             "bank_account_id": bank_account_id,
         },
@@ -133,16 +144,23 @@ def test_crud_investment_account(client: TestClient, headers):
     lst = client.get("/investments", headers=headers).json()
     assert [a["name"] for a in lst] == ["Tesouro Selic"]
 
-    # editar principal/indexador/tipo/nome
+    # editar indexador/tipo/nome
+    #
+    # ⚠️ **`principal_cents` SAIU deste PATCH, e a asserção mudou de propósito (Onda 2b-ii).**
+    # Antes desta onda o teste editava o principal para 700.000 e conferia o valor de volta. O
+    # principal agora é DERIVADO dos movimentos da conta bancária, e editá-lo responde **409** —
+    # coberto por `test_editar_o_principal_e_recusado_com_409`, logo abaixo. O que se prova aqui
+    # continua sendo o mesmo: os campos de PRODUTO (nome, indexador, tipo) são editáveis e a edição
+    # não encosta no rendimento acumulado.
     r = client.patch(
         f"/investments/{acc['id']}",
-        json={"name": "Tesouro IPCA", "index_rate_label": "IPCA+6%", "principal_cents": 700_000},
+        json={"name": "Tesouro IPCA", "index_rate_label": "IPCA+6%"},
         headers=headers,
     )
     assert r.status_code == 200, r.text
     assert r.json()["name"] == "Tesouro IPCA"
     assert r.json()["index_rate_label"] == "IPCA+6%"
-    assert r.json()["principal_cents"] == 700_000
+    assert r.json()["principal_cents"] == 500_000, "o principal não mudou — ele não vem daqui"
     # editar NÃO mexe no rendimento acumulado
     assert r.json()["accrued_yield_cents"] == 0
 

--- a/apps/api/tests/test_investments_principal.py
+++ b/apps/api/tests/test_investments_principal.py
@@ -268,3 +268,204 @@ def test_principais_derivados_resolve_em_lote(client, db, headers):
         a2["id"]: 2_000_00,
         a3["id"]: None,
     }
+
+
+# ── Os nove leitores da coluna (spec §4.2.1) ──────────────────────────────────────────────────
+
+
+def test_a_api_devolve_o_principal_derivado_e_ignora_a_coluna(client, db, headers):
+    """`GET /investments` responde o CALCULADO, não o que está gravado na coluna.
+
+    A coluna é semeada com um valor absurdo de propósito: se a API o devolvesse, o teste falharia
+    com um número reconhecível em vez de um zero ambíguo.
+    """
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 777_77  # o valor congelado, que ninguém pode mais ler
+    db.commit()
+
+    r = client.get("/investments", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()[0]["principal_cents"] == 10_000_00
+
+
+def test_rentabilidade_e_None_com_principal_None_e_com_principal_negativo(client, db, headers):
+    """`_pct` protege os TRÊS casos sem número: `None`, zero e negativo.
+
+    `None` levantaria `TypeError` (divisão por `None`). **Negativo é o mais perigoso dos três**:
+    devolveria um percentual de sinal invertido — plausível na tela, e errado. Rentabilidade sobre
+    principal negativo não é um número menor: é uma pergunta sem sentido.
+    """
+    # (a) principal None — saldo de abertura desconhecido
+    c_desconhecida = _conta_bancaria(
+        client,
+        headers,
+        name="CDB sem lastro",
+        opening_balance_cents=0,
+        opening_balance_is_known=False,
+    )
+    a_none = _aplicacao(client, headers, bank_account_id=c_desconhecida["id"], name="Sem lastro")
+    r = client.get(f"/investments/{a_none['id']}/rentability", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["principal_cents"] is None
+    assert r.json()["total_rentability_pct"] is None
+
+    # (b) principal negativo — resgate bruto
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplic = _conta_bancaria(client, headers, name="CDB neg", opening_balance_cents=10_000_00)
+    a_neg = _aplicacao(client, headers, bank_account_id=aplic["id"], name="Resgatada")
+    _rendimento(client, headers, a_neg["id"], valor=500_00, quando="2026-02-28")
+    _transferencia(
+        client,
+        headers,
+        de=aplic["id"],
+        para=corrente["id"],
+        valor=10_500_00,
+        quando="2026-03-05",
+        kind="investment_out",
+    )
+    r = client.get(f"/investments/{a_neg['id']}/rentability", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["principal_cents"] == -500_00, "o número aparece como é"
+    assert r.json()["total_rentability_pct"] is None, "a rentabilidade sobre ele, não"
+
+
+# ── Teste 7 da spec §5 — a recusa ─────────────────────────────────────────────────────────────
+
+
+def test_editar_o_principal_e_recusado_com_409(client, headers):
+    """`PATCH` com `principal_cents` → 409 apontando para a ação REAL (Onda 2b-ii).
+
+    ⚠️ **Este 409 é o OPOSTO do 409 da 2b-i.** Aquele era caminho normal — o dono batia nele ao
+    registrar rendimento, e por isso a tela oferecia a saída ali mesmo. Este é **inalcançável pela
+    tela** (o campo saiu do formulário): se disparar, é integração antiga ou defeito. É guarda de
+    contrato, não fluxo — e por isso **não** tem `detail["acao"]`: um `acao` sem modal do outro
+    lado seria um contrato com ninguém.
+
+    A asserção é sobre trechos ESPECÍFICOS da frase, não sobre uma palavra genérica: "aporte"
+    sozinho casaria com quase qualquer texto sobre aplicação. A manobra que a Onda 2 pegou foi
+    `"trilho" in detail` casando também *"fora do trilho"*.
+    """
+    conta = _conta_bancaria(client, headers)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    r = client.patch(
+        f"/investments/{app_['id']}", json={"principal_cents": 5_000_00}, headers=headers
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert isinstance(detail, str), "guarda de contrato não é 409 acionável — sem detail['acao']"
+    assert "calculado pelos movimentos" in detail
+    assert "registre a transferência" in detail
+
+
+def test_criar_com_principal_diferente_de_zero_e_recusado(client, headers):
+    """No CADASTRO o caminho do valor já aplicado é o **saldo de abertura** da conta bancária.
+
+    Recusar sem dizer onde informar seria o beco sem saída que a Onda 2b-i pagou para evitar.
+    """
+    conta = _conta_bancaria(client, headers)
+    r = client.post(
+        "/investments",
+        json={
+            "name": "Reserva",
+            "opened_at": "2026-01-01",
+            "bank_account_id": conta["id"],
+            "principal_cents": 10_000_00,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 409, r.text
+    assert "saldo de abertura" in r.json()["detail"]
+
+
+def test_criar_com_principal_zero_continua_passando(client, headers):
+    """O default do schema é `0`. Recusá-lo quebraria todo cliente que não manda o campo.
+
+    Sem este teste, a guarda mais óbvia (`if data.principal_cents is not None`) passaria verde e
+    quebraria o cadastro inteiro em produção — o campo tem default, então ele NUNCA é `None`.
+    """
+    conta = _conta_bancaria(client, headers)
+    r = client.post(
+        "/investments",
+        json={"name": "Reserva", "opened_at": "2026-01-01", "bank_account_id": conta["id"]},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── Teste 9 da spec §5 — a auditoria ──────────────────────────────────────────────────────────
+
+
+def test_a_auditoria_reporta_a_divergencia_sem_corrigir(client, db, headers):
+    """O script REPORTA. Se ele corrigisse, o `UPDATE` que esta onda existe para não fazer voltaria
+    pela porta dos fundos — e alguém o rodaria no deploy sem ler a saída.
+    """
+    from app.scripts import investment_audit
+
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 777_77
+    db.commit()
+
+    linhas = investment_audit.auditar(db)
+
+    assert linhas == [
+        {
+            "id": app_["id"],
+            "name": "Reserva",
+            "coluna_cents": 777_77,
+            "derivado_cents": 10_000_00,
+            "diverge": True,
+        }
+    ]
+    db.refresh(acc)
+    assert acc.principal_cents == 777_77, "a auditoria NÃO corrige — a coluna segue como estava"
+
+
+def test_a_auditoria_nao_marca_divergencia_quando_batem(client, db, headers):
+    """Controle negativo: sem ele, um `diverge: True` fixo passaria no teste acima."""
+    from app.scripts import investment_audit
+
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 10_000_00
+    db.commit()
+
+    assert investment_audit.auditar(db)[0]["diverge"] is False
+
+
+def test_a_auditoria_nao_chama_de_divergencia_o_que_ela_nao_consegue_comparar(client, db, headers):
+    """Principal `None` (saldo de abertura desconhecido) não é divergência — é ausência de medida.
+
+    Marcá-lo mandaria o dono caçar um erro que não existe. É o modo de falha que o épico chama de
+    "pior do que ficar calado".
+    """
+    from app.scripts import investment_audit
+
+    conta = _conta_bancaria(
+        client, headers, opening_balance_cents=0, opening_balance_is_known=False
+    )
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 999_99
+    db.commit()
+
+    linha = investment_audit.auditar(db)[0]
+    assert linha["derivado_cents"] is None
+    assert linha["diverge"] is False
+
+
+def test_a_auditoria_formata_valor_negativo_e_desconhecido(client, headers):
+    """`_reais` é o que o dono lê na saída — negativo com sinal, `None` como "não sei"."""
+    from app.scripts.investment_audit import _reais
+
+    assert _reais(10_000_00) == "R$ 10.000,00"
+    assert _reais(-500_00) == "-R$ 500,00"
+    assert _reais(0) == "R$ 0,00"
+    assert _reais(None) == "não sei"

--- a/apps/api/tests/test_investments_principal.py
+++ b/apps/api/tests/test_investments_principal.py
@@ -1,0 +1,270 @@
+"""O principal da aplicação é CALCULADO, não digitado (Onda 2b-ii).
+
+    principal = opening_balance_cents da conta de aplicação
+              + Σ movimentos daquela conta com `source <> 'yield'`
+
+Os três termos e o porquê de cada um estão na spec §3. O que estes testes seguram é que a derivação
+não vire uma segunda fórmula e não conte o rendimento duas vezes.
+
+RLS não é exercida aqui (SQLite — ver `conftest.py`); o isolamento cross-tenant da aplicação já é
+coberto por `test_investments_rls.py` (`rls_e2e`, Postgres real).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.modules.investments import service as inv_service
+from app.modules.investments.models import InvestmentAccount
+
+REGISTER = {
+    "legal_name": "Deriva Consultoria",
+    "document": "11444777000161",
+    "slug": "deriva",
+    "email": "deriva@example.com",
+    "name": "Dora",
+    "password": "uma-senha-bem-grande",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _conta_bancaria(
+    client: TestClient,
+    headers,
+    *,
+    name="CDB Itaú",
+    kind="investment",
+    opening_date="2026-01-01",
+    opening_balance_cents=0,
+    opening_balance_is_known=True,
+) -> dict:
+    r = client.post(
+        "/bank/accounts",
+        json={
+            "name": name,
+            "kind": kind,
+            "opening_date": opening_date,
+            "opening_balance_cents": opening_balance_cents,
+            "opening_balance_is_known": opening_balance_is_known,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _aplicacao(client: TestClient, headers, *, bank_account_id: str | None, name="Reserva") -> dict:
+    r = client.post(
+        "/investments",
+        json={
+            "name": name,
+            "kind": "CDB",
+            "index_rate_label": "CDI 110%",
+            "opened_at": "2026-01-01",
+            "bank_account_id": bank_account_id,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _transferencia(client, headers, *, de: str, para: str, valor: int, quando: str, kind: str):
+    r = client.post(
+        "/bank/transfers",
+        json={
+            "from_account_id": de,
+            "to_account_id": para,
+            "amount_cents": valor,
+            "posted_at": quando,
+            "kind": kind,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _rendimento(client, headers, account_id: str, *, valor: int, quando: str):
+    r = client.post(
+        f"/investments/{account_id}/yield",
+        json={"amount_cents": valor, "date": quando, "chart_account_id": None},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _acc(db: Session, account_id: str) -> InvestmentAccount:
+    return db.get(InvestmentAccount, account_id)
+
+
+# ── Teste 6 da spec §5 ────────────────────────────────────────────────────────────────────────
+
+
+def test_o_saldo_de_abertura_entra_no_principal(client, db, headers):
+    """O dinheiro que já estava aplicado no dia do cadastro é principal, e nunca teve movimento.
+
+    Sem este termo, uma conta cadastrada com R$ 10.000 aplicados mostraria principal ZERO — um
+    número errado com aparência de fato, que é a família de defeito que a Onda 0 existe para não
+    repetir. É também o caso do fundador: ele cadastra a conta com o saldo que já tem.
+    """
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == 10_000_00
+
+
+# ── Teste 5 da spec §5 ────────────────────────────────────────────────────────────────────────
+
+
+def test_aporte_MOVE_o_principal(client, db, headers):
+    """Transferir da corrente para a aplicação aumenta o principal. É a metade viva do recorte."""
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client,
+        headers,
+        de=corrente["id"],
+        para=aplicacao["id"],
+        valor=3_000_00,
+        quando="2026-02-10",
+        kind="investment_in",
+    )
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == 13_000_00
+
+
+# ── Teste 4 da spec §5 ────────────────────────────────────────────────────────────────────────
+
+
+def test_rendimento_NAO_move_o_principal(client, db, headers):
+    """Registrar rendimento não mexe no principal — ele já é contado por `accrued_yield_cents`.
+
+    ⚠️ Este teste sozinho NÃO prova o recorte: se `exclude_sources` fosse ignorado e a soma
+    excluísse tudo, ele passaria igual. Quem o completa é `test_aporte_MOVE_o_principal`, acima.
+    Os dois juntos particionam o conjunto: um membro de cada lado.
+    """
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _rendimento(client, headers, app_["id"], valor=150_00, quando="2026-02-28")
+
+    acc = _acc(db, app_["id"])
+    assert acc.accrued_yield_cents == 150_00, "o rendimento foi registrado (controle positivo)"
+    assert inv_service.principal_derivado(db, acc) == 10_000_00, "e NÃO entrou no principal"
+
+
+# ── Teste 2 da spec §5 — a invariante ─────────────────────────────────────────────────────────
+
+
+def test_a_invariante_saldo_igual_principal_mais_rendimento(client, db, headers):
+    """`derived_balance(conta) == principal + accrued_yield`, com aporte, rendimento E resgate.
+
+    Vale POR CONSTRUÇÃO enquanto todo rendimento tiver perna bancária — que é o que a Onda 2b-i
+    garantiu com o 409 de `register_yield`. Quebrá-la é sintoma de movimento escrito por fora da
+    Regra da Origem.
+    """
+    from app.modules.bank import service as bank_service
+
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client,
+        headers,
+        de=corrente["id"],
+        para=aplicacao["id"],
+        valor=3_000_00,
+        quando="2026-02-10",
+        kind="investment_in",
+    )
+    _rendimento(client, headers, app_["id"], valor=150_00, quando="2026-02-28")
+    _transferencia(
+        client,
+        headers,
+        de=aplicacao["id"],
+        para=corrente["id"],
+        valor=2_000_00,
+        quando="2026-03-05",
+        kind="investment_out",
+    )
+
+    acc = _acc(db, app_["id"])
+    saldo = bank_service.derived_balance(db, bank_account_id=aplicacao["id"])
+    assert saldo == inv_service.principal_derivado(db, acc) + acc.accrued_yield_cents
+    assert saldo == 11_150_00, "10.000 + 3.000 + 150 − 2.000"
+
+
+# ── Teste 3 da spec §5 ────────────────────────────────────────────────────────────────────────
+
+
+def test_saldo_de_abertura_desconhecido_da_None_e_NAO_zero(client, db, headers):
+    """Conta cadastrada como "tenho a conta e não sei o saldo" (Story 8.21) ⇒ principal `None`.
+
+    **Zero seria uma afirmação** — *"você não tem nada aplicado"* —, falsa e indistinguível de um
+    saldo genuinamente zerado. `None` é a ausência da afirmação, e é o princípio que a 8.21 fixou:
+    suprimir a afirmação, nunca o número.
+    """
+    conta = _conta_bancaria(
+        client, headers, opening_balance_cents=0, opening_balance_is_known=False
+    )
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    principal = inv_service.principal_derivado(db, _acc(db, app_["id"]))
+    assert principal is None
+    assert principal != 0, "o 0 aqui seria uma afirmação; queremos a ausência dela"
+
+
+def test_aplicacao_sem_vinculo_da_None(client, db, headers):
+    """Sem `bank_account_id` não há de onde derivar. `None`, não zero, pelo mesmo motivo acima."""
+    app_ = _aplicacao(client, headers, bank_account_id=None)
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) is None
+
+
+def test_principal_negativo_quando_o_resgate_excede(client, db, headers):
+    """Resgate BRUTO (principal + rendimento não lançado) deixa o principal negativo — e aparece.
+
+    Clampar em zero seria esconder; recusar o resgate seria recusar um fato que já aconteceu no
+    banco. O número aparece como é, e quem o nomeia é a tela (spec §4.4).
+    """
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client,
+        headers,
+        de=aplicacao["id"],
+        para=corrente["id"],
+        valor=10_500_00,
+        quando="2026-03-05",
+        kind="investment_out",
+    )
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == -500_00
+
+
+def test_principais_derivados_resolve_em_lote(client, db, headers):
+    """A versão de lote existe para o `GET /investments` não virar N+1 — uma query, N contas."""
+    c1 = _conta_bancaria(client, headers, name="CDB A", opening_balance_cents=1_000_00)
+    c2 = _conta_bancaria(client, headers, name="CDB B", opening_balance_cents=2_000_00)
+    a1 = _aplicacao(client, headers, bank_account_id=c1["id"], name="A")
+    a2 = _aplicacao(client, headers, bank_account_id=c2["id"], name="B")
+    a3 = _aplicacao(client, headers, bank_account_id=None, name="C")
+
+    accs = [_acc(db, a["id"]) for a in (a1, a2, a3)]
+    assert inv_service.principais_derivados(db, accs) == {
+        a1["id"]: 1_000_00,
+        a2["id"]: 2_000_00,
+        a3["id"]: None,
+    }

--- a/apps/api/tests/test_investments_principal_gate.py
+++ b/apps/api/tests/test_investments_principal_gate.py
@@ -1,0 +1,78 @@
+"""**Teste de ausência** — `investment_accounts.principal_cents` está congelada (Onda 2b-ii).
+
+Quem ler a coluna vai receber `0` (ou o que sobrou de antes da onda), nunca o principal real. E
+**nada quebra** se alguém voltar a lê-la: a coluna existe, tem valor, a leitura funciona. Só o dono,
+meses depois, veria a tela discordar do extrato sobre quanto ele tem aplicado.
+
+Este teste é o consumidor mecânico que essa mudança não tem sozinha.
+
+**Precedente exato:** `tenant_profiles.timezone`, congelada em 2026-08-07 (migration 0073). Ela
+tinha **três** consumidores que a investigação inicial não achou — Agenda, Cockpit e a validade das
+notificações. Corrigir só o caminho óbvio teria quebrado os três em silêncio.
+
+`app/scripts/investment_audit.py` lê a coluna **de propósito**, para comparar com o derivado, e está
+fora do alcance desta varredura **por construção**: ela só visita `app/modules/`. Não é uma exceção
+escrita numa lista — é uma consequência de onde o arquivo mora, e por isso não pode ser ampliada
+por engano.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MODULES = Path(__file__).resolve().parents[1] / "app" / "modules"
+
+# O model DEFINE a coluna — mencioná-la lá não é lê-la.
+_PODEM_MENCIONAR = {"investments/models.py"}
+
+# Os nomes que o atributo tinha nos call sites reais antes da onda: `a.principal_cents` (router),
+# `acc.principal_cents` (service) e `data.principal_cents` (o payload do schema). `data` fica de
+# FORA da lista de propósito: ler o campo do REQUEST é legítimo — é assim que a recusa 409 sabe
+# que alguém tentou editar. O que está proibido é ler o campo da LINHA.
+_BASES_PROIBIDAS = {"a", "acc", "account", "conta", "aplicacao", "InvestmentAccount"}
+
+
+def _ofensores(raiz: Path, ignorar: set[str], bases: set[str] = _BASES_PROIBIDAS) -> list[str]:
+    achados: list[str] = []
+    for arquivo in sorted(raiz.rglob("*.py")):
+        rel = arquivo.relative_to(raiz).as_posix()
+        if rel in ignorar:
+            continue
+        arvore = ast.parse(arquivo.read_text(encoding="utf-8"))
+        for no in ast.walk(arvore):
+            if not isinstance(no, ast.Attribute) or no.attr != "principal_cents":
+                continue
+            base = no.value
+            nome = base.id if isinstance(base, ast.Name) else None
+            if nome in bases:
+                achados.append(f"{rel}:{no.lineno} ({nome}.principal_cents)")
+    return achados
+
+
+def test_ninguem_le_o_principal_da_coluna():
+    ofensores = _ofensores(_MODULES, _PODEM_MENCIONAR)
+    assert not ofensores, (
+        "Estes pontos leem `principal_cents` da COLUNA, que está congelada desde a Onda 2b-ii. "
+        "Use `investments.service.principal_derivado(db, acc)` — ou, para várias contas, "
+        f"`principais_derivados(db, accs)`: {ofensores}"
+    )
+
+
+def test_o_gate_reprova_quando_a_leitura_existe(tmp_path: Path):
+    """**Controle positivo.** Um gate que nunca reprovou nada não é um gate — é um teste que passa
+    e não prova nada, a família dominante da Onda 2 (oito ocorrências independentes).
+    """
+    (tmp_path / "fake.py").write_text(
+        "def f(acc):\n    return acc.principal_cents\n", encoding="utf-8"
+    )
+    assert _ofensores(tmp_path, set()) == ["fake.py:2 (acc.principal_cents)"]
+
+
+def test_o_gate_nao_reprova_a_leitura_do_PAYLOAD():
+    """`data.principal_cents` é o campo do REQUEST, e lê-lo é como a recusa 409 funciona.
+
+    Sem este teste, alguém "endurecendo" o gate acrescentaria `data` à lista de bases proibidas, a
+    guarda de `create_account`/`update_account` viraria inalcançável, e o principal voltaria a ser
+    editável — com o gate verde o tempo todo.
+    """
+    assert "data" not in _BASES_PROIBIDAS

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -37,6 +37,7 @@ import {
   naturezaParaEnvio,
   operationNatureLabel,
   OPERATION_NATURE_OUTRO,
+  ROTA_MOVIMENTOS,
   OPERATION_NATURE_TRANSFERENCIA,
   OPERATION_NATURES,
   origemLabel,
@@ -478,7 +479,7 @@ function AccountDetail({
     setError(null);
     try {
       const [t, c] = await Promise.all([
-        api.get<BankTransaction[]>("/bank/transactions", {
+        api.get<BankTransaction[]>(ROTA_MOVIMENTOS, {
           params: {
             bank_account_id: account.id,
             start: range.start,

--- a/apps/web/src/features/financeiro/InvestimentosPage.tsx
+++ b/apps/web/src/features/financeiro/InvestimentosPage.tsx
@@ -4,11 +4,18 @@ import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
 import { type ChartAccount } from "./planoContas";
-import type { BankAccount } from "./contas";
 import {
+  type BankAccount,
+  type BankTransaction,
+  formatDateBR,
+  ROTA_MOVIMENTOS,
+} from "./contas";
+import {
+  avisoDeResgateExcedente,
   contasDeAplicacao,
   formatBRL,
   formatPct,
+  formatPrincipal,
   type InvestmentAccount,
   type Rentability,
   rotuloDoVinculo,
@@ -127,7 +134,15 @@ export default function InvestimentosPage() {
                   value={rotuloDoVinculo(a, contas)}
                   tone={a.bank_account_id ? undefined : "text-amber-700"}
                 />
-                <Stat label="Principal" value={formatBRL(a.principal_cents)} />
+                <Stat
+                  label="Principal aplicado"
+                  value={formatPrincipal(a.principal_cents)}
+                  tone={
+                    a.principal_cents !== null && a.principal_cents < 0
+                      ? "text-amber-700"
+                      : undefined
+                  }
+                />
                 <Stat label="Rendimento acumulado" value={formatBRL(a.accrued_yield_cents)} />
                 <Stat
                   label="Rentabilidade total"
@@ -144,6 +159,18 @@ export default function InvestimentosPage() {
                   tone="text-primary-700"
                 />
               </div>
+
+              {/* O aviso fica COLADO no número que ele explica, e não numa seção de avisos no fim
+                  da tela: em ~360px um aviso distante do valor é um aviso que ninguém lê. É a lição
+                  dos PRs #56 e #58, onde o checkbox e a ação que o tornava efetivo viviam em blocos
+                  separados e uma conta real foi paga sem o dono ver. */}
+              {avisoDeResgateExcedente(a.principal_cents) && (
+                <p className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  {avisoDeResgateExcedente(a.principal_cents)}
+                </p>
+              )}
+
+              {a.bank_account_id && <ExtratoDaAplicacao bankAccountId={a.bank_account_id} />}
             </div>
           );
         })}
@@ -162,6 +189,98 @@ export default function InvestimentosPage() {
         onError={setError}
         contas={contas}
       />
+    </div>
+  );
+}
+
+/**
+ * Extrato da aplicação — aportes, resgates e rendimentos (Onda 2b-ii, R3 do fundador).
+ *
+ * ⚠️ **Segunda superfície sobre o mesmo razão, de propósito** (decisão do fundador, 2026-08-08): a
+ * primeira é "Ver movimentos" em `ContasSaldosPage`, porque a conta de aplicação é uma
+ * `bank_account` como qualquer outra. A garantia contra as duas discordarem é **mecânica, não
+ * disciplina**: as duas chamam o MESMO endpoint, sem consulta própria e sem filtro reescrito. O que
+ * difere entre elas é apresentação. Se alguém der a esta um filtro próprio, o teste
+ * `o extrato da aplicação não é uma segunda fonte` (investimentos.test.ts) protesta.
+ */
+function ExtratoDaAplicacao({ bankAccountId }: { bankAccountId: string }) {
+  const [aberto, setAberto] = useState(false);
+  const [movimentos, setMovimentos] = useState<BankTransaction[] | null>(null);
+
+  useEffect(() => {
+    if (!aberto) return;
+    let vivo = true;
+    api
+      .get<BankTransaction[]>(ROTA_MOVIMENTOS, { params: { bank_account_id: bankAccountId } })
+      .then((r) => {
+        // `Array.isArray`, nunca `?? []`: com `data = []` o acesso a uma propriedade herdada de
+        // Array devolve FUNÇÃO, e um setter do React que recebe função a executa — foi assim que o
+        // ClientTimeline derrubou a página inteira de Conversas.
+        if (vivo) setMovimentos(Array.isArray(r.data) ? r.data : []);
+      })
+      .catch(() => {
+        // Um painel embutido nunca deve poder derrubar quem o hospeda.
+        if (vivo) setMovimentos([]);
+      });
+    return () => {
+      vivo = false;
+    };
+  }, [aberto, bankAccountId]);
+
+  return (
+    <div className="mt-4 border-t border-neutral-100 pt-3">
+      <button
+        onClick={() => setAberto((v) => !v)}
+        className="text-sm font-medium text-primary-700 hover:underline"
+      >
+        {aberto ? "Ocultar extrato" : "Ver extrato da aplicação"}
+      </button>
+      {aberto && (
+        <div className="mt-3">
+          {movimentos === null ? (
+            <p className="text-sm text-neutral-500">Carregando…</p>
+          ) : movimentos.length === 0 ? (
+            <p className="text-sm text-neutral-500">Nenhum movimento nesta aplicação ainda.</p>
+          ) : (
+            // ⚠️ **LISTA, não tabela — e a decisão foi medida, não escolhida.** A primeira versão
+            // era uma `<table>` de 3 colunas com `min-w-[20rem]` dentro de `overflow-x-auto`. Em
+            // 360px o aceite visual mostrou a coluna de VALOR nascendo fora da vista: "R$ 3." no
+            // lugar de "R$ 3.000,00". O `overflow-x-auto` fez o seu trabalho (rolava, em vez de
+            // cortar em silêncio como o `overflow-hidden` do PR #58) — mas num extrato o valor é
+            // *a* informação, e informação que exige rolagem lateral para existir é informação que
+            // o dono não lê.
+            //
+            // **A lição do PR #58 era "role, não corte". A daqui é mais funda: em 360px uma tabela
+            // de 3 colunas não cabe, e a saída não é fazer a rolagem funcionar melhor — é não
+            // precisar dela.** Data e descrição empilham à esquerda; o valor fica à direita,
+            // sempre visível, com `whitespace-nowrap`. O `min-w-0` é o que permite ao bloco da
+            // esquerda encolher: sem ele o flex usa a largura do conteúdo e o valor é empurrado
+            // para fora de novo — foi assim que a `FilaPagamentosPage` ficou quebrada por duas
+            // sessões com um teste de `flex-wrap` verde.
+            <ul className="text-sm">
+              {movimentos.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex items-start justify-between gap-3 border-b border-neutral-50 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-xs text-neutral-500">{formatDateBR(m.posted_at)}</p>
+                    <p className="break-words text-neutral-700">{m.description}</p>
+                  </div>
+                  <p
+                    className={
+                      "whitespace-nowrap font-medium " +
+                      (m.amount_cents < 0 ? "text-neutral-700" : "text-accent-700")
+                    }
+                  >
+                    {formatBRL(m.amount_cents)}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -231,7 +350,6 @@ function NewAccountModal({
   const [name, setName] = useState("");
   const [kind, setKind] = useState<string>(SUGGESTED_KINDS[0]);
   const [indexLabel, setIndexLabel] = useState("");
-  const [principal, setPrincipal] = useState("");
   const [openedAt, setOpenedAt] = useState("");
   const [bankAccountId, setBankAccountId] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -245,7 +363,6 @@ function NewAccountModal({
         name,
         kind,
         index_rate_label: indexLabel,
-        principal_cents: Math.round(Number(principal.replace(",", ".")) * 100) || 0,
         opened_at: openedAt,
         // Onda 2b-i: a aplicação nasce vinculada. Sem isso o dono cadastra e leva um 409 no
         // primeiro rendimento — o beco que o 409 acionável existe justamente para evitar.
@@ -254,7 +371,6 @@ function NewAccountModal({
       onCreated();
       setName("");
       setIndexLabel("");
-      setPrincipal("");
       setOpenedAt("");
       setBankAccountId("");
       onClose();
@@ -289,13 +405,15 @@ function NewAccountModal({
           onChange={setIndexLabel}
           placeholder="Ex.: CDI 110%"
         />
-        <Field
-          label="Principal aplicado (R$)"
-          value={principal}
-          onChange={setPrincipal}
-          type="text"
-          placeholder="Ex.: 10000,00"
-        />
+        {/* Onda 2b-ii: o campo do principal SAIU — ele é calculado dos movimentos da conta.
+            A frase abaixo não é decoração: sem ela o campo apenas some e quem cadastra a aplicação
+            não descobre onde informar o que já tem aplicado. Recusar sem dizer onde é o beco que o
+            409 acionável da 2b-i existe para evitar. */}
+        <p className="text-xs text-neutral-500">
+          O valor já aplicado vem do <strong>saldo de abertura</strong> da conta bancária da
+          aplicação — informe-o ao cadastrar a conta. Depois disso, aporte e resgate são
+          transferências entre as suas contas.
+        </p>
         <Field label="Data de aplicação" value={openedAt} onChange={setOpenedAt} type="date" />
         <SeletorDeConta contas={contas} value={bankAccountId} onChange={setBankAccountId} />
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}

--- a/apps/web/src/features/financeiro/contas.ts
+++ b/apps/web/src/features/financeiro/contas.ts
@@ -72,6 +72,17 @@ export interface BankAccount {
 }
 
 /** `BankTransactionOut` (Story 8.3). */
+/**
+ * A rota dos movimentos — **uma constante, dois consumidores** (Onda 2b-ii).
+ *
+ * `ContasSaldosPage` ("Ver movimentos") e `InvestimentosPage` (o extrato da aplicação) exibem o
+ * MESMO razão em superfícies diferentes. A duplicação de superfície foi uma decisão; a de
+ * CONSULTA não é: duas telas com filtros próprios sobre o mesmo dado divergem, e a que diverge é
+ * a que ninguém olha. A constante é o que torna isso estrutural em vez de disciplina, e o gate
+ * `nenhuma tela escreve a rota de movimentos à mão` (investimentos.test.ts) o mantém assim.
+ */
+export const ROTA_MOVIMENTOS = "/bank/transactions";
+
 export interface BankTransaction {
   id: string;
   bank_account_id: string;

--- a/apps/web/src/features/financeiro/investimentos.test.ts
+++ b/apps/web/src/features/financeiro/investimentos.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { BankAccount } from "./contas";
+import { type BankAccount, ROTA_MOVIMENTOS } from "./contas";
 import {
+  avisoDeResgateExcedente,
   contasDeAplicacao,
+  formatBRL,
   formatPct,
+  formatPrincipal,
+  PRINCIPAL_DESCONHECIDO,
   type InvestmentAccount,
   rotuloDoVinculo,
 } from "./investimentos";
@@ -51,5 +55,75 @@ describe("contasDeAplicacao / rotuloDoVinculo (Onda 2b-i)", () => {
   it("não inventa nome quando o vínculo aponta para conta fora da lista", () => {
     const app = { id: "a1", bank_account_id: "sumida" } as InvestmentAccount;
     expect(rotuloDoVinculo(app, contas)).toBe("Vincular a uma conta");
+  });
+});
+
+// ── Onda 2b-ii — o principal calculado ───────────────────────────────────────────────────────
+
+describe("formatPrincipal (Onda 2b-ii)", () => {
+  it("formata o valor quando ele é afirmável", () => {
+    // O NBSP (U+00A0) do `Intl.NumberFormat` é normalizado aqui de propósito: comparar contra
+    // `formatBRL` seria tautológico (ele É a implementação), e comparar contra o literal com
+    // espaço comum falha por um caractere invisível — que foi o que aconteceu ao escrever isto.
+    expect(formatPrincipal(1_000_000).replace(/ /g, " ")).toBe("R$ 10.000,00");
+  });
+
+  it("negativo é mostrado como é — clampar em zero seria esconder", () => {
+    expect(formatPrincipal(-50_000)).toBe(formatBRL(-50_000));
+  });
+
+  it("null vira a frase de não-saber, nunca R$ 0,00", () => {
+    // Zero seria a afirmação "você não tem nada aplicado" — falsa, e indistinguível de um saldo
+    // genuinamente zerado. É o princípio da Story 8.21.
+    expect(formatPrincipal(null)).toBe(PRINCIPAL_DESCONHECIDO);
+    expect(formatPrincipal(null)).not.toBe(formatBRL(0));
+  });
+});
+
+describe("avisoDeResgateExcedente (Onda 2b-ii)", () => {
+  it("nomeia a diferença e a ação quando o principal é negativo", () => {
+    const aviso = avisoDeResgateExcedente(-50_000);
+    expect(aviso).toContain(formatBRL(50_000));
+    expect(aviso).toContain("registre o rendimento do período");
+    // "não adivinha" é literal e é regra do épico (Artigo IV): o sistema sabe que falta, e não
+    // lança sozinho. Se esta asserção cair, alguém tirou a única frase que impede a próxima
+    // pessoa de "resolver" o problema inferindo o valor.
+    expect(aviso).toContain("não adivinha");
+  });
+
+  it("cala quando o principal é positivo, zero ou desconhecido", () => {
+    expect(avisoDeResgateExcedente(1_000_000)).toBeNull();
+    expect(avisoDeResgateExcedente(0)).toBeNull();
+    expect(avisoDeResgateExcedente(null)).toBeNull();
+  });
+});
+
+describe("o extrato da aplicação não é uma segunda fonte (Onda 2b-ii)", () => {
+  const fontes = import.meta.glob("./{InvestimentosPage,ContasSaldosPage}.tsx", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>;
+
+  it("as duas telas existem e foram lidas — controle positivo do gate abaixo", () => {
+    // Sem isto, um glob que deixasse de casar tornaria o gate seguinte vacuamente verde: zero
+    // arquivos varridos, zero ofensores, tudo "passando". É a família do teste que passa e não
+    // prova nada.
+    expect(Object.keys(fontes).sort()).toEqual([
+      "./ContasSaldosPage.tsx",
+      "./InvestimentosPage.tsx",
+    ]);
+  });
+
+  it("nenhuma das duas escreve a rota de movimentos à mão", () => {
+    // A duplicação de SUPERFÍCIE foi aceita (decisão do fundador, 2026-08-08): o extrato aparece
+    // na tela da aplicação E em Contas & Saldos. A de CONSULTA, não — duas telas com filtros
+    // próprios sobre o mesmo razão divergem, e a que diverge é a que ninguém olha. As duas
+    // consomem `ROTA_MOVIMENTOS`, e é este gate que impede a string solta de voltar.
+    const ofensores = Object.entries(fontes)
+      .filter(([, fonte]) => fonte.includes(`"${ROTA_MOVIMENTOS}"`))
+      .map(([caminho]) => caminho);
+
+    expect(ofensores).toEqual([]);
   });
 });

--- a/apps/web/src/features/financeiro/investimentos.ts
+++ b/apps/web/src/features/financeiro/investimentos.ts
@@ -22,7 +22,13 @@ export interface InvestmentAccount {
   name: string;
   kind: string;
   index_rate_label: string;
-  principal_cents: number;
+  /**
+   * Onda 2b-ii — CALCULADO dos movimentos da conta bancária vinculada, não mais digitado.
+   * `null` = inafirmável (sem vínculo, ou saldo de abertura declarado desconhecido — Story
+   * 8.21). **`null` não é zero:** zero seria a afirmação "você não tem nada aplicado".
+   * Pode ser NEGATIVO: resgate bruto que levou rendimento ainda não lançado junto.
+   */
+  principal_cents: number | null;
   accrued_yield_cents: number;
   opened_at: string;
   created_at: string;
@@ -37,7 +43,7 @@ export interface InvestmentAccount {
 
 export interface Rentability {
   account_id: string;
-  principal_cents: number;
+  principal_cents: number | null; // Onda 2b-ii — ver InvestmentAccount
   accrued_yield_cents: number;
   total_rentability_pct: number | null;
   period_rentability_pct: number | null;
@@ -84,4 +90,37 @@ export function contasDeAplicacao(contas: BankAccount[]): BankAccount[] {
 export function rotuloDoVinculo(account: InvestmentAccount, contas: BankAccount[]): string {
   const conta = contas.find((c) => c.id === account.bank_account_id);
   return conta ? conta.name : VINCULAR_LABEL;
+}
+
+// ── Onda 2b-ii: o principal é CALCULADO, e pode não ser afirmável ───────────────────────────
+
+/** O texto de não-saber do principal. Uma frase, um lugar — a tela nunca a escreve à mão. */
+export const PRINCIPAL_DESCONHECIDO = "Não informado";
+
+/**
+ * Formata o principal. `null` vira a frase de não-saber, **nunca "R$ 0,00"**.
+ *
+ * Zero seria uma afirmação ("você não tem nada aplicado"), falsa e indistinguível de um saldo
+ * genuinamente zerado — o mesmo princípio pelo qual a Projeção de Caixa cala o runway em vez de
+ * mostrar um número sem lastro (Story 8.21).
+ */
+export function formatPrincipal(cents: number | null): string {
+  if (cents === null || cents === undefined) return PRINCIPAL_DESCONHECIDO;
+  return formatBRL(cents);
+}
+
+/**
+ * O aviso do resgate que levou rendimento junto — `null` quando não há o que dizer.
+ *
+ * O banco credita o resgate BRUTO (principal + rendimento). Registrado como transferência contra um
+ * principal menor, o derivado fica negativo. O e1p **sabe** quanto falta e **não** lança sozinho: o
+ * valor certo do rendimento é fato do banco, não dedução nossa (Artigo IV — No Invention).
+ */
+export function avisoDeResgateExcedente(principalCents: number | null): string | null {
+  if (principalCents === null || principalCents === undefined || principalCents >= 0) return null;
+  return (
+    `Você resgatou ${formatBRL(-principalCents)} a mais do que aportou. Se essa diferença é ` +
+    "rendimento que ainda não foi lançado, registre o rendimento do período — o e1p não adivinha " +
+    "o valor."
+  );
 }

--- a/docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md
+++ b/docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md
@@ -1,0 +1,1792 @@
+# Onda 2b-ii — `principal_cents` derivado · Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `investment_accounts.principal_cents` deixa de ser um campo digitado e passa a ser calculado dos movimentos da conta bancária da aplicação.
+
+**Architecture:** A soma de movimentos que já existe (`bank/service._movements_sums`, a única do repositório) ganha um recorte por `source`; `investments/service` a consome para derivar o principal, excluindo `source='yield'` para não contar o rendimento duas vezes. A coluna antiga fica congelada com gate AST. **Sem migration, sem `UPDATE`, sem tabela nova** — o backfill do design-mãe §6.2 foi substituído por um script que reporta e pela correção como ato do dono.
+
+**Tech Stack:** Python 3.13, FastAPI, SQLAlchemy 2, pytest (SQLite em memória) · React 18 + TypeScript + Vite, vitest
+
+**Spec:** `docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md`
+**Branch:** `feat/onda-2b-ii-principal-derivado` (já criada, com a spec commitada)
+
+## Global Constraints
+
+- **Idioma:** produto e comentários de domínio em **PT-BR**. Commits em PT-BR, Conventional Commits, referenciando a onda: `feat: o principal da aplicação passa a ser calculado [Onda 2b-ii]`.
+- **Dinheiro em centavos** (`int`), sempre. Nunca `float` para valor.
+- **"Hoje" é `hoje_do_tenant(db)`**, nunca `date.today()` nem `datetime.now(UTC).date()`. O gate `tests/test_fuso_do_tenant.py` reprova o contrário — inclusive em teste.
+- **`investments` pode importar `bank`; `bank` NÃO pode importar `investments`.** Gate: `tests/test_money_planes.py::test_bank_transfers_nao_importa_investments`.
+- **RLS é a única garantia de isolamento** — nenhuma query filtra `tenant_id` manualmente.
+- **Rodar a suíte em PRIMEIRO PLANO**, nunca em background: `cd apps/api && .venv/Scripts/python -m pytest -q`.
+- **Nenhuma migration nesta onda.** Se um passo parecer pedir uma, pare e releia a spec §1.1.
+- **`main` é protegida (GH006), 4 checks obrigatórios.** Push e PR são do `@devops`.
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade | Ação |
+|---|---|---|
+| `apps/api/app/modules/bank/service.py` | Ganha `exclude_sources` na soma e a porta pública `movement_sums` | Modify |
+| `apps/api/app/modules/investments/service.py` | `principais_derivados`, `principal_derivado`, `_pct` robusto, a recusa 409 | Modify |
+| `apps/api/app/modules/investments/schemas.py` | `principal_cents` vira `int \| None` nos dois schemas de saída | Modify |
+| `apps/api/app/modules/investments/router.py` | `_out` passa a receber o principal derivado | Modify |
+| `apps/api/app/scripts/investment_audit.py` | Reporta divergência coluna × derivado. Sem `--fix` | Create |
+| `apps/api/tests/test_investments_principal.py` | Os testes 2,3,4,5,6,10 da spec §5 | Create |
+| `apps/api/tests/test_investments_principal_gate.py` | O gate AST da coluna congelada, com controle positivo | Create |
+| `apps/api/tests/test_investments.py` | O teste 7 (409 em create/update) | Modify |
+| `apps/web/src/features/financeiro/investimentos.ts` | Tipos `number \| null` + helper do aviso de resgate excedente | Modify |
+| `apps/web/src/features/financeiro/investimentos.test.ts` | Testes puros do helper e da formatação | Modify |
+| `apps/web/src/features/financeiro/InvestimentosPage.tsx` | Principal sem campo, o aviso, o extrato | Modify |
+| `CLAUDE.md` | A entrada da onda — **AC obrigatório** | Modify |
+
+---
+
+## Task 1: A soma de movimentos aprende a excluir uma origem
+
+**Files:**
+- Modify: `apps/api/app/modules/bank/service.py:557` (`_movements_sums`), e acrescentar `movement_sums` logo após `_movements_sum` (`:647`)
+- Test: `apps/api/tests/test_bank_corte_de_data.py`
+
+**Interfaces:**
+- Consumes: nada (primeira task)
+- Produces:
+  - `bank.service.movement_sums(db: Session, *, accounts: Sequence[BankAccount], until: date | None = None, exclude_sources: frozenset[str] = frozenset()) -> dict[str, int]` — a porta **pública** da única soma de movimentos do repositório. `until=None` significa **hoje**, como em `derived_balance`. Conta sem movimento não aparece no dicionário; o chamador usa `.get(id, 0)`.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+O arquivo **já tem** os helpers de que este teste precisa: as fixtures `headers` e `tenant_id`, a
+fábrica `_conta(client, headers, **over)` (abre a conta **ontem**, para que "hoje" seja posterior à
+abertura) e `_plantar(db, *, tenant_id, account_id, amount_cents, posted_at, status)`, que monta o
+movimento **direto pelo model**. **Não crie helper novo** — o único ajuste é dar a `_plantar` a
+origem da linha, que hoje é fixa em `SOURCE_MANUAL`.
+
+Primeiro torne `_plantar` capaz de plantar outra origem. Na assinatura (`:109`), acrescente o
+último parâmetro, e troque o `source=SOURCE_MANUAL` fixo do corpo por `source=source`:
+
+```python
+def _plantar(
+    db: Session,
+    *,
+    tenant_id: str,
+    account_id: str,
+    amount_cents: int,
+    posted_at: date,
+    status: str = STATUS_UNMATCHED,
+    source: str = SOURCE_MANUAL,
+) -> BankTransaction:
+```
+
+Aditivo: o default preserva byte a byte o comportamento de todos os chamadores que já existem.
+
+Agora acrescente ao final do arquivo:
+
+```python
+def test_movement_sums_exclui_a_origem_pedida(client, db, headers, tenant_id):
+    """`exclude_sources` tira uma origem da soma sem tocar nas outras (Onda 2b-ii).
+
+    É o recorte de que o principal derivado depende: o rendimento já é contado por
+    `accrued_yield_cents` e, desde a 2b-i, também gera `bank_transaction` — sem este filtro ele
+    entraria DUAS vezes no saldo da aplicação.
+
+    ⚠️ **Dois `assert`, e é de propósito.** Com só o caso do rendimento excluído, ignorar
+    `exclude_sources` por completo ainda passaria: é o mutante `>` → `>=` da Onda 2, que sobreviveu
+    a 58 testes por faltar o caso do outro lado. O primeiro `assert` é o outro lado.
+    """
+    from app.modules.bank import service as bank_service
+    from app.modules.bank.models import SOURCE_YIELD
+
+    conta = _conta(client, headers, kind=KIND_INVESTMENT, opening_balance_cents=0)
+    hoje = _hoje()
+
+    _plantar(
+        db, tenant_id=tenant_id, account_id=conta["id"], amount_cents=15_00, posted_at=hoje
+    )
+    _plantar(
+        db,
+        tenant_id=tenant_id,
+        account_id=conta["id"],
+        amount_cents=100_00,
+        posted_at=hoje,
+        source=SOURCE_YIELD,
+    )
+
+    acc = bank_service.get_account(db, conta["id"])
+
+    sem_recorte = bank_service.movement_sums(db, accounts=[acc])
+    assert sem_recorte.get(acc.id) == 115_00, "sem recorte, os dois movimentos entram"
+
+    sem_rendimento = bank_service.movement_sums(
+        db, accounts=[acc], exclude_sources=frozenset({SOURCE_YIELD})
+    )
+    assert sem_rendimento.get(acc.id) == 15_00, "o rendimento saiu; o manual FICOU"
+```
+
+`KIND_INVESTMENT` vem de `app.modules.bank.models` — acrescente-o ao bloco de import do topo do
+arquivo se ele ainda não estiver lá (`KIND_CHECKING` já está).
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_bank_corte_de_data.py::test_movement_sums_exclui_a_origem_pedida -v
+```
+
+Esperado: **FAIL** com `AttributeError: module 'app.modules.bank.service' has no attribute 'movement_sums'`.
+
+- [ ] **Step 3: Acrescentar o parâmetro em `_movements_sums`**
+
+Em `apps/api/app/modules/bank/service.py`, na assinatura de `_movements_sums` (`:557`), acrescente o último parâmetro:
+
+```python
+def _movements_sums(
+    db: Session,
+    *,
+    accounts: Sequence[BankAccount],
+    until: date | None = None,
+    since: date | None = None,
+    sign: int | None = None,
+    exclude_sources: frozenset[str] = frozenset(),
+) -> dict[str, int]:
+```
+
+E, dentro do corpo, logo após o bloco do `sign` (antes do `return`):
+
+```python
+    if exclude_sources:
+        stmt = stmt.where(BankTransaction.source.notin_(exclude_sources))
+```
+
+Acrescente à docstring da função, junto das outras cláusulas do `WHERE`:
+
+```
+          AND (:exclude_sources vazio OR source NOT IN :exclude_sources)  -- Onda 2b-ii
+```
+
+e, abaixo da explicação do `sign`:
+
+```
+    ⚠️ **[Onda 2b-ii] `exclude_sources` existe para que o principal derivado NÃO seja uma segunda
+    fórmula.** O principal de uma aplicação é a soma dos movimentos da conta dela **menos os de
+    rendimento** (que já são contados por `accrued_yield_cents`). Escrever essa soma noutro lugar
+    duplicaria o piso `posted_at > opening_date` e o `status <> 'ignored'`, e o dia em que um dos
+    dois fosse corrigido só de um lado o principal passaria a divergir do saldo por um motivo que
+    ninguém acharia. Default vazio: todo chamador anterior a esta onda segue idêntico.
+```
+
+- [ ] **Step 4: Acrescentar a porta pública**
+
+Logo após `_movements_sum` (`apps/api/app/modules/bank/service.py:647`):
+
+```python
+def movement_sums(
+    db: Session,
+    *,
+    accounts: Sequence[BankAccount],
+    until: date | None = None,
+    exclude_sources: frozenset[str] = frozenset(),
+) -> dict[str, int]:
+    """A porta PÚBLICA da soma de movimentos — `{bank_account_id: centavos}`.
+
+    Fina de propósito: delega para `_movements_sums`, que continua sendo a **única** implementação
+    da fórmula. Ela existe porque `investments` precisa da soma com `exclude_sources` (Onda 2b-ii) e
+    importar um símbolo `_` de outro módulo é o tipo de acesso que ninguém encontra depois — e que
+    o `dedup-checker` não consegue julgar.
+
+    `until=None` significa **hoje**, como em `derived_balance` (Story 8.10). Conta sem movimento não
+    aparece no dicionário; use `.get(id, 0)`.
+    """
+    return _movements_sums(
+        db, accounts=accounts, until=resolve_until(until, _today(db)), exclude_sources=exclude_sources
+    )
+```
+
+- [ ] **Step 5: Rodar o teste novo e a suíte de bank**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_bank_corte_de_data.py -v
+cd apps/api && .venv/Scripts/python -m pytest tests/ -q -k "bank"
+```
+
+Esperado: tudo **PASS**. Se algo de `bank` quebrou, o `exclude_sources` não é aditivo como deveria — pare e investigue antes de seguir.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/bank/service.py apps/api/tests/test_bank_corte_de_data.py
+git commit -m "feat: a soma de movimentos aprende a excluir uma origem [Onda 2b-ii]"
+```
+
+---
+
+## Task 2: O principal derivado
+
+**Files:**
+- Modify: `apps/api/app/modules/investments/service.py` (acrescentar após `list_accounts`, `:171`)
+- Test: `apps/api/tests/test_investments_principal.py` (criar)
+
+**Interfaces:**
+- Consumes: `bank.service.movement_sums(db, *, accounts, until=None, exclude_sources=frozenset()) -> dict[str, int]` (Task 1)
+- Produces:
+  - `investments.service.principais_derivados(db: Session, accs: Sequence[InvestmentAccount]) -> dict[str, int | None]` — chaveado pelo id da **`InvestmentAccount`**. `None` = inafirmável (sem vínculo, ou saldo de abertura desconhecido).
+  - `investments.service.principal_derivado(db: Session, acc: InvestmentAccount) -> int | None` — delega para a de lote.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Crie `apps/api/tests/test_investments_principal.py`:
+
+```python
+"""O principal da aplicação é CALCULADO, não digitado (Onda 2b-ii).
+
+    principal = opening_balance_cents da conta de aplicação
+              + Σ movimentos daquela conta com source <> 'yield'
+
+Os três termos e o porquê de cada um estão na spec §3. O que estes testes seguram é que a
+derivação não vire uma segunda fórmula e não conte o rendimento duas vezes.
+
+RLS não é exercida aqui (SQLite — ver conftest); o isolamento cross-tenant da aplicação já é
+coberto por `test_investments_rls.py`.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.modules.investments import service as inv_service
+from app.modules.investments.models import InvestmentAccount
+
+REGISTER = {
+    "legal_name": "Deriva Consultoria",
+    "document": "11444777000161",
+    "slug": "deriva",
+    "email": "deriva@example.com",
+    "name": "Dora",
+    "password": "uma-senha-bem-grande",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _conta_bancaria(
+    client: TestClient,
+    headers,
+    *,
+    name="CDB Itaú",
+    kind="investment",
+    opening_date="2026-01-01",
+    opening_balance_cents=0,
+    opening_balance_is_known=True,
+) -> dict:
+    r = client.post(
+        "/bank/accounts",
+        json={
+            "name": name,
+            "kind": kind,
+            "opening_date": opening_date,
+            "opening_balance_cents": opening_balance_cents,
+            "opening_balance_is_known": opening_balance_is_known,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _aplicacao(client: TestClient, headers, *, bank_account_id: str | None, name="Reserva") -> dict:
+    r = client.post(
+        "/investments",
+        json={
+            "name": name,
+            "kind": "CDB",
+            "index_rate_label": "CDI 110%",
+            "opened_at": "2026-01-01",
+            "bank_account_id": bank_account_id,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _transferencia(client, headers, *, de: str, para: str, valor: int, quando: str, kind: str):
+    r = client.post(
+        "/bank/transfers",
+        json={
+            "from_account_id": de,
+            "to_account_id": para,
+            "amount_cents": valor,
+            "transfer_date": quando,
+            "kind": kind,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _acc(db: Session, account_id: str) -> InvestmentAccount:
+    return db.get(InvestmentAccount, account_id)
+
+
+# ── Teste 6 da spec §5 ────────────────────────────────────────────────────────────────────────
+def test_o_saldo_de_abertura_entra_no_principal(client, db, headers):
+    """O dinheiro que já estava aplicado no dia do cadastro é principal, e nunca teve movimento.
+
+    Sem este termo, uma conta cadastrada com R$ 10.000 aplicados mostraria principal ZERO — um
+    número errado com aparência de fato, que é a família de defeito que a Onda 0 existe para não
+    repetir. É também o caso do fundador: ele cadastra a conta com o saldo que já tem.
+    """
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == 10_000_00
+
+
+# ── Teste 5 da spec §5 ────────────────────────────────────────────────────────────────────────
+def test_aporte_MOVE_o_principal(client, db, headers):
+    """Transferir da corrente para a aplicação aumenta o principal. É a metade viva do recorte."""
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client,
+        headers,
+        de=corrente["id"],
+        para=aplicacao["id"],
+        valor=3_000_00,
+        quando="2026-02-10",
+        kind="investment_in",
+    )
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == 13_000_00
+
+
+# ── Teste 4 da spec §5 ────────────────────────────────────────────────────────────────────────
+def test_rendimento_NAO_move_o_principal(client, db, headers):
+    """Registrar rendimento não mexe no principal — ele já é contado por `accrued_yield_cents`.
+
+    ⚠️ Este teste sozinho NÃO prova o recorte: se `exclude_sources` fosse ignorado e a soma
+    excluísse tudo, ele passaria igual. Quem o completa é `test_aporte_MOVE_o_principal`, acima.
+    Os dois juntos particionam o conjunto: um membro de cada lado.
+    """
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    r = client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 150_00, "date": "2026-02-28", "chart_account_id": None},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    acc = _acc(db, app_["id"])
+    assert acc.accrued_yield_cents == 150_00, "o rendimento foi registrado (controle positivo)"
+    assert inv_service.principal_derivado(db, acc) == 10_000_00, "e NÃO entrou no principal"
+
+
+# ── Teste 2 da spec §5 — a invariante ─────────────────────────────────────────────────────────
+def test_a_invariante_saldo_igual_principal_mais_rendimento(client, db, headers):
+    """`derived_balance(conta) == principal + accrued_yield`, com aporte, rendimento E resgate.
+
+    Vale POR CONSTRUÇÃO enquanto todo rendimento tiver perna bancária — que é o que a 2b-i
+    garantiu com o 409 de `register_yield`. Quebrá-la é sintoma de movimento escrito por fora da
+    Regra da Origem.
+    """
+    from app.modules.bank import service as bank_service
+
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client, headers, de=corrente["id"], para=aplicacao["id"],
+        valor=3_000_00, quando="2026-02-10", kind="investment_in",
+    )
+    client.post(
+        f"/investments/{app_['id']}/yield",
+        json={"amount_cents": 150_00, "date": "2026-02-28", "chart_account_id": None},
+        headers=headers,
+    )
+    _transferencia(
+        client, headers, de=aplicacao["id"], para=corrente["id"],
+        valor=2_000_00, quando="2026-03-05", kind="investment_out",
+    )
+
+    acc = _acc(db, app_["id"])
+    saldo = bank_service.derived_balance(db, bank_account_id=aplicacao["id"])
+    assert saldo == inv_service.principal_derivado(db, acc) + acc.accrued_yield_cents
+    assert saldo == 11_150_00, "10.000 + 3.000 + 150 − 2.000"
+
+
+# ── Teste 3 da spec §5 ────────────────────────────────────────────────────────────────────────
+def test_saldo_de_abertura_desconhecido_da_None_e_NAO_zero(client, db, headers):
+    """Conta cadastrada como "tenho a conta e não sei o saldo" (Story 8.21) ⇒ principal `None`.
+
+    **Zero seria uma afirmação** — *"você não tem nada aplicado"* —, falsa e indistinguível de um
+    saldo genuinamente zerado. `None` é a ausência da afirmação, e é o princípio que a 8.21 fixou:
+    suprimir a afirmação, nunca o número.
+    """
+    conta = _conta_bancaria(
+        client, headers, opening_balance_cents=0, opening_balance_is_known=False
+    )
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    principal = inv_service.principal_derivado(db, _acc(db, app_["id"]))
+    assert principal is None
+    assert principal != 0, "o 0 aqui seria uma afirmação; queremos a ausência dela"
+
+
+def test_aplicacao_sem_vinculo_da_None(client, db, headers):
+    """Sem `bank_account_id` não há de onde derivar. `None`, não zero, pelo mesmo motivo acima."""
+    app_ = _aplicacao(client, headers, bank_account_id=None)
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) is None
+
+
+def test_principal_negativo_quando_o_resgate_excede(client, db, headers):
+    """Resgate BRUTO (principal + rendimento não lançado) deixa o principal negativo — e aparece.
+
+    Clampar em zero seria esconder; recusar o resgate seria recusar um fato que já aconteceu no
+    banco. O número aparece como é, e quem o nomeia é a tela (spec §4.4).
+    """
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplicacao = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=aplicacao["id"])
+
+    _transferencia(
+        client, headers, de=aplicacao["id"], para=corrente["id"],
+        valor=10_500_00, quando="2026-03-05", kind="investment_out",
+    )
+
+    assert inv_service.principal_derivado(db, _acc(db, app_["id"])) == -500_00
+
+
+def test_principais_derivados_resolve_em_lote(client, db, headers):
+    """A versão de lote existe para o `GET /investments` não virar N+1 — uma query, N contas."""
+    c1 = _conta_bancaria(client, headers, name="CDB A", opening_balance_cents=1_000_00)
+    c2 = _conta_bancaria(client, headers, name="CDB B", opening_balance_cents=2_000_00)
+    a1 = _aplicacao(client, headers, bank_account_id=c1["id"], name="A")
+    a2 = _aplicacao(client, headers, bank_account_id=c2["id"], name="B")
+    a3 = _aplicacao(client, headers, bank_account_id=None, name="C")
+
+    accs = [_acc(db, a["id"]) for a in (a1, a2, a3)]
+    assert inv_service.principais_derivados(db, accs) == {
+        a1["id"]: 1_000_00,
+        a2["id"]: 2_000_00,
+        a3["id"]: None,
+    }
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -v
+```
+
+Esperado: **FAIL** com `AttributeError: module 'app.modules.investments.service' has no attribute 'principal_derivado'`.
+
+- [ ] **Step 3: Implementar a derivação**
+
+Em `apps/api/app/modules/investments/service.py`, acrescente após `list_accounts` (`:171`). Os imports novos vão junto dos que já existem no topo:
+
+```python
+from collections.abc import Sequence
+
+from app.core.money_planes import ORIGEM_INDISPONIVEL
+```
+
+```python
+def principais_derivados(
+    db: Session, accs: Sequence[InvestmentAccount]
+) -> dict[str, int | None]:
+    """O principal CALCULADO de cada aplicação — `{investment_account_id: centavos | None}`.
+
+        principal = opening_balance_cents da conta de aplicação
+                  + Σ movimentos daquela conta com `source <> 'yield'`
+
+    Os três termos, e por que cada um está aqui (spec §3):
+
+    **(a) O saldo de abertura entra.** É o dinheiro que já estava aplicado no dia do cadastro —
+    principal que nunca teve movimento. Somar só os movimentos daria R$ 0,00 numa conta com
+    R$ 10.000 aplicados: um número errado com aparência de fato.
+
+    **(b) `source <> 'yield'` impede a dupla contagem.** O rendimento já é contado por
+    `accrued_yield_cents` e, desde a Onda 2b-i, também gera `bank_transaction`. Sem o recorte, cada
+    rendimento entraria duas vezes no saldo da aplicação.
+
+    **(c) O piso `posted_at > opening_date` e o teto `<= hoje` não são escolha desta função** —
+    vêm de `_movements_sums`, a única soma de movimentos do repositório. Um aporte agendado para o
+    mês que vem não é principal aplicado hoje.
+
+    ⚠️ **`None` NÃO é zero, e a distinção é o ponto.** Devolvemos `None` em dois casos — aplicação
+    sem vínculo, e conta cujo saldo de abertura o dono declarou **não saber** (Story 8.21,
+    `origem_do_saldo_derivado`). Zero seria a afirmação *"você não tem nada aplicado"*, falsa e
+    indistinguível de um saldo genuinamente zerado. É o princípio da Onda 0 e da 8.21: suprimir a
+    afirmação, nunca o número.
+
+    ⚠️ **A procedência é lida de `bank_service.origem_do_saldo_derivado`, nunca recomparada aqui.**
+    A Story 8.21 pagou exatamente esse preço: a mesma decisão escrita duas vezes no `router.py`
+    fazia a mesma conta responder coisas diferentes por portas diferentes.
+
+    O principal **pode ser negativo** (resgate bruto que leva rendimento ainda não lançado junto).
+    Não é clampado: quem o nomeia é a tela (spec §4.4), e clampar seria esconder.
+    """
+    vinculadas = {a.id: a.bank_account_id for a in accs if a.bank_account_id}
+    if not vinculadas:
+        return {a.id: None for a in accs}
+
+    contas = {
+        c.id: c
+        for c in bank_service.list_accounts(db, include_archived=True)
+        if c.id in set(vinculadas.values())
+    }
+    somas = bank_service.movement_sums(
+        db, accounts=list(contas.values()), exclude_sources=frozenset({SOURCE_YIELD})
+    )
+
+    resultado: dict[str, int | None] = {}
+    for a in accs:
+        conta = contas.get(a.bank_account_id) if a.bank_account_id else None
+        if conta is None or bank_service.origem_do_saldo_derivado(conta) == ORIGEM_INDISPONIVEL:
+            resultado[a.id] = None
+            continue
+        resultado[a.id] = conta.opening_balance_cents + somas.get(conta.id, 0)
+    return resultado
+
+
+def principal_derivado(db: Session, acc: InvestmentAccount) -> int | None:
+    """O principal de UMA aplicação. Delega para `principais_derivados` — ver a fórmula lá.
+
+    Uma implementação, dois usos: duas cópias da fórmula divergiriam no dia em que uma delas
+    ganhasse uma condição, e o sintoma seria um principal que muda conforme a tela que o pede —
+    exatamente o que `_movements_sum`/`_movements_sums` já evitam um nível abaixo.
+    """
+    return principais_derivados(db, [acc])[acc.id]
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -v
+```
+
+Esperado: **9 passed**.
+
+- [ ] **Step 5: Provar por mutação que o recorte está vivo**
+
+Copie o arquivo antes de mutar — **nunca use `git checkout` para restaurar** (já apagou uma sessão inteira de trabalho não commitado nesta onda do épico):
+
+```bash
+cp apps/api/app/modules/investments/service.py /tmp/service.py.bak
+```
+
+Troque `exclude_sources=frozenset({SOURCE_YIELD})` por `exclude_sources=frozenset()` e rode:
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -q
+```
+
+Esperado: **`test_rendimento_NAO_move_o_principal` e `test_a_invariante_...` FALHAM.** Se passarem, o recorte não está sendo exercitado e o teste é do tipo errado — conserte o teste, não o código.
+
+```bash
+cp /tmp/service.py.bak apps/api/app/modules/investments/service.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/investments/service.py apps/api/tests/test_investments_principal.py
+git commit -m "feat: o principal da aplicação passa a ser calculado dos movimentos [Onda 2b-ii]"
+```
+
+---
+
+## Task 3: Os nove leitores da coluna, de uma vez
+
+**Files:**
+- Modify: `apps/api/app/modules/investments/service.py:333-337` (`_pct`) e `:360-369` (`rentability`)
+- Modify: `apps/api/app/modules/investments/schemas.py:82`, `:91`
+- Modify: `apps/api/app/modules/investments/router.py:25-35` (`_out`) e todas as rotas que o chamam
+- Test: `apps/api/tests/test_investments_principal.py` (acrescentar)
+
+**Interfaces:**
+- Consumes: `principais_derivados`, `principal_derivado` (Task 2)
+- Produces:
+  - `InvestmentAccountOut.principal_cents: int | None`
+  - `RentabilityOut.principal_cents: int | None`
+  - `investments.router._out(a: InvestmentAccount, principal_cents: int | None) -> InvestmentAccountOut` — **assinatura nova, dois parâmetros**
+
+**Por que de uma vez.** O inventário da spec §4.2.1 tem nove leitores. Fatiar isto deixaria a API respondendo `None` num campo tipado `int` no meio do caminho — 500 em produção se o deploy pegasse o estado intermediário.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescente a `apps/api/tests/test_investments_principal.py`:
+
+```python
+def test_a_api_devolve_o_principal_derivado_e_ignora_a_coluna(client, db, headers):
+    """`GET /investments` responde o CALCULADO, não o que está gravado na coluna.
+
+    A coluna é semeada com um valor absurdo de propósito: se a API o devolvesse, o teste falharia
+    com um número reconhecível em vez de um zero ambíguo.
+    """
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 777_77  # o valor congelado, que ninguém pode mais ler
+    db.commit()
+
+    r = client.get("/investments", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()[0]["principal_cents"] == 10_000_00
+
+
+def test_rentabilidade_e_None_com_principal_None_e_com_principal_negativo(client, db, headers):
+    """`_pct` protege os TRÊS casos sem número: `None`, zero e negativo.
+
+    `None` levantaria `TypeError` (divisão por `None`). **Negativo é o mais perigoso dos três**:
+    devolveria um percentual de sinal invertido — plausível na tela, e errado. Rentabilidade sobre
+    principal negativo não é um número menor: é uma pergunta sem sentido.
+    """
+    # (a) principal None — saldo de abertura desconhecido
+    c_desconhecida = _conta_bancaria(
+        client, headers, name="CDB ?", opening_balance_cents=0, opening_balance_is_known=False
+    )
+    a_none = _aplicacao(client, headers, bank_account_id=c_desconhecida["id"], name="Sem lastro")
+    r = client.get(f"/investments/{a_none['id']}/rentability", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["principal_cents"] is None
+    assert r.json()["total_rentability_pct"] is None
+
+    # (b) principal negativo — resgate bruto
+    corrente = _conta_bancaria(client, headers, name="Itaú PJ", kind="checking")
+    aplic = _conta_bancaria(client, headers, name="CDB neg", opening_balance_cents=10_000_00)
+    a_neg = _aplicacao(client, headers, bank_account_id=aplic["id"], name="Resgatada")
+    client.post(
+        f"/investments/{a_neg['id']}/yield",
+        json={"amount_cents": 500_00, "date": "2026-02-28", "chart_account_id": None},
+        headers=headers,
+    )
+    _transferencia(
+        client, headers, de=aplic["id"], para=corrente["id"],
+        valor=10_500_00, quando="2026-03-05", kind="investment_out",
+    )
+    r = client.get(f"/investments/{a_neg['id']}/rentability", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["principal_cents"] == -500_00, "o número aparece como é"
+    assert r.json()["total_rentability_pct"] is None, "a rentabilidade sobre ele, não"
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -k "api_devolve or rentabilidade_e_None" -v
+```
+
+Esperado: **FAIL** — o primeiro devolvendo `77777`, o segundo com `ValidationError` (`principal_cents` não aceita `None`) ou `TypeError`.
+
+- [ ] **Step 3: Os dois schemas de saída**
+
+Em `apps/api/app/modules/investments/schemas.py`, troque as duas linhas:
+
+```python
+class InvestmentAccountOut(BaseModel):
+    id: str
+    name: str
+    kind: str
+    index_rate_label: str
+    # Onda 2b-ii: CALCULADO dos movimentos da conta bancária vinculada, não mais a coluna.
+    # `None` = inafirmável (sem vínculo, ou saldo de abertura declarado desconhecido — Story 8.21).
+    # **`None` não é zero:** zero seria a afirmação "você não tem nada aplicado".
+    principal_cents: int | None
+    accrued_yield_cents: int
+    opened_at: date
+    bank_account_id: str | None
+    created_at: datetime
+```
+
+```python
+class RentabilityOut(BaseModel):
+    account_id: str
+    principal_cents: int | None  # Onda 2b-ii — ver InvestmentAccountOut
+    accrued_yield_cents: int
+    # Rentabilidade TOTAL (rendimento acumulado / principal). `None` quando o principal é `None`,
+    # zero ou NEGATIVO — ver `service._pct`.
+    total_rentability_pct: float | None
+    # Rentabilidade do PERÍODO. Mesmas três condições de `None`.
+    period_rentability_pct: float | None
+    period_yield_cents: int
+    start: date | None
+    end: date | None
+```
+
+- [ ] **Step 4: `_pct` e `rentability`**
+
+Em `apps/api/app/modules/investments/service.py`, substitua `_pct` (`:333-337`):
+
+```python
+def _pct(numerator: int, principal_cents: int | None) -> float | None:
+    """Rentabilidade (fração), ou `None` quando a pergunta não tem sentido.
+
+    Três casos sem número, e o terceiro é o que a Onda 2b-ii acrescentou:
+
+    - **`None`** — o principal é inafirmável (sem vínculo, ou saldo de abertura desconhecido).
+      Dividir levantaria `TypeError`.
+    - **zero** — divisão por zero, protegida desde a 5.6.
+    - **negativo** — resgate bruto que levou rendimento ainda não lançado junto. Dividir devolveria
+      um percentual de **sinal invertido**: plausível na tela, e errado. *"Quanto rendeu
+      percentualmente o que você não aplicou?"* não é uma pergunta com resposta menor — é uma
+      pergunta sem resposta.
+
+    O `None` já é renderizado como "—" pela tela desde a 5.6 (`investimentos.ts::formatPct`): a
+    superfície existe e não precisa ser inventada.
+    """
+    if principal_cents is None or principal_cents <= 0:
+        return None
+    return numerator / principal_cents
+```
+
+E, em `rentability` (`:360-369`), troque as três linhas que leem a coluna:
+
+```python
+    principal = principal_derivado(db, acc)
+
+    return {
+        "account_id": acc.id,
+        "principal_cents": principal,
+        "accrued_yield_cents": acc.accrued_yield_cents,
+        "total_rentability_pct": _pct(acc.accrued_yield_cents, principal),
+        "period_rentability_pct": _pct(period_yield, principal),
+        "period_yield_cents": period_yield,
+        "start": start,
+        "end": end,
+    }
+```
+
+- [ ] **Step 5: O router**
+
+Em `apps/api/app/modules/investments/router.py`, troque `_out` (`:25-35`):
+
+```python
+def _out(a: InvestmentAccount, principal_cents: int | None) -> InvestmentAccountOut:
+    """O principal vem de FORA (Onda 2b-ii) — `a.principal_cents` está congelado.
+
+    O parâmetro é obrigatório de propósito: um default lendo a coluna seria exatamente o caminho
+    por onde o valor digitado voltaria a vencer, e nada quebraria para avisar.
+    """
+    return InvestmentAccountOut(
+        id=a.id,
+        name=a.name,
+        kind=a.kind,
+        index_rate_label=a.index_rate_label,
+        principal_cents=principal_cents,
+        accrued_yield_cents=a.accrued_yield_cents,
+        opened_at=a.opened_at,
+        bank_account_id=a.bank_account_id,
+        created_at=a.created_at,
+    )
+```
+
+E ajuste **todos** os chamadores. Na listagem, use a versão de **lote** (uma query, não N):
+
+```python
+@router.get("", response_model=list[InvestmentAccountOut])
+def list_accounts(
+    _user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> list[InvestmentAccountOut]:
+    contas = service.list_accounts(db)
+    # Lote de propósito: uma query para N aplicações. `principal_derivado` num laço seria N+1,
+    # que é o que `_movements_sums` existe para evitar um nível abaixo.
+    principais = service.principais_derivados(db, contas)
+    return [_out(a, principais[a.id]) for a in contas]
+```
+
+Nas rotas de uma conta só (`create_account`, `update_account`, `register_yield` e qualquer outra que retorne `InvestmentAccountOut`), use:
+
+```python
+    return _out(acc, service.principal_derivado(db, acc))
+```
+
+Encontre todas com:
+
+```bash
+cd apps/api && grep -n "_out(" app/modules/investments/router.py
+```
+
+**Nenhuma pode continuar chamando `_out` com um argumento só** — o Python vai reclamar, e é essa a intenção do parâmetro obrigatório.
+
+- [ ] **Step 6: Rodar a suíte de investimentos inteira**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py tests/test_investments_principal.py -v
+```
+
+Esperado: **PASS**. Testes antigos de `test_investments.py` que assertavam o principal digitado **vão falhar — e devem**: o comportamento mudou. Ajuste-os para o valor derivado e **escreva na docstring por que a asserção mudou de propósito**. Ajustar asserção sem justificar é a manobra que esconde regressão; aqui a mudança é real e precisa estar dita.
+
+- [ ] **Step 7: Suíte inteira + lint**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest -q
+cd apps/api && .venv/Scripts/python -m ruff check .
+```
+
+Esperado: tudo verde, `All checks passed!`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/investments/ apps/api/tests/
+git commit -m "feat: a API responde o principal calculado e a coluna deixa de ser lida [Onda 2b-ii]"
+```
+
+---
+
+## Task 4: A recusa — o principal não se edita mais
+
+**Files:**
+- Modify: `apps/api/app/modules/investments/service.py` (`create_account` `:124-143`, `update_account` `:146-167`)
+- Test: `apps/api/tests/test_investments.py`
+
+**Interfaces:**
+- Consumes: nada de tasks anteriores
+- Produces: `investments.service.PrincipalNaoEditavelError(InvestmentError)` — 409, `detail` **não** estruturado (ver abaixo)
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescente a `apps/api/tests/test_investments.py`:
+
+```python
+def test_editar_o_principal_e_recusado_com_409(client, headers):
+    """`PATCH` com `principal_cents` → 409 apontando para a ação REAL (Onda 2b-ii).
+
+    ⚠️ **Este 409 é o OPOSTO do 409 da 2b-i.** Aquele era caminho normal — o dono batia nele ao
+    registrar rendimento, e por isso a tela oferecia a saída ali mesmo. Este é **inalcançável pela
+    tela** (o campo saiu do formulário): se disparar, é integração antiga ou defeito. É guarda de
+    contrato, não fluxo — e por isso **não** tem `detail["acao"]`: um `acao` sem modal do outro
+    lado seria contrato com ninguém.
+
+    A asserção é sobre um trecho ESPECÍFICO da frase, não sobre uma palavra genérica. "aporte"
+    sozinho casaria com quase qualquer texto sobre aplicação; a manobra que a Onda 2 pegou foi
+    `"trilho" in detail` casando também *"fora do trilho"*.
+    """
+    conta = _conta_bancaria(client, headers)
+    r = client.post(
+        "/investments",
+        json={"name": "Reserva", "opened_at": "2026-01-01", "bank_account_id": conta["id"]},
+        headers=headers,
+    )
+    account_id = r.json()["id"]
+
+    r = client.patch(
+        f"/investments/{account_id}", json={"principal_cents": 5_000_00}, headers=headers
+    )
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert isinstance(detail, str), "guarda de contrato não é 409 acionável — sem detail['acao']"
+    assert "calculado pelos movimentos" in detail
+    assert "registre a transferência" in detail
+
+
+def test_criar_com_principal_diferente_de_zero_e_recusado(client, headers):
+    """No CADASTRO o caminho do valor já aplicado é o **saldo de abertura** da conta bancária.
+
+    Recusar sem dizer onde informar seria o beco sem saída que a 2b-i pagou para evitar.
+    """
+    conta = _conta_bancaria(client, headers)
+    r = client.post(
+        "/investments",
+        json={
+            "name": "Reserva",
+            "opened_at": "2026-01-01",
+            "bank_account_id": conta["id"],
+            "principal_cents": 10_000_00,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 409, r.text
+    assert "saldo de abertura" in r.json()["detail"]
+
+
+def test_criar_com_principal_zero_continua_passando(client, headers):
+    """O default do schema é `0`. Recusá-lo quebraria todo cliente que não manda o campo.
+
+    Sem este teste, a guarda mais óbvia (`if data.principal_cents is not None`) passaria verde e
+    quebraria o cadastro inteiro em produção — o campo tem default, então ele NUNCA é `None`.
+    """
+    conta = _conta_bancaria(client, headers)
+    r = client.post(
+        "/investments",
+        json={"name": "Reserva", "opened_at": "2026-01-01", "bank_account_id": conta["id"]},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py -k "principal" -v
+```
+
+Esperado: os dois primeiros **FAIL** (200/201 em vez de 409); o terceiro já passa (é o controle).
+
+- [ ] **Step 3: Implementar a recusa**
+
+Em `apps/api/app/modules/investments/service.py`, logo após `ContaNaoVinculadaError`:
+
+```python
+_PRINCIPAL_DERIVADO_MSG = (
+    "O valor aplicado agora é calculado pelos movimentos da conta. Para mudar quanto está "
+    "aplicado, registre a transferência que você fez de verdade — da conta corrente para a "
+    "aplicação (aporte) ou da aplicação para a corrente (resgate)."
+)
+
+_PRINCIPAL_NO_CADASTRO_MSG = (
+    "No cadastro, o valor já aplicado é o saldo de abertura da conta bancária da aplicação — é "
+    "lá que ele é informado, uma vez."
+)
+
+
+class PrincipalNaoEditavelError(InvestmentError):
+    """O principal é derivado (Onda 2b-ii) e não se edita.
+
+    ⚠️ **`detail` fica em texto, sem `{"acao": ...}` — e a ausência é a decisão.** O 409 acionável
+    da 8.12/2b-i existe porque a tela reconhece a situação e oferece a saída ali mesmo. Este 409 é
+    **inalcançável pela tela** (o campo saiu do formulário na E6): quem o recebe é uma integração
+    antiga ou um defeito. Um `acao` sem modal do outro lado seria um contrato com ninguém, e
+    convidaria a próxima pessoa a construir o modal que não deve existir.
+
+    A ação que a mensagem manda fazer **existe hoje**: `investment_in`/`investment_out` são
+    `TRANSFER_KINDS` desde a Onda 2, e a tela de transferência está em `ContasSaldosPage`. Recusar
+    apontando para uma ação inexistente é o defeito que esta classe existe para não cometer.
+    """
+
+    def __init__(self, mensagem: str) -> None:
+        super().__init__(mensagem, 409)
+```
+
+Em `create_account`, como **primeira** linha do corpo:
+
+```python
+    # Onda 2b-ii. `principal_cents` tem default `0` no schema, então a guarda é sobre o VALOR e não
+    # sobre a presença: `is not None` recusaria todo cadastro que simplesmente não manda o campo.
+    if data.principal_cents:
+        raise PrincipalNaoEditavelError(_PRINCIPAL_NO_CADASTRO_MSG)
+```
+
+e **remova** a linha `principal_cents=data.principal_cents,` da construção do `InvestmentAccount` — a coluna nasce no default `0` do model e nunca mais é escrita.
+
+Em `update_account`, substitua o bloco `if data.principal_cents is not None:` (`:158-159`) por:
+
+```python
+    if data.principal_cents is not None:
+        # Aqui `is not None` É a guarda certa: no `Update` o default é `None` e significa
+        # "não altera" — o oposto exato do `Create`. A assimetria é deliberada e testada.
+        raise PrincipalNaoEditavelError(_PRINCIPAL_DERIVADO_MSG)
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments.py tests/test_investments_principal.py -v
+```
+
+Esperado: **PASS**. Testes antigos que criavam aplicação com `principal_cents` preenchido vão falhar — troque-os por conta bancária com `opening_balance_cents`, que é o caminho novo.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/investments/service.py apps/api/tests/test_investments.py
+git commit -m "feat: o principal deixa de ser editável e a recusa nomeia a ação real [Onda 2b-ii]"
+```
+
+---
+
+## Task 5: O gate que congela a coluna
+
+**Files:**
+- Test: `apps/api/tests/test_investments_principal_gate.py` (criar)
+
+**Interfaces:**
+- Consumes: o estado final das Tasks 2, 3 e 4 (nenhum leitor da coluna em `app/modules/`)
+- Produces: nada consumido por tasks posteriores
+
+**Por que depois das outras.** Rodado antes, ele reprova o próprio código em construção.
+
+- [ ] **Step 1: Escrever o gate e o controle positivo**
+
+Crie `apps/api/tests/test_investments_principal_gate.py`:
+
+```python
+"""**Teste de ausência** — `investment_accounts.principal_cents` está congelada (Onda 2b-ii).
+
+Quem ler a coluna vai receber `0` (ou o que sobrou de antes da onda), não o principal real. Nada
+quebra se alguém voltar a lê-la: a coluna existe, tem valor, a leitura funciona. Só o dono, meses
+depois, veria a tela discordar do extrato sobre quanto ele tem aplicado.
+
+Este teste é o consumidor mecânico que essa mudança não tem sozinha.
+
+**Precedente exato:** `tenant_profiles.timezone`, congelada em 2026-08-07 (migration 0073). Ela
+tinha TRÊS consumidores que a investigação inicial não achou — Agenda, Cockpit e a validade das
+notificações. Corrigir só o caminho óbvio teria quebrado os três em silêncio.
+
+`app/scripts/investment_audit.py` lê a coluna **de propósito**, para comparar com o derivado, e
+está fora do alcance desta varredura por construção: ela só visita `app/modules/`.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MODULES = Path(__file__).resolve().parents[1] / "app" / "modules"
+
+# O model DEFINE a coluna — mencioná-la lá não é lê-la.
+_PODEM_MENCIONAR = {"investments/models.py"}
+
+
+def _ofensores(raiz: Path, ignorar: set[str]) -> list[str]:
+    achados: list[str] = []
+    for arquivo in raiz.rglob("*.py"):
+        rel = arquivo.relative_to(raiz).as_posix()
+        if rel in ignorar:
+            continue
+        arvore = ast.parse(arquivo.read_text(encoding="utf-8"))
+        for no in ast.walk(arvore):
+            # `<algo>.principal_cents` — o padrão de TODOS os call sites que existiam antes da
+            # onda: `a.principal_cents`, `acc.principal_cents`, `data.principal_cents`.
+            if isinstance(no, ast.Attribute) and no.attr == "principal_cents":
+                base = no.value
+                nome = base.id if isinstance(base, ast.Name) else None
+                if nome in {"a", "acc", "account", "conta", "aplicacao", "InvestmentAccount"}:
+                    achados.append(f"{rel}:{no.lineno} ({nome}.principal_cents)")
+    return achados
+
+
+def test_ninguem_le_o_principal_da_coluna():
+    assert not _ofensores(_MODULES, _PODEM_MENCIONAR), (
+        "Estes pontos leem `principal_cents` da COLUNA, que está congelada desde a Onda 2b-ii. "
+        "Use `investments.service.principal_derivado(db, acc)` — ou, para várias contas, "
+        f"`principais_derivados(db, accs)`: {_ofensores(_MODULES, _PODEM_MENCIONAR)}"
+    )
+
+
+def test_o_gate_reprova_quando_a_leitura_existe(tmp_path):
+    """**Controle positivo.** Um gate que nunca reprovou nada não é um gate — é um teste que passa
+    e não prova nada, a família dominante da Onda 2 (oito ocorrências independentes).
+    """
+    (tmp_path / "fake.py").write_text(
+        "def f(acc):\n    return acc.principal_cents\n", encoding="utf-8"
+    )
+    achados = _ofensores(tmp_path, set())
+    assert achados == ["fake.py:2 (acc.principal_cents)"]
+```
+
+- [ ] **Step 2: Rodar os dois**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal_gate.py -v
+```
+
+Esperado: **2 passed**. Se `test_ninguem_le_o_principal_da_coluna` falhar, ele está certo e o código é que não terminou — volte à Task 3 e trate o que ele apontou. **Não acrescente o arquivo a `_PODEM_MENCIONAR` para fazer o teste passar**: a allowlist é para quem lê de propósito, e a lista é a garantia.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/test_investments_principal_gate.py
+git commit -m "test: gate de ausência congela a coluna principal_cents [Onda 2b-ii]"
+```
+
+---
+
+## Task 6: O script que confere e não corrige
+
+**Files:**
+- Create: `apps/api/app/scripts/investment_audit.py`
+- Test: `apps/api/tests/test_investments_principal.py` (acrescentar)
+
+**Interfaces:**
+- Consumes: `principais_derivados` (Task 2)
+- Produces: `app.scripts.investment_audit.auditar(db) -> list[dict]` — por aplicação: `{"id", "name", "coluna_cents", "derivado_cents", "diverge"}`. `derivado_cents` é `int | None`.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Acrescente a `apps/api/tests/test_investments_principal.py`:
+
+```python
+def test_a_auditoria_reporta_a_divergencia_sem_corrigir(client, db, headers):
+    """O script REPORTA. Se ele corrigisse, o `UPDATE` que esta onda existe para não fazer
+    voltaria pela porta dos fundos — e alguém o rodaria no deploy sem ler a saída.
+    """
+    from app.scripts import investment_audit
+
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 777_77
+    db.commit()
+
+    linhas = investment_audit.auditar(db)
+
+    assert linhas == [
+        {
+            "id": app_["id"],
+            "name": "Reserva",
+            "coluna_cents": 777_77,
+            "derivado_cents": 10_000_00,
+            "diverge": True,
+        }
+    ]
+    db.refresh(acc)
+    assert acc.principal_cents == 777_77, "a auditoria NÃO corrige — a coluna segue como estava"
+
+
+def test_a_auditoria_nao_marca_divergencia_quando_batem(client, db, headers):
+    """Controle negativo: sem ele, `diverge: True` fixo passaria no teste acima."""
+    from app.scripts import investment_audit
+
+    conta = _conta_bancaria(client, headers, opening_balance_cents=10_000_00)
+    app_ = _aplicacao(client, headers, bank_account_id=conta["id"])
+    acc = _acc(db, app_["id"])
+    acc.principal_cents = 10_000_00
+    db.commit()
+
+    assert investment_audit.auditar(db)[0]["diverge"] is False
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -k auditoria -v
+```
+
+Esperado: **FAIL** com `ModuleNotFoundError: No module named 'app.scripts.investment_audit'`.
+
+- [ ] **Step 3: Escrever o script**
+
+Crie `apps/api/app/scripts/investment_audit.py`:
+
+```python
+"""Confere o principal das aplicações: o que a coluna congelada diz × o que os movimentos dizem.
+
+    docker compose exec api python -m app.scripts.investment_audit
+
+**Não existe `--fix`, e a ausência é a decisão.** A Onda 2b-ii substituiu o backfill do design-mãe
+§6.2 — o único `UPDATE` sobre dado existente do épico, exposto à armadilha do `FORCE ROW LEVEL
+SECURITY` — por *auditoria + ato do dono*. Uma flag de correção reintroduziria exatamente o que a
+onda existe para não fazer, e alguém a rodaria no deploy sem ler a saída.
+
+O que fazer com uma divergência: **o dono corrige por ato na tela** — declarando o saldo de abertura
+da conta de aplicação, ou registrando o aporte que faltou como transferência. É o mesmo mecanismo
+pelo qual a Onda 2b-i vinculou a aplicação legada, já validado em campo.
+
+⚠️ **Isolamento:** itera a tabela GLOBAL `tenants` e abre `tenant_session` por tenant (RLS fixada),
+mesmo padrão de `merge_duplicate_clients` e `migrate_attachments_to_s3`. Uma consulta em tabela com
+RLS **sem** tenant devolve zero linhas **sem erro** — foi assim que a sondagem de `phone_key` em
+produção quase virou um "está tudo limpo" falso. Por isso a saída imprime **quantos tenants foram
+varridos**: `0 aplicações em 0 tenants` e `0 aplicações em 7 tenants` são resultados diferentes, e o
+primeiro é um bug deste script.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db, tenant_session
+from app.modules.auth.models import Tenant
+from app.modules.investments import service as inv_service
+
+logger = logging.getLogger("e1p.investment_audit")
+
+
+def auditar(db: Session) -> list[dict]:
+    """Uma linha por aplicação do tenant da sessão. **Só lê.**
+
+    `coluna_cents` lê `principal_cents` de propósito — é o único lugar do repositório autorizado a
+    fazê-lo, e é por isso que este arquivo vive em `app/scripts/` e não em `app/modules/`: o gate
+    `test_investments_principal_gate.py` varre só os módulos.
+    """
+    contas = inv_service.list_accounts(db)
+    derivados = inv_service.principais_derivados(db, contas)
+    linhas = []
+    for a in contas:
+        derivado = derivados[a.id]
+        linhas.append(
+            {
+                "id": a.id,
+                "name": a.name,
+                "coluna_cents": a.principal_cents,
+                "derivado_cents": derivado,
+                # `None` (inafirmável) NÃO é divergência: é ausência de comparação. Tratá-lo como
+                # divergente mandaria o dono caçar um erro que não existe — o modo de falha que o
+                # épico chama de "pior do que ficar calado".
+                "diverge": derivado is not None and derivado != a.principal_cents,
+            }
+        )
+    return linhas
+
+
+def _tenant_ids() -> list[str]:
+    gen = get_db()
+    db = next(gen)
+    try:
+        return [t.id for t in db.scalars(select(Tenant)).all()]
+    finally:
+        gen.close()
+
+
+def _reais(cents: int | None) -> str:
+    return "não sei" if cents is None else f"R$ {cents / 100:,.2f}".replace(",", "@").replace(
+        ".", ","
+    ).replace("@", ".")
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info("=== Auditoria do principal das aplicações (Onda 2b-ii) — SÓ LEITURA ===")
+
+    tenants = _tenant_ids()
+    total = divergentes = 0
+    for tenant_id in tenants:
+        with tenant_session(tenant_id) as db:
+            for linha in auditar(db):
+                total += 1
+                if not linha["diverge"]:
+                    continue
+                divergentes += 1
+                logger.info("")
+                logger.info("  %s (tenant %s)", linha["name"], tenant_id)
+                logger.info("    principal na coluna : %s", _reais(linha["coluna_cents"]))
+                logger.info("    principal calculado : %s", _reais(linha["derivado_cents"]))
+                logger.info(
+                    "    -> declare o saldo de abertura da conta de aplicação, ou registre o "
+                    "aporte que faltou como transferência"
+                )
+
+    logger.info("")
+    logger.info(
+        "%d aplicação(ões) em %d tenant(s); %d com divergência.", total, len(tenants), divergentes
+    )
+    if not tenants:
+        logger.warning(
+            "NENHUM tenant varrido — isto é um defeito deste script, não um banco limpo."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest tests/test_investments_principal.py -k auditoria -v
+```
+
+Esperado: **2 passed**.
+
+- [ ] **Step 5: Rodar o script de verdade contra o dev**
+
+```bash
+cd apps/api && .venv/Scripts/python -m app.scripts.investment_audit
+```
+
+Esperado: uma linha de resumo com a contagem de tenants. **Se sair `0 aplicação(ões) em 0 tenant(s)` mais o WARNING, o script não está enxergando o banco** — não é aprovação, é o defeito que ele mesmo denuncia.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/scripts/investment_audit.py apps/api/tests/test_investments_principal.py
+git commit -m "feat: auditoria do principal reporta divergência e não corrige [Onda 2b-ii]"
+```
+
+---
+
+## Task 7: Os tipos e o aviso, no frontend
+
+**Files:**
+- Modify: `apps/web/src/features/financeiro/investimentos.ts:25`, `:40`
+- Test: `apps/web/src/features/financeiro/investimentos.test.ts`
+
+**Interfaces:**
+- Consumes: o contrato da API (Task 3) — `principal_cents: number | null`
+- Produces:
+  - `InvestmentAccount.principal_cents: number | null`, `Rentability.principal_cents: number | null`
+  - `formatPrincipal(cents: number | null): string`
+  - `avisoDeResgateExcedente(cents: number | null): string | null`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Acrescente a `apps/web/src/features/financeiro/investimentos.test.ts`:
+
+```ts
+import { avisoDeResgateExcedente, formatPrincipal } from "./investimentos";
+
+describe("formatPrincipal", () => {
+  it("formata o valor quando ele é afirmável", () => {
+    expect(formatPrincipal(1_000_000)).toBe("R$ 10.000,00");
+  });
+
+  it("negativo é mostrado como é — clampar em zero seria esconder", () => {
+    expect(formatPrincipal(-50_000)).toBe("-R$ 500,00");
+  });
+
+  it("null vira a frase de não-saber, nunca R$ 0,00", () => {
+    // Zero seria a afirmação "você não tem nada aplicado" — falsa, e indistinguível de um saldo
+    // genuinamente zerado. É o princípio da Story 8.21.
+    expect(formatPrincipal(null)).toBe("Não informado");
+    expect(formatPrincipal(null)).not.toBe("R$ 0,00");
+  });
+});
+
+describe("avisoDeResgateExcedente", () => {
+  it("nomeia a diferença e a ação quando o principal é negativo", () => {
+    const aviso = avisoDeResgateExcedente(-50_000);
+    expect(aviso).toContain("R$ 500,00");
+    expect(aviso).toContain("registre o rendimento do período");
+    // "não adivinha" é literal e é regra do épico (Artigo IV): o sistema sabe que falta, e não
+    // lança sozinho. Se esta asserção cair, alguém tirou a única frase que impede a próxima
+    // pessoa de "resolver" o problema inferindo o valor.
+    expect(aviso).toContain("não adivinha");
+  });
+
+  it("cala quando o principal é positivo, zero ou desconhecido", () => {
+    expect(avisoDeResgateExcedente(1_000_000)).toBeNull();
+    expect(avisoDeResgateExcedente(0)).toBeNull();
+    expect(avisoDeResgateExcedente(null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+pnpm --filter @e1p/web test -- --run investimentos
+```
+
+Esperado: **FAIL** — `formatPrincipal` e `avisoDeResgateExcedente` não existem.
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/web/src/features/financeiro/investimentos.ts`, troque os dois campos de tipo:
+
+```ts
+export interface InvestmentAccount {
+  id: string;
+  name: string;
+  kind: string;
+  index_rate_label: string;
+  /**
+   * Onda 2b-ii — CALCULADO dos movimentos da conta bancária vinculada, não mais digitado.
+   * `null` = inafirmável (sem vínculo, ou saldo de abertura declarado desconhecido — Story 8.21).
+   * **`null` não é zero:** zero seria a afirmação "você não tem nada aplicado".
+   * Pode ser NEGATIVO: resgate bruto que levou rendimento ainda não lançado junto.
+   */
+  principal_cents: number | null;
+  accrued_yield_cents: number;
+  opened_at: string;
+  created_at: string;
+  bank_account_id: string | null;
+}
+```
+
+E o mesmo em `Rentability`:
+
+```ts
+  principal_cents: number | null;  // Onda 2b-ii — ver InvestmentAccount
+```
+
+Acrescente os dois helpers ao final do arquivo:
+
+```ts
+/** O texto de não-saber do principal. Uma frase, um lugar — a tela nunca a escreve à mão. */
+export const PRINCIPAL_DESCONHECIDO = "Não informado";
+
+/**
+ * Formata o principal. `null` vira a frase de não-saber, **nunca "R$ 0,00"**.
+ *
+ * Zero seria uma afirmação ("você não tem nada aplicado"), falsa e indistinguível de um saldo
+ * genuinamente zerado — o mesmo princípio pelo qual a Projeção de Caixa cala o runway em vez de
+ * mostrar um número sem lastro (Story 8.21).
+ */
+export function formatPrincipal(cents: number | null): string {
+  if (cents === null || cents === undefined) return PRINCIPAL_DESCONHECIDO;
+  return formatBRL(cents);
+}
+
+/**
+ * O aviso do resgate que levou rendimento junto — `null` quando não há o que dizer.
+ *
+ * O banco credita o resgate BRUTO (principal + rendimento). Registrado como transferência contra um
+ * principal menor, o derivado fica negativo. O e1p **sabe** quanto falta e **não** lança sozinho: o
+ * valor certo do rendimento é fato do banco, não dedução nossa (Artigo IV — No Invention).
+ */
+export function avisoDeResgateExcedente(principalCents: number | null): string | null {
+  if (principalCents === null || principalCents === undefined || principalCents >= 0) return null;
+  return (
+    `Você resgatou ${formatBRL(-principalCents)} a mais do que aportou. Se essa diferença é ` +
+    "rendimento que ainda não foi lançado, registre o rendimento do período — o e1p não adivinha " +
+    "o valor."
+  );
+}
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+pnpm --filter @e1p/web test -- --run investimentos
+pnpm --filter @e1p/web exec tsc --noEmit
+```
+
+Esperado: testes **PASS**. O `tsc` vai **falhar** em `InvestimentosPage.tsx:130` (`formatBRL` não aceita `null`) — é esperado e é a Task 8. Anote o erro e siga.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/financeiro/investimentos.ts apps/web/src/features/financeiro/investimentos.test.ts
+git commit -m "feat: os tipos do principal aceitam não-saber e negativo [Onda 2b-ii]"
+```
+
+---
+
+## Task 8: A tela — principal sem campo, o aviso e o extrato
+
+**Files:**
+- Modify: `apps/web/src/features/financeiro/InvestimentosPage.tsx` (`:130` o `Stat`, `:230-265` o formulário)
+- Test: `apps/web/src/features/financeiro/investimentos.test.ts`
+
+**Interfaces:**
+- Consumes: `formatPrincipal`, `avisoDeResgateExcedente`, `PRINCIPAL_DESCONHECIDO` (Task 7)
+- Produces: nada consumido por tasks posteriores
+
+- [ ] **Step 1: O `Stat` do principal e o aviso**
+
+Em `InvestimentosPage.tsx`, troque a linha `:130`:
+
+```tsx
+                <Stat
+                  label="Principal aplicado"
+                  value={formatPrincipal(a.principal_cents)}
+                  tone={
+                    a.principal_cents !== null && a.principal_cents < 0
+                      ? "text-amber-700"
+                      : undefined
+                  }
+                />
+```
+
+E, **logo abaixo do bloco de `Stat`s** (fora do `grid`, ocupando a largura inteira), o aviso:
+
+```tsx
+              {avisoDeResgateExcedente(a.principal_cents) && (
+                <p className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  {avisoDeResgateExcedente(a.principal_cents)}
+                </p>
+              )}
+```
+
+⚠️ **O aviso fica colado no número, não numa seção "avisos" no fim da tela.** Em ~360px um aviso distante do valor que ele explica é um aviso que ninguém lê — a lição dos PRs #56 e #58, onde o checkbox e a ação que o tornava efetivo viviam em blocos separados e uma conta real foi paga sem o dono ver.
+
+Importe os helpers no topo do arquivo, junto do `formatPct` que já vem de lá:
+
+```tsx
+import { avisoDeResgateExcedente, formatPrincipal } from "./investimentos";
+```
+
+- [ ] **Step 2: Tirar o campo do formulário**
+
+No modal de criação (`:230-265`), remova o estado `principal`, o `<input>` correspondente e a linha `principal_cents:` do `api.post`. No lugar do campo, uma frase que **diz onde o valor mora agora**:
+
+```tsx
+              <p className="text-xs text-neutral-500">
+                O valor já aplicado vem do <strong>saldo de abertura</strong> da conta bancária da
+                aplicação — informe-o ao cadastrar a conta. Depois disso, aporte e resgate são
+                transferências entre as suas contas.
+              </p>
+```
+
+**Sem esta frase o campo apenas some**, e quem cadastra a aplicação não descobre onde informar o que tem aplicado. Recusar sem dizer onde é o beco que a 2b-i pagou para evitar.
+
+- [ ] **Step 3: O extrato da aplicação**
+
+Abaixo dos `Stat`s de cada aplicação vinculada, um bloco recolhível com os movimentos da conta:
+
+```tsx
+{a.bank_account_id && <ExtratoDaAplicacao bankAccountId={a.bank_account_id} />}
+```
+
+E o componente, no mesmo arquivo:
+
+```tsx
+/**
+ * Extrato da aplicação — aportes, resgates e rendimentos.
+ *
+ * ⚠️ **Segunda superfície sobre o mesmo razão, de propósito** (decisão do fundador, 2026-08-08): a
+ * primeira é "Ver movimentos" em `ContasSaldosPage`, porque a conta de aplicação é uma
+ * `bank_account` como qualquer outra. A garantia contra as duas discordarem é **mecânica**: as
+ * duas chamam o MESMO endpoint, sem consulta própria e sem filtro reescrito. O que difere entre
+ * elas é apresentação. Se alguém der a esta um filtro próprio, `investimentos.test.ts` protesta.
+ */
+function ExtratoDaAplicacao({ bankAccountId }: { bankAccountId: string }) {
+  const [aberto, setAberto] = useState(false);
+  const [movimentos, setMovimentos] = useState<BankTransaction[] | null>(null);
+  const fuso = useFuso();
+
+  useEffect(() => {
+    if (!aberto) return;
+    let vivo = true;
+    api
+      .get<BankTransaction[]>("/bank/transactions", { params: { bank_account_id: bankAccountId } })
+      .then((r) => {
+        if (vivo) setMovimentos(Array.isArray(r.data) ? r.data : []);
+      })
+      .catch(() => {
+        if (vivo) setMovimentos([]);
+      });
+    return () => {
+      vivo = false;
+    };
+  }, [aberto, bankAccountId]);
+
+  return (
+    <div className="mt-4 border-t border-neutral-100 pt-3">
+      <button
+        onClick={() => setAberto((v) => !v)}
+        className="text-sm font-medium text-primary-700 hover:underline"
+      >
+        {aberto ? "Ocultar extrato" : "Ver extrato da aplicação"}
+      </button>
+      {aberto && (
+        <div className="mt-3 overflow-x-auto">
+          {movimentos === null ? (
+            <p className="text-sm text-neutral-500">Carregando…</p>
+          ) : movimentos.length === 0 ? (
+            <p className="text-sm text-neutral-500">Nenhum movimento nesta aplicação ainda.</p>
+          ) : (
+            <table className="w-full min-w-[20rem] text-sm">
+              <tbody>
+                {movimentos.map((m) => (
+                  <tr key={m.id} className="border-b border-neutral-50">
+                    <td className="py-2 pr-3 whitespace-nowrap text-neutral-500">
+                      {formatDay(m.posted_at, fuso)}
+                    </td>
+                    <td className="py-2 pr-3">{m.user_description || m.raw_description}</td>
+                    <td
+                      className={
+                        "py-2 text-right whitespace-nowrap " +
+                        (m.amount_cents < 0 ? "text-neutral-700" : "text-accent-700")
+                      }
+                    >
+                      {formatBRL(m.amount_cents)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Importe `BankTransaction` de `./contas`, `formatDay` de `@/lib/datetime` e `useFuso` de `@/store/auth` — confira os caminhos exatos como `ContasSaldosPage.tsx` os importa e **use os mesmos**.
+
+⚠️ **`overflow-x-auto` na tabela, nunca `overflow-hidden`.** Em tela estreita o `hidden` **corta** a coluna de valor sem deixar rastro — foi o defeito exato do PR #58 na `PagarPage`, onde os botões de ação (inclusive **Estornar**) ficaram invisíveis, sem jeito de conferir ou desfazer.
+
+⚠️ **`Array.isArray`, não `?? []`.** Com `data = []`, `data.entries` é uma **função** (`Array.prototype.entries`) e um setter do React que recebe função a **executa** — foi assim que o `ClientTimeline` derrubou a página inteira de Conversas.
+
+- [ ] **Step 4: O teste que amarra o endpoint único**
+
+Acrescente a `investimentos.test.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("o extrato da aplicação não é uma segunda fonte", () => {
+  it("bate no mesmo endpoint que Contas & Saldos, sem consulta própria", () => {
+    const dir = join(__dirname);
+    const investimentos = readFileSync(join(dir, "InvestimentosPage.tsx"), "utf-8");
+    const contas = readFileSync(join(dir, "ContasSaldosPage.tsx"), "utf-8");
+
+    // A duplicação de superfície foi aceita (decisão do fundador). A de CONSULTA, não: duas telas
+    // com filtros próprios sobre o mesmo razão divergem, e a que diverge é a que ninguém olha.
+    expect(investimentos).toContain('"/bank/transactions"');
+    expect(contas).toContain('"/bank/transactions"');
+  });
+});
+```
+
+- [ ] **Step 5: Rodar tudo**
+
+```bash
+pnpm --filter @e1p/web test -- --run
+pnpm --filter @e1p/web exec tsc --noEmit
+```
+
+Esperado: testes **PASS**, `tsc` com **exit 0** (o erro anotado na Task 7 sumiu).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/financeiro/
+git commit -m "feat: a tela da aplicação mostra o principal calculado e o extrato [Onda 2b-ii]"
+```
+
+---
+
+## Task 9: O aceite em ~360px e a memória do projeto
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: tudo
+- Produces: nada
+
+- [ ] **Step 1: Medir a tela em 360px — de verdade**
+
+Suba a stack (`docker start infra-postgres-1 infra-api-1` + `pnpm --filter @e1p/web dev`) e abra `http://127.0.0.1:5173/financeiro/investimentos` (**`127.0.0.1`, não `localhost`** — a 5173 pode colidir com outro projeto). Com o Playwright MCP, redimensione para **360×740** e verifique, com screenshot:
+
+- [ ] o valor do principal aparece inteiro, sem corte
+- [ ] o aviso de resgate excedente aparece **junto** do número, sem rolagem para descobri-lo
+- [ ] a tabela do extrato **rola na horizontal** e a coluna de valor é alcançável
+- [ ] nada da linha de `Stat`s some atrás da borda
+
+⚠️ **`toContain("flex-wrap")` NÃO é aceite.** Aquela asserção passou com a `FilaPagamentosPage` quebrada em produção por duas sessões: `flex-wrap` não quebra a linha quando o irmão é `min-w-0 flex-1`. **Layout só se prova medindo** — screenshot, não string.
+
+Se algo estiver cortado, corrija e repita. Esta é a quarta vez que este débito aparece no épico e três PRs de campo já foram pagos por ele.
+
+- [ ] **Step 2: Escrever a entrada no `CLAUDE.md`**
+
+Acrescente **após** a seção "Onda 2b-i", escrita a partir do código que subiu e não do que o plano pretendia:
+
+````markdown
+### Onda 2b-ii — o principal deixa de ser digitado (e o backfill deixa de existir)
+
+> Spec: `docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md`
+
+**A onda que era "o item de maior risco do épico inteiro" não tem migration.** Todo documento
+anterior descrevia a 2b-ii como a onda do backfill — o único `UPDATE` sobre dado existente do
+épico, sob a armadilha do `FORCE RLS` (`UPDATE` filtrado a zero linhas **em silêncio**, que o
+SQLite dos testes não pega). Duas coisas o dissolveram: a **2b-i já executou os passos 1-2 do
+design-mãe §6.2 por ato do dono** (coluna via DDL puro, vínculo pela tela), e
+`investment_accounts` está **vazia em produção**. Os passos 3-4 não tinham sobre o que rodar.
+
+> **A regra que fica (reverberar): quando um backfill existe para reconstruir histórico que um
+> ATO DO DONO reconstrói melhor, o backfill é o caminho pior.** Ele escreve sem testemunha, num
+> regime onde o fracasso é silencioso. Trocar escrita retroativa por *auditoria + ato* foi a
+> manobra da 2b-i; esta é a segunda aplicação, e agora é padrão.
+
+- [x] **`principal = opening_balance_cents + Σ movimentos com `source <> 'yield'`.** O saldo de
+  abertura entra, e **isso não estava no design-mãe**: é o dinheiro que já estava aplicado no dia
+  do cadastro, principal que nunca teve movimento. Sem ele, uma conta cadastrada com R$ 10.000
+  mostraria principal ZERO — número errado com aparência de fato, a família que a Onda 0 existe
+  para não repetir. O recorte de `source` impede a dupla contagem: o rendimento já é
+  `accrued_yield_cents` e, desde a 2b-i, também é `bank_transaction`.
+- [x] **`exclude_sources` entrou em `_movements_sums`, não numa query nova.** A docstring dela já
+  dizia por quê: duas cópias da fórmula divergiriam, e o sintoma seria um saldo que muda conforme
+  a tela que o pede. `bank.service.movement_sums` é a porta pública fina — existe porque
+  `investments` precisava dela e importar um símbolo `_` de outro módulo é acesso que ninguém
+  encontra depois.
+- [x] **Saldo de abertura desconhecido ⇒ principal `None`, nunca zero.** Reusa
+  `origem_do_saldo_derivado` (Story 8.21) em vez de recomparar — foi exatamente essa recomparação
+  duplicada que a 8.21 pagou para eliminar. Zero seria a afirmação *"você não tem nada
+  aplicado"*, falsa e indistinguível de um saldo genuinamente zerado.
+- [x] **A coluna `principal_cents` está CONGELADA** — sem leitor, sem escritor, gate AST com
+  controle positivo. Terceiro uso do padrão (`attachments.data`, `tenant_profiles.timezone`).
+  **Eram NOVE leitores**, levantados por `grep` antes de a spec fechar e não durante a
+  implementação — a lição da 0073, onde três consumidores não apareceram na investigação inicial.
+  Drop numa migration posterior.
+- [x] **O leitor que quase passou: `_pct` DIVIDE pelo principal.** Com `None` levantaria
+  `TypeError`; com **negativo** devolveria um percentual de sinal invertido — plausível na tela, e
+  errado. Agora protege os três casos (`None`, zero, negativo). *"Quanto rendeu percentualmente o
+  que você não aplicou?"* não é pergunta com resposta menor: é pergunta sem resposta.
+- [x] **Editar o principal: 409, e ele é o OPOSTO do 409 da 2b-i.** Aquele era caminho normal e
+  por isso a tela oferecia a saída no próprio modal. Este é **inalcançável pela tela** (o campo
+  saiu do formulário): se disparar, é integração antiga ou defeito. Por isso **não** tem
+  `detail["acao"]` — um `acao` sem modal do outro lado é contrato com ninguém. A guarda do
+  `create` é sobre o **valor** (`if data.principal_cents:`) e a do `update` sobre a **presença**
+  (`is not None`), porque o default do schema é `0` num e `None` no outro; a assimetria é
+  deliberada e testada.
+- [x] **REQ-25 cumprido na LEITURA, não na escrita — desvio declarado.** O resgate bruto deixa o
+  principal negativo. Recusar o resgate exigiria `bank/transfers.py` consultar `investments`, que
+  o gate `test_bank_transfers_nao_importa_investments` proíbe — e recusaria um fato que **já
+  aconteceu no banco**, o inverso do princípio da Onda 0. A tela nomeia a diferença e a ação, e
+  **não adivinha o valor** (Artigo IV): o sistema sabe que faltam R$ 500 e não os lança sozinho.
+- [x] **`app/scripts/investment_audit.py` — sem `--fix`, e a ausência é a decisão.** Com uma flag
+  de correção, alguém a rodaria no deploy sem ler a saída e o `UPDATE` voltaria pela porta dos
+  fundos. Imprime **quantos tenants varreu**: `0 aplicações em 0 tenants` e `0 em 7` são
+  resultados diferentes, e o primeiro é bug do próprio script (a lição da sondagem de `phone_key`,
+  onde a RLS devolveu zero linhas sem erro e o silêncio quase virou aprovação).
+- [x] **O extrato da aplicação é a SEGUNDA superfície sobre o mesmo razão, de propósito** (decisão
+  do fundador). A primeira é "Ver movimentos" em Contas & Saldos. A garantia contra divergência é
+  mecânica, não disciplina: as duas chamam o **mesmo endpoint**, com teste amarrando.
+
+- **Dívida:** `packages/shared-types/src/generated.ts` tem `principal_cents` em quatro lugares e
+  segue defasado desde o PR #45, sem check de drift no CI. Dívida do épico, não desta onda.
+- **Dívida:** REQ-26 (cotização e liquidação em datas diferentes) segue não implementado —
+  declarado fora de escopo, não esquecido.
+- **Dívida:** o `DROP COLUMN principal_cents` é migration posterior, depois de um ciclo.
+````
+
+- [ ] **Step 3: Conferir que nada acima ficou desatualizado**
+
+A seção da Onda 2b-i diz *"a 2b-ii continua com o único backfill do épico, e ele continua sendo o
+item de maior risco"*. **Isso deixou de ser verdade.** Troque por:
+
+```markdown
+- **Dívida:** ~~a 2b-ii continua com o único backfill do épico~~ — **FECHADA na 2b-ii
+  (2026-08-08): o backfill não foi mitigado, deixou de existir.** Ver a seção da Onda 2b-ii.
+```
+
+**Dívida resolvida e ainda escrita manda o próximo leitor resolver de novo o que já está
+resolvido** (§5, passo 4 deste arquivo).
+
+- [ ] **Step 4: Verificação final**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest -q          # em PRIMEIRO PLANO
+cd apps/api && .venv/Scripts/python -m ruff check .        # All checks passed!
+pnpm --filter @e1p/web test -- --run
+pnpm --filter @e1p/web exec tsc --noEmit                   # exit 0
+cd apps/api && .venv/Scripts/python -m alembic heads       # UM head só, 0075 — sem migration nova
+```
+
+⚠️ **`scripts/check.sh` mascara falha de frontend com `|| true` no vitest** — rode as etapas
+individualmente, como acima, até isso ser corrigido.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: a Onda 2b-ii entra na memória do projeto [Onda 2b-ii]"
+```
+
+---
+
+## Verificação final (antes de abrir o PR)
+
+- [ ] Suíte backend inteira verde, **em primeiro plano**
+- [ ] `ruff check` limpo
+- [ ] Suíte frontend inteira verde + `tsc --noEmit` exit 0
+- [ ] `alembic heads` → **um head só, `0075`** — se apareceu `0076`, alguém escreveu uma migration
+      e o §1.1 da spec foi violado
+- [ ] `python -m app.scripts.investment_audit` roda e imprime a contagem de tenants
+- [ ] Aceite visual em ~360px feito **com screenshot**, não com asserção de classe CSS
+- [ ] A entrada no `CLAUDE.md` existe e a dívida da 2b-i foi fechada
+- [ ] **PR obrigatório:** `main` é protegida (GH006), 4 checks. Push é do `@devops`.

--- a/docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md
+++ b/docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md
@@ -322,7 +322,7 @@ def _transferencia(client, headers, *, de: str, para: str, valor: int, quando: s
             "from_account_id": de,
             "to_account_id": para,
             "amount_cents": valor,
-            "transfer_date": quando,
+            "posted_at": quando,
             "kind": kind,
         },
         headers=headers,

--- a/docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md
+++ b/docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md
@@ -1,0 +1,387 @@
+# Onda 2b-ii — `principal_cents` derivado (e o backfill que deixou de existir)
+
+> **Data:** 2026-08-08 · **Epic:** 8 (Controle Bancário Nativo) · **Onda:** 2b, segunda metade
+> **Sucede:** Onda 2b-i (`docs/superpowers/specs/2026-08-07-onda-2b-i-perna-bancaria-do-rendimento-design.md`)
+> **Referência normativa:** `docs/prd/epic-8-controle-bancario.md` §647 (escopo original da 2b),
+> §F-D7 · `docs/architecture/controle-bancario-design.md` §6.2, §6.3 · REQ-23, REQ-25, REQ-27 ·
+> **R3 do fundador**
+
+---
+
+## 1. Por que esta onda existe, e por que ela ficou pequena
+
+`investment_accounts.principal_cents` é um campo **digitado** (`investments/models.py:49`,
+`schemas.py:19` e `:42`). O dono informa quanto tem aplicado, o e1p acredita, e **nunca mais
+confere**. Um resgate feito no app do banco não muda aquele número; nada protesta. É o ponto cego
+que o R3 do fundador aponta e que o ADR 0003 registra como motivo da onda
+(`docs/decisions/0003-controle-bancario-nativo.md:32`).
+
+A onda torna o principal **derivado dos movimentos da conta bancária da aplicação** — a Regra 4 do
+épico (*"saldo é derivado dos movimentos, nunca coluna, nunca digitado"*) aplicada ao último lugar
+do produto onde ela ainda não valia.
+
+### 1.1 O item de maior risco do épico deixou de existir — e isso é uma decisão, não sorte
+
+Todo documento anterior a esta spec descreve a 2b-ii como **a onda do backfill**: o único `UPDATE`
+sobre dado existente do épico inteiro, exposto à armadilha do `FORCE ROW LEVEL SECURITY` da
+migration 0046 (o `UPDATE` filtrado a zero linhas **em silêncio**, que o SQLite dos testes não pega).
+O PRD chama isso de *"o item de maior risco do épico inteiro"* (§656-659), o F-D7 manda dar-lhe
+story própria e atenção de gate, e o plano da 2b-i o reafirma como dívida em aberto.
+
+Duas coisas o dissolveram:
+
+1. **A 2b-i já executou os passos 1 e 2 do §6.2 — por ato do dono, não por migration.** A coluna
+   `investment_accounts.bank_account_id` entrou como DDL puro (`ADD COLUMN` + `CREATE INDEX`, que a
+   RLS não alcança) e a aplicação legada foi vinculada **pelo dono, na tela**. O mecanismo já foi
+   validado em campo.
+2. **`investment_accounts` está vazia em produção** (confirmado pelo fundador em 2026-08-08; ver
+   §7, Suposição S1). Os passos 3 e 4 — a transferência sintética de aporte inicial e um movimento
+   por `Charge` de rendimento legada — não têm sobre o que rodar.
+
+**Decisão:** esta onda **não escreve `UPDATE` nenhum, e não tem migration.** No lugar do backfill,
+entrega o que o próprio §6.2 já pedia junto dele — um script que *"reporta divergências sem corrigir
+em silêncio"* — e deixa a correção ser **ato do dono**, exatamente como a 2b-i fez com o vínculo.
+
+> **A regra que fica:** quando um backfill existe para reconstruir histórico que **um ato do dono
+> reconstrói melhor**, o backfill é o caminho pior — ele escreve sem testemunha, num regime (`FORCE
+> RLS`) onde o fracasso é silencioso. Trocar escrita retroativa por *auditoria + ato* foi a manobra
+> da 2b-i; esta onda é a segunda aplicação dela, e agora é padrão.
+
+### 1.2 O que esta onda NÃO destrava
+
+Nada da métrica primária. **P3 fechou na 2b-i**; a leitura do gate não depende de uma linha desta
+onda. Isto está escrito porque o §647 do PRD descreve os cinco entregáveis da 2b em bloco, e quem
+ler o bloco pode concluir que a métrica ainda espera por eles. Não espera.
+
+---
+
+## 2. Escopo
+
+### 2.1 Entra
+
+| # | Entregável |
+|---|---|
+| **E1** | `principal_cents` passa a ser **calculado** dos movimentos da conta bancária vinculada |
+| **E2** | A coluna `investment_accounts.principal_cents` fica **congelada** — sem leitor, sem escritor, com gate AST |
+| **E3** | `create_account` e `update_account` **recusam** `principal_cents` (409), nomeando a ação real |
+| **E4** | O principal excedido por resgate aparece **negativo e nomeado** na tela (REQ-25, resolvido pela leitura) |
+| **E5** | `python -m app.scripts.investment_audit` — reporta divergência, **nunca corrige** |
+| **E6** | `InvestimentosPage`: principal calculado (sem campo), o aviso do E4, e o **extrato da aplicação** |
+| **E7** | Aceite visual em **~360px** do que o E6 acrescenta |
+
+### 2.2 Não entra
+
+- **Migration.** Nenhuma. Ver §1.1. O `DROP COLUMN principal_cents` é migration **posterior**, um
+  ciclo depois, pelo mesmo critério que manteve `attachments.data` (Story 3.5) e
+  `tenant_profiles.timezone` (migration 0073) vivas por um ciclo.
+- **Cotização/liquidação em datas diferentes (REQ-26).** Duas pernas de um resgate com datas
+  distintas. Não há caso em produção e o modelo de transferência atual pareia as duas pernas na
+  mesma data. Fica registrado como não-feito, não como esquecido.
+- **Rendimento automático por indexador.** Continua sendo lançamento explícito do dono
+  (`investments/models.py:3-6`). Nada nesta onda muda isso.
+
+### 2.3 Direção de import — pré-decidida, não escolhida aqui
+
+`investments` **já** importa `bank.service` e `bank.origin` desde a 2b-i
+(`investments/service.py:54-56`), e essa direção é a legal. O inverso — `bank` importar
+`investments` — é **proibido** por gate (`test_bank_transfers_nao_importa_investments`,
+`tests/test_money_planes.py`). Toda decisão da §4 respeita isso sem exceção; onde ela apertou, foi a
+decisão que mudou (§4.4), nunca o gate.
+
+---
+
+## 3. A fórmula
+
+```
+principal_cents = opening_balance_cents da conta de aplicação
+                + Σ bank_transactions daquela conta
+                    WHERE source <> 'yield'
+                      AND status <> 'ignored'
+                      AND posted_at > opening_date
+                      AND posted_at <= hoje_do_tenant
+```
+
+Três termos, e cada um está lá por um motivo que some no código:
+
+**(a) `opening_balance_cents` entra, e o design-mãe §6.2 não dizia isso.** É o dinheiro que já
+estava aplicado no dia em que o dono cadastrou a conta — principal que nunca teve movimento. Somar
+só os movimentos daria **R$ 0,00 de principal numa conta com R$ 10.000 aplicados**: um número errado
+com aparência de fato, que é a família de defeito que a Onda 0 existe para não repetir.
+
+**(b) `source <> 'yield'` é o que impede a dupla contagem.** O rendimento já é contado por
+`accrued_yield_cents`, e desde a 2b-i ele também gera `bank_transaction`. Sem este recorte, cada
+rendimento entraria **duas vezes** no saldo total da aplicação.
+
+**(c) O piso `posted_at > opening_date` e o teto `<= hoje` não são escolhas desta onda** — são o
+`WHERE` de `_movements_sums` (`bank/service.py:557`), a **única** implementação da soma de
+movimentos do repositório. O piso existe porque movimento anterior à abertura já está dentro do
+`opening_balance_cents`; o teto porque `until=None` significa **hoje** desde a Story 8.10, e um
+aporte agendado para o mês que vem não é principal aplicado hoje.
+
+### 3.1 A invariante, e quem a verifica
+
+```
+derived_balance(conta_de_aplicação) == principal_cents + accrued_yield_cents
+```
+
+Vale **por construção** enquanto todo rendimento tiver perna bancária — que é o que a 2b-i garantiu
+com o 409 de `register_yield`. É a invariante que o design-mãe §6.2 já pedia (*"antes de qualquer
+resgate"*), agora sem a ressalva: com o rendimento gerando movimento, ela vale **depois** do resgate
+também. Quebrá-la é sintoma de movimento escrito por fora da Regra da Origem.
+
+### 3.2 Saldo de abertura desconhecido ⇒ o principal é `None`, nunca zero
+
+A Story 8.21 (PR #94) criou `bank_accounts.opening_balance_is_known`: `false` significa *"tenho a
+conta e **não sei** o saldo"*, e nesse estado `opening_balance_cents` é **placeholder, não
+afirmação** (`bank/service.py:820-839`, `origem_do_saldo_derivado`).
+
+Uma conta de aplicação nesse estado torna o principal **inafirmável**. A resposta é `None` e a tela
+diz que não sabe — **não zero**. Zero seria a afirmação *"você não tem nada aplicado"*, que é falsa
+e indistinguível de um saldo genuinamente zerado.
+
+Isto **reusa** `origem_do_saldo_derivado` em vez de repetir a comparação. A Story 8.21 pagou
+exatamente esse preço: a procedência estava escrita duas vezes no `router.py`, e duas leituras da
+mesma conta por portas diferentes podiam divergir. **Uma decisão, um lugar.**
+
+---
+
+## 4. Desenho
+
+### 4.1 E1 — onde a derivação mora
+
+Em `investments/service.py`, como `principal_derivado(db, acc) -> int | None`. Ela pede a soma a
+`bank/service.py`, que ganha o parâmetro `exclude_sources` em `_movements_sums`.
+
+**O parâmetro entra na função existente, não numa query nova**, e a razão está escrita na docstring
+dela: *"duas cópias da mesma fórmula divergiriam no dia em que uma delas ganhasse uma condição — e o
+sintoma seria um saldo que muda conforme a tela que o pede"*. Uma segunda soma de movimentos no
+repositório também tornaria a Regra dos Planos §1.3a inauditável.
+
+`exclude_sources` é `frozenset[str]`, default vazio — todo chamador existente segue idêntico.
+
+### 4.2 E2 — a coluna congelada
+
+`principal_cents` continua na tabela e **ninguém a lê nem a escreve**. `InvestmentAccountOut.principal_cents`
+passa a ser preenchido pela derivação; o ORM mantém o atributo, e é justamente por isso que o gate
+existe: nada no código **quebra** se alguém voltar a ler `acc.principal_cents` — só volta a mentir.
+
+Gate: varredura AST sobre `app/modules/` reprovando o acesso ao atributo fora da definição do model.
+O script de auditoria (§4.5) o lê **de propósito**, para comparar, e vive em `app/scripts/` — fora
+do alcance da varredura por construção, não por exceção escrita. Com **controle positivo**: um teste
+que prova que o gate reprova quando a leitura existe. Um gate sem controle positivo é um teste que
+passa e não prova nada — a família dominante da Onda 2, oito ocorrências.
+
+Precedente exato: `tenant_profiles.timezone` (migration 0073), congelada em 2026-08-07 com
+`test_ninguem_le_mais_o_fuso_do_perfil`. E a lição registrada junto: **três consumidores da coluna
+antiga não apareceram na investigação inicial**, e corrigir só o caminho óbvio teria quebrado os
+três em silêncio. Por isso o inventário abaixo foi levantado **antes** desta spec fechar, não
+durante a implementação.
+
+#### 4.2.1 O inventário dos leitores — nove, e um deles muda o contrato
+
+| Leitor | O que acontece |
+|---|---|
+| `investments/router.py:31` | Passa a receber o derivado em vez de `a.principal_cents` |
+| `investments/service.py:134` (`create_account`) | Deixa de gravar — o campo é recusado (§4.3) |
+| `investments/service.py:158-159` (`update_account`) | Deixa de gravar — idem |
+| `investments/service.py:362` (`rentability`) | Devolve o derivado |
+| **`investments/service.py:364-365`** | **Divide por ele. Ver abaixo.** |
+| `investments/schemas.py:82` (`InvestmentAccountOut`) | `int` → `int \| None` |
+| `investments/schemas.py:91` (rentabilidade) | `int` → `int \| None` |
+| `apps/web/.../investimentos.ts:25,40` | `number` → `number \| null` |
+| `apps/web/.../InvestimentosPage.tsx:130,248` | `:130` exibe (trata `null`); `:248` é o campo do formulário, que **sai** |
+
+**O leitor que muda o contrato.** `_pct` (`service.py:333-337`) já devolve `None` quando o principal
+é `0` — divisão por zero, protegida desde a 5.6. Com o principal podendo ser `None` (§3.2) ela
+levantaria `TypeError` em vez de proteger, e **com o principal podendo ser negativo** (§4.4) ela
+devolveria uma rentabilidade de sinal invertido — um número plausível, e errado.
+
+> **Decisão:** `_pct` devolve `None` para principal `None` **e** para principal `<= 0`, e não só
+> para `== 0`. Rentabilidade sobre principal negativo não é um número menor: é uma pergunta sem
+> sentido (*"quanto rendeu percentualmente o que você não aplicou?"*). O `None` já é renderizado
+> pela tela desde a 5.6 — a superfície existe e não precisa ser inventada.
+
+**`packages/shared-types/src/generated.ts` tem `principal_cents` em quatro lugares e está defasado
+desde o PR #45**, sem check de drift no CI. É dívida conhecida do épico; esta onda **não** a fecha e
+**não** finge que ela não existe. Quem regenerar, regenera; quem não, deixa como está e a lista
+acima é o inventário verdadeiro.
+
+### 4.3 E3 — a recusa, e por que ela é diferente do 409 da 2b-i
+
+`update_account` com `principal_cents` presente → **409**:
+
+> *"O valor aplicado agora é calculado pelos movimentos da conta. Para mudar quanto está aplicado,
+> registre a transferência que você fez de verdade — da conta corrente para a aplicação (aporte) ou
+> da aplicação para a corrente (resgate)."*
+
+`create_account` com `principal_cents` diferente de zero → **409**, com a segunda metade da verdade:
+
+> *"No cadastro, o valor já aplicado é o **saldo de abertura** da conta bancária da aplicação — é lá
+> que ele é informado, uma vez."*
+
+Duas observações que precisam estar escritas antes de alguém abrir o arquivo:
+
+- **Este 409 é o oposto do 409 da 2b-i.** Aquele era caminho normal — o dono batia nele ao registrar
+  rendimento, e por isso a tela tinha de oferecer a saída ali mesmo (sem o que ele seria beco sem
+  saída, a classe do item 12 do WhatsApp). Este é **inalcançável pela tela**, porque o E6 remove o
+  campo. Se disparar, é integração antiga ou defeito. Ele é guarda de contrato, **não** fluxo — e
+  por isso **não** ganha `detail["acao"]`: um `acao` sem modal do outro lado seria um contrato com
+  ninguém.
+- **A ação que a mensagem manda fazer existe hoje, e isso foi conferido.** `investment_in` e
+  `investment_out` já são `TRANSFER_KINDS` desde a Onda 2 (`bank/schemas.py:385-387`), e a tela de
+  transferência já está em `ContasSaldosPage.tsx`. **Recusar apontando para uma ação inexistente é
+  o defeito que esta linha existe para não cometer.**
+
+### 4.4 E4 — REQ-25: a leitura protesta, a escrita não recusa
+
+O banco credita o resgate **bruto**: R$ 10.500 que são R$ 10.000 de principal mais R$ 500 de
+rendimento. Registrado como uma transferência de −R$ 10.500 contra um principal de R$ 10.000, o
+derivado dá **−R$ 500**.
+
+O REQ-25 manda *"pedir o `register_yield` antes de fechar o resgate"*. **Esta spec desvia disso no
+tempo — de propósito, e o desvio está declarado aqui porque o Artigo IV (No Invention) exige que
+divergir de um requisito seja ato, não omissão.**
+
+Três caminhos, e por que os dois primeiros caem:
+
+| Caminho | Por que não |
+|---|---|
+| Clampar em zero | Esconde. É a mentira por omissão que a Onda 0 e a 8.21 desmontaram duas vezes |
+| Recusar o resgate (409) | O dinheiro **já saiu do banco**. Recusar um fato consumado é o inverso do princípio da Onda 0. E exigiria `bank/transfers.py` consultar `investments` — o gate `test_bank_transfers_nao_importa_investments` proíbe, e a saída legítima (porta de saída registrada, `Protocol` + DTO + fiação fail-closed no boot) custa mais do que o problema |
+| **A tela nomeia** ✅ | O número aparece como é, e a afirmação que ele sustentaria é substituída pela ação |
+
+A tela:
+
+> **Principal aplicado −R$ 500,00** ⚠️
+> *"Você resgatou R$ 500,00 a mais do que aportou. Se essa diferença é rendimento que ainda não foi
+> lançado, registre o rendimento do período — o e1p não adivinha o valor."*
+
+**O "não adivinha" é literal e é a metade do REQ-25 que esta spec cumpre integralmente:** o sistema
+sabe que faltam R$ 500 e **não** os lança sozinho. O valor certo do rendimento é fato do banco, não
+dedução do e1p.
+
+### 4.5 E5 — o script que confere
+
+`python -m app.scripts.investment_audit`. Para cada aplicação: o que a coluna congelada diz, o que
+os movimentos dizem, e a diferença. Saída em texto, código de saída 0 sempre (é relatório, não gate
+de CI).
+
+Duas armadilhas que ele tem de evitar, as duas já pagas neste repo:
+
+- **Silêncio que parece aprovação.** Consulta em tabela com RLS sem tenant devolve **zero linhas,
+  sem erro** — foi assim que a sondagem de `phone_key` em produção quase virou um *"está tudo
+  limpo"* falso. O script **itera tenants** abrindo sessão de tenant (o padrão do `app.worker`) e
+  **imprime quantos varreu**. `0 aplicações em 0 tenants` e `0 aplicações em 7 tenants` são
+  resultados diferentes, e o primeiro é um bug do próprio script.
+- **Corrigir em silêncio.** **Não existe `--fix`.** Se existisse, alguém o rodaria no deploy sem ler
+  a saída, e o `UPDATE` que esta onda existe para não fazer voltaria pela porta dos fundos.
+
+### 4.6 E6 — a tela
+
+`InvestimentosPage`, por aplicação:
+
+- **Principal aplicado** — número calculado, **sem campo de edição**. Com `opening_balance_is_known
+  = false`, no lugar do número vai a frase de não-saber e o caminho para declarar o saldo.
+- **Rendimento acumulado** e **rentabilidade** — inalterados.
+- **O aviso do E4**, quando o principal for negativo.
+- **Extrato da aplicação** — aportes, resgates e rendimentos em ordem. É o *"não apenas o lançamento
+  do quanto rendeu"* do R3, e o §6.3 do design-mãe.
+
+⚠️ **O extrato já existe em outra tela** — "Ver movimentos" em `ContasSaldosPage.tsx:457` —, porque
+a conta de aplicação é uma `bank_account` como qualquer outra. Esta onda cria deliberadamente a
+**segunda superfície** sobre o mesmo razão (decisão do fundador, 2026-08-08), e a garantia contra
+divergência é **mecânica, não disciplina**: os dois extratos chamam o **mesmo endpoint**
+(`GET /bank/transactions?bank_account_id=`), sem consulta própria e sem filtro reescrito. O que
+difere entre eles é apresentação. Teste em §5.
+
+**E7 — aceite visual em ~360px é item de trabalho, não dívida.** O débito está aberto em três
+lugares (8.13 AC9, 8.21, 2b-i) e **três PRs de correção de campo já foram pagos por ele** (#56, #58,
+#89) — em um deles uma conta real foi marcada paga sem o dono conseguir ver o checkbox. Abri-lo uma
+quarta vez é escolher pagar o quarto. E `toContain("flex-wrap")` **não** é aceite: layout só se
+prova medindo.
+
+---
+
+## 5. Como se prova que isto não é vácuo
+
+| # | Prova | Por que existe |
+|---|---|---|
+| 1 | Varredura AST: ninguém lê `principal_cents` da coluna — **com controle positivo** | A coluna congelada de 2026-08-07 tinha três leitores que a investigação inicial não achou |
+| 2 | `derived_balance == principal + accrued_yield` numa conta com aporte, rendimento e resgate | A invariante do §6.2, agora com quem a verifique |
+| 3 | Principal é `None` — **e um teste que falha se for `0`** | Zero é afirmação; `None` é a ausência dela (8.21) |
+| 4 | Registrar rendimento **não** move o principal | Metade do recorte `source <> 'yield'` |
+| 5 | Registrar aporte **move** o principal | A outra metade. **Com o caso 4 sozinho, apagar o filtro inteiro passa verde** — é o mutante `>` → `>=` da Onda 2, que sobreviveu a 58 testes por faltar o caso da borda |
+| 6 | `opening_balance_cents` entra no principal | Sem ele o teste 2 falharia só em conta cadastrada com saldo — o caso do fundador |
+| 7 | `create_account`/`update_account` com principal → 409, com a mensagem certa por asserção exata | Substring genérica casa demais: *"trilho"* casava *"fora do trilho"* na Onda 2 |
+| 8 | Os dois extratos batem no **mesmo** endpoint | O que impede a duplicação aceita no §4.6 de virar divergência |
+| 9 | O script imprime a contagem de tenants varridos | Distingue "nada errado" de "não olhei" |
+| 10 | Rentabilidade é `None` com principal `None` **e** com principal negativo | Sem isso, `None` vira `TypeError` e negativo vira um percentual de sinal invertido — plausível e errado (§4.2.1) |
+
+**Nenhum teste desta onda pode usar `date.today()`.** A comparação é com `hoje_do_tenant(db)`, e o
+gate `tests/test_fuso_do_tenant.py` já reprova o contrário. A 2b-i tropeçou nisto: um teste passou
+**antes** da implementação porque a janela caía fora por causa da borda de fuso.
+
+---
+
+## 6. Ordem de implementação
+
+1. `exclude_sources` em `_movements_sums` (§4.1) — mudança aditiva, suíte inteira segue verde
+2. `principal_derivado` + a resposta `None` do §3.2, com os testes 2/3/4/5/6
+3. Os nove leitores do §4.2.1, **de uma vez** — incluindo `_pct` e os schemas de saída, com o
+   teste 10. Fatiar isso deixaria a API respondendo `None` num campo tipado `int` no meio do caminho
+4. A recusa do §4.3 (E3), com o teste 7
+5. O gate AST do §4.2, com controle positivo — **depois** de 2, 3 e 4, senão ele reprova o próprio
+   código em construção
+6. O script (§4.5), com o teste 9
+7. A tela (§4.6) + o aviso do §4.4, com o teste 8
+8. Aceite em ~360px (E7)
+9. A entrada no `CLAUDE.md` — **AC obrigatório**, §5 passo 4
+
+**PR obrigatório:** `main` é protegida (GH006), 4 checks. Push é do `@devops`.
+
+---
+
+## 7. Suposições abertas e riscos
+
+**S1 — `investment_accounts` está vazia em produção.** Confirmado pelo fundador em 2026-08-08. **É
+a suposição que sustenta o §1.1 inteiro**, e é justamente a família que já custou três desenhos
+neste épico (a premissa plausível sobre o estado dos dados, não verificada com o dono). Aqui foi
+verificada — **e mesmo assim ela é sobre HOJE, não sobre o dia do deploy.**
+
+> **Mitigação, e é por isso que o E5 existe:** o script roda **antes** do deploy. Se o sócio
+> cadastrar uma aplicação no intervalo, ele imprime a divergência e o dono a resolve por ato
+> (declarando o saldo de abertura ou registrando o aporte). Nenhum caminho desta onda depende de a
+> tabela estar vazia — a ausência de backfill é uma decisão sobre **onde a correção mora**, não uma
+> aposta em zero linhas.
+
+**S2 — resgate bruto é o caso comum.** O banco não separa principal de rendimento no crédito. Se
+essa suposição estiver errada e o dono sempre resgatar valores redondos de principal, o aviso do
+§4.4 nunca dispara — e continua correto. Falso positivo dele é impossível; falso negativo é o dono
+não ter registrado o rendimento, que é exatamente o que ele diz.
+
+**Risco R1 — o principal negativo assusta.** Um número vermelho na tela pede explicação, e a
+explicação está colada nele por construção (§4.4). O risco real é a frase ser cortada em ~360px,
+deixando só o número. É o E7.
+
+**Risco R2 — a segunda superfície de extrato diverge.** Mitigado pelo endpoint único e pelo teste 8.
+Não eliminado: uma mudança futura pode dar ao `InvestimentosPage` um filtro próprio, e nada além do
+teste 8 protestaria.
+
+---
+
+## 8. Rastreabilidade
+
+| Requisito | Onde |
+|---|---|
+| REQ-23 (`principal_cents` derivado, deixa de ser digitado) | §3, §4.1, §4.2, E1/E2 |
+| REQ-25 (resgate não gera receita; o sistema pede, não infere) | §4.4 — **cumprido na leitura, não na escrita; desvio declarado** |
+| REQ-26 (pernas em datas diferentes) | §2.2 — **fora de escopo, declarado** |
+| REQ-27 (`Charge` de rendimento no "Recebido") | Resolvido antes desta onda (filtro `_INVESTMENT_REF_PREFIX` em `receivables`) |
+| R3 do fundador (*"não apenas o quanto rendeu"*) | §4.6 — o extrato |
+| design-mãe §6.2 passos 1-2 | Entregues na **2b-i** |
+| design-mãe §6.2 passos 3-4 (o backfill) | **Não executados — §1.1** |
+| design-mãe §6.2 passo 5 (não dropar a coluna) | §4.2 — congelada, drop posterior |
+| design-mãe §6.2 passo 6 (409 na edição) | §4.3 |
+| design-mãe §6.2 (script de auditoria) | §4.5 |
+| design-mãe §6.3 (extrato na tela) | §4.6 |
+| PRD F-D7 (*"merece story própria e atenção de gate"*) | Atendido — a story existe; o gate agora julga **ausência** de backfill, com o §1.1 como justificativa escrita |


### PR DESCRIPTION
## O que muda para o dono

Hoje ele digita quanto tem aplicado, o e1p acredita e **nunca mais confere** — um resgate feito no app do banco não muda aquele número e nada protesta. A partir daqui o e1p **calcula** o valor aplicado a partir dos movimentos da conta bancária da aplicação, e o campo sai do formulário.

## A decisão que encolheu a onda

Todo documento anterior descrevia a 2b-ii como **a onda do backfill**: o único `UPDATE` sobre dado existente do épico, exposto à armadilha do `FORCE ROW LEVEL SECURITY` da migration 0046 — o `UPDATE` filtrado a zero linhas **em silêncio**, que o SQLite dos testes não pega. O PRD §656 a chama de *"o item de maior risco do épico inteiro"* e o F-D7 manda dar-lhe atenção de gate.

**Ele não foi mitigado: deixou de existir.** Duas coisas o dissolveram — a Onda 2b-i já executou os passos 1-2 do design-mãe §6.2 **por ato do dono** (coluna via DDL puro, vínculo pela tela), e `investment_accounts` está vazia em produção. Os passos 3-4 não tinham sobre o que rodar.

**Este PR não tem migration. `alembic heads` segue em `0075`.** No lugar do backfill: um script que reporta e não corrige, e a correção como ato do dono — a mesma manobra da 2b-i, agora padrão.

> **A regra que fica:** quando um backfill existe para reconstruir histórico que um **ato do dono** reconstrói melhor, o backfill é o caminho pior. Ele escreve sem testemunha, num regime onde o fracasso é silencioso.

## A fórmula

```
principal = opening_balance_cents da conta de aplicação
          + Σ movimentos daquela conta com source <> 'yield'
```

- **O saldo de abertura entra, e isso não estava no design-mãe.** É o dinheiro que já estava aplicado no dia do cadastro — principal que nunca teve movimento. Sem ele, uma conta cadastrada com R$ 10.000 mostraria principal **zero**.
- **`source <> 'yield'` impede a dupla contagem** — o rendimento já é `accrued_yield_cents` e, desde a 2b-i, também é `bank_transaction`.
- **Saldo de abertura desconhecido ⇒ principal `None`, nunca zero.** Zero seria a afirmação *"você não tem nada aplicado"*, falsa e indistinguível de um saldo genuinamente zerado (princípio da Story 8.21).

Invariante que passa a valer por construção, com teste: `derived_balance(conta) == principal + accrued_yield`.

## REQ-25 — desvio declarado

O banco credita o resgate **bruto** (principal + rendimento embutido), o que deixa o principal negativo. O REQ-25 manda *"pedir o `register_yield` antes de fechar o resgate"*. **Cumprido na leitura, não na escrita:** recusar exigiria `bank/transfers.py` consultar `investments` (proibido pelo gate `test_bank_transfers_nao_importa_investments`) e recusaria um fato que **já aconteceu no banco** — o inverso do princípio da Onda 0. A tela nomeia a diferença e **não adivinha o valor** (Artigo IV).

## Três achados que valem mais que o código

**1. Os leitores indiretos.** O inventário buscou por `principal_cents` e achou nove. O décimo não menciona a coluna — o Diagnóstico consome a *rentabilidade*, dois saltos adiante. Quem o pegou foram os testes, não o grep. Um deles era o `rls_e2e` de vazamento de PII cross-tenant, que sem a conta vinculada passaria **verde por vacuidade**, sem exercitar o vetor que existe para exercitar.

**2. `_pct` divide pelo principal.** Com `None` levantaria `TypeError`; com **negativo** devolveria um percentual de sinal invertido — plausível na tela, e errado. Agora protege três casos, não um.

**3. O aceite em ~360px foi feito, com screenshot, e achou defeito.** O extrato nasceu como `<table>` de 3 colunas com `min-w-[20rem]` dentro de `overflow-x-auto`; em 360px a coluna de **valor** nascia fora da vista (`R$ 3.` em lugar de `R$ 3.000,00`). Virou lista. O `overflow-x-auto` fez o trabalho dele — rolava, não cortava em silêncio como o PR #58 — mas num extrato o valor é *a* informação, e informação que exige rolagem lateral é informação que o dono não lê. **Nenhuma asserção de classe CSS pegaria isto.**

## Verificação

| | |
|---|---|
| Suíte backend (SQLite) | 1949 passed, 1 skipped |
| `rls_e2e` (Postgres real) | 56 passed |
| `ruff check` | All checks passed |
| Frontend (vitest) | 539 passed |
| `tsc --noEmit` | exit 0 |
| `alembic heads` | **`0075` — nenhuma migration nova** |

## Dívida

- ⚠️ **Pré-existente, medido e NÃO corrigido aqui:** em 360px a página rola 15px na horizontal por causa do `ChevronDown` em `app/AppShell.tsx:209` — idêntico com e sem o extrato, ausente em Contas & Saldos. Vale para **todas** as telas. Fora do escopo: misturar defeito existente com regra nova no mesmo diff tira do gate a capacidade de julgar qual mudança quebrou o quê.
- `generated.ts` tem `principal_cents` em quatro lugares e segue defasado desde o PR #45 (dívida do épico).
- REQ-26 (cotização e liquidação em datas diferentes): fora de escopo, declarado.
- `DROP COLUMN principal_cents`: migration posterior, depois de um ciclo.

## Docs

- Spec: `docs/superpowers/specs/2026-08-08-onda-2b-ii-principal-derivado-design.md`
- Plano: `docs/superpowers/plans/2026-08-08-onda-2b-ii-principal-derivado.md`
- `CLAUDE.md`: seção da Onda 2b-ii, com a dívida da 2b-i fechada

🤖 Generated with [Claude Code](https://claude.com/claude-code)
