### PR TITLE
feat: o card do Kanban diz de onde o contato veio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1775,6 +1775,25 @@ contato quando na verdade tinha uma etiqueta a mais em alguns.
   build ou com um `bg-primary-50` vencendo na cascata — e os dois selos idênticos na tela, que é o
   defeito de origem. O teste de jsdom afirma só o que jsdom sabe (elementos distintos, origem
   antes das tags) e **diz no próprio comentário** que a cor é aferida no navegador.
+  - ⚠️ **E a asserção é ABSOLUTA, porque a relativa não bastava — provado por mutação.** A primeira
+    versão comparava `expect(origem).not.toBe(tag)`, e o `bug-hunter` do §5 aplicou a mutação que
+    **TROCA as duas cores**: a diferença se preserva, o significado se inverte, e **os 16 testes
+    ficaram verdes** — com o comentário do `CrmPage` afirmando o oposto do que a tela mostrava.
+    Hoje o que se afirma é o **matiz**: origem acromática (croma ≤ 8), tag colorida (≥ 12). Os dois
+    limiares são **medidos** (`neutral-100` = 3, `primary-50` = 18), não escolhidos, e a mutação
+    agora morre (`Expected >= 12, Received 3`).
+    > **A regra que fica: comparação relativa entre dois papéis não prova papel nenhum.**
+    > `a !== b` sobrevive a trocar `a` com `b` — e trocar os dois é exatamente a forma que o
+    > defeito assume quando alguém "arruma as cores" sem ler o comentário. Se o teste existe para
+    > dizer QUAL é qual, ele tem de afirmar cada um por si.
+- [x] **`rotuloDaOrigem` usa `Object.hasOwn`, e o `?? source` ingênuo era bug** (achado do
+  `bug-hunter`). Indexar objeto literal alcança `Object.prototype`: `rotuloDaOrigem("constructor")`
+  devolvia a **função `Object`** — que o `??` não pega, porque função não é nula. A assinatura
+  `: string` mentia, e o React renderizava o selo **VAZIO** (com "Functions are not valid as a
+  React child" no console): card sem origem, o defeito que este módulo existe para corrigir.
+  Inalcançável hoje (`ClientBase._source` recusa fora de `SOURCE_VALUES`; a coluna é `NOT NULL`
+  desde a 0003) e travado assim mesmo, com os cinco herdados em `it.each` — o custo é uma linha, e
+  o dia em que um caminho de escrita novo contornar o schema não vem anunciado.
 - **Dívida — e é a pergunta que abriu tudo:** a conversa avulsa **continua nascendo na Entrada**,
   continua sem poder ser descartada (não existe `DELETE /crm/clients`, só mover para "Perda", que
   grava negociação perdida sobre algo que nunca foi negociação), e `_cards_parados` vai cobrá-la
@@ -1782,6 +1801,15 @@ contato quando na verdade tinha uma etiqueta a mais em alguns.
   do fundador**: primeiro ver a composição real da Entrada com a origem à vista. Quem retomar
   começa por [`whatsapp_inbox/service.py`] (a porta que cria) e por `crm/service.py:229` (o
   `stages[0]` que enfileira).
+- **Dívida (levantada pelo `dedup-checker` e pelo `regression-tester`, nenhuma introduzida aqui):**
+  `SOURCE_VALUES` é mantido por **três listas manuais sem vínculo mecânico** — o `set` Python, as
+  chaves de `_ROTULO_DE_CHEGADA` e as de `origem.ts`. Um sétimo `source` no backend faz o card
+  exibir o valor cru **em silêncio**; um `export type ClientSource` em `shared-types` trocaria isso
+  por erro de TypeScript. E o padrão `rounded-pill` inline já passou de **7 ocorrências**
+  (`Attachments.tsx:79` é quase idêntico ao selo novo) sem nunca virar um `<Pill>` — este diff
+  seguiu a convenção local, não a piorou. **Acessibilidade:** a distinção origem × tag é por cor e
+  posição; o texto difere e o selo tem `title`, então não é codificação puramente cromática, mas
+  não há forma nem ícone separando os dois.
 
 ## Vima: o Registro de Fatos e o briefing (PRs #85 e #90, 2026-08-06/07)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1737,6 +1737,52 @@ contato" nem marcação de histórico como lido.
   `apps/web/e2e/conversas-360.spec.ts` (mede `toBeInViewport` e `boundingBox`, não classe CSS).
   **Fecha a dívida "validação manual em ~360px do painel de Conversas".**
 
+### O card diz de onde o contato veio (2026-08-15)
+
+O fundador olhou a Entrada e perguntou por que uma conversa avulsa de WhatsApp vira lead. A
+investigação achou um defeito **anterior** a essa pergunta: os cards do site exibiam
+`vindo-do-site` e os do WhatsApp não exibiam nada, então a coluna parecia ter duas naturezas de
+contato quando na verdade tinha uma etiqueta a mais em alguns.
+
+- ⚠️ **`vindo-do-site` é TAG, não origem** — não é escrita por nenhum caminho de produção (só
+  aparece em `test_crm_merge.py` e na spec da jornada única). Chegou ali à mão ou por uma ação
+  `add_tag` de funil. **A regra que fica: `source` é a origem, fato do sistema; `tags` é marcação
+  do dono. As duas nunca se parecem na tela** — selo cinza × pílula roxa —, porque foi confundir
+  uma com a outra que produziu a pergunta.
+- [x] **Zero backend, zero migration, e vale retroativamente.** `BoardClient` herda de `ClientOut`,
+  então `source` **já chegava** no board; [`CrmPage.tsx`] apenas renderizava `client.tags` e o
+  ignorava. Como `source` tem default `"manual"` e nunca é nulo, **todo card ganhou origem de uma
+  vez**, inclusive os que já estavam na tela.
+- [x] **`features/crm/origem.ts` cobre os SEIS de `SOURCE_VALUES`, não os cinco de
+  `_ROTULO_DE_CHEGADA`** — o mapa do backend esquece o `ai`, que a validação aceita. Origem que o
+  backend grava e a tela não sabe nomear apareceria crua no card.
+  - ⚠️ **Ele NÃO é espelho do mapa do backend, e não deve virar um.** Lá a string é FRASE de linha
+    do tempo ("Chegou pelo WhatsApp"); aqui é SELO que divide largura com o nome e as tags em
+    360px. Superfícies diferentes, vocabulários diferentes — copiar a frase longa para o card
+    seria a duplicação ruim, não esta. O eixo a manter sincronizado é `SOURCE_VALUES`.
+  - Origem desconhecida cai no **próprio valor**, com teste do não-membro: sem ele o mapa passaria
+    vazio, e um backend mais novo que a tela devolveria o card a não ter origem nenhuma — o
+    defeito que este arquivo existe para corrigir, de volta pela porta dos fundos.
+- [x] **`textoForaDaTela` ganhou `raiz`** (`e2e/support/medidas.ts`), no mesmo padrão que
+  `alvosPequenos` já tinha. **O Kanban rola de lado por construção**: a página mede 360 (não é ela
+  que rola), mas as colunas seguintes ficam fora da viewport e apareciam como três cortes —
+  "Em contato", o contador dela e "Solte um card aqui" —, nenhum deles texto de card. Sem o
+  recorte, esses três afogariam qualquer corte real. Escopo que deixa de casar cai no documento
+  inteiro, **nunca em lista vazia**, e `crm-360.spec.ts` tem controle positivo com seletor podre
+  provando que o `[]` escopado é resultado e não vacuidade.
+- [x] **A distinção visual é medida por COR COMPUTADA, nunca por classe** (`crm-360.spec.ts`).
+  `toContain("bg-neutral-100")` ficaria verde com o Tailwind desligado, com a classe purgada do
+  build ou com um `bg-primary-50` vencendo na cascata — e os dois selos idênticos na tela, que é o
+  defeito de origem. O teste de jsdom afirma só o que jsdom sabe (elementos distintos, origem
+  antes das tags) e **diz no próprio comentário** que a cor é aferida no navegador.
+- **Dívida — e é a pergunta que abriu tudo:** a conversa avulsa **continua nascendo na Entrada**,
+  continua sem poder ser descartada (não existe `DELETE /crm/clients`, só mover para "Perda", que
+  grava negociação perdida sobre algo que nunca foi negociação), e `_cards_parados` vai cobrá-la
+  no briefing em 10 dias. Separar "o contato existe" de "está no funil" foi **adiado por decisão
+  do fundador**: primeiro ver a composição real da Entrada com a origem à vista. Quem retomar
+  começa por [`whatsapp_inbox/service.py`] (a porta que cria) e por `crm/service.py:229` (o
+  `stages[0]` que enfileira).
+
 ## Vima: o Registro de Fatos e o briefing (PRs #85 e #90, 2026-08-06/07)
 
 > Spec: `docs/superpowers/specs/2026-08-06-vima-registro-de-fatos-e-briefing-design.md` ·

--- a/apps/web/e2e/crm-360.spec.ts
+++ b/apps/web/e2e/crm-360.spec.ts
@@ -60,15 +60,37 @@ test("a origem não se parece com a tag", async ({ page }) => {
   // COR COMPUTADA, não classe CSS. `toContain("bg-neutral-100")` ficaria verde com o Tailwind
   // desligado, com a classe purgada do build, ou com um `bg-primary-50` vindo depois na cascata —
   // e a tela estaria com os dois selos idênticos, que é o defeito de origem desta mudança.
-  const cor = (sel: ReturnType<typeof page.getByText>) =>
-    sel.evaluate((el) => getComputedStyle(el).backgroundColor);
+  //
+  // ⚠️ E a asserção é ABSOLUTA, não relativa. `expect(origem).not.toBe(tag)` — a primeira forma
+  // deste teste — sobrevivia à mutação que TROCA as duas cores: a diferença se preserva e o
+  // significado se inverte, com o comentário do `CrmPage` dizendo o contrário do que a tela
+  // mostra. Um caçador de bugs aplicou exatamente essa mutação e os 16 testes ficaram verdes.
+  //
+  // O que se afirma é o MATIZ, não o tom: a origem é acromática (cinza) e a tag é colorida (roxo).
+  // Assim o teste não quebra quando o design system reajustar a escala — só quando alguém trocar
+  // o papel das duas.
+  //
+  // Os limiares são MEDIDOS, não escolhidos: `neutral-100` (#ececef) dá croma **3** e `primary-50`
+  // dá **18** nesta build. 8 e 12 dividem essa faixa com folga dos dois lados. Se um dia
+  // encostarem, o design system aproximou as duas cores — e aí o teste está certo em reclamar,
+  // porque a tela terá deixado de distinguir origem de tag.
+  const croma = (sel: ReturnType<typeof page.getByText>) =>
+    sel.evaluate((el) => {
+      const [r, g, b] = (getComputedStyle(el).backgroundColor.match(/\d+/g) ?? []).map(Number);
+      if (r === undefined) return { croma: -1, opaco: false };
+      return {
+        croma: Math.max(r, g, b) - Math.min(r, g, b),
+        // Um selo sem fundo nenhum tem croma 0 e passaria como "cinza" — mas ele não existe na
+        // tela. `backgroundColor` transparente vem como `rgba(0, 0, 0, 0)`: 4 números.
+        opaco: !getComputedStyle(el).backgroundColor.startsWith("rgba(0, 0, 0, 0)"),
+      };
+    });
 
-  const daOrigem = await cor(page.getByTitle("De onde este contato veio").nth(1));
-  const daTag = await cor(page.getByText("vindo-do-site"));
+  const origem = await croma(page.getByTitle("De onde este contato veio").nth(1));
+  const tag = await croma(page.getByText("vindo-do-site"));
 
-  expect(daOrigem).not.toBe(daTag);
-  // Controle positivo: sem ele, dois elementos com fundo TRANSPARENTE passariam iguais no
-  // `not.toBe` acima jamais — mas um selo sem fundo nenhum é um selo que não existe.
-  expect(daOrigem).not.toBe("rgba(0, 0, 0, 0)");
-  expect(daTag).not.toBe("rgba(0, 0, 0, 0)");
+  expect(origem.opaco).toBe(true);
+  expect(tag.opaco).toBe(true);
+  expect(origem.croma).toBeLessThanOrEqual(8); // cinza (medido: 3)
+  expect(tag.croma).toBeGreaterThanOrEqual(12); // roxo (medido: 18)
 });

--- a/apps/web/e2e/crm-360.spec.ts
+++ b/apps/web/e2e/crm-360.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+// O atributo `with { type: "json" }` NÃO é opcional: o Playwright carrega os specs como ESM
+// nativo do Node, que recusa importar JSON sem ele ("needs an import attribute").
+import fixtures from "./fixtures/crm.json" with { type: "json" };
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O card do Kanban em 360px, depois que ele passou a dizer de onde o contato veio.
+ *
+ * O selo é o terceiro inquilino de uma linha que já dividia largura entre nome e tags, num card
+ * que ainda tem alça de arrastar à esquerda e botão de ficha à direita. É exatamente a forma que
+ * estourou a topbar (§5.1): todo filho encolhendo, ninguém com largura mínima.
+ *
+ * A fixture é de PIOR CASO PLAUSÍVEL: o rótulo mais comprido ("Integração") num card que também
+ * tem o nome mais longo e duas tags, e o card de WhatsApp com o nome caindo no telefone cru —
+ * que é como ele nasce quando o contato não tem `pushName`.
+ */
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, fixtures);
+});
+
+test("todo card diz de onde veio, e a origem cabe na tela", async ({ page }) => {
+  await page.goto("/crm");
+
+  const doWhatsapp = page.getByTitle("De onde este contato veio").first();
+  await expect(doWhatsapp).toHaveText("WhatsApp");
+  await expect(doWhatsapp).toBeInViewport();
+
+  // O rótulo mais comprido, no card mais cheio. `toHaveText` (e não `toContainText`) porque um
+  // selo truncado pela metade ainda conteria o começo da palavra.
+  const daIntegracao = page.getByTitle("De onde este contato veio").nth(1);
+  await expect(daIntegracao).toHaveText("Integração");
+  await expect(daIntegracao).toBeInViewport();
+
+  // A PÁGINA não rola de lado — quem rola é o contêiner do board, e isso é o que um Kanban é.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // Por isso a varredura é escopada à PRIMEIRA coluna (`.w-72`, a que está na tela). Sem o
+  // recorte, "Em contato", o contador dela e o "Solte um card aqui" aparecem como cortados —
+  // três achados que existem porque a segunda coluna está adiante no deslizador, não porque
+  // algum card esteja quebrado. Medido antes de escopar: eram exatamente esses três, e nenhum
+  // texto de card. O comportamento é PRÉ-EXISTENTE e fora do escopo desta mudança.
+  expect(await textoForaDaTela(page, ".w-72")).toEqual([]);
+
+  // CONTROLE POSITIVO do recorte acima. Sem ele, um `.w-72` que deixasse de casar (renomear a
+  // largura da coluna basta) devolveria vazio e o teste aprovaria a tela para sempre, sem medir
+  // nada. Com seletor podre a varredura cai no documento inteiro e volta a achar as colunas
+  // adiante — prova de que a função enxerga corte NESTA página, e que o `[]` acima é resultado.
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});
+
+test("a origem não se parece com a tag", async ({ page }) => {
+  await page.goto("/crm");
+  await expect(page.getByText("vindo-do-site")).toBeVisible();
+
+  // COR COMPUTADA, não classe CSS. `toContain("bg-neutral-100")` ficaria verde com o Tailwind
+  // desligado, com a classe purgada do build, ou com um `bg-primary-50` vindo depois na cascata —
+  // e a tela estaria com os dois selos idênticos, que é o defeito de origem desta mudança.
+  const cor = (sel: ReturnType<typeof page.getByText>) =>
+    sel.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+  const daOrigem = await cor(page.getByTitle("De onde este contato veio").nth(1));
+  const daTag = await cor(page.getByText("vindo-do-site"));
+
+  expect(daOrigem).not.toBe(daTag);
+  // Controle positivo: sem ele, dois elementos com fundo TRANSPARENTE passariam iguais no
+  // `not.toBe` acima jamais — mas um selo sem fundo nenhum é um selo que não existe.
+  expect(daOrigem).not.toBe("rgba(0, 0, 0, 0)");
+  expect(daTag).not.toBe("rgba(0, 0, 0, 0)");
+});

