### PR TITLE
fix: os movimentos abrem dentro do cartao da conta, nao no fim da pagina

### DIFF
--- a/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
@@ -258,6 +258,48 @@ describe("AC1/AC2/AC3 — as portas e as ações por conta", () => {
   });
 });
 
+describe("⚠️ Os movimentos abrem DENTRO do cartão da conta, não no fim da página", () => {
+  /**
+   * Reportado pelo dono em 13/08/2026, com dinheiro lançado na conta errada.
+   *
+   * O painel era irmão da lista inteira: abrir a 1ª conta o colocava DEPOIS de todas as outras. No
+   * caminho de volta até ele havia N rodapés "Lançar movimento" de contas diferentes, e o dono
+   * clicou no que estava mais perto do painel que estava lendo — que era de outra conta.
+   *
+   * Por isso a asserção é de **containment de DOM**, e não de presença de texto: antes da correção
+   * o texto "Movimentos — Nubank PJ" também aparecia na tela. O que estava errado era ONDE.
+   */
+  const duasContas = [
+    conta({ id: "acc-1", name: "Itaú PJ", institution: "Itaú" }),
+    conta({ id: "acc-2", name: "Nubank PJ", institution: "Nubank", is_primary: false }),
+  ];
+  const cartaoDe = (nome: string) => screen.getByText(nome).closest("li") as HTMLElement;
+
+  it("o painel da conta aberta é filho do cartão dela", async () => {
+    mockApi(duasContas);
+    renderPage();
+    await screen.findByText("Nubank PJ");
+
+    await userEvent.click(within(cartaoDe("Nubank PJ")).getByRole("button", { name: "Ver movimentos" }));
+
+    const painel = await screen.findByText(/Movimentos — Nubank PJ/);
+    expect(cartaoDe("Nubank PJ")).toContainElement(painel);
+  });
+
+  it("nenhum outro cartão fica entre a conta aberta e os movimentos dela", async () => {
+    mockApi(duasContas);
+    renderPage();
+    await screen.findByText("Itaú PJ");
+
+    await userEvent.click(within(cartaoDe("Itaú PJ")).getByRole("button", { name: "Ver movimentos" }));
+    await screen.findByText(/Movimentos — Itaú PJ/);
+
+    // O cartão da outra conta não hospeda painel nenhum — e, principalmente, o "Lançar movimento"
+    // dele deixa de estar no caminho entre o painel aberto e os olhos do dono.
+    expect(within(cartaoDe("Nubank PJ")).queryByText(/Movimentos —/)).toBeNull();
+  });
+});
+
 describe("REL-001 — as ações que mexem no saldo não podem falhar em silêncio", () => {
   /**
    * ⚠️ `ignorar`, `desfazerIgnorar` e `removerDeclaracao` chamavam a API **sem `try/catch`**: numa

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -8,7 +8,7 @@ import {
   Trash2,
   Wallet,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
@@ -145,7 +145,6 @@ export default function ContasSaldosPage() {
   );
 
   const resumo = useMemo(() => resumoSaldos(accounts), [accounts]);
-  const selecionada = accounts.find((a) => a.id === selectedId) ?? null;
 
   async function arquivar(a: BankAccount) {
     if (
@@ -257,19 +256,25 @@ export default function ContasSaldosPage() {
                 }
                 onArchive={() => arquivar(a)}
                 onSetPrimary={() => tornarPrincipal(a)}
-              />
+              >
+                {/* ⚠️ Os movimentos moram DENTRO do cartão da conta, e não no fim da página.
+                    Enquanto o painel era irmão desta lista, abrir a 1ª conta o jogava DEPOIS de
+                    todas as outras — e no caminho de volta até ele havia N rodapés "Lançar
+                    movimento" de contas diferentes. Em 13/08/2026 o dono clicou no que estava mais
+                    perto do painel que estava lendo, e o dinheiro entrou na conta errada. Aqui o
+                    único "Lançar movimento" vizinho do painel é o da conta do painel. */}
+                {selectedId === a.id && (
+                  <AccountDetail
+                    account={a}
+                    onChanged={load}
+                    onDeclare={() => setDeclarando(a)}
+                    onLaunch={() => setLancando(a)}
+                  />
+                )}
+              </AccountCard>
             ))}
           </ul>
         </section>
-      )}
-
-      {selecionada && (
-        <AccountDetail
-          account={selecionada}
-          onChanged={load}
-          onDeclare={() => setDeclarando(selecionada)}
-          onLaunch={() => setLancando(selecionada)}
-        />
       )}
 
       <AccountModal
@@ -353,6 +358,7 @@ function AccountCard({
   onTransfer,
   onArchive,
   onSetPrimary,
+  children,
 }: {
   account: BankAccount;
   checkpoint: BankBalanceCheckpoint | null;
@@ -365,6 +371,8 @@ function AccountCard({
   onTransfer: (() => void) | null;
   onArchive: () => void;
   onSetPrimary: () => void;
+  /** O painel de movimentos da conta, quando ela está aberta — renderizado DENTRO deste cartão. */
+  children?: ReactNode;
 }) {
   const arquivada = account.archived_at !== null;
   return (
@@ -495,6 +503,7 @@ function AccountCard({
           </>
         )}
       </div>
+      {children}
     </li>
   );
 }
@@ -637,7 +646,9 @@ function AccountDetail({
   }
 
   return (
-    <section className="space-y-4 rounded-2xl bg-white p-5 shadow-sm">
+    // Sem `bg-white`/`shadow-sm`/`rounded-2xl`: isto não é mais um cartão solto no fim da página —
+    // é uma seção do cartão da conta, separada das ações dela por uma borda.
+    <section className="mt-4 space-y-4 border-t border-neutral-100 pt-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="font-semibold text-neutral-800">Movimentos — {account.name}</h2>


### PR DESCRIPTION
## O defeito

Em 13/08/2026 o dono lancou dinheiro na conta errada em `/financeiro/contas`.

O painel de movimentos era irmao da lista inteira — renderizado depois do `</ul>`. Abrir a 1a conta jogava o painel DEPOIS de todas as outras, e no caminho de volta ate ele havia N rodapes "Lancar movimento" de contas diferentes. Ele clicou no que estava mais perto do painel que estava lendo, e o modal (que nomeia a conta no titulo) nao segurou: quem ja clicou de acordo com o que estava vendo nao le o titulo.

## A correcao

O painel passa a ser filho do `<li>` da conta aberta, logo abaixo das acoes dela. O unico "Lancar movimento" vizinho do painel e o da conta do painel.

`AccountDetail` nao mudou de comportamento — so de lugar. Perdeu `bg-white`/`shadow-sm`/`rounded-2xl` (nao e mais um cartao solto) e virou secao separada por borda dentro do cartao.

Descartadas na conversa com o dono: modo foco (esconder as outras contas) e colapsar as demais em linhas. Ele escolheu o acordeao — as outras contas continuam visiveis.

## Verificacao

- Teste novo falhou pelo motivo certo antes do fix (`<li> does not contain: <h2>`) e passa depois. **A assercao e containment de DOM, nao presenca de texto**: antes da correcao o texto "Movimentos — X" tambem aparecia na tela; o que estava errado era ONDE.
- `vitest run` (web): 606/606.
- `tsc --noEmit` e `eslint --max-warnings 0`: limpos.
- Gate de layout Playwright 360px: 19/19, incluindo `toque-360` desta tela.
- Conferido por captura em 1280px e 360px com a API mockada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
