### PR TITLE
fix: a linha do abandono dizia so a data, e o leitor tinha que adivinhar [Vima V2]

### DIFF
--- a/apps/api/app/scripts/nucleo_activation.py
+++ b/apps/api/app/scripts/nucleo_activation.py
@@ -153,6 +153,24 @@ def respostas_por_origem(entradas: Sequence[AuditEntry]) -> dict[str, int]:
     return contagem
 
 
+def situacao_do_fim(p: Passagem, fuso: str | None) -> str:
+    """Como a passagem terminou, **dita por extenso**. Pura.
+
+    ⚠️ A primeira versão imprimia a data crua (`12/08/2026 08:47`) quando havia abandono, ao lado
+    de `sem abandono registrado` quando não havia. Quem lesse o relatório meses depois não tinha
+    como saber o que aquela data solta significava — só descobria comparando as duas linhas.
+    **É a classe de erro que este projeto mais paga: o artefato cujo consumidor é um humano num
+    ciclo futuro, e humano não levanta `TypeError`.** Achado no primeiro uso real em produção
+    (2026-08-13), lendo a saída com o fundador.
+
+    Existe como função separada por isso: é a única frase do script que um humano tem de
+    interpretar, e agora ela tem consumidor mecânico.
+    """
+    if p.fim is None:
+        return "sem abandono registrado"
+    return f"abandonou em {format_datetime_br(p.fim, fuso)}"
+
+
 def rodape(*, passagens: int, tenants: int, abandonos: int) -> str:
     return (
         f"{passagens} passagem(ns) pelo núcleo em {tenants} tenant(s); "
@@ -189,7 +207,7 @@ def main() -> int:
             logger.info("")
             logger.info("  %s (tenant %s) — fuso %s", slug, tenant_id, fuso)
             for n, p in enumerate(passagens, start=1):
-                fim = format_datetime_br(p.fim, fuso) if p.fim else "sem abandono registrado"
+                fim = situacao_do_fim(p, fuso)
                 logger.info(
                     "    passagem %d: abriu %s com %d pergunta(s) à vista",
                     n,

--- a/apps/api/tests/test_nucleo_activation.py
+++ b/apps/api/tests/test_nucleo_activation.py
@@ -120,6 +120,30 @@ def test_respostas_por_origem_separa_as_tres_portas():
     assert contagem == {"nucleo": 1, "gancho": 1, "config": 2}
 
 
+def test_o_fim_da_passagem_e_dito_por_extenso():
+    """A saída não pode largar uma data solta e esperar que o leitor adivinhe o que ela é.
+
+    Achado lendo o primeiro relatório real com o fundador (2026-08-13): a linha do abandono saía
+    como `respondidas 0 · puladas 0 · 12/08/2026 08:47`, e só dava para deduzir o significado
+    comparando com a linha que dizia "sem abandono registrado". É a classe de erro que este
+    projeto mais documenta — o artefato cujo consumidor é um humano num ciclo futuro.
+
+    Membro e não-membro escritos, no mesmo teste.
+    """
+    abandonada = na.Passagem(
+        abertura=datetime(2026, 8, 12, 11, 47, tzinfo=UTC),
+        exibidas=6,
+        fim=datetime(2026, 8, 12, 11, 47, tzinfo=UTC),
+    )
+    concluida = na.Passagem(abertura=datetime(2026, 8, 13, 19, 14, tzinfo=UTC), exibidas=6)
+
+    frase = na.situacao_do_fim(abandonada, "America/Sao_Paulo")
+
+    # A data continua lá, e agora vem NOMEADA — e no fuso do tenant (11:47Z == 08:47 em SP).
+    assert frase == "abandonou em 12/08/2026 08:47"
+    assert na.situacao_do_fim(concluida, "America/Sao_Paulo") == "sem abandono registrado"
+
+
 def test_o_rodape_diz_QUANTOS_TENANTS_foram_varridos():
     """A lição literal do `investment_audit.py`.
 


### PR DESCRIPTION
## O defeito

A saída de `app/scripts/nucleo_activation.py` imprimia, quando havia abandono:

```
passagem 1: abriu 12/08/2026 08:47 com 6 pergunta(s) à vista
  respondidas 0 · puladas 0 · 12/08/2026 08:47
```

Uma **data solta**, sem dizer o que ela é. O único jeito de descobrir o significado era comparar com a linha de uma passagem concluída, que diz `sem abandono registrado`. Quem lesse o relatório meses depois — que é exatamente o consumidor para quem o script foi escrito — não tinha como saber.

Agora:

```
  respondidas 0 · puladas 0 · abandonou em 12/08/2026 08:47
```

## Como apareceu

**Não foi teste nem revisão.** Apareceu na primeira leitura real da saída em produção (2026-08-13), com o fundador, quando eu mesmo não soube dizer o que aquela data significava.

É a classe de defeito que este repositório mais documenta: **o artefato cujo único consumidor é um humano num ciclo futuro** — e humano não levanta `TypeError`. O Epic 8 a registra quatro vezes; a diferença aqui é que o ciclo futuro foi de 40 minutos.

## O que mudou

- `situacao_do_fim(p, fuso)` extraída como função **pura**. Ela existe separada de propósito: é a única frase do relatório que um humano precisa interpretar, e agora tem **consumidor mecânico**.
- `main()` passa a chamá-la. Nenhuma outra mudança de comportamento.

## Teste

`test_o_fim_da_passagem_e_dito_por_extenso` — **membro e não-membro no mesmo caso** (abandonada e concluída), com a data conferida **no fuso do tenant** (`11:47Z` → `08:47` em São Paulo), não em UTC.

**Provado por mutação:** devolver a data crua (`return format_datetime_br(p.fim, fuso)`) derruba o teste. A mutação foi restaurada por **cópia de arquivo**, nunca por `git checkout` — a lição já paga neste repositório.

- Suíte completa: **2113 passed, 1 skipped**.
- `ruff check app tests` limpo.

## Escopo

Uma linha de comportamento e um teste. Nada de novo, nada removido, nenhuma migration — e nenhuma outra correção junto, para o gate conseguir julgar o que quebrou o quê.

🤖 Generated with [Claude Code](https://claude.com/claude-code)