--- a/apps/web/e2e/fixtures/crm.json
+++ b/apps/web/e2e/fixtures/crm.json
@@ -1,0 +1,63 @@
+{
+  "/crm/board": {
+    "columns": [
+      {
+        "stage": {
+          "id": "s1",
+          "name": "Entrada",
+          "position": 0,
+          "is_won": false,
+          "is_lost": false,
+          "is_archived": false
+        },
+        "clients": [
+          {
+            "id": "c1",
+            "tenant_id": "t1",
+            "name": "554399706687",
+            "email": null,
+            "phone": "554399706687",
+            "document": null,
+            "gender": "unspecified",
+            "birthdate": null,
+            "notes": "",
+            "tags": [],
+            "source": "whatsapp",
+            "stage_id": "s1",
+            "stage_entered_at": "2026-08-13T12:00:00Z",
+            "created_at": "2026-08-13T12:00:00Z",
+            "last_interaction_at": "2026-08-13T12:00:00Z"
+          },
+          {
+            "id": "c2",
+            "tenant_id": "t1",
+            "name": "Maria Aparecida Gonçalves de Souza",
+            "email": "maria.aparecida.goncalves@exemplo.com.br",
+            "phone": "5511987654321",
+            "document": null,
+            "gender": "unspecified",
+            "birthdate": null,
+            "notes": "",
+            "tags": ["vindo-do-site", "orçamento-enviado"],
+            "source": "api",
+            "stage_id": "s1",
+            "stage_entered_at": "2026-08-12T09:30:00Z",
+            "created_at": "2026-08-12T09:30:00Z",
+            "last_interaction_at": "2026-08-14T18:45:00Z"
+          }
+        ]
+      },
+      {
+        "stage": {
+          "id": "s2",
+          "name": "Em contato",
+          "position": 1,
+          "is_won": false,
+          "is_lost": false,
+          "is_archived": false
+        },
+        "clients": []
+      }
+    ]
+  }
+}

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -84,9 +84,16 @@ export async function alvosPequenos(page: Page, min = 44, raiz?: string): Promis
  * Texto que só EXISTE se o dono rolar de lado — o defeito que a Onda 2b-ii achou na primeira
  * medição (`R$ 3.` no lugar de `R$ 3.000,00`). Para cada folha com texto, acha o ancestral que
  * recorta e mede quanto sobra fora dele.
+ *
+ * `raiz` recorta a VARREDURA (nunca o cálculo: o ancestral que recorta continua sendo procurado
+ * para cima, mesmo fora dela). Use quando a tela tiver um deslizador horizontal LEGÍTIMO e a
+ * pergunta for sobre o que está dentro do painel visível — o Kanban é o caso: as colunas seguintes
+ * ficam fora da viewport por construção, e sem o recorte elas afogam o resultado com três cortes
+ * que não são defeito de ninguém. Escopo que deixou de casar cai no documento inteiro, e não em
+ * lista vazia: um seletor podre tem de aparecer como ruído, nunca como aprovação.
  */
-export async function textoForaDaTela(page: Page): Promise<Corte[]> {
-  return page.evaluate(() => {
+export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[]> {
+  return page.evaluate((raizSel) => {
     const descrever = (el: Element): string => {
       const cls =
         typeof el.className === "string"
@@ -112,7 +119,8 @@ export async function textoForaDaTela(page: Page): Promise<Corte[]> {
     };
     const vw = document.documentElement.clientWidth;
     const fora: { texto: string; descricao: string; forcaFora: number }[] = [];
-    for (const el of [...document.querySelectorAll("body *")].filter(visivel)) {
+    const escopo: ParentNode = raizSel ? (document.querySelector(raizSel) ?? document.body) : document.body;
+    for (const el of [...escopo.querySelectorAll("*")].filter(visivel)) {
       if (el.children.length > 0 || !(el.textContent ?? "").trim()) continue;
       const r = el.getBoundingClientRect();
       const limite = Math.min(recorte(el).getBoundingClientRect().right, vw);
@@ -126,5 +134,5 @@ export async function textoForaDaTela(page: Page): Promise<Corte[]> {
       }
     }
     return fora;
-  });
+  }, raiz);
 }

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -82,7 +82,10 @@ describe("CrmPage — Novo cliente (Story 7.15, Task 1)", () => {
 });
 
 /** Board com um card só, para exercitar a linha da última interação. */
-function boardComCard(lastInteractionAt: string | null) {
+function boardComCard(
+  lastInteractionAt: string | null,
+  extra: { source?: string; tags?: string[] } = {},
+) {
   return {
     columns: [
       {
@@ -94,7 +97,7 @@ function boardComCard(lastInteractionAt: string | null) {
           {
             id: "c1", tenant_id: "t1", name: "Flavio Kato", email: null, phone: null,
             document: null, gender: "unspecified", birthdate: null, notes: "",
-            tags: [], source: "landing", stage_id: "s1",
+            tags: extra.tags ?? [], source: extra.source ?? "landing", stage_id: "s1",
             created_at: "2026-07-01T10:00:00Z",
             stage_entered_at: "2026-07-28T12:00:00Z",
             last_interaction_at: lastInteractionAt,
@@ -105,10 +108,13 @@ function boardComCard(lastInteractionAt: string | null) {
   };
 }
 
-function mockarBoard(lastInteractionAt: string | null) {
+function mockarBoard(
+  lastInteractionAt: string | null,
+  extra: { source?: string; tags?: string[] } = {},
+) {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/crm/board") {
-      return Promise.resolve({ data: boardComCard(lastInteractionAt) } as never);
+      return Promise.resolve({ data: boardComCard(lastInteractionAt, extra) } as never);
     }
     return Promise.resolve({ data: [] } as never);
   });
@@ -146,5 +152,41 @@ describe("CrmPage — a data que explica a posição na fila", () => {
 
     // `stage_entered_at` é coluna não-nula: todo card sempre sabe desde quando está ali.
     expect(await screen.findByText("na etapa desde: 28/07")).toBeInTheDocument();
+  });
+});
+
+describe("CrmPage — de onde o contato veio", () => {
+  // O card do WhatsApp não dizia NADA sobre a origem, enquanto os do site exibiam a tag
+  // `vindo-do-site` — e tag é marcação do dono, não origem. Quem olhava a Entrada não conseguia
+  // distinguir a oportunidade real da conversa avulsa que caiu no WhatsApp.
+  it("o card do WhatsApp diz que veio do WhatsApp", async () => {
+    mockarBoard(null, { source: "whatsapp" });
+    renderPage();
+
+    expect(await screen.findByTitle("De onde este contato veio")).toHaveTextContent("WhatsApp");
+  });
+
+  // `source` tem default "manual" no backend e nunca é nulo: NENHUM card fica sem origem.
+  it("card sem porta de entrada conhecida ainda diz de onde veio", async () => {
+    mockarBoard(null, { source: "manual" });
+    renderPage();
+
+    expect(await screen.findByTitle("De onde este contato veio")).toHaveTextContent("Manual");
+  });
+
+  it("a origem é um selo próprio, antes das tags — não mais uma tag no meio delas", async () => {
+    mockarBoard(null, { source: "landing", tags: ["vindo-do-site"] });
+    renderPage();
+
+    const origem = await screen.findByTitle("De onde este contato veio");
+    const tag = screen.getByText("vindo-do-site");
+
+    // Elementos DISTINTOS: a asserção não pode ser por texto solto, senão passaria com os dois
+    // pintados iguais — que é exatamente o defeito sendo corrigido.
+    expect(origem).not.toBe(tag);
+    expect(origem).toHaveTextContent("Site");
+    // E a origem vem ANTES na leitura do card. (A distinção VISUAL não é aferível em jsdom; ela
+    // é medida no navegador, em `e2e/crm-360.spec.ts`, comparando a cor computada das duas.)
+    expect(origem.compareDocumentPosition(tag)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 });

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -6,6 +6,7 @@ import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatDateShort } from "../../lib/datetime";
 import GanchoDaVima from "../dna/GanchoDaVima";
+import { rotuloDaOrigem } from "./origem";
 import { usePrimaryAction } from "../../store/pageActions";
 import { useFuso } from "../../store/auth";
 
@@ -199,15 +200,23 @@ function Card({ client, stageId }: { client: BoardClient; stageId: string }) {
       <GripVertical size={16} className="mt-0.5 shrink-0 text-neutral-300" />
       <div className="min-w-0 flex-1">
         <p className="font-medium text-neutral-800">{client.name}</p>
-        {client.tags.length > 0 && (
-          <div className="mt-1 flex flex-wrap gap-1">
-            {client.tags.map((t) => (
-              <span key={t} className="rounded-pill bg-primary-50 px-2 text-[10px] text-primary-700">
-                {t}
-              </span>
-            ))}
-          </div>
-        )}
+        {/* Origem e tags dividem a mesma linha e NÃO podem se parecer: a origem é fato do
+            sistema (cinza), a tag é marcação do dono (roxo). Confundir as duas foi o que fez o
+            `vindo-do-site` — uma tag digitada — passar por "de onde veio" enquanto todo card de
+            WhatsApp não dizia nada. `source` nunca é nulo, então o selo aparece em todo card. */}
+        <div className="mt-1 flex flex-wrap gap-1">
+          <span
+            title="De onde este contato veio"
+            className="rounded-pill bg-neutral-100 px-2 text-[10px] text-neutral-600"
+          >
+            {rotuloDaOrigem(client.source)}
+          </span>
+          {client.tags.map((t) => (
+            <span key={t} className="rounded-pill bg-primary-50 px-2 text-[10px] text-primary-700">
+              {t}
+            </span>
+          ))}
+        </div>
         {/* As duas datas dizem coisas diferentes: a primeira explica a POSIÇÃO do card na
             fila (a coluna é ordenada por ela), a segunda, o quão fria está a conversa. */}
         <p className="mt-1 text-[10px] text-neutral-400">

--- a/apps/web/src/features/crm/origem.test.ts
+++ b/apps/web/src/features/crm/origem.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { rotuloDaOrigem } from "./origem";
+
+describe("rotuloDaOrigem", () => {
+  // Os SEIS de `SOURCE_VALUES` (crm/models.py) — não os cinco de `_ROTULO_DE_CHEGADA`, que
+  // esquece o `ai`. Um valor que o backend ACEITA e a tela não sabe nomear apareceria cru.
+  it("traduz os seis canais que o backend valida em SOURCE_VALUES", () => {
+    expect(rotuloDaOrigem("whatsapp")).toBe("WhatsApp");
+    expect(rotuloDaOrigem("landing")).toBe("Site");
+    expect(rotuloDaOrigem("api")).toBe("Integração");
+    expect(rotuloDaOrigem("import")).toBe("Importado");
+    expect(rotuloDaOrigem("manual")).toBe("Manual");
+    expect(rotuloDaOrigem("ai")).toBe("IA");
+  });
+
+  // O NÃO-MEMBRO. Sem ele o mapa passaria vazio, e uma porta de entrada nova (backend mais novo
+  // que a tela em deploy) deixaria o card SEM origem nenhuma — de volta ao defeito que este
+  // arquivo existe para corrigir. Mesma disciplina de `_titulo_de_chegada` no backend: um source
+  // desconhecido cai num rótulo honesto em vez de sumir.
+  it("origem desconhecida aparece crua, nunca some", () => {
+    expect(rotuloDaOrigem("instagram")).toBe("instagram");
+  });
+});

--- a/apps/web/src/features/crm/origem.test.ts
+++ b/apps/web/src/features/crm/origem.test.ts
@@ -20,4 +20,19 @@ describe("rotuloDaOrigem", () => {
   it("origem desconhecida aparece crua, nunca some", () => {
     expect(rotuloDaOrigem("instagram")).toBe("instagram");
   });
+
+  // `ROTULOS` é objeto literal, então a indexação alcança `Object.prototype`: sem guarda,
+  // `rotuloDaOrigem("constructor")` devolve a FUNÇÃO `Object` — e a assinatura `: string` mente.
+  // O React não quebra, mas loga "Functions are not valid as a React child" e o selo fica VAZIO:
+  // um card sem origem nenhuma, que é o defeito que este arquivo existe para corrigir.
+  //
+  // Hoje é inalcançável pela API (`ClientBase._source` recusa fora de `SOURCE_VALUES`, e a coluna
+  // é `nullable=False` desde a 0003). Fica travado assim mesmo: o custo é uma linha, e o dia em
+  // que um caminho de escrita novo contornar o schema não vem anunciado.
+  it.each(["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"])(
+    "%s é origem desconhecida como qualquer outra, não herança de Object",
+    (herdado) => {
+      expect(rotuloDaOrigem(herdado)).toBe(herdado);
+    },
+  );
 });

--- a/apps/web/src/features/crm/origem.ts
+++ b/apps/web/src/features/crm/origem.ts
@@ -1,0 +1,24 @@
+/**
+ * De onde o contato veio, em uma palavra — o selo do card do Kanban.
+ *
+ * **Não é espelho de `_ROTULO_DE_CHEGADA` (`crm/service.py`), e não deve virar um.** Lá a string é
+ * uma FRASE de linha do tempo ("Chegou pelo WhatsApp"); aqui é um SELO de card, que divide a
+ * largura com o nome e as tags em 360px. Superfícies diferentes, vocabulários diferentes: copiar a
+ * frase longa para cá seria a duplicação ruim, não esta.
+ *
+ * ⚠️ O eixo a manter sincronizado é `SOURCE_VALUES` (`crm/models.py`), que tem SEIS membros — um a
+ * mais que o mapa do backend, que esquece o `ai`. Origem que o backend aceita e a tela não nomeia
+ * apareceria crua no card.
+ */
+const ROTULOS: Record<string, string> = {
+  whatsapp: "WhatsApp",
+  landing: "Site",
+  api: "Integração",
+  import: "Importado",
+  manual: "Manual",
+  ai: "IA",
+};
+
+export function rotuloDaOrigem(source: string): string {
+  return ROTULOS[source] ?? source;
+}

--- a/apps/web/src/features/crm/origem.ts
+++ b/apps/web/src/features/crm/origem.ts
@@ -20,5 +20,10 @@ const ROTULOS: Record<string, string> = {
 };
 
 export function rotuloDaOrigem(source: string): string {
-  return ROTULOS[source] ?? source;
+  // `hasOwn`, e não `ROTULOS[source] ?? source`: a indexação de objeto literal alcança
+  // `Object.prototype`, então `"constructor"` devolvia a FUNÇÃO `Object` — o `??` não a pega,
+  // porque função não é nula. A assinatura `: string` mentia, e o React renderizava um selo
+  // VAZIO (com "Functions are not valid as a React child" no console): card sem origem, que é
+  // exatamente o defeito que este módulo existe para corrigir.
+  return Object.hasOwn(ROTULOS, source) ? ROTULOS[source] : source;
 }


### PR DESCRIPTION
## Por quê

O fundador olhou a Entrada do Kanban e perguntou por que uma conversa avulsa de WhatsApp vira lead. A investigação achou um defeito **anterior** a essa pergunta: os cards do site exibiam a tag `vindo-do-site` e os do WhatsApp não exibiam nada, então a coluna parecia ter duas naturezas de contato quando só tinha uma etiqueta a mais em alguns.

`vindo-do-site` é **tag, não origem** — nenhum caminho de produção a escreve (só aparece em `test_crm_merge.py` e na spec da jornada única). Chegou ali à mão ou por uma ação `add_tag` de funil.

## O que muda

Todo card passa a trazer um selo cinza com a origem: **WhatsApp · Site · Integração · Importado · Manual · IA**.

**Zero backend, zero migration, retroativo.** `BoardClient` herda de `ClientOut`, então `source` já chegava no board — o card é que o ignorava. Como `source` tem default `"manual"` e nunca é nulo, todos os contatos existentes ganharam origem de uma vez.

A regra que fica: **`source` é a origem (fato do sistema), `tags` é marcação do dono, e as duas nunca se parecem na tela** — selo cinza × pílula roxa. Foi confundir uma com a outra que produziu a pergunta.

## Decisões

- **`features/crm/origem.ts` cobre os SEIS de `SOURCE_VALUES`**, não os cinco de `_ROTULO_DE_CHEGADA` — o mapa do backend esquece o `ai`, que a validação aceita. Origem que o backend grava e a tela não nomeia apareceria crua.
- **Não é espelho daquele mapa, e não deve virar um.** Lá a string é frase de linha do tempo ("Chegou pelo WhatsApp"); aqui é selo que divide largura com nome e tags em 360px. O eixo a manter sincronizado é `SOURCE_VALUES`.
- **`textoForaDaTela` ganhou `raiz`**, no padrão que `alvosPequenos` já tinha. O Kanban rola de lado por construção: a página mede 360 (não é ela que rola), mas as colunas seguintes apareciam como três cortes — nenhum deles texto de card. Escopo que deixa de casar cai no documento inteiro, **nunca em lista vazia**, com controle positivo por seletor podre.

## Verificação

| Gate | Resultado |
|---|---|
| `pnpm lint` | limpo |
| `pnpm typecheck` | limpo |
| `pnpm test` (vitest) | **616 passaram** / 64 arquivos |
| `pnpm e2e` (Playwright, 360px) | **21 passaram**, incluindo os 19 pré-existentes que usam a `medidas.ts` alterada |

Agentes de QA do §5 rodados sobre o primeiro commit:

- **regression-tester: PASSOU** (632 execuções, 0 falhas). Confirmou por leitura — não só por execução — que `escopo.querySelectorAll("*")` com `escopo = document.body` é o mesmo conjunto do antigo `document.querySelectorAll("body *")`, e que `raiz` afeta só quais elementos entram na varredura, nunca como cada um é julgado.
- **dedup-checker: LIMPO.** Nenhuma duplicação nociva; validou a decisão de não espelhar `_ROTULO_DE_CHEGADA` e confirmou que não há terceira cópia.
- **bug-hunter: SEGURO**, com dois achados — **os dois corrigidos no segundo commit**.

## Os dois achados do bug-hunter (commit 2)

**1. `rotuloDaOrigem` alcançava `Object.prototype`.** `ROTULOS["constructor"]` devolvia a **função `Object`** — que o `?? source` não pega, porque função não é nula. A assinatura `: string` mentia e o React renderizava o selo **vazio**. Agora `Object.hasOwn`, com os cinco herdados em `it.each`. Inalcançável hoje (validação Pydantic + coluna `NOT NULL` desde a 0003), travado assim mesmo.

**2. O e2e de cor era relativo, e a mutação sobrevivia.** Comparava `expect(origem).not.toBe(tag)`. O bug-hunter aplicou a mutação que **troca as duas cores**: a diferença se preserva, o significado se inverte, e os 16 testes ficaram verdes — com o comentário do `CrmPage` afirmando o oposto do que a tela mostrava. Agora a asserção é **absoluta e sobre o matiz**: origem acromática (croma ≤ 8), tag colorida (≥ 12), com os limiares **medidos** (`neutral-100` = 3, `primary-50` = 18) e não escolhidos. Mutação verificada morta: `Expected >= 12, Received 3`.

> **A regra registrada no CLAUDE.md:** comparação relativa entre dois papéis não prova papel nenhum. `a !== b` sobrevive a trocar `a` com `b` — e trocar os dois é exatamente a forma que o defeito assume quando alguém "arruma as cores" sem ler o comentário.

## O que este PR NÃO faz

A conversa avulsa **continua nascendo na Entrada**, continua sem poder ser descartada (não existe `DELETE /crm/clients`; só mover para "Perda", que grava negociação perdida sobre algo que nunca foi negociação) e `_cards_parados` vai cobrá-la no briefing em 10 dias.

Separar "o contato existe" de "está no funil" foi **adiado por decisão do fundador**: primeiro ver a composição real da Entrada com a origem à vista. Registrado como dívida no CLAUDE.md, com os dois pontos de partida para quem retomar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
