### PR TITLE
feat: a ficha do contato passa a falar com Conversas [Onda 1]

### DIFF
--- a/apps/api/app/modules/crm/router.py
+++ b/apps/api/app/modules/crm/router.py
@@ -22,6 +22,7 @@ from app.modules.crm.schemas import (
     StageOut,
     StageUpdate,
 )
+from app.modules.whatsapp_inbox import service as inbox_service
 
 router = APIRouter(prefix="/crm", tags=["crm"])
 
@@ -42,6 +43,9 @@ def get_board(
 ) -> Board:
     columns = service.build_board(db, user.tenant_id)
     ultimo = service.last_interaction_map(db)
+    # Consulta agregada, uma para o board inteiro — o custo não cresce com a quantidade de
+    # cards. Lida do módulo DONO da regra de "não lida" em vez de reimplementada aqui.
+    esperando = inbox_service.unread_client_ids(db)
     return Board(
         columns=[
             BoardColumn(
@@ -50,6 +54,7 @@ def get_board(
                     BoardClient(
                         **ClientOut.model_validate(c).model_dump(),
                         last_interaction_at=ultimo.get(c.id),
+                        unread=c.id in esperando,
                     )
                     for c in clients
                 ],

--- a/apps/api/app/modules/crm/schemas.py
+++ b/apps/api/app/modules/crm/schemas.py
@@ -167,15 +167,18 @@ class ClientOut(BaseModel):
 
 
 class BoardClient(ClientOut):
-    """`ClientOut` + a data da última interação.
+    """`ClientOut` + os sinais que só o board calcula.
 
-    Campo separado do `ClientOut` de propósito: só o board calcula isso (via duas consultas
-    agrupadas). Se `last_interaction_at` vivesse em `ClientOut`, todo endpoint que devolve
-    cliente passaria a afirmar `null` — e `null` significaria tanto "sem interação" quanto
-    "não calculei", que são coisas diferentes.
+    Campos separados do `ClientOut` de propósito: só o board calcula isso (via consultas
+    agrupadas). Se vivessem em `ClientOut`, todo endpoint que devolve cliente passaria a
+    afirmar `null` — e `null` significaria tanto "sem interação" quanto "não calculei", que
+    são coisas diferentes.
     """
 
     last_interaction_at: datetime | None = None
+    # Tem mensagem do contato esperando resposta. Booleano e não contador: o card não tem
+    # espaço para número, e "quantas" é pergunta da tela de Conversas.
+    unread: bool = False
 
 
 class BoardColumn(BaseModel):

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -161,13 +161,18 @@ def list_conversations(
 
 @router.get("/{chat_id}/timeline")
 def get_timeline(
-    chat_id: str, user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+    chat_id: str,
+    # `None` por padrão preserva o comportamento de hoje (histórico inteiro) para a tela de
+    # Conversas, que é a mesma rota. Só a ficha 360° manda `limit` (ver BlocoDaConversa.tsx).
+    limit: int | None = Query(default=None, gt=0),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
 ) -> list[dict]:
     # Conversa inexistente vira 404 explícito (o service levanta): antes o id era de cliente e
     # um id desconhecido devolvia 200 com lista vazia — indistinguível de "conversa sem
     # mensagem" e péssimo pra diagnosticar.
     try:
-        return service.get_timeline(db, chat_id=chat_id)
+        return service.get_timeline(db, chat_id=chat_id, limit=limit)
     except service.WhatsappInboxError as e:
         raise _err(e) from e
 

--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -152,9 +152,11 @@ def _err(e: service.WhatsappInboxError) -> HTTPException:
 
 @router.get("")
 def list_conversations(
-    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db)
+    client_id: str | None = Query(default=None),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
 ) -> list[dict]:
-    return service.list_conversations(db, user.tenant_id)
+    return service.list_conversations(db, user.tenant_id, client_id=client_id)
 
 
 @router.get("/{chat_id}/timeline")

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -563,9 +563,10 @@ def list_conversations(
     chats = {c.id: c for c in db.scalars(consulta_chats).all()}
     if client_id is not None and not chats:
         # Contato sem NENHUMA conversa — o caso comum na ficha 360° (a maioria dos contatos
-        # nunca escreveu). Sai cedo: um `IN (chats.keys())` vazio abaixo teria que virar
-        # `IN (NULL)` ou equivalente para não silenciosamente casar com TUDO (comportamento
-        # de `IN ()` varia por dialeto), e não há mensagem nenhuma a carregar mesmo.
+        # nunca escreveu). O SQLAlchemy já compila `.in_(())` (coleção vazia) para uma
+        # expressão que nunca bate (`IN (NULL) AND (1 != 1)`), então não há risco de casar
+        # com tudo por engano — a saída antecipada aqui é só para não pagar o round-trip de
+        # uma consulta cujo resultado já sabemos, de antemão, que vem vazio.
         return []
 
     consulta_msgs = select(WhatsappMessage).order_by(

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -533,7 +533,9 @@ def _preview(msg: WhatsappMessage, chat: WhatsappChat) -> str:
     return body
 
 
-def list_conversations(db: Session, tenant_id: str) -> list[dict]:
+def list_conversations(
+    db: Session, tenant_id: str, *, client_id: str | None = None
+) -> list[dict]:
     """Uma linha por CONVERSA com pelo menos 1 mensagem, ordenada pela mais recente.
 
     Indexado por `whatsapp_chats`, não mais por cliente do CRM — é o que permite grupo existir
@@ -542,8 +544,17 @@ def list_conversations(db: Session, tenant_id: str) -> list[dict]:
 
     `tenant_id` não filtra a query explicitamente: a sessão já chega escopada por RLS (mesma
     convenção de `crm_service.build_board`), é mantido no parâmetro por simetria com o resto do
-    módulo (e uso futuro, ex.: auditoria)."""
-    chats = {c.id: c for c in db.scalars(select(WhatsappChat)).all()}
+    módulo (e uso futuro, ex.: auditoria).
+
+    `client_id` filtra as conversas de UM contato (a ficha 360° usa isso). Grupo tem
+    `client_id` nulo e portanto nunca aparece filtrado — que é o correto: grupo não é contato
+    do CRM. Um contato pode ter MAIS DE UMA conversa (`@lid` + telefone), então a lista
+    filtrada não tem tamanho garantido de 1.
+    """
+    consulta_chats = select(WhatsappChat)
+    if client_id is not None:
+        consulta_chats = consulta_chats.where(WhatsappChat.client_id == client_id)
+    chats = {c.id: c for c in db.scalars(consulta_chats).all()}
     last_msgs: dict[str, WhatsappMessage] = {}
     # Segunda chave de ordenação (`id`) é o desempate: duas mensagens do mesmo chat podem cair
     # no mesmo instante (mesma transação de ingestão), e sem uma chave estável "a última

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -545,8 +545,12 @@ def list_conversations(db: Session, tenant_id: str) -> list[dict]:
     módulo (e uso futuro, ex.: auditoria)."""
     chats = {c.id: c for c in db.scalars(select(WhatsappChat)).all()}
     last_msgs: dict[str, WhatsappMessage] = {}
+    # Segunda chave de ordenação (`id`) é o desempate: duas mensagens do mesmo chat podem cair
+    # no mesmo instante (mesma transação de ingestão), e sem uma chave estável "a última
+    # mensagem" mudaria de corrida para corrida. `unread_client_ids` usa o MESMO desempate
+    # (created_at, id) — é o contrato que mantém as duas funções de acordo em empate.
     for msg in db.scalars(
-        select(WhatsappMessage).order_by(WhatsappMessage.created_at)
+        select(WhatsappMessage).order_by(WhatsappMessage.created_at, WhatsappMessage.id)
     ).all():
         if msg.chat_id is not None:
             last_msgs[msg.chat_id] = msg  # a última iteração (ordem crescente) vence
@@ -593,33 +597,41 @@ def unread_client_ids(db: Session) -> set[str]:
     o card é um só. Grupo nunca entra — `client_id` é nulo nele por decisão de produto.
 
     A sessão já chega escopada por RLS (mesma convenção de `list_conversations`).
+
+    O desempate de mensagens no mesmo instante TEM que ser o mesmo dos dois lados, ou as duas
+    funções divergem em silêncio no exato caso que a paridade deveria pegar (duas mensagens do
+    mesmo chat na mesma transação, uma `in` outra `out` — o board diria uma coisa, a caixa de
+    entrada diria outra). Por isso a query abaixo não pergunta "existe ALGUMA mensagem `in`
+    empatada no topo" — isso seria um teste existencial, não "qual é a última mensagem" — ela
+    elege exatamente UMA linha por chat via `row_number() OVER (... ORDER BY created_at DESC,
+    id DESC)`, o mesmo par `(created_at, id)` que `list_conversations` usa (lá em ordem
+    crescente, "a última iteração vence" — aqui em ordem decrescente, "a primeira linha vence";
+    os dois pegam a mesma mensagem).
     """
-    # Últimas mensagens: uma linha por chat, obtida por max(created_at) agrupado. Empate de
-    # instante (duas mensagens no mesmo commit) resolve-se pegando qualquer uma das empatadas
-    # e checando se ALGUMA delas é `in` — que é a pergunta que interessa. Não precisamos saber
-    # qual é "a" última, só se a conversa terminou com o contato falando.
-    max_por_chat = (
+    ultima_por_chat = (
         select(
             WhatsappMessage.chat_id.label("chat_id"),
-            func.max(WhatsappMessage.created_at).label("ultima_em"),
+            WhatsappMessage.direction.label("direction"),
+            WhatsappMessage.created_at.label("created_at"),
+            func.row_number()
+            .over(
+                partition_by=WhatsappMessage.chat_id,
+                order_by=(WhatsappMessage.created_at.desc(), WhatsappMessage.id.desc()),
+            )
+            .label("rn"),
         )
         .where(WhatsappMessage.chat_id.is_not(None))
-        .group_by(WhatsappMessage.chat_id)
         .subquery()
     )
     linhas = db.execute(
         select(WhatsappChat.client_id)
-        .join(max_por_chat, max_por_chat.c.chat_id == WhatsappChat.id)
-        .join(
-            WhatsappMessage,
-            (WhatsappMessage.chat_id == WhatsappChat.id)
-            & (WhatsappMessage.created_at == max_por_chat.c.ultima_em),
-        )
+        .join(ultima_por_chat, ultima_por_chat.c.chat_id == WhatsappChat.id)
         .where(
+            ultima_por_chat.c.rn == 1,
             WhatsappChat.client_id.is_not(None),
-            WhatsappMessage.direction == DIRECTION_IN,
+            ultima_por_chat.c.direction == DIRECTION_IN,
             (WhatsappChat.last_read_at.is_(None))
-            | (max_por_chat.c.ultima_em > WhatsappChat.last_read_at),
+            | (ultima_por_chat.c.created_at > WhatsappChat.last_read_at),
         )
     ).all()
     return {client_id for (client_id,) in linhas}

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import audit, facts, whatsapp
@@ -574,6 +574,55 @@ def list_conversations(db: Session, tenant_id: str) -> list[dict]:
         })
     out.sort(key=lambda c: c["last_message_at"], reverse=True)
     return out
+
+
+def unread_client_ids(db: Session) -> set[str]:
+    """Contatos com mensagem esperando resposta, para o ponto no card do Kanban.
+
+    ⚠️ ESTA É A MESMA REGRA de `list_conversations` acima ("a última mensagem da conversa é do
+    contato e chegou depois do `last_read_at`"), escrita uma segunda vez. Mexeu em uma, mexa na
+    outra — `test_whatsapp_inbox_nao_lidas.py::test_unread_client_ids_concorda_com_list_conversations`
+    existe exatamente para pegar quem esquecer.
+
+    A duplicação é deliberada: `list_conversations` materializa TODAS as mensagens do tenant
+    para achar a última de cada chat. A tela de Conversas paga esse preço uma vez a cada 7s
+    para um usuário; o board não pode pagá-lo a cada navegação. Aqui é uma consulta agregada,
+    de custo independente do volume de mensagens.
+
+    Devolve CONTATOS, não conversas: o mesmo contato pode ter dois chats (`@lid` + telefone) e
+    o card é um só. Grupo nunca entra — `client_id` é nulo nele por decisão de produto.
+
+    A sessão já chega escopada por RLS (mesma convenção de `list_conversations`).
+    """
+    # Últimas mensagens: uma linha por chat, obtida por max(created_at) agrupado. Empate de
+    # instante (duas mensagens no mesmo commit) resolve-se pegando qualquer uma das empatadas
+    # e checando se ALGUMA delas é `in` — que é a pergunta que interessa. Não precisamos saber
+    # qual é "a" última, só se a conversa terminou com o contato falando.
+    max_por_chat = (
+        select(
+            WhatsappMessage.chat_id.label("chat_id"),
+            func.max(WhatsappMessage.created_at).label("ultima_em"),
+        )
+        .where(WhatsappMessage.chat_id.is_not(None))
+        .group_by(WhatsappMessage.chat_id)
+        .subquery()
+    )
+    linhas = db.execute(
+        select(WhatsappChat.client_id)
+        .join(max_por_chat, max_por_chat.c.chat_id == WhatsappChat.id)
+        .join(
+            WhatsappMessage,
+            (WhatsappMessage.chat_id == WhatsappChat.id)
+            & (WhatsappMessage.created_at == max_por_chat.c.ultima_em),
+        )
+        .where(
+            WhatsappChat.client_id.is_not(None),
+            WhatsappMessage.direction == DIRECTION_IN,
+            (WhatsappChat.last_read_at.is_(None))
+            | (max_por_chat.c.ultima_em > WhatsappChat.last_read_at),
+        )
+    ).all()
+    return {client_id for (client_id,) in linhas}
 
 
 def get_chat(db: Session, *, chat_id: str) -> WhatsappChat:

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -582,8 +582,20 @@ def list_conversations(
     # Segunda chave de ordenação (`id`) é o desempate: duas mensagens do mesmo chat podem cair
     # no mesmo instante (mesma transação de ingestão), e sem uma chave estável "a última
     # mensagem" mudaria de corrida para corrida. `unread_client_ids` usa o MESMO desempate
-    # (created_at, id) — é o contrato que mantém as duas funções de acordo em empate. Esta
-    # ordenação e o laço "última iteração vence" abaixo NÃO mudam com o filtro — só QUAIS
+    # (created_at, id) — é a REGRA que mantém as duas funções de acordo em empate.
+    #
+    # ⚠️ O que `test_unread_client_ids_concorda_com_list_conversations` PROVA: que a regra, como
+    # está escrita hoje dos dois lados, produz a mesma resposta. O que ele NÃO garante: que
+    # apagar a coluna `id` do `ORDER BY` de UM dos dois lados derrube o teste. Sem desempate
+    # explícito, a ordem de linhas empatadas fica a critério do motor (o padrão SQL não a
+    # especifica); sob SQLite (o motor dos testes) ela tende a seguir a ordem física de inserção
+    # — e, pela fixture atual, isso reproduz por acaso a resposta certa de um dos dois lados
+    # mesmo sem o `id`. Ou seja: a guarda pega quem MUDA a regra (ex.: inverte para "menor id
+    # vence" só aqui), mas não é rede de segurança confiável contra quem apenas REMOVE o `id` do
+    # `ORDER BY` — trate esta coluna como parte do contrato, não como algo que o teste denuncia
+    # sozinho se sumir.
+    #
+    # Esta ordenação e o laço "última iteração vence" abaixo NÃO mudam com o filtro — só QUAIS
     # linhas entram na consulta muda.
     for msg in db.scalars(consulta_msgs).all():
         if msg.chat_id is not None:
@@ -634,14 +646,16 @@ def unread_client_ids(db: Session) -> set[str]:
     A sessão já chega escopada por RLS (mesma convenção de `list_conversations`).
 
     O desempate de mensagens no mesmo instante TEM que ser o mesmo dos dois lados, ou as duas
-    funções divergem em silêncio no exato caso que a paridade deveria pegar (duas mensagens do
-    mesmo chat na mesma transação, uma `in` outra `out` — o board diria uma coisa, a caixa de
-    entrada diria outra). Por isso a query abaixo não pergunta "existe ALGUMA mensagem `in`
-    empatada no topo" — isso seria um teste existencial, não "qual é a última mensagem" — ela
-    elege exatamente UMA linha por chat via `row_number() OVER (... ORDER BY created_at DESC,
-    id DESC)`, o mesmo par `(created_at, id)` que `list_conversations` usa (lá em ordem
-    crescente, "a última iteração vence" — aqui em ordem decrescente, "a primeira linha vence";
-    os dois pegam a mesma mensagem).
+    funções podem divergir em silêncio (duas mensagens do mesmo chat na mesma transação, uma
+    `in` outra `out` — o board diria uma coisa, a caixa de entrada diria outra). Por isso a
+    query abaixo não pergunta "existe ALGUMA mensagem `in` empatada no topo" — isso seria um
+    teste existencial, não "qual é a última mensagem" — ela elege exatamente UMA linha por chat
+    via `row_number() OVER (... ORDER BY created_at DESC, id DESC)`, o mesmo par
+    `(created_at, id)` que `list_conversations` usa (lá em ordem crescente, "a última iteração
+    vence" — aqui em ordem decrescente, "a primeira linha vence"; os dois pegam a mesma
+    mensagem). Sobre o quanto o teste de paridade realmente PROVA isso — e o que ele deixa
+    passar se alguém só apagar o `id` do `ORDER BY` — ver o comentário no laço de
+    `list_conversations` acima, junto ao mesmo desempate.
     """
     ultima_por_chat = (
         select(
@@ -679,13 +693,21 @@ def get_chat(db: Session, *, chat_id: str) -> WhatsappChat:
     return chat
 
 
-def get_timeline(db: Session, *, chat_id: str) -> list[dict]:
+def get_timeline(db: Session, *, chat_id: str, limit: int | None = None) -> list[dict]:
     """Mescla WhatsappMessage (a conversa) + Notification(channel=whatsapp) do cliente vinculado
     (avisos automáticos já existentes: cobrança, contrato, etc.) — leitura combinada, SEM
     migrar nenhum dado antigo (ver design doc §2).
 
     Os avisos automáticos só entram quando a conversa tem cliente: eles são endereçados a um
-    contato do CRM, e grupo não tem um."""
+    contato do CRM, e grupo não tem um.
+
+    `limit`, quando informado, corta para as N entradas mais recentes do CONJUNTO MESCLADO — não
+    N de cada fonte (mensagem e notificação são ordenadas juntas antes do corte). "N de cada
+    fonte" devolveria um recorte errado: uma conversa com 3 notificações recentes e 200
+    mensagens antigas mostraria as notificações inteiras e nenhuma mensagem, quando o pedido é
+    "as 5 falas mais recentes, seja qual for a origem". A tela de Conversas não passa `limit`
+    (quer o histórico inteiro, como hoje); a ficha 360° passa 5 — sem isto ela baixava a
+    conversa inteira do WhatsApp só para mostrar cinco bolhas (ver BlocoDaConversa.tsx)."""
     chat = get_chat(db, chat_id=chat_id)
     entries: list[dict] = []
     for msg in db.scalars(
@@ -726,6 +748,12 @@ def get_timeline(db: Session, *, chat_id: str) -> list[dict]:
                 "created_at": notif.created_at,
             })
     entries.sort(key=lambda e: e["created_at"])
+    if limit is not None:
+        # Corte pelo FIM da lista ascendente = as mais recentes, na mesma ordem (ascendente) que
+        # a tela de Conversas já espera. `limit <= 0` como "nada" e não "tudo": um `[-0:]` bateria
+        # com a lista inteira por acaso da aritmética de slice do Python, e uma chamada com limite
+        # zero pedindo "nada" não pode devolver "tudo" por causa disso.
+        entries = entries[-limit:] if limit > 0 else []
     return entries
 
 

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -550,19 +550,41 @@ def list_conversations(
     `client_id` nulo e portanto nunca aparece filtrado — que é o correto: grupo não é contato
     do CRM. Um contato pode ter MAIS DE UMA conversa (`@lid` + telefone), então a lista
     filtrada não tem tamanho garantido de 1.
+
+    Com `client_id`, a carga de MENSAGENS também é restrita aos chats que sobreviveram ao
+    filtro (`WHERE chat_id IN (...)`) — sem isso, a ficha 360° materializaria todas as
+    mensagens do tenant a cada abertura de contato, o mesmo custo que esta função já paga
+    para a tela de Conversas (que o board evita chamando `unread_client_ids` em vez desta
+    função). Sem filtro, o caminho é o de sempre: nenhuma restrição, todas as mensagens.
     """
     consulta_chats = select(WhatsappChat)
     if client_id is not None:
         consulta_chats = consulta_chats.where(WhatsappChat.client_id == client_id)
     chats = {c.id: c for c in db.scalars(consulta_chats).all()}
+    if client_id is not None and not chats:
+        # Contato sem NENHUMA conversa — o caso comum na ficha 360° (a maioria dos contatos
+        # nunca escreveu). Sai cedo: um `IN (chats.keys())` vazio abaixo teria que virar
+        # `IN (NULL)` ou equivalente para não silenciosamente casar com TUDO (comportamento
+        # de `IN ()` varia por dialeto), e não há mensagem nenhuma a carregar mesmo.
+        return []
+
+    consulta_msgs = select(WhatsappMessage).order_by(
+        WhatsappMessage.created_at, WhatsappMessage.id
+    )
+    if client_id is not None:
+        # Restringe a carga aos chats já filtrados — sem isto o filtro só podaria o
+        # RESULTADO, e a função continuaria pagando o custo de materializar TODAS as
+        # mensagens do tenant para achar a última de cada chat.
+        consulta_msgs = consulta_msgs.where(WhatsappMessage.chat_id.in_(chats.keys()))
+
     last_msgs: dict[str, WhatsappMessage] = {}
     # Segunda chave de ordenação (`id`) é o desempate: duas mensagens do mesmo chat podem cair
     # no mesmo instante (mesma transação de ingestão), e sem uma chave estável "a última
     # mensagem" mudaria de corrida para corrida. `unread_client_ids` usa o MESMO desempate
-    # (created_at, id) — é o contrato que mantém as duas funções de acordo em empate.
-    for msg in db.scalars(
-        select(WhatsappMessage).order_by(WhatsappMessage.created_at, WhatsappMessage.id)
-    ).all():
+    # (created_at, id) — é o contrato que mantém as duas funções de acordo em empate. Esta
+    # ordenação e o laço "última iteração vence" abaixo NÃO mudam com o filtro — só QUAIS
+    # linhas entram na consulta muda.
+    for msg in db.scalars(consulta_msgs).all():
         if msg.chat_id is not None:
             last_msgs[msg.chat_id] = msg  # a última iteração (ordem crescente) vence
 
@@ -596,7 +618,8 @@ def unread_client_ids(db: Session) -> set[str]:
 
     ⚠️ ESTA É A MESMA REGRA de `list_conversations` acima ("a última mensagem da conversa é do
     contato e chegou depois do `last_read_at`"), escrita uma segunda vez. Mexeu em uma, mexa na
-    outra — `test_whatsapp_inbox_nao_lidas.py::test_unread_client_ids_concorda_com_list_conversations`
+    outra —
+    `test_whatsapp_inbox_nao_lidas.py::test_unread_client_ids_concorda_com_list_conversations`
     existe exatamente para pegar quem esquecer.
 
     A duplicação é deliberada: `list_conversations` materializa TODAS as mensagens do tenant

--- a/apps/api/tests/test_crm_board_nao_lida.py
+++ b/apps/api/tests/test_crm_board_nao_lida.py
@@ -1,0 +1,125 @@
+# apps/api/tests/test_crm_board_nao_lida.py
+"""O board do Kanban devolve `unread` por card — o ponto de 'esperando resposta'."""
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.modules.crm.models import Client
+from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
+    DIRECTION_IN,
+    WhatsappChat,
+    WhatsappMessage,
+)
+
+REGISTER = {
+    "legal_name": "Estúdio Ana",
+    "document": "11222333000181",
+    "slug": "estudioana",
+    "email": "ana@example.com",
+    "name": "Ana",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    """`/crm/board` é rota autenticada — sem isto tudo aqui é 401. Mesmo padrão de
+    `test_crm.py`."""
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _contato(client: TestClient, headers: dict[str, str], nome: str) -> str:
+    """Cria pela API, e não montando o modelo à mão.
+
+    O contato precisa nascer no tenant AUTENTICADO e na primeira etapa do funil — `POST
+    /crm/clients` faz as duas coisas (`create_client` chama `ensure_stages`). Um `Client(...)`
+    direto no banco com `tenant_id` inventado passaria em SQLite, onde não há RLS, e mediria
+    uma situação que não existe em produção.
+    """
+    resp = client.post("/crm/clients", json={"name": nome}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _conversa_esperando(db, client_id: str) -> None:
+    """Uma mensagem do contato, nunca lida. O `tenant_id` vem do próprio contato."""
+    contato = db.get(Client, client_id)
+    chat = WhatsappChat(
+        tenant_id=contato.tenant_id, chat_jid=f"5511{client_id[:9]}@s.whatsapp.net",
+        kind=CHAT_KIND_DIRECT, client_id=client_id,
+    )
+    db.add(chat)
+    db.commit()
+    db.add(WhatsappMessage(
+        tenant_id=contato.tenant_id, chat_id=chat.id, client_id=client_id,
+        direction=DIRECTION_IN, text_body="oi, tudo bem?",
+        created_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
+    ))
+    db.commit()
+
+
+def _cards(payload: dict) -> dict[str, dict]:
+    return {c["id"]: c for col in payload["columns"] for c in col["clients"]}
+
+
+def test_board_marca_unread_so_em_quem_espera_resposta(client, db, headers):
+    esperando = _contato(client, headers, "Quem escreveu")
+    quieto = _contato(client, headers, "Quem nao escreveu")
+    _conversa_esperando(db, esperando)
+
+    resp = client.get("/crm/board", headers=headers)
+    assert resp.status_code == 200
+    cards = _cards(resp.json())
+    assert cards[esperando]["unread"] is True
+    assert cards[quieto]["unread"] is False
+
+
+def test_board_unread_e_sempre_booleano(client, db, headers):
+    """Nunca `null`: o card decide mostrar o ponto ou não, e não tem terceiro estado."""
+    _contato(client, headers, "Sem conversa nenhuma")
+    cards = _cards(client.get("/crm/board", headers=headers).json())
+    assert cards, "o board veio sem card nenhum — o teste não mediu nada"
+    assert all(isinstance(c["unread"], bool) for c in cards.values())
+
+
+def _consultas_do_board(client, headers, engine) -> int:
+    """Quantas consultas SQL um GET /crm/board dispara."""
+    from sqlalchemy import event
+
+    contador = []
+
+    def _antes(_conn, _cursor, statement, _params, _context, _many):
+        contador.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _antes)
+    try:
+        assert client.get("/crm/board", headers=headers).status_code == 200
+    finally:
+        event.remove(engine, "before_cursor_execute", _antes)
+    return len(contador)
+
+
+def test_board_nao_faz_uma_consulta_por_card(client, db, headers):
+    """Dobrar os cards não pode dobrar as consultas.
+
+    O jeito errado de implementar `unread` é perguntar por contato, dentro do laço que monta
+    as colunas. Funciona no teste de duas linhas e derruba o board de quem tem 200 leads no
+    funil — e a falha é invisível em qualquer teste que só olhe o JSON de resposta.
+
+    Este é o mesmo motivo pelo qual `last_interaction_map` existe como consulta agrupada.
+    """
+    engine = db.get_bind()
+    for i in range(2):
+        _conversa_esperando(db, _contato(client, headers, f"Contato {i}"))
+    com_2 = _consultas_do_board(client, headers, engine)
+
+    for i in range(2, 8):
+        _conversa_esperando(db, _contato(client, headers, f"Contato {i}"))
+    com_8 = _consultas_do_board(client, headers, engine)
+
+    assert com_8 == com_2, (
+        f"{com_2} consultas com 2 cards e {com_8} com 8 — o custo está crescendo com os cards"
+    )

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -34,17 +34,24 @@ def _chat(db, *, jid: str, client_id: str | None, kind: str = CHAT_KIND_DIRECT,
     return chat
 
 
-def _msg(db, *, chat: WhatsappChat, direction: str, minutos: int, texto: str = "oi") -> None:
-    db.add(WhatsappMessage(
+def _msg(db, *, chat: WhatsappChat, direction: str, minutos: int, texto: str = "oi",
+         msg_id: str | None = None) -> None:
+    # `msg_id` só é passado quando o teste precisa CONTROLAR o desempate (duas mensagens no
+    # mesmo `created_at`): o `id` é o critério de desempate depois de `created_at`, e o default
+    # da coluna é um UUID aleatório — sem fixar o id, um teste de empate seria não-determinístico.
+    kwargs = dict(
         tenant_id=TENANT_ID, chat_id=chat.id, client_id=chat.client_id,
         direction=direction, text_body=texto,
         created_at=BASE + timedelta(minutes=minutos),
-    ))
+    )
+    if msg_id is not None:
+        kwargs["id"] = msg_id
+    db.add(WhatsappMessage(**kwargs))
     db.commit()
 
 
 def _cenario_completo(db) -> None:
-    """As cinco situações que a regra precisa distinguir."""
+    """As seis situações que a regra precisa distinguir."""
     # 1. Nunca lida, última é do contato → ESPERANDO RESPOSTA.
     c1 = _chat(db, jid="5511900000001@s.whatsapp.net", client_id="cli-1")
     _msg(db, chat=c1, direction=DIRECTION_IN, minutos=10)
@@ -71,8 +78,21 @@ def _cenario_completo(db) -> None:
     c5b = _chat(db, jid="99995@lid", client_id="cli-5")
     _msg(db, chat=c5b, direction=DIRECTION_IN, minutos=30)
 
+    # 6. EMPATE: duas mensagens do MESMO chat no MESMO instante, uma `in` outra `out`, nunca
+    #    lida. O desempate é (created_at, id) — aqui elege a de MAIOR id como "a última", e os
+    #    ids abaixo são escolhidos de propósito para que seja a `out` ("id-c6-out" > "id-c6-in"
+    #    na comparação de string). Contato EM DIA, portanto: a última mensagem de verdade é a
+    #    `out`, mesmo com a `in` empatada no mesmo instante. Uma checagem EXISTENCIAL ("existe
+    #    ALGUMA mensagem `in` empatada no topo?") erraria isso — acharia a `in` e marcaria como
+    #    esperando resposta. É este chat que faz o teste de paridade abaixo discriminar as duas
+    #    implementações: só a que pergunta "qual É a última" (não "existe alguma") concorda com
+    #    `list_conversations` aqui.
+    c6 = _chat(db, jid="5511900000006@s.whatsapp.net", client_id="cli-6")
+    _msg(db, chat=c6, direction=DIRECTION_IN, minutos=40, msg_id="id-c6-in")
+    _msg(db, chat=c6, direction=DIRECTION_OUT, minutos=40, msg_id="id-c6-out")
 
-def test_unread_client_ids_distingue_as_cinco_situacoes(db):
+
+def test_unread_client_ids_distingue_as_seis_situacoes(db):
     _cenario_completo(db)
     assert inbox_service.unread_client_ids(db) == {"cli-1", "cli-5"}
 

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -139,7 +139,65 @@ def test_list_conversations_filtrado_nunca_traz_grupo(db):
 
 
 def test_list_conversations_filtrado_contato_sem_conversa_devolve_vazio(db):
-    """A ficha 360° chama isto para TODO contato, e a maioria nunca escreveu — o filtro não
-    pode virar `IN ()` (que em alguns dialetos casa com tudo) nem lançar exceção."""
+    """A ficha 360° chama isto para TODO contato, e a maioria nunca escreveu — o caminho de
+    `client_id` sem nenhum chat correspondente precisa devolver lista vazia, não lançar."""
     _cenario_completo(db)
     assert inbox_service.list_conversations(db, TENANT_ID, client_id="cli-sem-conversa") == []
+
+
+def test_list_conversations_filtrado_nao_le_mensagem_de_outro_contato(db):
+    """Prova que o filtro `client_id` restringe a CONSULTA, não só o resultado em Python.
+
+    Um teste que só olha `len(retorno)` ou `{c["client_id"] for c in retorno}` passaria
+    IGUAL se a filtragem fosse feita depois de carregar toda mensagem do tenant em memória
+    (o bug que o Finding 2 do review corrigiu) — o resultado final seria o mesmo, só o CUSTO
+    mudaria, e nenhuma assert sobre o JSON de saída enxerga custo.
+
+    Por isso este teste captura a consulta SQL de fato disparada (via `before_cursor_execute`,
+    mesma técnica de `test_crm_board_nao_lida.py::test_board_nao_faz_uma_consulta_por_card`) e
+    REEXECUTA essa consulta capturada numa conexão nova, contando quantas LINHAS ela devolve.
+    Se a query estiver restrita a `chat_id IN (...)` do contato-alvo, ela traz só a mensagem
+    dele. Se alguém reverter a restrição, a mesma consulta capturada volta a trazer todas as
+    mensagens do tenant — e é exatamente essa diferença de contagem que este teste mede.
+    """
+    from sqlalchemy import event
+
+    alvo = _chat(db, jid="5511900000010@s.whatsapp.net", client_id="cli-alvo")
+    _msg(db, chat=alvo, direction=DIRECTION_IN, minutos=1)
+
+    # Ruído: várias mensagens de OUTROS contatos, para que "ler tudo" e "ler só o alvo"
+    # produzam contagens bem diferentes (não bastaria 1 mensagem de ruído — 1 versus 2 também
+    # discrimina, mas fica frágil a qualquer ajuste incidental de cenário).
+    for i in range(10):
+        outro = _chat(db, jid=f"5511900002{i:03d}@s.whatsapp.net", client_id=f"cli-ruido-{i}")
+        _msg(db, chat=outro, direction=DIRECTION_IN, minutos=i)
+
+    engine = db.get_bind()
+    capturado: dict[str, object] = {}
+
+    def _antes(_conn, _cursor, statement, params, _context, _many):
+        # `whatsapp_chats` também é consultada nesta chamada — filtramos pela tabela de
+        # mensagens, que é a única cujo CUSTO este teste está medindo.
+        if "whatsapp_messages" in statement:
+            capturado["statement"] = statement
+            capturado["params"] = params
+
+    event.listen(engine, "before_cursor_execute", _antes)
+    try:
+        resultado = inbox_service.list_conversations(db, TENANT_ID, client_id="cli-alvo")
+    finally:
+        event.remove(engine, "before_cursor_execute", _antes)
+
+    assert resultado, "cenário não mediu nada — o contato-alvo devia ter 1 conversa"
+    assert "statement" in capturado, "nenhuma consulta a whatsapp_messages foi capturada"
+
+    # Reexecuta a MESMA consulta (texto + parâmetros) capturada, numa conexão nova — não
+    # confiamos em contar chamadas nem em ler o texto do SQL à procura de "WHERE"/"IN"
+    # (frágil a reformatação); contamos as LINHAS que a consulta de fato traz.
+    with engine.connect() as conn:
+        linhas = conn.exec_driver_sql(capturado["statement"], capturado["params"]).fetchall()
+
+    assert len(linhas) == 1, (
+        f"a consulta de mensagens trouxe {len(linhas)} linha(s) para um filtro de 1 "
+        "contato com 1 mensagem — deveria trazer só a dele, não o ruído dos outros 10"
+    )

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -114,3 +114,25 @@ def test_unread_client_ids_concorda_com_list_conversations(db):
 def test_unread_client_ids_vazio_sem_mensagem(db):
     _chat(db, jid="5511900000009@s.whatsapp.net", client_id="cli-9")
     assert inbox_service.unread_client_ids(db) == set()
+
+
+def test_list_conversations_filtra_por_client_id(db):
+    _cenario_completo(db)
+    do_contato = inbox_service.list_conversations(db, TENANT_ID, client_id="cli-5")
+    assert len(do_contato) == 2  # o caso `@lid` + telefone: duas conversas, um contato
+    assert {c["client_id"] for c in do_contato} == {"cli-5"}
+
+
+def test_list_conversations_sem_filtro_continua_trazendo_grupo(db):
+    """O filtro é OPCIONAL e não pode mudar o comportamento da tela de Conversas."""
+    _cenario_completo(db)
+    todas = inbox_service.list_conversations(db, TENANT_ID)
+    assert any(c["kind"] == "group" for c in todas)
+
+
+def test_list_conversations_filtrado_nunca_traz_grupo(db):
+    """Grupo tem `client_id` nulo — filtrar por contato jamais pode trazê-lo."""
+    _cenario_completo(db)
+    for cid in ("cli-1", "cli-5"):
+        assert all(c["kind"] != "group" for c in inbox_service.list_conversations(
+            db, TENANT_ID, client_id=cid))

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -1,0 +1,96 @@
+# apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+"""`unread_client_ids` — o agregado que alimenta o ponto do card do Kanban.
+
+O teste central aqui é o de PARIDADE. A regra de "não lida" vive inline dentro de
+`list_conversations`; este agregado é uma segunda expressão da mesma regra, escrita porque
+`list_conversations` carrega todas as mensagens do tenant em memória e o board não pode pagar
+isso. Duas expressões da mesma regra divergem em silêncio — o card diria "esperando resposta"
+com a caixa de entrada limpa. O teste de paridade é o que impede isso.
+"""
+from datetime import UTC, datetime, timedelta
+
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
+    CHAT_KIND_GROUP,
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    WhatsappChat,
+    WhatsappMessage,
+)
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+BASE = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+
+
+def _chat(db, *, jid: str, client_id: str | None, kind: str = CHAT_KIND_DIRECT,
+          last_read_at: datetime | None = None) -> WhatsappChat:
+    chat = WhatsappChat(
+        tenant_id=TENANT_ID, chat_jid=jid, kind=kind, title=jid,
+        client_id=client_id, last_read_at=last_read_at,
+    )
+    db.add(chat)
+    db.commit()
+    return chat
+
+
+def _msg(db, *, chat: WhatsappChat, direction: str, minutos: int, texto: str = "oi") -> None:
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, chat_id=chat.id, client_id=chat.client_id,
+        direction=direction, text_body=texto,
+        created_at=BASE + timedelta(minutes=minutos),
+    ))
+    db.commit()
+
+
+def _cenario_completo(db) -> None:
+    """As cinco situações que a regra precisa distinguir."""
+    # 1. Nunca lida, última é do contato → ESPERANDO RESPOSTA.
+    c1 = _chat(db, jid="5511900000001@s.whatsapp.net", client_id="cli-1")
+    _msg(db, chat=c1, direction=DIRECTION_IN, minutos=10)
+
+    # 2. Lida DEPOIS da última mensagem → em dia.
+    c2 = _chat(db, jid="5511900000002@s.whatsapp.net", client_id="cli-2",
+               last_read_at=BASE + timedelta(minutes=99))
+    _msg(db, chat=c2, direction=DIRECTION_IN, minutos=10)
+
+    # 3. Última mensagem é NOSSA → em dia, mesmo sem nunca ter sido "lida".
+    c3 = _chat(db, jid="5511900000003@s.whatsapp.net", client_id="cli-3")
+    _msg(db, chat=c3, direction=DIRECTION_IN, minutos=10)
+    _msg(db, chat=c3, direction=DIRECTION_OUT, minutos=20)
+
+    # 4. GRUPO com mensagem nova → nunca conta: grupo não é contato do CRM.
+    g = _chat(db, jid="120363000000000000@g.us", client_id=None, kind=CHAT_KIND_GROUP)
+    _msg(db, chat=g, direction=DIRECTION_IN, minutos=10)
+
+    # 5. DOIS chats para o MESMO contato (o caso `@lid` + telefone). Um em dia, outro não —
+    #    o contato aparece uma vez só, porque o conjunto é de CONTATOS, não de conversas.
+    c5a = _chat(db, jid="5511900000005@s.whatsapp.net", client_id="cli-5",
+                last_read_at=BASE + timedelta(minutes=99))
+    _msg(db, chat=c5a, direction=DIRECTION_IN, minutos=10)
+    c5b = _chat(db, jid="99995@lid", client_id="cli-5")
+    _msg(db, chat=c5b, direction=DIRECTION_IN, minutos=30)
+
+
+def test_unread_client_ids_distingue_as_cinco_situacoes(db):
+    _cenario_completo(db)
+    assert inbox_service.unread_client_ids(db) == {"cli-1", "cli-5"}
+
+
+def test_unread_client_ids_concorda_com_list_conversations(db):
+    """PARIDADE — a guarda contra as duas definições divergirem.
+
+    Se alguém ajustar a regra em um dos dois lugares e esquecer o outro, este teste cai.
+    """
+    _cenario_completo(db)
+    pela_caixa_de_entrada = {
+        c["client_id"]
+        for c in inbox_service.list_conversations(db, TENANT_ID)
+        if c["unread"] and c["client_id"]
+    }
+    assert inbox_service.unread_client_ids(db) == pela_caixa_de_entrada
+
+
+def test_unread_client_ids_vazio_sem_mensagem(db):
+    _chat(db, jid="5511900000009@s.whatsapp.net", client_id="cli-9")
+    assert inbox_service.unread_client_ids(db) == set()

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -136,3 +136,10 @@ def test_list_conversations_filtrado_nunca_traz_grupo(db):
     for cid in ("cli-1", "cli-5"):
         assert all(c["kind"] != "group" for c in inbox_service.list_conversations(
             db, TENANT_ID, client_id=cid))
+
+
+def test_list_conversations_filtrado_contato_sem_conversa_devolve_vazio(db):
+    """A ficha 360° chama isto para TODO contato, e a maioria nunca escreveu — o filtro não
+    pode virar `IN ()` (que em alguns dialetos casa com tudo) nem lançar exceção."""
+    _cenario_completo(db)
+    assert inbox_service.list_conversations(db, TENANT_ID, client_id="cli-sem-conversa") == []

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -1,6 +1,8 @@
 # apps/api/tests/test_whatsapp_inbox_service.py
 """Testes do serviço do inbox de WhatsApp: ingestão do webhook, lead automático, timeline
 unificada, janela de 24h, resposta (texto/mídia/template)."""
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from sqlalchemy import select
 
@@ -557,6 +559,62 @@ def test_get_timeline_merges_conversation_and_automated(db):
     timeline = inbox_service.get_timeline(db, chat_id=chat.id)
     sources = {e["source"] for e in timeline}
     assert sources == {"conversation", "automated"}
+
+
+def test_get_timeline_sem_limit_devolve_tudo(db):
+    """A tela de Conversas chama `get_timeline` sem `limit` e quer o histórico INTEIRO — o
+    comportamento de hoje não pode mudar quando o parâmetro simplesmente não é passado."""
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900006666", source="manual")
+    db.add(client)
+    db.flush()
+    chat = _chat_for(db, client)
+    base = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+    for i in range(12):
+        db.add(WhatsappMessage(
+            tenant_id=TENANT_ID, client_id=client.id, chat_id=chat.id, direction=DIRECTION_IN,
+            kind="text", text_body=f"m{i}", created_at=base + timedelta(minutes=i),
+        ))
+    db.commit()
+    timeline = inbox_service.get_timeline(db, chat_id=chat.id)
+    assert len(timeline) == 12
+    assert [e["text_body"] for e in timeline] == [f"m{i}" for i in range(12)]
+
+
+def test_get_timeline_limit_corta_as_mais_recentes_do_conjunto_mesclado(db):
+    """`limit` tem que cortar o CONJUNTO MESCLADO (mensagem + notificação) já ordenado por
+    instante — não N de cada fonte separadamente. Um corte "por fonte" (ex.: últimas N mensagens
+    + últimas N notificações) devolveria um recorte incorreto sempre que as duas fontes se
+    intercalam no tempo, que é exatamente o cenário abaixo."""
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900007777", source="manual")
+    db.add(client)
+    db.flush()
+    chat = _chat_for(db, client)
+    base = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+
+    # Intercaladas de propósito: m0(0) m1(10) n0(15) m2(20) m3(30) n1(35) m4(40) — a ordem real
+    # do conjunto mesclado. As 3 mais recentes do MESCLADO são m3, n1, m4 (30/35/40). "3 de cada
+    # fonte" incluiria m2 (20) por engano — é essa diferença que o teste prova.
+    for i, minutos in enumerate([0, 10, 20, 30, 40]):
+        db.add(WhatsappMessage(
+            tenant_id=TENANT_ID, client_id=client.id, chat_id=chat.id, direction=DIRECTION_IN,
+            kind="text", text_body=f"m{i}", created_at=base + timedelta(minutes=minutos),
+        ))
+    for i, minutos in enumerate([15, 35]):
+        db.add(Notification(
+            tenant_id=TENANT_ID, channel="whatsapp", recipient=client.phone, client_id=client.id,
+            message=f"n{i}", status="sent", created_at=base + timedelta(minutes=minutos),
+        ))
+    db.commit()
+
+    timeline = inbox_service.get_timeline(db, chat_id=chat.id, limit=3)
+    assert [e["text_body"] for e in timeline] == ["m3", "n1", "m4"]
+
+    # E sem `limit`, o mesmo cenário continua devolvendo as 7 entradas na ordem cronológica —
+    # prova de que o corte é aditivo (opt-in), não uma mudança do caminho sem `limit`.
+    tudo = inbox_service.get_timeline(db, chat_id=chat.id)
+    assert [e["text_body"] for e in tudo] == ["m0", "m1", "n0", "m2", "m3", "n1", "m4"]
 
 
 def test_send_reply_text_within_window(db, monkeypatch: pytest.MonkeyPatch):

--- a/apps/web/e2e/crm-360.spec.ts
+++ b/apps/web/e2e/crm-360.spec.ts
@@ -94,3 +94,27 @@ test("a origem não se parece com a tag", async ({ page }) => {
   expect(origem.croma).toBeLessThanOrEqual(8); // cinza (medido: 3)
   expect(tag.croma).toBeGreaterThanOrEqual(12); // roxo (medido: 18)
 });
+
+test("o ponto de mensagem esperando resposta não empurra o nome para fora", async ({ page }) => {
+  await page.goto("/crm");
+
+  // O ponto está no card MAIS CHEIO da fixture: nome longo + duas tags + alça de arrastar +
+  // botão de ficha. A linha do nome já era a mais disputada do card antes de ganhar inquilino.
+  const ponto = page.getByLabel("Mensagem esperando resposta");
+  await expect(ponto).toBeVisible();
+  await expect(ponto).toBeInViewport();
+
+  // O ponto tem `shrink-0`; quem cede é o nome, via `truncate`. A prova de que a divisão
+  // funciona é o ponto estar INTEIRO dentro do card — 8px de largura, não 3 amassados.
+  const caixaDoPonto = await ponto.boundingBox();
+  expect(caixaDoPonto?.width).toBeGreaterThanOrEqual(7);
+
+  // E nada da primeira coluna saiu da tela. Mesmo recorte `.w-72` e mesmo controle positivo
+  // do primeiro teste deste arquivo — sem o controle, um seletor que deixasse de casar
+  // aprovaria a tela para sempre.
+  expect(await textoForaDaTela(page, ".w-72")).toEqual([]);
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+});

--- a/apps/web/e2e/ficha-conversa-360.spec.ts
+++ b/apps/web/e2e/ficha-conversa-360.spec.ts
@@ -92,6 +92,10 @@ test("a conversa na ficha cabe em 360px, mesmo com texto sem espaço", async ({ 
   // conteúdo fora da tela por acidente para o seletor podre encontrar. Por isso o controle planta,
   // só para o instante desta asserção, um texto sem filhos fora da tela: prova de que a função
   // ENXERGA corte nesta página quando ele existe — e não que a fixture por acaso nunca produz um.
+  // O `<span>` acima é INLINE — some do DOM sozinho quando o Playwright fecha o contexto de
+  // teste ao final (não há `marca.remove()`: cada teste roda numa página nova). Ele só prova o
+  // caminho ANTIGO (`r.right`), o de sempre: inline reporta `scrollWidth === clientWidth === 0`,
+  // então nunca cai no ramo `scrollWidth`.
   await page.evaluate(() => {
     const marca = document.createElement("span");
     marca.textContent = "marca de controle positivo";
@@ -100,4 +104,32 @@ test("a conversa na ficha cabe em 360px, mesmo com texto sem espaço", async ({ 
     document.body.appendChild(marca);
   });
   expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});
+
+test("textoForaDaTela pega bloco SEM largura própria que vaza via scrollWidth", async ({ page }) => {
+  // Controle positivo do ramo NOVO (`scrollWidth`), que o teste acima não cobre: o `<span>` dele
+  // é inline e nunca cai nesse ramo (ver comentário lá). Revertendo `medidas.ts` para o
+  // `r.right` puro (o Finding 2 do review final), aquele teste continua passando — SEM
+  // ESTE aqui, o ponto cego que a Onda 1 fechou reabriria em silêncio.
+  //
+  // O elemento é um `<div>` de BLOCO (não `<span>`), sem `width` própria — herda a do contêiner
+  // por `display:block` — com um token sem espaço, hífen ou barra: não tem onde quebrar. É o
+  // cenário real que a bolha de chat expôs antes do `break-words` (ver o comentário no topo
+  // deste arquivo): a CAIXA fica presa na largura do contêiner, a tinta vaza sem alargá-la, e
+  // `getBoundingClientRect().right` não vê nada — só `scrollWidth` vê.
+  await page.goto("/crm/clients/c1");
+  await expect(page.getByRole("link", { name: "Abrir conversa" })).toBeVisible();
+
+  await page.evaluate(() => {
+    const bloco = document.createElement("div");
+    bloco.textContent =
+      "blocoDeTesteSemLarguraPropriaComUmTokenBemLongoSemEspacoQueVazaViaScrollWidth1234567890";
+    bloco.setAttribute("data-marca-scrollwidth-bloco", "");
+    document.querySelector('[data-testid="secao-conversa"]')?.appendChild(bloco);
+  });
+
+  const cortes = await textoForaDaTela(page, '[data-testid="secao-conversa"]');
+  const achado = cortes.find((c) => c.texto.startsWith("blocoDeTesteSemLarguraPropria"));
+  expect(achado).toBeDefined();
+  expect(achado!.forcaFora).toBeGreaterThan(0);
 });

--- a/apps/web/e2e/ficha-conversa-360.spec.ts
+++ b/apps/web/e2e/ficha-conversa-360.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O bloco de Conversa da ficha 360° em 360px.
+ *
+ * O caso que estoura uma bolha de chat não é texto longo — é texto longo SEM ESPAÇO, que não
+ * tem onde quebrar. `max-w-[85%]` limita a caixa e não o conteúdo: sem `break-words` o texto
+ * transborda a bolha e leva a página junto. É por isso que a mensagem de entrada abaixo é um
+ * token contínuo, sem espaço, hífen OU barra — uma URL não bastaria: `/` e `-` são pontos de
+ * quebra válidos por padrão do navegador (UAX #14), e um `lorem ipsum` teria espaço sobrando.
+ *
+ * ⚠️ Esta falta de espaço, hífen e barra também expôs um ponto cego em `textoForaDaTela`
+ * (`support/medidas.ts`): um bloco sem `width` própria mantém a CAIXA no tamanho do contêiner
+ * mesmo quando o texto não tem onde quebrar — a tinta vaza da caixa sem alargá-la, e
+ * `getBoundingClientRect` só vê caixa, não tinta. Como a ficha vive dentro do `<main
+ * overflow-x-hidden>` do `AppShell`, essa tinta era cortada em silêncio: nem a página rolava,
+ * nem a varredura via nada, e o teste passava com o texto de fato cortado no meio da palavra
+ * (confirmado por screenshot antes do conserto). `textoForaDaTela` agora também compara
+ * `scrollWidth` com `clientWidth` do próprio elemento — corrigido ali, não afrouxado aqui.
+ */
+const CONVERSA = {
+  chat_id: "chat-1",
+  kind: "direct",
+  title: "Ju",
+  phone: "554384035398",
+  client_id: "c1",
+  last_message_at: "2026-08-15T23:16:00Z",
+  last_message_preview: "Boa noite",
+  unread: false,
+};
+
+const fixtures = {
+  "/crm/clients/c1": {
+    id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: "554384035398",
+    document: null, gender: "unspecified", birthdate: null, notes: "", tags: [],
+    source: "whatsapp", stage_id: "s1", stage_entered_at: "2026-08-15T12:00:00Z",
+    created_at: "2026-08-15T12:00:00Z",
+  },
+  "/whatsapp-conversations/chat-1/timeline": [
+    {
+      source: "conversation", direction: "in", kind: "text",
+      text_body: "aReallyLongTokenWithNoSpacesSlashesOrHyphensThatSimulatesAWorstCasePayload1234567890",
+      media_attachment_id: null, purpose_label: null, sender_name: null,
+      created_at: "2026-08-15T23:10:00Z",
+    },
+    {
+      source: "conversation", direction: "out", kind: "text",
+      text_body: "Oi Ju! Aqui é do Doro Eventos. Recebemos seu contato e vamos te chamar pelo nosso número oficial.",
+      media_attachment_id: null, purpose_label: null, sender_name: null,
+      created_at: "2026-08-15T23:16:00Z",
+    },
+  ],
+  "/whatsapp-conversations": [CONVERSA],
+  // Mapeado de propósito: sem esta chave, o prefixo mais longo que casa é `/crm/clients/c1` e
+  // o `ClientTimeline` receberia o OBJETO do cliente onde espera `{entries, truncated}`. Ele
+  // degrada em vez de quebrar (`Array.isArray(data?.entries)`), mas o teste estaria medindo
+  // uma ficha sem Histórico — ou seja, uma tela mais curta que a real.
+  "/crm/clients/c1/timeline": { entries: [], truncated: false },
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, fixtures);
+});
+
+test("a conversa na ficha cabe em 360px, mesmo com texto sem espaço", async ({ page }) => {
+  await page.goto("/crm/clients/c1");
+
+  await expect(page.getByRole("link", { name: "Abrir conversa" })).toBeVisible();
+
+  // A PÁGINA não rola de lado. A ficha é uma coluna só — aqui, ao contrário do board, rolagem
+  // horizontal é defeito e não recurso.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // Varredura escopada à seção da conversa, com o controle positivo de sempre.
+  //
+  // ⚠️ O `<Section>` de `ClientDetailPage` é o MESMO componente para as sete seções da ficha
+  // (Histórico, Conversa, Cobranças, Contratos...) — todas renderizam `div.rounded-2xl.bg-white`,
+  // e `querySelector` devolve só a PRIMEIRA ocorrência no documento (mesma lógica do `.w-72` do
+  // `crm-360.spec.ts`, que pega a primeira coluna). Nesta página a primeira `.rounded-2xl.bg-white`
+  // é o CABEÇALHO do cliente (linha 86 do componente), não a Conversa — um seletor de classe
+  // teria medido a seção errada em silêncio. Por isso a seção ganhou `data-testid="secao-conversa"`.
+  expect(await textoForaDaTela(page, '[data-testid="secao-conversa"]')).toEqual([]);
+
+  // CONTROLE POSITIVO — mas diferente do `crm-360.spec.ts`. Lá o seletor podre cai no documento
+  // inteiro e pesca a segunda coluna do Kanban, que fica fora da tela DE PROPÓSITO. Aqui não: a
+  // ficha é coluna única e, correta, não tem NENHUM corte em lugar nenhum da página — não existe
+  // conteúdo fora da tela por acidente para o seletor podre encontrar. Por isso o controle planta,
+  // só para o instante desta asserção, um texto sem filhos fora da tela: prova de que a função
+  // ENXERGA corte nesta página quando ele existe — e não que a fixture por acaso nunca produz um.
+  await page.evaluate(() => {
+    const marca = document.createElement("span");
+    marca.textContent = "marca de controle positivo";
+    marca.style.cssText = "position:absolute;left:9999px;top:0;white-space:nowrap;";
+    marca.setAttribute("data-marca-controle-positivo", "");
+    document.body.appendChild(marca);
+  });
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});

--- a/apps/web/e2e/fixtures/crm.json
+++ b/apps/web/e2e/fixtures/crm.json
@@ -26,7 +26,8 @@
             "stage_id": "s1",
             "stage_entered_at": "2026-08-13T12:00:00Z",
             "created_at": "2026-08-13T12:00:00Z",
-            "last_interaction_at": "2026-08-13T12:00:00Z"
+            "last_interaction_at": "2026-08-13T12:00:00Z",
+            "unread": false
           },
           {
             "id": "c2",
@@ -43,7 +44,8 @@
             "stage_id": "s1",
             "stage_entered_at": "2026-08-12T09:30:00Z",
             "created_at": "2026-08-12T09:30:00Z",
-            "last_interaction_at": "2026-08-14T18:45:00Z"
+            "last_interaction_at": "2026-08-14T18:45:00Z",
+            "unread": true
           }
         ]
       },

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -131,9 +131,15 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       // elemento NÃO recorta a si mesmo (`overflow-x` computado é `visible`) — truncamento com
       // reticências (`.truncate`: `overflow:hidden` nele mesmo) também tem `scrollWidth >
       // clientWidth`, e ali é a UI funcionando como projetada, não um corte a denunciar.
+      //
+      // MÁXIMO entre os dois, nunca substituição: `scrollWidth` exclui borda, `r.right - r.left`
+      // inclui. Num elemento com borda onde `clientWidth < scrollWidth <= clientWidth +
+      // larguraDaBorda`, trocar `r.right` por `r.left + scrollWidth` teria devolvido um corte
+      // MENOR que o antigo caminho já enxergava — a régua ficando mais cega no exato ponto onde
+      // devia ficar mais afiada.
       const direita =
         getComputedStyle(el).overflowX === "visible" && el.scrollWidth > el.clientWidth + 0.5
-          ? r.left + el.scrollWidth
+          ? Math.max(r.right, r.left + el.scrollWidth)
           : r.right;
       const sobra = +(direita - limite).toFixed(1);
       if (sobra > 0.5) {

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -124,7 +124,18 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       if (el.children.length > 0 || !(el.textContent ?? "").trim()) continue;
       const r = el.getBoundingClientRect();
       const limite = Math.min(recorte(el).getBoundingClientRect().right, vw);
-      const sobra = +(r.right - limite).toFixed(1);
+      // A CAIXA nem sempre é o CONTEÚDO. Um bloco sem `width` própria fica travado na largura do
+      // contêiner mesmo quando o texto não tem onde quebrar (`overflow-wrap: normal` + palavra sem
+      // espaço) — a tinta vaza para fora da caixa sem alargá-la, e `getBoundingClientRect` não vê
+      // tinta, só caixa. `scrollWidth` vê: é o conteúdo real do próprio elemento. Só conta quando o
+      // elemento NÃO recorta a si mesmo (`overflow-x` computado é `visible`) — truncamento com
+      // reticências (`.truncate`: `overflow:hidden` nele mesmo) também tem `scrollWidth >
+      // clientWidth`, e ali é a UI funcionando como projetada, não um corte a denunciar.
+      const direita =
+        getComputedStyle(el).overflowX === "visible" && el.scrollWidth > el.clientWidth + 0.5
+          ? r.left + el.scrollWidth
+          : r.right;
+      const sobra = +(direita - limite).toFixed(1);
       if (sobra > 0.5) {
         fora.push({
           texto: (el.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 60),

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -78,6 +78,9 @@ export default function App() {
           <Route path="/crm" element={<CrmPage />} />
           <Route path="/crm/clients/:id" element={<ClientDetailPage />} />
           <Route path="/conversas" element={<ConversasPage />} />
+          {/* A conversa tem URL própria desde a Onda 1: é assim que a ficha 360° aponta para ela, e
+              de quebra o botão voltar do navegador passa a funcionar nesta tela. */}
+          <Route path="/conversas/:chatId" element={<ConversasPage />} />
           <Route path="/financeiro" element={<FinanceiroPage />} />
           <Route path="/financeiro/contas" element={<ContasSaldosPage />} />
           {/* Story 8.7 — rota DELIBERADAMENTE fora da sidebar: a conferência é resposta a um

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import ConversasPage from "./ConversasPage";
 
@@ -9,6 +9,15 @@ vi.mock("../../lib/api", () => ({
   api: { get: vi.fn(), post: vi.fn() },
   apiErrorMessage: (e: unknown) => String(e),
 }));
+
+// Nenhum teste deste arquivo depende de chamadas de um teste anterior — cada um remonta seu
+// próprio `mockImplementation`. Sem isto, o HISTÓRICO de chamadas (não só o resultado) vaza de
+// um teste para o próximo, o que já quebrou uma asserção `not.toHaveBeenCalledWith` real (ver
+// describe "a conversa tem URL própria"). `clearAllMocks`, não `resetAllMocks`: reset apagaria
+// a implementação que cada teste instala antes do reset ter chance de rodar de novo.
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function renderNaRota(rota: string) {
   return render(
@@ -367,12 +376,6 @@ describe("ConversasPage — painel de histórico", () => {
 
 /** Duas conversas, para que "abriu a certa" seja uma afirmação com conteúdo. */
 function mockarDuasConversas() {
-  // Este arquivo não zera os mocks entre testes (só o DOM, em test-setup.ts). As asserções
-  // abaixo checam QUAIS urls foram chamadas (não só o resultado final), então o histórico de
-  // chamadas dos testes anteriores no arquivo vazaria para cá sem isto — inclusive um
-  // "/whatsapp-conversations/c1/timeline" de outro describe, que quebraria o `not.toHaveBeenCalledWith`.
-  vi.mocked(api.get).mockClear();
-  vi.mocked(api.post).mockClear();
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/whatsapp-conversations") {
       return Promise.resolve({
@@ -436,6 +439,10 @@ describe("ConversasPage — a conversa tem URL própria", () => {
     renderNaRota("/conversas");
     await userEvent.click(await screen.findByText("Doro Eventos"));
     expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+    // A prova de que a URL realmente mudou (não só que "alguma" conversa abriu): o componente lê
+    // o id da URL via `useParams`, então uma timeline buscada para c1 só acontece se a rota virou
+    // /conversas/c1 — mesmo raciocínio do primeiro teste deste describe.
+    expect(api.get).toHaveBeenCalledWith("/whatsapp-conversations/c1/timeline");
   });
 
   it("chatId que não existe cai na lista com aviso, e não em tela branca", async () => {
@@ -443,5 +450,18 @@ describe("ConversasPage — a conversa tem URL própria", () => {
     renderNaRota("/conversas/nao-existe");
     expect(await screen.findByText(/conversa não encontrada/i)).toBeInTheDocument();
     expect(screen.getByText("Doro Eventos")).toBeInTheDocument();
+  });
+
+  it("chatId que não existe NÃO monta o painel de conversa nem bate a API dele", async () => {
+    // Achado da revisão: `mockarDuasConversas` responde `/timeline` para QUALQUER id (inclusive
+    // um inventado), então uma checagem só de "a tela não quebrou" não pega o painel montando por
+    // engano — o mock "concorda" alegremente com o id errado. A prova real é dupla: o campo de
+    // digitar (só existe com uma conversa aberta de verdade) não aparece, E a API do painel nunca
+    // foi chamada para o id que não existe.
+    mockarDuasConversas();
+    renderNaRota("/conversas/nao-existe");
+    await screen.findByText(/conversa não encontrada/i);
+    expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument();
+    expect(api.get).not.toHaveBeenCalledWith("/whatsapp-conversations/nao-existe/timeline");
   });
 });

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -465,3 +465,93 @@ describe("ConversasPage — a conversa tem URL própria", () => {
     expect(api.get).not.toHaveBeenCalledWith("/whatsapp-conversations/nao-existe/timeline");
   });
 });
+
+// ── "Ainda carregando" vs. "carregou e está vazia" ──────────────────────────
+//
+// Achado da revisão final: `naoEncontrada` exigia `conversations.length > 0`, então um tenant
+// SEM NENHUMA conversa nunca tornava essa condição verdadeira — um `/conversas/:id` de bookmark
+// velho ficava travado para sempre (não um flash: permanente). Os quatro testes abaixo cobrem os
+// estados que a distinção "carregou" vs. "não carregou ainda" precisa separar corretamente, e
+// verificam em cada um o invariante do celular: lista OU conversa, nunca as duas.
+
+/** No celular (jsdom não aplica CSS de verdade), a classe `hidden` é o que de fato esconde a
+ * coluna — checar direto na `className` em vez de `toBeVisible()`, que não enxerga Tailwind
+ * sem folha de estilo carregada. */
+function visivelNoCelular(el: HTMLElement): boolean {
+  return !el.className.split(/\s+/).includes("hidden");
+}
+
+describe("ConversasPage — carregando vs. vazia", () => {
+  it("chatId desconhecido num tenant SEM NENHUMA conversa mostra aviso, não fica travado", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderNaRota("/conversas/nao-existe");
+
+    expect(await screen.findByText(/conversa não encontrada/i)).toBeInTheDocument();
+    expect(screen.getByText(/nenhuma conversa ainda/i)).toBeInTheDocument();
+    // Lista visível (com o aviso), painel escondido — não os dois ao mesmo tempo no celular.
+    expect(visivelNoCelular(screen.getByTestId("lista-conversas"))).toBe(true);
+    expect(visivelNoCelular(screen.getByTestId("painel-conversa"))).toBe(false);
+  });
+
+  it("id válido ANTES da lista responder mostra um carregando neutro, nunca 'selecione uma conversa'", async () => {
+    // `/whatsapp-conversations` fica pendurada de propósito — simula o instante entre o mount e
+    // a resposta do fetch, que hoje (achado da revisão) mostrava "Selecione uma conversa" para
+    // um usuário que JÁ selecionou, via link ou bookmark.
+    let resolvePendente!: (v: unknown) => void;
+    const pendente = new Promise((resolve) => { resolvePendente = resolve; });
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") return pendente as Promise<never>;
+      if (url === "/whatsapp-conversations/c1/timeline") return Promise.resolve({ data: [] } as never);
+      // Janela aberta de propósito: sem isto o fio (uma vez montado) trocaria o campo de texto
+      // pelo seletor de template, e a asserção de `/mensagem/i` do fim deste teste erraria por
+      // um motivo que nada tem a ver com o que ele está provando.
+      if (url === "/whatsapp-conversations/c1/window") {
+        return Promise.resolve({ data: { within_session_window: true } } as never);
+      }
+      return Promise.resolve({ data: [] } as never);
+    });
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+
+    renderNaRota("/conversas/c1");
+
+    expect(await screen.findByText(/carregando conversa/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^selecione uma conversa$/i)).not.toBeInTheDocument();
+    // Lista escondida, painel (com o carregando) visível — mesmo invariante do celular.
+    expect(visivelNoCelular(screen.getByTestId("lista-conversas"))).toBe(false);
+    expect(visivelNoCelular(screen.getByTestId("painel-conversa"))).toBe(true);
+
+    resolvePendente({
+      data: [{
+        chat_id: "c1", kind: "direct" as const, title: "Ju", phone: "5511999998888",
+        client_id: "cli-1", last_message_at: "2026-08-15T23:10:00Z",
+        last_message_preview: "Boa noite", unread: false,
+      }],
+    });
+    // Resolveu e achou a conversa: o carregando neutro dá lugar ao fio de verdade.
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+    expect(screen.queryByText(/carregando conversa/i)).not.toBeInTheDocument();
+  });
+
+  it("/conversas sem id mostra só a lista, painel escondido — sem carregando nem aviso", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas");
+
+    expect(await screen.findByText("Doro Eventos")).toBeInTheDocument();
+    expect(screen.queryByText(/carregando conversa/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/conversa não encontrada/i)).not.toBeInTheDocument();
+    expect(visivelNoCelular(screen.getByTestId("lista-conversas"))).toBe(true);
+    expect(visivelNoCelular(screen.getByTestId("painel-conversa"))).toBe(false);
+  });
+
+  it("chatId válido, tenant COM conversas: lista some no celular, painel mostra o fio", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas/c1");
+
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+    expect(visivelNoCelular(screen.getByTestId("lista-conversas"))).toBe(false);
+    expect(visivelNoCelular(screen.getByTestId("painel-conversa"))).toBe(true);
+  });
+});

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import ConversasPage from "./ConversasPage";
@@ -8,6 +9,17 @@ vi.mock("../../lib/api", () => ({
   api: { get: vi.fn(), post: vi.fn() },
   apiErrorMessage: (e: unknown) => String(e),
 }));
+
+function renderNaRota(rota: string) {
+  return render(
+    <MemoryRouter initialEntries={[rota]}>
+      <Routes>
+        <Route path="/conversas" element={<ConversasPage />} />
+        <Route path="/conversas/:chatId" element={<ConversasPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
 
 describe("ConversasPage", () => {
   it("lista as conversas e mostra o fio ao clicar numa delas", async () => {
@@ -38,7 +50,7 @@ describe("ConversasPage", () => {
     });
     vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
 
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await waitFor(() => screen.getByText("Doro Eventos"));
     await userEvent.click(screen.getByText("Doro Eventos"));
     // A prévia da lista e o corpo da mensagem no fio coincidem neste fixture, então mais de um
@@ -90,7 +102,7 @@ describe("ConversasPage", () => {
     });
     vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
 
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await waitFor(() => screen.getByText("Murilo Moreschi"));
     await userEvent.click(screen.getByText("Murilo Moreschi"));
     await waitFor(() => screen.getByText("sempre na curva"));
@@ -149,7 +161,7 @@ describe("ConversasPage", () => {
     });
     vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
 
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await waitFor(() => screen.getByText("Automação Residencial"));
     await userEvent.click(screen.getByText("Automação Residencial"));
 
@@ -194,7 +206,7 @@ describe("ConversasPage", () => {
       return Promise.resolve({ data: [] });
     });
 
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await waitFor(() => screen.getByText("Cliente Antigo"));
     await userEvent.click(screen.getByText("Cliente Antigo"));
     await waitFor(() => expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument());
@@ -251,7 +263,7 @@ describe("ConversasPage", () => {
     });
     vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
 
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await waitFor(() => screen.getByText("Cliente A"));
 
     await userEvent.click(screen.getByText("Cliente A"));
@@ -310,7 +322,7 @@ function mockarConversas(conversas: unknown[]) {
 describe("ConversasPage — painel de histórico", () => {
   it("conversa direta com contato mostra o histórico do CRM", async () => {
     mockarConversas([CONVERSA_DIRETA]);
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await userEvent.click(await screen.findByText("Flavio Kato"));
 
     expect(await screen.findByTestId("painel-historico")).toBeInTheDocument();
@@ -319,7 +331,7 @@ describe("ConversasPage — painel de histórico", () => {
 
   it("conversa de grupo diz em TEXTO que não há contato ligado", async () => {
     mockarConversas([GRUPO]);
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await userEvent.click(await screen.findByText("Turma 2026"));
 
     expect(
@@ -332,7 +344,7 @@ describe("ConversasPage — painel de histórico", () => {
     // configuração de `advanceTimers` e falha de forma confusa sem ela.
     vi.useFakeTimers();
     mockarConversas([CONVERSA_DIRETA]);
-    render(<ConversasPage />);
+    renderNaRota("/conversas");
     await vi.advanceTimersByTimeAsync(0);      // resolve a carga inicial das conversas
     fireEvent.click(screen.getByText("Flavio Kato"));
     await vi.advanceTimersByTimeAsync(0);      // resolve a carga da timeline
@@ -348,5 +360,88 @@ describe("ConversasPage — painel de histórico", () => {
     await vi.advanceTimersByTimeAsync(21_000); // 3 ciclos de POLL_MS
     expect(chamadasDeTimeline()).toBe(antes);
     vi.useRealTimers();
+  });
+});
+
+// ── Conversa com URL própria ────────────────────────────────────────────────
+
+/** Duas conversas, para que "abriu a certa" seja uma afirmação com conteúdo. */
+function mockarDuasConversas() {
+  // Este arquivo não zera os mocks entre testes (só o DOM, em test-setup.ts). As asserções
+  // abaixo checam QUAIS urls foram chamadas (não só o resultado final), então o histórico de
+  // chamadas dos testes anteriores no arquivo vazaria para cá sem isto — inclusive um
+  // "/whatsapp-conversations/c1/timeline" de outro describe, que quebraria o `not.toHaveBeenCalledWith`.
+  vi.mocked(api.get).mockClear();
+  vi.mocked(api.post).mockClear();
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/whatsapp-conversations") {
+      return Promise.resolve({
+        data: [
+          {
+            chat_id: "c1", kind: "direct" as const, title: "Doro Eventos",
+            phone: "5511999999999", client_id: "cli-1",
+            last_message_at: "2026-07-19T10:00:00Z",
+            last_message_preview: "Oi, quero o cardápio", unread: true,
+          },
+          {
+            chat_id: "c2", kind: "direct" as const, title: "Murilo Moreschi",
+            phone: "5511977776666", client_id: "cli-2",
+            last_message_at: "2026-07-20T11:00:00Z",
+            last_message_preview: "Ok", unread: false,
+          },
+        ],
+      });
+    }
+    if (url.endsWith("/timeline")) {
+      return Promise.resolve({
+        data: [{
+          source: "conversation", direction: "in", kind: "text",
+          text_body: "Oi, quero o cardápio", media_attachment_id: null,
+          purpose_label: null, sender_name: null, created_at: "2026-07-19T10:00:00Z",
+        }],
+      });
+    }
+    if (url.endsWith("/window")) {
+      return Promise.resolve({ data: { within_session_window: true } });
+    }
+    if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+    return Promise.resolve({ data: [] });
+  });
+  // Abrir uma conversa dispara POST /{id}/read. Sem isto o `await` recebe undefined e o
+  // teste passa por acidente — melhor mockar do que depender disso.
+  vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+}
+
+describe("ConversasPage — a conversa tem URL própria", () => {
+  it("com /conversas/:chatId, abre aquela conversa direto", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas/c2");
+    // O campo de digitar só existe quando uma conversa está aberta.
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+    // E abriu a CERTA: a prova é qual timeline foi buscada, não o título na tela — título
+    // aparece na lista também, e a asserção ficaria verde com a conversa errada aberta.
+    expect(api.get).toHaveBeenCalledWith("/whatsapp-conversations/c2/timeline");
+    expect(api.get).not.toHaveBeenCalledWith("/whatsapp-conversations/c1/timeline");
+  });
+
+  it("com /conversas, mostra a lista sem nenhuma conversa aberta", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas");
+    expect(await screen.findByText("Doro Eventos")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument();
+  });
+
+  it("clicar numa conversa muda a URL", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas");
+    await userEvent.click(await screen.findByText("Doro Eventos"));
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+  });
+
+  it("chatId que não existe cai na lista com aviso, e não em tela branca", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas/nao-existe");
+    expect(await screen.findByText(/conversa não encontrada/i)).toBeInTheDocument();
+    expect(screen.getByText("Doro Eventos")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -3,6 +3,7 @@ import type {
 } from "@e1p/shared-types";
 import { ChevronLeft, History, Paperclip, Send, Users, X } from "lucide-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
 import { formatDate, formatTime } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
@@ -45,7 +46,11 @@ function listStamp(iso: string | null, tz: string): string {
 export default function ConversasPage() {
   const fuso = useFuso();
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
-  const [selected, setSelected] = useState<string | null>(null);
+  // A conversa aberta é a da URL, não estado local. Isso é o que permite a ficha 360° apontar
+  // para uma conversa específica — e faz o botão voltar do navegador funcionar aqui.
+  const { chatId } = useParams();
+  const navigate = useNavigate();
+  const selected = chatId ?? null;
   // Abaixo de `lg` o painel de histórico é uma GAVETA, não uma coluna (ver o comentário no
   // <aside>). Este estado só governa a gaveta; em `lg+` a coluna aparece sempre.
   const [historicoAberto, setHistoricoAberto] = useState(false);
@@ -62,6 +67,11 @@ export default function ConversasPage() {
   }, [loadConversations]);
 
   const conversaSelecionada = conversations.find((c) => c.chat_id === selected) ?? null;
+  // Id que não existe (link velho, conversa apagada) não pode virar tela branca: a lista já
+  // carregou, então mostramos ela com um aviso. `conversations.length > 0` evita o falso aviso
+  // no primeiro render, antes de a lista chegar.
+  const naoEncontrada = selected !== null && conversaSelecionada === null
+    && conversations.length > 0;
 
   return (
     <div className="flex h-[calc(100vh-8rem)] gap-4">
@@ -73,12 +83,17 @@ export default function ConversasPage() {
           assim desde sempre; a divisão principal é que nunca foi tratada. */}
       <div
         className={`w-full shrink-0 overflow-y-auto rounded-2xl bg-white shadow-sm lg:w-80 ${
-          selected ? "hidden lg:block" : "block"
+          selected && !naoEncontrada ? "hidden lg:block" : "block"
         }`}
       >
         <div className="border-b border-neutral-100 p-4">
           <h1 className="font-semibold text-neutral-800">Conversas</h1>
         </div>
+        {naoEncontrada && (
+          <p className="border-b border-amber-100 bg-amber-50 p-3 text-xs text-amber-700">
+            Conversa não encontrada. Escolha uma da lista.
+          </p>
+        )}
         {conversations.length === 0 ? (
           <p className="p-4 text-sm text-neutral-400">Nenhuma conversa ainda.</p>
         ) : (
@@ -86,7 +101,7 @@ export default function ConversasPage() {
             <button
               key={c.chat_id}
               onClick={() => {
-                setSelected(c.chat_id);
+                navigate(`/conversas/${c.chat_id}`);
                 setHistoricoAberto(false);
               }}
               className={`block w-full border-b border-neutral-50 px-4 py-3 text-left hover:bg-neutral-50 ${
@@ -125,7 +140,7 @@ export default function ConversasPage() {
             chatId={selected}
             chat={conversations.find((c) => c.chat_id === selected) ?? null}
             onSent={loadConversations}
-            onVoltar={() => setSelected(null)}
+            onVoltar={() => navigate("/conversas")}
           />
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-neutral-400">

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -131,10 +131,18 @@ export default function ConversasPage() {
       </div>
       <div
         className={`min-w-0 flex-1 rounded-2xl bg-white shadow-sm ${
-          selected ? "block" : "hidden lg:block"
+          selected && !naoEncontrada ? "block" : "hidden lg:block"
         }`}
       >
-        {selected ? (
+        {/* `conversaSelecionada` (não só `!naoEncontrada`) de propósito: no primeiro render, antes
+            da lista carregar, `naoEncontrada` ainda é `false` (ver o comentário acima) — sem esta
+            checagem extra o painel montava otimisticamente para QUALQUER id da URL, inclusive um
+            inventado, disparando `/timeline` e `/window` para uma conversa que não existe antes
+            de sabermos se ela existe. Exigir a conversa encontrada faz o painel esperar a lista
+            carregar antes de buscar qualquer coisa — para um id válido isso é imperceptível (a
+            lista já estava carregada quando o clique aconteceu); para um id inválido, o painel
+            simplesmente nunca chega a montar. */}
+        {selected && !naoEncontrada && conversaSelecionada ? (
           <ConversationThread
             key={selected}
             chatId={selected}

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -46,6 +46,14 @@ function listStamp(iso: string | null, tz: string): string {
 export default function ConversasPage() {
   const fuso = useFuso();
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  // Distingue "a lista ainda não respondeu" de "a lista respondeu e está vazia" — as duas
+  // batiam no mesmo `conversations.length === 0` antes desta flag, e um tenant SEM nenhuma
+  // conversa não tinha como sair do primeiro caso: `naoEncontrada` (abaixo) exigia
+  // `conversations.length > 0`, que para esse tenant nunca vira verdade. Um `/conversas/:id`
+  // de um bookmark velho ficava preso para sempre — não um flash, um estado permanente (lista
+  // some no celular, painel travado em "Selecione uma conversa", botão de histórico apontando
+  // para nada). Setada uma vez, no `finally` do primeiro fetch que resolve.
+  const [listaCarregada, setListaCarregada] = useState(false);
   // A conversa aberta é a da URL, não estado local. Isso é o que permite a ficha 360° apontar
   // para uma conversa específica — e faz o botão voltar do navegador funcionar aqui.
   const { chatId } = useParams();
@@ -56,8 +64,17 @@ export default function ConversasPage() {
   const [historicoAberto, setHistoricoAberto] = useState(false);
 
   const loadConversations = useCallback(async () => {
-    const { data } = await api.get<ConversationSummary[]>("/whatsapp-conversations");
-    setConversations(data);
+    try {
+      const { data } = await api.get<ConversationSummary[]>("/whatsapp-conversations");
+      setConversations(data);
+    } finally {
+      // No `finally`, não no `try`: mesmo se a primeira chamada falhar, "ainda carregando"
+      // não pode durar para sempre — mas sucesso e falha são tratados como "resolveu", não
+      // como "resolveu com dado válido". Não há tela de erro dedicada aqui porque o polling
+      // de 7s já tenta de novo sozinho; um "carregando" perene em caso de erro seria pior que
+      // deixar a próxima rodada corrigir.
+      setListaCarregada(true);
+    }
   }, []);
 
   useEffect(() => {
@@ -68,10 +85,10 @@ export default function ConversasPage() {
 
   const conversaSelecionada = conversations.find((c) => c.chat_id === selected) ?? null;
   // Id que não existe (link velho, conversa apagada) não pode virar tela branca: a lista já
-  // carregou, então mostramos ela com um aviso. `conversations.length > 0` evita o falso aviso
-  // no primeiro render, antes de a lista chegar.
-  const naoEncontrada = selected !== null && conversaSelecionada === null
-    && conversations.length > 0;
+  // carregou (`listaCarregada`), então mostramos ela com um aviso. Antes disto resolver, não é
+  // "não encontrada" — é "ainda não sabemos", e o painel abaixo trata os dois casos de forma
+  // diferente (ver comentário lá).
+  const naoEncontrada = listaCarregada && selected !== null && conversaSelecionada === null;
 
   return (
     <div className="flex h-[calc(100vh-8rem)] gap-4">
@@ -82,6 +99,7 @@ export default function ConversasPage() {
           jornada inteira do contato. A gaveta do histórico (mais abaixo) já tratava o celular
           assim desde sempre; a divisão principal é que nunca foi tratada. */}
       <div
+        data-testid="lista-conversas"
         className={`w-full shrink-0 overflow-y-auto rounded-2xl bg-white shadow-sm lg:w-80 ${
           selected && !naoEncontrada ? "hidden lg:block" : "block"
         }`}
@@ -130,18 +148,24 @@ export default function ConversasPage() {
         )}
       </div>
       <div
+        data-testid="painel-conversa"
         className={`min-w-0 flex-1 rounded-2xl bg-white shadow-sm ${
           selected && !naoEncontrada ? "block" : "hidden lg:block"
         }`}
       >
-        {/* `conversaSelecionada` (não só `!naoEncontrada`) de propósito: no primeiro render, antes
-            da lista carregar, `naoEncontrada` ainda é `false` (ver o comentário acima) — sem esta
-            checagem extra o painel montava otimisticamente para QUALQUER id da URL, inclusive um
-            inventado, disparando `/timeline` e `/window` para uma conversa que não existe antes
-            de sabermos se ela existe. Exigir a conversa encontrada faz o painel esperar a lista
-            carregar antes de buscar qualquer coisa — para um id válido isso é imperceptível (a
-            lista já estava carregada quando o clique aconteceu); para um id inválido, o painel
-            simplesmente nunca chega a montar. */}
+        {/* `conversaSelecionada` (não só `!naoEncontrada`) de propósito: mesmo depois de
+            `listaCarregada` virar `true`, exigir a conversa encontrada é o que impede o painel
+            de montar otimisticamente para QUALQUER id da URL, inclusive um inventado, disparando
+            `/timeline` e `/window` para uma conversa que não existe antes de sabermos se ela
+            existe. Para um id válido isso é imperceptível (a lista já estava carregada quando o
+            clique aconteceu); para um id inválido, o painel simplesmente nunca chega a montar.
+
+            Três estados, não dois — é por isso que existe o ramo do meio: um id na URL cuja
+            lista AINDA não respondeu (`!listaCarregada`) não é a mesma coisa que "nenhum id
+            selecionado". Antes desta distinção os dois caíam no mesmo "Selecione uma conversa" —
+            uma mensagem ativamente ERRADA para quem acabou de clicar/colar um link e está
+            esperando a resposta chegar. O rótulo neutro de carregamento evita prometer uma ação
+            ("selecione") que o usuário já tomou. */}
         {selected && !naoEncontrada && conversaSelecionada ? (
           <ConversationThread
             key={selected}
@@ -150,6 +174,10 @@ export default function ConversasPage() {
             onSent={loadConversations}
             onVoltar={() => navigate("/conversas")}
           />
+        ) : selected && !listaCarregada ? (
+          <div className="flex h-full items-center justify-center text-sm text-neutral-400">
+            Carregando conversa...
+          </div>
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-neutral-400">
             Selecione uma conversa

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -91,9 +91,48 @@ describe("BlocoDaConversa", () => {
     expect(screen.getByText(/\+1 outra conversa/i)).toBeInTheDocument();
   });
 
+  it("com três conversas, pluraliza corretamente o aviso da outras", async () => {
+    mockar([
+      { ...conversa("chat-1", "Ju"), last_message_at: "2026-08-01T10:00:00Z" },
+      { ...conversa("chat-2", "Ju"), last_message_at: "2026-08-05T10:00:00Z" },
+      { ...conversa("chat-3", "Ju"), last_message_at: "2026-08-15T23:10:00Z" },
+    ]);
+    renderBloco();
+    expect(await screen.findByText(/\+2 outras conversas/i)).toBeInTheDocument();
+  });
+
+  it("escolhe a conversa com data em vez da sem data, mesmo a sem data vindo primeiro", async () => {
+    // A sem-data aparece PRIMEIRO de propósito: se `maisRecente` naivamente pegasse o primeiro
+    // item da lista, o teste pegaria isso.
+    mockar([
+      { ...conversa("chat-sem-data", "Ju"), last_message_at: null },
+      { ...conversa("chat-com-data", "Ju"), last_message_at: "2026-08-10T10:00:00Z" },
+    ]);
+    renderBloco();
+    expect(await screen.findByRole("link", { name: /abrir conversa/i }))
+      .toHaveAttribute("href", "/conversas/chat-com-data");
+  });
+
   it("falha de rede vira aviso, não derruba a ficha", async () => {
     vi.mocked(api.get).mockRejectedValue(new Error("caiu"));
     renderBloco();
     expect(await screen.findByText(/não foi possível carregar a conversa/i)).toBeInTheDocument();
+  });
+
+  it("falha só na timeline (segunda chamada) também vira aviso, sem meio-render", async () => {
+    // A lista de conversas carrega bem — só o histórico de mensagens falha. Hoje as duas
+    // chamadas dividem um único try/catch, então o bloco inteiro degrada para o aviso. Este
+    // teste existe para pegar um futuro refactor que separe as duas chamadas e deixe o link
+    // "Abrir conversa" pendurado com a área de mensagens vazia, sem avisar o dono de nada.
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url.startsWith("/whatsapp-conversations?")) {
+        return Promise.resolve({ data: [conversa("chat-1", "Ju")] } as never);
+      }
+      if (url.includes("/timeline")) return Promise.reject(new Error("caiu no timeline"));
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderBloco();
+    expect(await screen.findByText(/não foi possível carregar a conversa/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /abrir conversa/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { api } from "../../lib/api";
+import BlocoDaConversa from "./BlocoDaConversa";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+
+const conversa = (chat_id: string, title: string) => ({
+  chat_id, kind: "direct", title, phone: "5511999998888",
+  client_id: "cli-1", last_message_at: "2026-08-15T23:10:00Z",
+  last_message_preview: "Boa noite", unread: false,
+});
+
+const mensagens = [
+  {
+    source: "conversation", direction: "in", kind: "text",
+    text_body: "Boa noite", media_attachment_id: null, purpose_label: null,
+    sender_name: null, created_at: "2026-08-15T23:10:00Z",
+  },
+  {
+    source: "conversation", direction: "out", kind: "text",
+    text_body: "Oi Ju, tudo bem?", media_attachment_id: null, purpose_label: null,
+    sender_name: null, created_at: "2026-08-15T23:16:00Z",
+  },
+];
+
+function mockar(conversas: unknown[], timeline: unknown[] = mensagens) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url.startsWith("/whatsapp-conversations?")) {
+      return Promise.resolve({ data: conversas } as never);
+    }
+    if (url.includes("/timeline")) return Promise.resolve({ data: timeline } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+}
+
+const renderBloco = () =>
+  render(
+    <MemoryRouter>
+      <BlocoDaConversa clientId="cli-1" />
+    </MemoryRouter>,
+  );
+
+// Corpo em bloco de propósito: `mockReset()` devolve o próprio mock (para encadeamento), e um
+// `beforeEach` de expressão única devolveria esse mock como seu retorno. O Vitest trata QUALQUER
+// função devolvida por `beforeEach`/`it` como um hook de limpeza pós-teste — e chamaria
+// `api.get()` sem argumento nenhum depois de cada teste, um `url` `undefined` que quebrava
+// `url.startsWith(...)` no `mockar`. Mesmo padrão de `ConversasPage.test.tsx`/`ClientTimeline.test.tsx`.
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("BlocoDaConversa", () => {
+  it("mostra as últimas mensagens da conversa", async () => {
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+    expect(await screen.findByText("Boa noite")).toBeInTheDocument();
+    expect(screen.getByText("Oi Ju, tudo bem?")).toBeInTheDocument();
+  });
+
+  it("leva para a conversa com o link certo", async () => {
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+    const link = await screen.findByRole("link", { name: /abrir conversa/i });
+    expect(link).toHaveAttribute("href", "/conversas/chat-1");
+  });
+
+  it("sem conversa, diz isso e NÃO oferece iniciar uma", async () => {
+    mockar([]);
+    renderBloco();
+    expect(await screen.findByText(/nenhuma conversa no whatsapp/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /iniciar/i })).not.toBeInTheDocument();
+  });
+
+  it("com duas conversas, mostra a mais recente e avisa da outra", async () => {
+    // Fora de ordem de propósito: o bloco escolhe pela data, não pela posição na lista.
+    mockar([
+      { ...conversa("chat-antigo", "Ju"), last_message_at: "2026-08-01T10:00:00Z" },
+      { ...conversa("chat-novo", "Ju"), last_message_at: "2026-08-15T23:10:00Z" },
+    ]);
+    renderBloco();
+    expect(await screen.findByRole("link", { name: /abrir conversa/i }))
+      .toHaveAttribute("href", "/conversas/chat-novo");
+    expect(screen.getByText(/\+1 outra conversa/i)).toBeInTheDocument();
+  });
+
+  it("falha de rede vira aviso, não derruba a ficha", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("caiu"));
+    renderBloco();
+    expect(await screen.findByText(/não foi possível carregar a conversa/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -65,6 +65,17 @@ describe("BlocoDaConversa", () => {
     expect(screen.getByText("Oi Ju, tudo bem?")).toBeInTheDocument();
   });
 
+  it("pede a timeline já cortada no servidor (limit=5), não a inteira", async () => {
+    // Achado da revisão final: a ficha baixava a conversa INTEIRA (podem ser milhares de
+    // mensagens num cliente ativo) só para mostrar cinco bolhas, cortando no cliente com
+    // `.slice(-5)`. O corte tem que ser um parâmetro na URL, não um `.slice` depois do fetch —
+    // senão o bug volta na próxima vez que alguém tocar neste componente sem notar a régua.
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+    await screen.findByText("Boa noite");
+    expect(api.get).toHaveBeenCalledWith("/whatsapp-conversations/chat-1/timeline?limit=5");
+  });
+
   it("leva para a conversa com o link certo", async () => {
     mockar([conversa("chat-1", "Ju")]);
     renderBloco();

--- a/apps/web/src/features/crm/BlocoDaConversa.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.tsx
@@ -36,10 +36,13 @@ export default function BlocoDaConversa({ clientId }: { clientId: string }) {
       setConversas(lista);
       const recente = maisRecente(lista);
       if (recente) {
+        // `limit` corta no SERVIDOR — sem isto a ficha baixava a conversa inteira (podem ser
+        // milhares de mensagens num cliente ativo) só para mostrar cinco bolhas. O backend já
+        // devolve na ordem ascendente que este componente espera; nada a reordenar aqui.
         const t = await api.get<TimelineEntry[]>(
-          `/whatsapp-conversations/${recente.chat_id}/timeline`,
+          `/whatsapp-conversations/${recente.chat_id}/timeline?limit=${ULTIMAS}`,
         );
-        setMensagens(Array.isArray(t.data) ? t.data.slice(-ULTIMAS) : []);
+        setMensagens(Array.isArray(t.data) ? t.data : []);
       } else {
         setMensagens([]);
       }

--- a/apps/web/src/features/crm/BlocoDaConversa.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.tsx
@@ -84,7 +84,7 @@ export default function BlocoDaConversa({ clientId }: { clientId: string }) {
           mensagens.map((m, i) => (
             <div
               key={`${m.created_at}-${i}`}
-              className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+              className={`max-w-[85%] break-words rounded-2xl px-3 py-2 text-sm ${
                 m.direction === "out"
                   ? "self-end bg-primary-50 text-neutral-800"
                   : "self-start bg-neutral-100 text-neutral-700"

--- a/apps/web/src/features/crm/BlocoDaConversa.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.tsx
@@ -1,0 +1,128 @@
+import type { ConversationSummary, TimelineEntry } from "@e1p/shared-types";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api } from "../../lib/api";
+import { formatTime } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+
+/** Quantas falas cabem sem a ficha virar uma segunda tela de Conversas. */
+const ULTIMAS = 5;
+
+/**
+ * O teor da conversa na ficha 360° — uma JANELA, não um posto de trabalho.
+ *
+ * Mostra e leva para lá; responder continua sendo trabalho da tela de Conversas. A regra da
+ * janela de 24h da Meta e a escolha de template vivem lá, e duplicá-las aqui criaria um
+ * segundo lugar para o envio falhar de um jeito diferente.
+ *
+ * Não confundir com o `ClientTimeline` logo acima na ficha: aquele é a NARRATIVA do
+ * relacionamento (chegou, moveu, pagou, escreveu); este é o TEOR, o que foi dito.
+ */
+export default function BlocoDaConversa({ clientId }: { clientId: string }) {
+  const fuso = useFuso();
+  const [conversas, setConversas] = useState<ConversationSummary[]>([]);
+  const [mensagens, setMensagens] = useState<TimelineEntry[]>([]);
+  const [erro, setErro] = useState(false);
+  const [carregando, setCarregando] = useState(true);
+
+  const load = useCallback(async () => {
+    // Falha aqui NÃO pode derrubar a ficha — mesma postura do `ClientTimeline`, que degrada
+    // para um aviso em vez de levar junto cobranças, contratos e o resto da tela.
+    try {
+      const { data } = await api.get<ConversationSummary[]>(
+        `/whatsapp-conversations?client_id=${encodeURIComponent(clientId)}`,
+      );
+      const lista = Array.isArray(data) ? data : [];
+      setConversas(lista);
+      const recente = maisRecente(lista);
+      if (recente) {
+        const t = await api.get<TimelineEntry[]>(
+          `/whatsapp-conversations/${recente.chat_id}/timeline`,
+        );
+        setMensagens(Array.isArray(t.data) ? t.data.slice(-ULTIMAS) : []);
+      } else {
+        setMensagens([]);
+      }
+      setErro(false);
+    } catch {
+      setErro(true);
+      setConversas([]);
+      setMensagens([]);
+    } finally {
+      setCarregando(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (carregando) return <p className="py-4 text-sm text-neutral-400">Carregando conversa...</p>;
+  if (erro) {
+    return (
+      <p className="py-4 text-sm text-amber-700">
+        Não foi possível carregar a conversa.
+      </p>
+    );
+  }
+
+  const recente = maisRecente(conversas);
+  if (!recente) {
+    // Sem botão de "iniciar conversa": a janela de 24h da Meta não permite abrir conversa do
+    // nada, e um botão que sempre falha é pior que nenhum.
+    return <p className="py-4 text-center text-sm text-neutral-400">Nenhuma conversa no WhatsApp.</p>;
+  }
+
+  const outras = conversas.length - 1;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1.5">
+        {mensagens.length === 0 ? (
+          <p className="text-sm text-neutral-400">Conversa ainda sem mensagens.</p>
+        ) : (
+          mensagens.map((m, i) => (
+            <div
+              key={`${m.created_at}-${i}`}
+              className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+                m.direction === "out"
+                  ? "self-end bg-primary-50 text-neutral-800"
+                  : "self-start bg-neutral-100 text-neutral-700"
+              }`}
+            >
+              <p className="whitespace-pre-wrap">{m.text_body || `[${m.kind}]`}</p>
+              <p className="mt-0.5 text-[10px] text-neutral-400">{formatTime(m.created_at, fuso)}</p>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          to={`/conversas/${recente.chat_id}`}
+          className="text-sm font-medium text-primary-600 hover:text-primary-700"
+        >
+          Abrir conversa
+        </Link>
+        {/* Um contato pode ter MAIS DE UMA conversa (`@lid` + telefone — ver o comentário em
+            whatsapp_inbox/models.py). Mostrar só a mais recente sem dizer que há outra
+            esconderia mensagem do dono. */}
+        {outras > 0 && (
+          <Link to="/conversas" className="text-xs text-neutral-400 hover:text-neutral-600">
+            +{outras} outra conversa
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A conversa mais recente do contato — por data, não pela ordem em que a API devolveu. */
+function maisRecente(lista: ConversationSummary[]): ConversationSummary | null {
+  return lista.reduce<ConversationSummary | null>((melhor, c) => {
+    if (!melhor) return c;
+    if (!c.last_message_at) return melhor;
+    if (!melhor.last_message_at) return c;
+    return c.last_message_at > melhor.last_message_at ? c : melhor;
+  }, null);
+}

--- a/apps/web/src/features/crm/BlocoDaConversa.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.tsx
@@ -109,7 +109,7 @@ export default function BlocoDaConversa({ clientId }: { clientId: string }) {
             esconderia mensagem do dono. */}
         {outras > 0 && (
           <Link to="/conversas" className="text-xs text-neutral-400 hover:text-neutral-600">
-            +{outras} outra conversa
+            +{outras} outra{outras > 1 ? "s" : ""} conversa{outras > 1 ? "s" : ""}
           </Link>
         )}
       </div>

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -121,8 +121,11 @@ export default function ClientDetailPage() {
       {/* Conversa vem depois do Histórico e antes do financeiro: o Histórico conta O QUE
           aconteceu, a Conversa mostra O QUE FOI DITO, e só então vêm as seções operacionais.
           O bloco carrega sozinho — não entra no `load()` da página, para que uma falha do
-          WhatsApp não segure a ficha inteira. */}
-      <Section icon={<MessageCircle size={16} />} title="Conversa">
+          WhatsApp não segure a ficha inteira.
+          `testId`: o `<Section>` é o MESMO componente para todas as sete seções da ficha —
+          `rounded-2xl bg-white p-5 shadow-sm` não distingue esta da de Cobranças ou Contratos,
+          e a régua de 360px precisa de um recorte que aponte só para esta. */}
+      <Section icon={<MessageCircle size={16} />} title="Conversa" testId="secao-conversa">
         <BlocoDaConversa clientId={id} />
       </Section>
 
@@ -338,9 +341,20 @@ function StatusBadge({ status }: { status: string }) {
   return <span className={`rounded-pill px-2 py-0.5 text-xs ${map[status] ?? "bg-neutral-100"}`}>{label[status] ?? status}</span>;
 }
 
-function Section({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
+function Section({
+  icon,
+  title,
+  children,
+  testId,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  /** Opcional: só a seção de Conversa precisa hoje, para a régua de 360px conseguir recortá-la. */
+  testId?: string;
+}) {
   return (
-    <div className="rounded-2xl bg-white p-5 shadow-sm">
+    <div className="rounded-2xl bg-white p-5 shadow-sm" data-testid={testId}>
       <h2 className="mb-2 flex items-center gap-2 font-semibold text-neutral-800">
         {icon} {title}
       </h2>

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -7,7 +7,7 @@ import type {
   Quote,
 } from "@e1p/shared-types";
 import {
-  ArrowLeft, FileSignature, FileText, Gavel, History, Pencil, Receipt, Workflow,
+  ArrowLeft, FileSignature, FileText, Gavel, History, MessageCircle, Pencil, Receipt, Workflow,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -15,6 +15,7 @@ import { api, apiErrorMessage } from "../../lib/api";
 import { formatDate, formatDay } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
 import { rotaDaCobranca } from "../cobrancas/rota";
+import BlocoDaConversa from "./BlocoDaConversa";
 import ClientTimeline from "./ClientTimeline";
 import { hojeISO } from "../financeiro/contas";
 import { VOCAB_ENTRADA } from "../pagar/baixa";
@@ -115,6 +116,14 @@ export default function ClientDetailPage() {
           operacionais abaixo (Cobranças, Contratos, Orçamentos). */}
       <Section icon={<History size={16} />} title="Histórico">
         <ClientTimeline clientId={id} />
+      </Section>
+
+      {/* Conversa vem depois do Histórico e antes do financeiro: o Histórico conta O QUE
+          aconteceu, a Conversa mostra O QUE FOI DITO, e só então vêm as seções operacionais.
+          O bloco carrega sozinho — não entra no `load()` da página, para que uma falha do
+          WhatsApp não segure a ficha inteira. */}
+      <Section icon={<MessageCircle size={16} />} title="Conversa">
+        <BlocoDaConversa clientId={id} />
       </Section>
 
       {/* Cobranças */}

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -190,3 +190,30 @@ describe("CrmPage — de onde o contato veio", () => {
     expect(origem.compareDocumentPosition(tag)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 });
+
+describe("CrmPage — ponto de mensagem esperando resposta", () => {
+  const boardCom = (unread: boolean) => ({
+    columns: [{
+      stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
+      clients: [{
+        id: "c1", name: "Ju", email: null, phone: null, document: null,
+        notes: "", tags: [], source: "whatsapp", stage_id: "s1",
+        stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
+        unread,
+      }],
+    }],
+  });
+
+  it("mostra o ponto quando o contato está esperando resposta", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: boardCom(true) } as never);
+    renderPage();
+    expect(await screen.findByLabelText("Mensagem esperando resposta")).toBeInTheDocument();
+  });
+
+  it("não mostra o ponto quando não há nada esperando", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: boardCom(false) } as never);
+    renderPage();
+    expect(await screen.findByText("Ju")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Mensagem esperando resposta")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import type { Board } from "@e1p/shared-types";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
 import CrmPage from "./CrmPage";
@@ -192,12 +193,16 @@ describe("CrmPage — de onde o contato veio", () => {
 });
 
 describe("CrmPage — ponto de mensagem esperando resposta", () => {
-  const boardCom = (unread: boolean) => ({
+  // Tipado como `Board` (não `as never`): achado do review — o cast escondia que este
+  // literal já estava mais estreito que o `Client` real (faltavam tenant_id, gender,
+  // birthdate, created_at). Tipar aqui faz o compilador cobrar essas quatro colunas.
+  const boardCom = (unread: boolean): Board => ({
     columns: [{
       stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
       clients: [{
-        id: "c1", name: "Ju", email: null, phone: null, document: null,
-        notes: "", tags: [], source: "whatsapp", stage_id: "s1",
+        id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: null, document: null,
+        gender: "unspecified", birthdate: null, notes: "", tags: [], source: "whatsapp",
+        stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
         stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
         unread,
       }],

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -199,7 +199,20 @@ function Card({ client, stageId }: { client: BoardClient; stageId: string }) {
     >
       <GripVertical size={16} className="mt-0.5 shrink-0 text-neutral-300" />
       <div className="min-w-0 flex-1">
-        <p className="font-medium text-neutral-800">{client.name}</p>
+        {/* Nome e sinal na MESMA linha: o ponto é a única coisa que compete com o nome em
+            urgência, e ele não pode custar altura — o card já tem cinco linhas de conteúdo.
+            Mesma linguagem visual da lista de Conversas, para o dono não ter que aprender dois
+            vocabulários para o mesmo fato. */}
+        <p className="flex items-center gap-1.5 font-medium text-neutral-800">
+          <span className="truncate">{client.name}</span>
+          {client.unread && (
+            <span
+              aria-label="Mensagem esperando resposta"
+              title="Mensagem esperando resposta"
+              className="h-2 w-2 shrink-0 rounded-full bg-primary-600"
+            />
+          )}
+        </p>
         {/* Origem e tags dividem a mesma linha e NÃO podem se parecer: a origem é fato do
             sistema (cinza), a tag é marcação do dono (roxo). Confundir as duas foi o que fez o
             `vindo-do-site` — uma tag digitada — passar por "de onde veio" enquanto todo card de

--- a/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
+++ b/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
@@ -320,6 +320,9 @@ Crie `apps/api/tests/test_crm_board_nao_lida.py`:
 """O board do Kanban devolve `unread` por card — o ponto de 'esperando resposta'."""
 from datetime import UTC, datetime
 
+import pytest
+from fastapi.testclient import TestClient
+
 from app.modules.crm.models import Client
 from app.modules.whatsapp_inbox.models import (
     CHAT_KIND_DIRECT,
@@ -328,25 +331,48 @@ from app.modules.whatsapp_inbox.models import (
     WhatsappMessage,
 )
 
-TENANT_ID = "11111111-1111-1111-1111-111111111111"
+REGISTER = {
+    "legal_name": "Estúdio Ana",
+    "document": "11222333000181",
+    "slug": "estudioana",
+    "email": "ana@example.com",
+    "name": "Ana",
+    "password": "senha-bem-comprida",
+}
 
 
-def _contato(db, nome: str) -> Client:
-    c = Client(tenant_id=TENANT_ID, name=nome)
-    db.add(c)
-    db.commit()
-    return c
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    """`/crm/board` é rota autenticada — sem isto tudo aqui é 401. Mesmo padrão de
+    `test_crm.py`."""
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _contato(client: TestClient, headers: dict[str, str], nome: str) -> str:
+    """Cria pela API, e não montando o modelo à mão.
+
+    O contato precisa nascer no tenant AUTENTICADO e na primeira etapa do funil — `POST
+    /crm/clients` faz as duas coisas (`create_client` chama `ensure_stages`). Um `Client(...)`
+    direto no banco com `tenant_id` inventado passaria em SQLite, onde não há RLS, e mediria
+    uma situação que não existe em produção.
+    """
+    resp = client.post("/crm/clients", json={"name": nome}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
 
 
 def _conversa_esperando(db, client_id: str) -> None:
+    """Uma mensagem do contato, nunca lida. O `tenant_id` vem do próprio contato."""
+    contato = db.get(Client, client_id)
     chat = WhatsappChat(
-        tenant_id=TENANT_ID, chat_jid=f"55119{client_id[:8]}@s.whatsapp.net",
+        tenant_id=contato.tenant_id, chat_jid=f"5511{client_id[:9]}@s.whatsapp.net",
         kind=CHAT_KIND_DIRECT, client_id=client_id,
     )
     db.add(chat)
     db.commit()
     db.add(WhatsappMessage(
-        tenant_id=TENANT_ID, chat_id=chat.id, client_id=client_id,
+        tenant_id=contato.tenant_id, chat_id=chat.id, client_id=client_id,
         direction=DIRECTION_IN, text_body="oi, tudo bem?",
         created_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
     ))
@@ -357,26 +383,27 @@ def _cards(payload: dict) -> dict[str, dict]:
     return {c["id"]: c for col in payload["columns"] for c in col["clients"]}
 
 
-def test_board_marca_unread_so_em_quem_espera_resposta(client, db):
-    esperando = _contato(db, "Quem escreveu")
-    quieto = _contato(db, "Quem nao escreveu")
-    _conversa_esperando(db, esperando.id)
+def test_board_marca_unread_so_em_quem_espera_resposta(client, db, headers):
+    esperando = _contato(client, headers, "Quem escreveu")
+    quieto = _contato(client, headers, "Quem nao escreveu")
+    _conversa_esperando(db, esperando)
 
-    resp = client.get("/crm/board")
+    resp = client.get("/crm/board", headers=headers)
     assert resp.status_code == 200
     cards = _cards(resp.json())
-    assert cards[esperando.id]["unread"] is True
-    assert cards[quieto.id]["unread"] is False
+    assert cards[esperando]["unread"] is True
+    assert cards[quieto]["unread"] is False
 
 
-def test_board_unread_e_sempre_booleano(client, db):
+def test_board_unread_e_sempre_booleano(client, db, headers):
     """Nunca `null`: o card decide mostrar o ponto ou não, e não tem terceiro estado."""
-    _contato(db, "Sem conversa nenhuma")
-    cards = _cards(client.get("/crm/board").json())
+    _contato(client, headers, "Sem conversa nenhuma")
+    cards = _cards(client.get("/crm/board", headers=headers).json())
+    assert cards, "o board veio sem card nenhum — o teste não mediu nada"
     assert all(isinstance(c["unread"], bool) for c in cards.values())
 
 
-def _consultas_do_board(client, engine) -> int:
+def _consultas_do_board(client, headers, engine) -> int:
     """Quantas consultas SQL um GET /crm/board dispara."""
     from sqlalchemy import event
 
@@ -387,13 +414,13 @@ def _consultas_do_board(client, engine) -> int:
 
     event.listen(engine, "before_cursor_execute", _antes)
     try:
-        assert client.get("/crm/board").status_code == 200
+        assert client.get("/crm/board", headers=headers).status_code == 200
     finally:
         event.remove(engine, "before_cursor_execute", _antes)
     return len(contador)
 
 
-def test_board_nao_faz_uma_consulta_por_card(client, db):
+def test_board_nao_faz_uma_consulta_por_card(client, db, headers):
     """Dobrar os cards não pode dobrar as consultas.
 
     O jeito errado de implementar `unread` é perguntar por contato, dentro do laço que monta
@@ -404,12 +431,12 @@ def test_board_nao_faz_uma_consulta_por_card(client, db):
     """
     engine = db.get_bind()
     for i in range(2):
-        _conversa_esperando(db, _contato(db, f"Contato {i}").id)
-    com_2 = _consultas_do_board(client, engine)
+        _conversa_esperando(db, _contato(client, headers, f"Contato {i}"))
+    com_2 = _consultas_do_board(client, headers, engine)
 
     for i in range(2, 8):
-        _conversa_esperando(db, _contato(db, f"Contato {i}").id)
-    com_8 = _consultas_do_board(client, engine)
+        _conversa_esperando(db, _contato(client, headers, f"Contato {i}"))
+    com_8 = _consultas_do_board(client, headers, engine)
 
     assert com_8 == com_2, (
         f"{com_2} consultas com 2 cards e {com_8} com 8 — o custo está crescendo com os cards"

--- a/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
+++ b/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
@@ -26,6 +26,10 @@
 ```bash
 # API (do diretório apps/api)
 .venv/Scripts/python.exe -m pytest tests/test_arquivo.py -v
+# ⚠️ OBRIGATÓRIO em toda tarefa que toca Python. O CI roda
+# `ruff check . && pytest` DENTRO da imagem (.github/workflows/ci.yml:47) — um E501
+# derruba o build antes de qualquer teste rodar. Limite: 100 colunas.
+.venv/Scripts/python.exe -m ruff check .
 
 # Web (da raiz do repo)
 pnpm --filter @e1p/web test

--- a/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
+++ b/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
@@ -1,0 +1,1384 @@
+# Onda 1 — Conversa na ficha do contato: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A ficha do contato (`/crm/clients/:id`) passa a mostrar a conversa de WhatsApp daquele contato, o card do Kanban ganha um ponto quando há mensagem esperando resposta, e uma conversa passa a ter URL própria.
+
+**Architecture:** Cada módulo continua dono do seu dado. O `whatsapp_inbox` ganha um filtro por `client_id` na lista de conversas e uma função agregada `unread_client_ids` para o board; o CRM consome as duas sem saber formatar conversa. Nenhuma migration — o vínculo `whatsapp_chats.client_id` já existe.
+
+**Tech Stack:** FastAPI + SQLAlchemy + Pydantic (backend, Python 3.12); React + TypeScript + Vite + Tailwind (frontend); pytest (API), Vitest + Testing Library (web), Playwright (e2e).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md`
+
+## Global Constraints
+
+- **Diretório de trabalho:** `f:\Projetos\e1p\escritorio-1-pessoa`. Todos os caminhos deste plano são relativos a ele.
+- **Nunca commitar em `main`.** `main` é protegida (rejeita push direto, GH006). Trabalhe em branch e abra PR.
+- **`git push` e `gh pr create` são exclusivos do @devops.** Não faça push. Commite localmente e reporte.
+- **Rodar os testes em primeiro plano**, nunca em background.
+- **Fuso:** todo instante exibido usa o fuso do TENANT — `useFuso()` + `lib/datetime` no front, `hoje_do_tenant(db)` no back. Formatar com `toLocaleString` sem `timeZone` é regressão conhecida neste repo.
+- **Rede sempre mockada em teste de web** (`vi.mock("../../lib/api", ...)`). Nenhum teste bate em API real.
+- **Comentário em português**, explicando o *porquê* e não o *o quê* — é a convenção do repo inteiro.
+- **Testes de API rodam em SQLite em memória**; RLS não é exercida ali (ver `apps/api/tests/conftest.py`).
+
+**Comandos:**
+
+```bash
+# API (do diretório apps/api)
+.venv/Scripts/python.exe -m pytest tests/test_arquivo.py -v
+
+# Web (da raiz do repo)
+pnpm --filter @e1p/web test
+pnpm --filter @e1p/web typecheck
+pnpm --filter @e1p/web lint
+```
+
+**Antes de começar:** crie a branch de trabalho.
+
+```bash
+git checkout main && git pull
+git checkout -b feat/onda-1-conversa-na-ficha
+```
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade | Ação |
+|---|---|---|
+| `apps/api/app/modules/whatsapp_inbox/service.py` | `unread_client_ids()` e o filtro `client_id` em `list_conversations()` — o módulo dono da regra de "não lida" | Modificar |
+| `apps/api/app/modules/whatsapp_inbox/router.py` | Query param `client_id` no `GET ""` | Modificar |
+| `apps/api/app/modules/crm/schemas.py` | `BoardClient.unread` | Modificar |
+| `apps/api/app/modules/crm/router.py` | O board consome `unread_client_ids` | Modificar |
+| `apps/api/tests/test_whatsapp_inbox_nao_lidas.py` | Paridade entre as duas definições de "não lida" + filtro | Criar |
+| `apps/api/tests/test_crm_board_nao_lida.py` | O board devolve `unread` | Criar |
+| `packages/shared-types/src/index.ts` | `BoardClient.unread` | Modificar |
+| `apps/web/src/features/crm/BlocoDaConversa.tsx` | O bloco de conversa da ficha — arquivo próprio porque `ClientDetailPage` já tem 426 linhas | Criar |
+| `apps/web/src/features/crm/BlocoDaConversa.test.tsx` | Testes do bloco | Criar |
+| `apps/web/src/features/crm/ClientDetailPage.tsx` | Hospeda o bloco novo | Modificar |
+| `apps/web/src/features/crm/CrmPage.tsx` | O ponto no card | Modificar |
+| `apps/web/src/features/conversas/ConversasPage.tsx` | Seleção vem da URL | Modificar |
+| `apps/web/src/app/App.tsx` | Rota `/conversas/:chatId` | Modificar |
+
+**Ordem:** Tarefas 1→2 são backend (o contrato), 3 é o tipo compartilhado, 4→6 são frontend. Cada tarefa termina com commit e é revisável sozinha.
+
+---
+
+### Task 1: `unread_client_ids` — a mesma definição de "não lida", em forma agregada
+
+O card do Kanban precisa saber quais contatos têm mensagem esperando resposta. Não dá para reusar `list_conversations` para isso: ela carrega **todas** as mensagens do tenant em memória para achar a última de cada chat (`select(WhatsappMessage).order_by(created_at)`, linha ~547). A tela de Conversas tolera; o board, aberto a cada navegação, não.
+
+O risco é criar uma **segunda definição de "não lida"** que diverge da primeira em silêncio — o card diria "esperando resposta" com a caixa de entrada limpa. Por isso a função nova mora no mesmo módulo, colada na antiga, e um teste afirma que as duas concordam.
+
+**Files:**
+- Modify: `apps/api/app/modules/whatsapp_inbox/service.py` (adicionar após `list_conversations`, que termina por volta da linha 576)
+- Test: `apps/api/tests/test_whatsapp_inbox_nao_lidas.py` (criar)
+
+**Interfaces:**
+- Consumes: `WhatsappChat`, `WhatsappMessage`, `DIRECTION_IN` de `app.modules.whatsapp_inbox.models`; `list_conversations(db, tenant_id) -> list[dict]` já existente.
+- Produces: `unread_client_ids(db: Session) -> set[str]` — ids de `clients` com mensagem esperando resposta. Consumido pela Task 2.
+
+- [ ] **Step 1: Escrever o teste de paridade (vai falhar)**
+
+Crie `apps/api/tests/test_whatsapp_inbox_nao_lidas.py`:
+
+```python
+# apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+"""`unread_client_ids` — o agregado que alimenta o ponto do card do Kanban.
+
+O teste central aqui é o de PARIDADE. A regra de "não lida" vive inline dentro de
+`list_conversations`; este agregado é uma segunda expressão da mesma regra, escrita porque
+`list_conversations` carrega todas as mensagens do tenant em memória e o board não pode pagar
+isso. Duas expressões da mesma regra divergem em silêncio — o card diria "esperando resposta"
+com a caixa de entrada limpa. O teste de paridade é o que impede isso.
+"""
+from datetime import UTC, datetime, timedelta
+
+from app.modules.whatsapp_inbox import service as inbox_service
+from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
+    CHAT_KIND_GROUP,
+    DIRECTION_IN,
+    DIRECTION_OUT,
+    WhatsappChat,
+    WhatsappMessage,
+)
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+BASE = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+
+
+def _chat(db, *, jid: str, client_id: str | None, kind: str = CHAT_KIND_DIRECT,
+          last_read_at: datetime | None = None) -> WhatsappChat:
+    chat = WhatsappChat(
+        tenant_id=TENANT_ID, chat_jid=jid, kind=kind, title=jid,
+        client_id=client_id, last_read_at=last_read_at,
+    )
+    db.add(chat)
+    db.commit()
+    return chat
+
+
+def _msg(db, *, chat: WhatsappChat, direction: str, minutos: int, texto: str = "oi") -> None:
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, chat_id=chat.id, client_id=chat.client_id,
+        direction=direction, text_body=texto,
+        created_at=BASE + timedelta(minutes=minutos),
+    ))
+    db.commit()
+
+
+def _cenario_completo(db) -> None:
+    """As cinco situações que a regra precisa distinguir."""
+    # 1. Nunca lida, última é do contato → ESPERANDO RESPOSTA.
+    c1 = _chat(db, jid="5511900000001@s.whatsapp.net", client_id="cli-1")
+    _msg(db, chat=c1, direction=DIRECTION_IN, minutos=10)
+
+    # 2. Lida DEPOIS da última mensagem → em dia.
+    c2 = _chat(db, jid="5511900000002@s.whatsapp.net", client_id="cli-2",
+               last_read_at=BASE + timedelta(minutes=99))
+    _msg(db, chat=c2, direction=DIRECTION_IN, minutos=10)
+
+    # 3. Última mensagem é NOSSA → em dia, mesmo sem nunca ter sido "lida".
+    c3 = _chat(db, jid="5511900000003@s.whatsapp.net", client_id="cli-3")
+    _msg(db, chat=c3, direction=DIRECTION_IN, minutos=10)
+    _msg(db, chat=c3, direction=DIRECTION_OUT, minutos=20)
+
+    # 4. GRUPO com mensagem nova → nunca conta: grupo não é contato do CRM.
+    g = _chat(db, jid="120363000000000000@g.us", client_id=None, kind=CHAT_KIND_GROUP)
+    _msg(db, chat=g, direction=DIRECTION_IN, minutos=10)
+
+    # 5. DOIS chats para o MESMO contato (o caso `@lid` + telefone). Um em dia, outro não —
+    #    o contato aparece uma vez só, porque o conjunto é de CONTATOS, não de conversas.
+    c5a = _chat(db, jid="5511900000005@s.whatsapp.net", client_id="cli-5",
+                last_read_at=BASE + timedelta(minutes=99))
+    _msg(db, chat=c5a, direction=DIRECTION_IN, minutos=10)
+    c5b = _chat(db, jid="99995@lid", client_id="cli-5")
+    _msg(db, chat=c5b, direction=DIRECTION_IN, minutos=30)
+
+
+def test_unread_client_ids_distingue_as_cinco_situacoes(db):
+    _cenario_completo(db)
+    assert inbox_service.unread_client_ids(db) == {"cli-1", "cli-5"}
+
+
+def test_unread_client_ids_concorda_com_list_conversations(db):
+    """PARIDADE — a guarda contra as duas definições divergirem.
+
+    Se alguém ajustar a regra em um dos dois lugares e esquecer o outro, este teste cai.
+    """
+    _cenario_completo(db)
+    pela_caixa_de_entrada = {
+        c["client_id"]
+        for c in inbox_service.list_conversations(db, TENANT_ID)
+        if c["unread"] and c["client_id"]
+    }
+    assert inbox_service.unread_client_ids(db) == pela_caixa_de_entrada
+
+
+def test_unread_client_ids_vazio_sem_mensagem(db):
+    _chat(db, jid="5511900000009@s.whatsapp.net", client_id="cli-9")
+    assert inbox_service.unread_client_ids(db) == set()
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_nao_lidas.py -v
+```
+
+Esperado: FAIL com `AttributeError: module 'app.modules.whatsapp_inbox.service' has no attribute 'unread_client_ids'`.
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/api/app/modules/whatsapp_inbox/service.py`, **logo depois** de `list_conversations` (a proximidade física é parte da guarda — quem edita uma vê a outra):
+
+> ⚠️ **Não amarre a consulta ao dialeto.** A tentação aqui é desempatar mensagens do mesmo instante com `func.strftime` (SQLite) ou `func.to_char` (Postgres) num `if`. Não faça: os testes rodam em SQLite e produção é Postgres, então o ramo do Postgres não seria exercido por teste nenhum. A versão abaixo é dialeto-agnóstica porque não precisa saber *qual* é a última mensagem — só se a conversa terminou com o contato falando.
+
+```python
+def unread_client_ids(db: Session) -> set[str]:
+    """Contatos com mensagem esperando resposta, para o ponto no card do Kanban.
+
+    ⚠️ ESTA É A MESMA REGRA de `list_conversations` acima ("a última mensagem da conversa é do
+    contato e chegou depois do `last_read_at`"), escrita uma segunda vez. Mexeu em uma, mexa na
+    outra — `test_whatsapp_inbox_nao_lidas.py::test_unread_client_ids_concorda_com_list_conversations`
+    existe exatamente para pegar quem esquecer.
+
+    A duplicação é deliberada: `list_conversations` materializa TODAS as mensagens do tenant
+    para achar a última de cada chat. A tela de Conversas paga esse preço uma vez a cada 7s
+    para um usuário; o board não pode pagá-lo a cada navegação. Aqui é uma consulta agregada,
+    de custo independente do volume de mensagens.
+
+    Devolve CONTATOS, não conversas: o mesmo contato pode ter dois chats (`@lid` + telefone) e
+    o card é um só. Grupo nunca entra — `client_id` é nulo nele por decisão de produto.
+
+    A sessão já chega escopada por RLS (mesma convenção de `list_conversations`).
+    """
+    # Últimas mensagens: uma linha por chat, obtida por max(created_at) agrupado. Empate de
+    # instante (duas mensagens no mesmo commit) resolve-se pegando qualquer uma das empatadas
+    # e checando se ALGUMA delas é `in` — que é a pergunta que interessa. Não precisamos saber
+    # qual é "a" última, só se a conversa terminou com o contato falando.
+    max_por_chat = (
+        select(
+            WhatsappMessage.chat_id.label("chat_id"),
+            func.max(WhatsappMessage.created_at).label("ultima_em"),
+        )
+        .where(WhatsappMessage.chat_id.is_not(None))
+        .group_by(WhatsappMessage.chat_id)
+        .subquery()
+    )
+    linhas = db.execute(
+        select(WhatsappChat.client_id)
+        .join(max_por_chat, max_por_chat.c.chat_id == WhatsappChat.id)
+        .join(
+            WhatsappMessage,
+            (WhatsappMessage.chat_id == WhatsappChat.id)
+            & (WhatsappMessage.created_at == max_por_chat.c.ultima_em),
+        )
+        .where(
+            WhatsappChat.client_id.is_not(None),
+            WhatsappMessage.direction == DIRECTION_IN,
+            (WhatsappChat.last_read_at.is_(None))
+            | (max_por_chat.c.ultima_em > WhatsappChat.last_read_at),
+        )
+    ).all()
+    return {client_id for (client_id,) in linhas}
+```
+
+Confirme que o topo do arquivo já importa `func` de `sqlalchemy` e `select`; se `func` faltar, adicione ao import existente.
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_nao_lidas.py -v
+```
+
+Esperado: 3 passed.
+
+- [ ] **Step 5: Rodar a suíte do inbox inteira (nada pode ter quebrado)**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/ -k "whatsapp" -v
+```
+
+Esperado: tudo verde. Se algo falhar, é regressão sua — conserte antes de commitar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/service.py apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+git commit -m "feat: unread_client_ids, o agregado de 'esperando resposta' para o board"
+```
+
+---
+
+### Task 2: O filtro `client_id` na lista de conversas, e o board devolvendo `unread`
+
+**Files:**
+- Modify: `apps/api/app/modules/whatsapp_inbox/service.py` (assinatura de `list_conversations`)
+- Modify: `apps/api/app/modules/whatsapp_inbox/router.py:153-157`
+- Modify: `apps/api/app/modules/crm/schemas.py:169-178`
+- Modify: `apps/api/app/modules/crm/router.py:38-59`
+- Test: `apps/api/tests/test_whatsapp_inbox_nao_lidas.py` (acrescentar), `apps/api/tests/test_crm_board_nao_lida.py` (criar)
+
+**Interfaces:**
+- Consumes: `unread_client_ids(db) -> set[str]` da Task 1.
+- Produces: `GET /whatsapp-conversations?client_id=<id>` devolvendo só as conversas daquele contato; `BoardClient.unread: bool` no `GET /crm/board`. Consumidos pelas Tasks 4 e 5.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+Acrescente ao fim de `apps/api/tests/test_whatsapp_inbox_nao_lidas.py`:
+
+```python
+def test_list_conversations_filtra_por_client_id(db):
+    _cenario_completo(db)
+    do_contato = inbox_service.list_conversations(db, TENANT_ID, client_id="cli-5")
+    assert len(do_contato) == 2  # o caso `@lid` + telefone: duas conversas, um contato
+    assert {c["client_id"] for c in do_contato} == {"cli-5"}
+
+
+def test_list_conversations_sem_filtro_continua_trazendo_grupo(db):
+    """O filtro é OPCIONAL e não pode mudar o comportamento da tela de Conversas."""
+    _cenario_completo(db)
+    todas = inbox_service.list_conversations(db, TENANT_ID)
+    assert any(c["kind"] == "group" for c in todas)
+
+
+def test_list_conversations_filtrado_nunca_traz_grupo(db):
+    """Grupo tem `client_id` nulo — filtrar por contato jamais pode trazê-lo."""
+    _cenario_completo(db)
+    for cid in ("cli-1", "cli-5"):
+        assert all(c["kind"] != "group" for c in inbox_service.list_conversations(
+            db, TENANT_ID, client_id=cid))
+```
+
+Crie `apps/api/tests/test_crm_board_nao_lida.py`:
+
+```python
+# apps/api/tests/test_crm_board_nao_lida.py
+"""O board do Kanban devolve `unread` por card — o ponto de 'esperando resposta'."""
+from datetime import UTC, datetime
+
+from app.modules.crm.models import Client
+from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
+    DIRECTION_IN,
+    WhatsappChat,
+    WhatsappMessage,
+)
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _contato(db, nome: str) -> Client:
+    c = Client(tenant_id=TENANT_ID, name=nome)
+    db.add(c)
+    db.commit()
+    return c
+
+
+def _conversa_esperando(db, client_id: str) -> None:
+    chat = WhatsappChat(
+        tenant_id=TENANT_ID, chat_jid=f"55119{client_id[:8]}@s.whatsapp.net",
+        kind=CHAT_KIND_DIRECT, client_id=client_id,
+    )
+    db.add(chat)
+    db.commit()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT_ID, chat_id=chat.id, client_id=client_id,
+        direction=DIRECTION_IN, text_body="oi, tudo bem?",
+        created_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
+    ))
+    db.commit()
+
+
+def _cards(payload: dict) -> dict[str, dict]:
+    return {c["id"]: c for col in payload["columns"] for c in col["clients"]}
+
+
+def test_board_marca_unread_so_em_quem_espera_resposta(client, db):
+    esperando = _contato(db, "Quem escreveu")
+    quieto = _contato(db, "Quem nao escreveu")
+    _conversa_esperando(db, esperando.id)
+
+    resp = client.get("/crm/board")
+    assert resp.status_code == 200
+    cards = _cards(resp.json())
+    assert cards[esperando.id]["unread"] is True
+    assert cards[quieto.id]["unread"] is False
+
+
+def test_board_unread_e_sempre_booleano(client, db):
+    """Nunca `null`: o card decide mostrar o ponto ou não, e não tem terceiro estado."""
+    _contato(db, "Sem conversa nenhuma")
+    cards = _cards(client.get("/crm/board").json())
+    assert all(isinstance(c["unread"], bool) for c in cards.values())
+
+
+def _consultas_do_board(client, engine) -> int:
+    """Quantas consultas SQL um GET /crm/board dispara."""
+    from sqlalchemy import event
+
+    contador = []
+
+    def _antes(_conn, _cursor, statement, _params, _context, _many):
+        contador.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _antes)
+    try:
+        assert client.get("/crm/board").status_code == 200
+    finally:
+        event.remove(engine, "before_cursor_execute", _antes)
+    return len(contador)
+
+
+def test_board_nao_faz_uma_consulta_por_card(client, db):
+    """Dobrar os cards não pode dobrar as consultas.
+
+    O jeito errado de implementar `unread` é perguntar por contato, dentro do laço que monta
+    as colunas. Funciona no teste de duas linhas e derruba o board de quem tem 200 leads no
+    funil — e a falha é invisível em qualquer teste que só olhe o JSON de resposta.
+
+    Este é o mesmo motivo pelo qual `last_interaction_map` existe como consulta agrupada.
+    """
+    engine = db.get_bind()
+    for i in range(2):
+        _conversa_esperando(db, _contato(db, f"Contato {i}").id)
+    com_2 = _consultas_do_board(client, engine)
+
+    for i in range(2, 8):
+        _conversa_esperando(db, _contato(db, f"Contato {i}").id)
+    com_8 = _consultas_do_board(client, engine)
+
+    assert com_8 == com_2, (
+        f"{com_2} consultas com 2 cards e {com_8} com 8 — o custo está crescendo com os cards"
+    )
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_nao_lidas.py tests/test_crm_board_nao_lida.py -v
+```
+
+Esperado: os 3 novos do primeiro arquivo falham com `TypeError: list_conversations() got an unexpected keyword argument 'client_id'`; os 3 do segundo falham com `KeyError: 'unread'` (o de contagem de consultas passa desde já, e é isso mesmo — ele é uma trava contra a implementação errada, não um teste de funcionalidade nova).
+
+- [ ] **Step 3: Implementar o filtro no service**
+
+Em `apps/api/app/modules/whatsapp_inbox/service.py`, mude a assinatura de `list_conversations`:
+
+```python
+def list_conversations(
+    db: Session, tenant_id: str, *, client_id: str | None = None
+) -> list[dict]:
+```
+
+Acrescente ao fim da docstring existente:
+
+```
+    `client_id` filtra as conversas de UM contato (a ficha 360° usa isso). Grupo tem
+    `client_id` nulo e portanto nunca aparece filtrado — que é o correto: grupo não é contato
+    do CRM. Um contato pode ter MAIS DE UMA conversa (`@lid` + telefone), então a lista
+    filtrada não tem tamanho garantido de 1.
+```
+
+E filtre a carga de chats logo na primeira linha do corpo:
+
+```python
+    consulta_chats = select(WhatsappChat)
+    if client_id is not None:
+        consulta_chats = consulta_chats.where(WhatsappChat.client_id == client_id)
+    chats = {c.id: c for c in db.scalars(consulta_chats).all()}
+```
+
+(substituindo o `chats = {c.id: c for c in db.scalars(select(WhatsappChat)).all()}` que está lá). O resto da função já ignora mensagem cujo `chat_id` não está em `chats`, então nada mais muda.
+
+- [ ] **Step 4: Implementar o query param no router**
+
+Em `apps/api/app/modules/whatsapp_inbox/router.py`, troque o handler da linha 153:
+
+```python
+@router.get("")
+def list_conversations(
+    client_id: str | None = Query(default=None),
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> list[dict]:
+    return service.list_conversations(db, user.tenant_id, client_id=client_id)
+```
+
+Confirme que `Query` está importado de `fastapi` no topo do arquivo; se não, adicione ao import existente.
+
+- [ ] **Step 5: Implementar `unread` no board**
+
+Em `apps/api/app/modules/crm/schemas.py`, na classe `BoardClient` (linha 169):
+
+```python
+class BoardClient(ClientOut):
+    """`ClientOut` + os sinais que só o board calcula.
+
+    Campos separados do `ClientOut` de propósito: só o board calcula isso (via consultas
+    agrupadas). Se vivessem em `ClientOut`, todo endpoint que devolve cliente passaria a
+    afirmar `null` — e `null` significaria tanto "sem interação" quanto "não calculei", que
+    são coisas diferentes.
+    """
+
+    last_interaction_at: datetime | None = None
+    # Tem mensagem do contato esperando resposta. Booleano e não contador: o card não tem
+    # espaço para número, e "quantas" é pergunta da tela de Conversas.
+    unread: bool = False
+```
+
+Em `apps/api/app/modules/crm/router.py`, no `get_board` (linha 38):
+
+```python
+@router.get("/board", response_model=Board)
+def get_board(
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> Board:
+    columns = service.build_board(db, user.tenant_id)
+    ultimo = service.last_interaction_map(db)
+    # Consulta agregada, uma para o board inteiro — o custo não cresce com a quantidade de
+    # cards. Lida do módulo DONO da regra de "não lida" em vez de reimplementada aqui.
+    esperando = inbox_service.unread_client_ids(db)
+    return Board(
+        columns=[
+            BoardColumn(
+                stage=StageOut.model_validate(stage),
+                clients=[
+                    BoardClient(
+                        **ClientOut.model_validate(c).model_dump(),
+                        last_interaction_at=ultimo.get(c.id),
+                        unread=c.id in esperando,
+                    )
+                    for c in clients
+                ],
+            )
+            for stage, clients in columns
+        ]
+    )
+```
+
+Adicione o import no topo de `crm/router.py`:
+
+```python
+from app.modules.whatsapp_inbox import service as inbox_service
+```
+
+> ⚠️ Se esse import causar ciclo (o `whatsapp_inbox` importar `crm`), **não** resolva movendo a função: importe dentro da função `get_board`, com um comentário explicando. Rode `.venv/Scripts/python.exe -c "import app.main"` para checar.
+
+- [ ] **Step 6: Rodar e confirmar que passam**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/test_whatsapp_inbox_nao_lidas.py tests/test_crm_board_nao_lida.py -v
+```
+
+Esperado: 9 passed.
+
+- [ ] **Step 7: Rodar a suíte de API inteira**
+
+```bash
+cd apps/api && .venv/Scripts/python.exe -m pytest tests/ -q
+```
+
+Esperado: tudo verde. `list_conversations` mudou de assinatura (parâmetro novo tem default, então chamadas antigas seguem válidas) e o board ganhou campo — nenhum teste existente deveria quebrar. Se quebrar, é regressão sua.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/whatsapp_inbox/service.py apps/api/app/modules/whatsapp_inbox/router.py apps/api/app/modules/crm/schemas.py apps/api/app/modules/crm/router.py apps/api/tests/test_whatsapp_inbox_nao_lidas.py apps/api/tests/test_crm_board_nao_lida.py
+git commit -m "feat: conversas filtram por contato e o board diz quem espera resposta"
+```
+
+---
+
+### Task 3: O tipo compartilhado
+
+**Files:**
+- Modify: `packages/shared-types/src/index.ts:257-259`
+
+**Interfaces:**
+- Produces: `BoardClient.unread: boolean` para o front. Consumido pela Task 5.
+
+- [ ] **Step 1: Editar o tipo**
+
+Em `packages/shared-types/src/index.ts`, na interface `BoardClient` (linha 258):
+
+```typescript
+/** `Client` do board, com os sinais que só o board calcula. */
+export interface BoardClient extends Client {
+  last_interaction_at: string | null;
+  /** Tem mensagem do contato esperando resposta. */
+  unread: boolean;
+}
+```
+
+- [ ] **Step 2: Verificar que o typecheck passa**
+
+```bash
+pnpm --filter @e1p/web typecheck
+```
+
+Esperado: sem erro. (`CrmPage.tsx` ainda não usa `unread`; adicionar campo obrigatório a uma interface não quebra quem só lê os outros. Se algum **mock de teste** construir um `BoardClient` literal, o typecheck acusa — conserte os mocks acrescentando `unread: false`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/shared-types/src/index.ts
+git commit -m "feat: BoardClient carrega o sinal de mensagem esperando resposta"
+```
+
+---
+
+### Task 4: A conversa ganha URL própria (`/conversas/:chatId`)
+
+Hoje `ConversasPage` guarda a conversa selecionada em `useState` — não há como apontar para uma conversa de fora, que é justamente o que a ficha vai precisar fazer. Ganho colateral: o botão voltar do navegador passa a funcionar nessa tela.
+
+**Files:**
+- Modify: `apps/web/src/app/App.tsx:80`
+- Modify: `apps/web/src/features/conversas/ConversasPage.tsx:46-50,86-90`
+- Test: `apps/web/src/features/conversas/ConversasPage.test.tsx` (acrescentar)
+
+**Interfaces:**
+- Produces: rota `/conversas/:chatId`. Consumida pela Task 6.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+⚠️ `ConversasPage.test.tsx` hoje renderiza `<ConversasPage />` **sem router nenhum** e monta o mock de `api.get` dentro de cada `it`. Depois desta task a página passa a usar `useParams`/`useNavigate`, então **todos** os testes existentes precisam de um router em volta. Isso é parte da task, não um extra.
+
+Acrescente ao fim de `apps/web/src/features/conversas/ConversasPage.test.tsx`:
+
+```tsx
+// ── Conversa com URL própria ────────────────────────────────────────────────
+
+/** Duas conversas, para que "abriu a certa" seja uma afirmação com conteúdo. */
+function mockarDuasConversas() {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/whatsapp-conversations") {
+      return Promise.resolve({
+        data: [
+          {
+            chat_id: "c1", kind: "direct" as const, title: "Doro Eventos",
+            phone: "5511999999999", client_id: "cli-1",
+            last_message_at: "2026-07-19T10:00:00Z",
+            last_message_preview: "Oi, quero o cardápio", unread: true,
+          },
+          {
+            chat_id: "c2", kind: "direct" as const, title: "Murilo Moreschi",
+            phone: "5511977776666", client_id: "cli-2",
+            last_message_at: "2026-07-20T11:00:00Z",
+            last_message_preview: "Ok", unread: false,
+          },
+        ],
+      });
+    }
+    if (url.endsWith("/timeline")) {
+      return Promise.resolve({
+        data: [{
+          source: "conversation", direction: "in", kind: "text",
+          text_body: "Oi, quero o cardápio", media_attachment_id: null,
+          purpose_label: null, sender_name: null, created_at: "2026-07-19T10:00:00Z",
+        }],
+      });
+    }
+    if (url.endsWith("/window")) {
+      return Promise.resolve({ data: { within_session_window: true } });
+    }
+    if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+    return Promise.resolve({ data: [] });
+  });
+  // Abrir uma conversa dispara POST /{id}/read. Sem isto o `await` recebe undefined e o
+  // teste passa por acidente — melhor mockar do que depender disso.
+  vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+}
+
+function renderNaRota(rota: string) {
+  return render(
+    <MemoryRouter initialEntries={[rota]}>
+      <Routes>
+        <Route path="/conversas" element={<ConversasPage />} />
+        <Route path="/conversas/:chatId" element={<ConversasPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ConversasPage — a conversa tem URL própria", () => {
+  it("com /conversas/:chatId, abre aquela conversa direto", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas/c2");
+    // O campo de digitar só existe quando uma conversa está aberta.
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+    // E abriu a CERTA: a prova é qual timeline foi buscada, não o título na tela — título
+    // aparece na lista também, e a asserção ficaria verde com a conversa errada aberta.
+    expect(api.get).toHaveBeenCalledWith("/whatsapp-conversations/c2/timeline");
+    expect(api.get).not.toHaveBeenCalledWith("/whatsapp-conversations/c1/timeline");
+  });
+
+  it("com /conversas, mostra a lista sem nenhuma conversa aberta", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas");
+    expect(await screen.findByText("Doro Eventos")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/mensagem/i)).not.toBeInTheDocument();
+  });
+
+  it("clicar numa conversa muda a URL", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas");
+    await userEvent.click(await screen.findByText("Doro Eventos"));
+    expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
+  });
+
+  it("chatId que não existe cai na lista com aviso, e não em tela branca", async () => {
+    mockarDuasConversas();
+    renderNaRota("/conversas/nao-existe");
+    expect(await screen.findByText(/conversa não encontrada/i)).toBeInTheDocument();
+    expect(screen.getByText("Doro Eventos")).toBeInTheDocument();
+  });
+});
+```
+
+Troque a linha 4 do arquivo para importar os três do router:
+
+```tsx
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+```
+
+E envolva as duas chamadas `render(<ConversasPage />)` dos testes que já existem (procure por `render(<ConversasPage />)`) em `renderNaRota("/conversas")` — mova a função `renderNaRota` para cima do primeiro `describe` para que fique visível a todos.
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+```bash
+pnpm --filter @e1p/web test -- ConversasPage
+```
+
+Esperado: os 3 novos falham (a página ignora a URL hoje).
+
+- [ ] **Step 3: Adicionar a rota**
+
+Em `apps/web/src/app/App.tsx`, logo abaixo da linha 80:
+
+```tsx
+<Route path="/conversas" element={<ConversasPage />} />
+{/* A conversa tem URL própria desde a Onda 1: é assim que a ficha 360° aponta para ela, e
+    de quebra o botão voltar do navegador passa a funcionar nesta tela. */}
+<Route path="/conversas/:chatId" element={<ConversasPage />} />
+```
+
+- [ ] **Step 4: A seleção passa a vir da URL**
+
+Em `apps/web/src/features/conversas/ConversasPage.tsx`:
+
+Importe os hooks do router:
+
+```tsx
+import { useNavigate, useParams } from "react-router-dom";
+```
+
+Troque o `useState` da seleção (linha ~47) por leitura da URL:
+
+```tsx
+  // A conversa aberta é a da URL, não estado local. Isso é o que permite a ficha 360° apontar
+  // para uma conversa específica — e faz o botão voltar do navegador funcionar aqui.
+  const { chatId } = useParams();
+  const navigate = useNavigate();
+  const selected = chatId ?? null;
+```
+
+Troque o `onClick` de cada item da lista (linha ~87) para navegar:
+
+```tsx
+              onClick={() => {
+                navigate(`/conversas/${c.chat_id}`);
+                setHistoricoAberto(false);
+              }}
+```
+
+O botão de voltar (o `ChevronLeft` do modo celular) deve chamar `navigate("/conversas")` no lugar de `setSelected(null)`. Procure por `setSelected` no arquivo e troque **todas** as ocorrências restantes.
+
+Trate o id inexistente logo abaixo do `conversaSelecionada`:
+
+```tsx
+  const conversaSelecionada = conversations.find((c) => c.chat_id === selected) ?? null;
+  // Id que não existe (link velho, conversa apagada) não pode virar tela branca: a lista já
+  // carregou, então mostramos ela com um aviso. `conversations.length > 0` evita o falso aviso
+  // no primeiro render, antes de a lista chegar.
+  const naoEncontrada = selected !== null && conversaSelecionada === null
+    && conversations.length > 0;
+```
+
+E renderize o aviso acima da lista:
+
+```tsx
+        {naoEncontrada && (
+          <p className="border-b border-amber-100 bg-amber-50 p-3 text-xs text-amber-700">
+            Conversa não encontrada. Escolha uma da lista.
+          </p>
+        )}
+```
+
+Quando `naoEncontrada` for `true`, a lista precisa aparecer no celular — ajuste a classe do container da lista para tratar isso: onde hoje está `selected ? "hidden lg:block" : "block"`, use `selected && !naoEncontrada ? "hidden lg:block" : "block"`.
+
+- [ ] **Step 5: Rodar e confirmar que passam**
+
+```bash
+pnpm --filter @e1p/web test -- ConversasPage
+```
+
+Esperado: todos verdes, incluindo os que já existiam. Se um teste antigo quebrar porque renderizava `<ConversasPage />` sem `Routes`, envolva-o como nos testes novos.
+
+- [ ] **Step 6: Typecheck e lint**
+
+```bash
+pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+Esperado: ambos limpos. Se o lint reclamar de `setSelected` não usado, é porque sobrou uma ocorrência — remova o `useState`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/app/App.tsx apps/web/src/features/conversas/ConversasPage.tsx apps/web/src/features/conversas/ConversasPage.test.tsx
+git commit -m "feat: a conversa tem URL propria, e o botao voltar funciona em Conversas"
+```
+
+---
+
+### Task 5: O ponto no card do Kanban
+
+**Files:**
+- Modify: `apps/web/src/features/crm/CrmPage.tsx:187-240`
+- Test: `apps/web/src/features/crm/CrmPage.test.tsx` (acrescentar)
+
+**Interfaces:**
+- Consumes: `BoardClient.unread` da Task 3.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+Acrescente a `apps/web/src/features/crm/CrmPage.test.tsx`. Monte o board mockado no formato que o `beforeEach` do arquivo já usa para `/crm/board`:
+
+```tsx
+describe("CrmPage — ponto de mensagem esperando resposta", () => {
+  const boardCom = (unread: boolean) => ({
+    columns: [{
+      stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
+      clients: [{
+        id: "c1", name: "Ju", email: null, phone: null, document: null,
+        notes: "", tags: [], source: "whatsapp", stage_id: "s1",
+        stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
+        unread,
+      }],
+    }],
+  });
+
+  it("mostra o ponto quando o contato está esperando resposta", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: boardCom(true) } as never);
+    renderPage();
+    expect(await screen.findByLabelText("Mensagem esperando resposta")).toBeInTheDocument();
+  });
+
+  it("não mostra o ponto quando não há nada esperando", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: boardCom(false) } as never);
+    renderPage();
+    expect(await screen.findByText("Ju")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Mensagem esperando resposta")).not.toBeInTheDocument();
+  });
+});
+```
+
+Se o objeto de cliente acima não bater com o tipo `BoardClient` (campos a mais ou a menos), ajuste pelos campos reais de `Client` em `packages/shared-types/src/index.ts` — o typecheck vai dizer.
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+```bash
+pnpm --filter @e1p/web test -- CrmPage
+```
+
+Esperado: os 2 novos falham com "Unable to find a label with the text of: Mensagem esperando resposta".
+
+- [ ] **Step 3: Implementar**
+
+Em `apps/web/src/features/crm/CrmPage.tsx`, dentro de `Card`, na linha do nome (linha 202):
+
+```tsx
+        {/* Nome e sinal na MESMA linha: o ponto é a única coisa que compete com o nome em
+            urgência, e ele não pode custar altura — o card já tem cinco linhas de conteúdo.
+            Mesma linguagem visual da lista de Conversas, para o dono não ter que aprender dois
+            vocabulários para o mesmo fato. */}
+        <p className="flex items-center gap-1.5 font-medium text-neutral-800">
+          <span className="truncate">{client.name}</span>
+          {client.unread && (
+            <span
+              aria-label="Mensagem esperando resposta"
+              title="Mensagem esperando resposta"
+              className="h-2 w-2 shrink-0 rounded-full bg-primary-600"
+            />
+          )}
+        </p>
+```
+
+- [ ] **Step 4: Rodar e confirmar que passam**
+
+```bash
+pnpm --filter @e1p/web test -- CrmPage
+```
+
+Esperado: todos verdes.
+
+- [ ] **Step 5: Typecheck e lint**
+
+```bash
+pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/crm/CrmPage.tsx apps/web/src/features/crm/CrmPage.test.tsx
+git commit -m "feat: o card do Kanban avisa quando tem mensagem esperando resposta"
+```
+
+---
+
+### Task 6: O bloco de Conversa na ficha
+
+Arquivo próprio: `ClientDetailPage.tsx` já tem 426 linhas e cinco seções inline. Um sexto bloco com carregamento, estado vazio, tratamento de erro e multi-conversa dentro dele deixaria o arquivo inadministrável.
+
+**Files:**
+- Create: `apps/web/src/features/crm/BlocoDaConversa.tsx`
+- Create: `apps/web/src/features/crm/BlocoDaConversa.test.tsx`
+- Modify: `apps/web/src/features/crm/ClientDetailPage.tsx:9-11,116-118`
+
+**Interfaces:**
+- Consumes: `GET /whatsapp-conversations?client_id=` (Task 2), `GET /whatsapp-conversations/{chat_id}/timeline` (já existe, devolve `TimelineEntry[]`), rota `/conversas/:chatId` (Task 4).
+- Produces: `<BlocoDaConversa clientId={string} />`.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+Crie `apps/web/src/features/crm/BlocoDaConversa.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { api } from "../../lib/api";
+import BlocoDaConversa from "./BlocoDaConversa";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+
+const conversa = (chat_id: string, title: string) => ({
+  chat_id, kind: "direct", title, phone: "5511999998888",
+  client_id: "cli-1", last_message_at: "2026-08-15T23:10:00Z",
+  last_message_preview: "Boa noite", unread: false,
+});
+
+const mensagens = [
+  {
+    source: "conversation", direction: "in", kind: "text",
+    text_body: "Boa noite", media_attachment_id: null, purpose_label: null,
+    sender_name: null, created_at: "2026-08-15T23:10:00Z",
+  },
+  {
+    source: "conversation", direction: "out", kind: "text",
+    text_body: "Oi Ju, tudo bem?", media_attachment_id: null, purpose_label: null,
+    sender_name: null, created_at: "2026-08-15T23:16:00Z",
+  },
+];
+
+function mockar(conversas: unknown[], timeline: unknown[] = mensagens) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url.startsWith("/whatsapp-conversations?")) {
+      return Promise.resolve({ data: conversas } as never);
+    }
+    if (url.includes("/timeline")) return Promise.resolve({ data: timeline } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+}
+
+const renderBloco = () =>
+  render(
+    <MemoryRouter>
+      <BlocoDaConversa clientId="cli-1" />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => vi.mocked(api.get).mockReset());
+
+describe("BlocoDaConversa", () => {
+  it("mostra as últimas mensagens da conversa", async () => {
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+    expect(await screen.findByText("Boa noite")).toBeInTheDocument();
+    expect(screen.getByText("Oi Ju, tudo bem?")).toBeInTheDocument();
+  });
+
+  it("leva para a conversa com o link certo", async () => {
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+    const link = await screen.findByRole("link", { name: /abrir conversa/i });
+    expect(link).toHaveAttribute("href", "/conversas/chat-1");
+  });
+
+  it("sem conversa, diz isso e NÃO oferece iniciar uma", async () => {
+    mockar([]);
+    renderBloco();
+    expect(await screen.findByText(/nenhuma conversa no whatsapp/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /iniciar/i })).not.toBeInTheDocument();
+  });
+
+  it("com duas conversas, mostra a mais recente e avisa da outra", async () => {
+    // Fora de ordem de propósito: o bloco escolhe pela data, não pela posição na lista.
+    mockar([
+      { ...conversa("chat-antigo", "Ju"), last_message_at: "2026-08-01T10:00:00Z" },
+      { ...conversa("chat-novo", "Ju"), last_message_at: "2026-08-15T23:10:00Z" },
+    ]);
+    renderBloco();
+    expect(await screen.findByRole("link", { name: /abrir conversa/i }))
+      .toHaveAttribute("href", "/conversas/chat-novo");
+    expect(screen.getByText(/\+1 outra conversa/i)).toBeInTheDocument();
+  });
+
+  it("falha de rede vira aviso, não derruba a ficha", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("caiu"));
+    renderBloco();
+    expect(await screen.findByText(/não foi possível carregar a conversa/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+```bash
+pnpm --filter @e1p/web test -- BlocoDaConversa
+```
+
+Esperado: FAIL — `Failed to resolve import "./BlocoDaConversa"`.
+
+- [ ] **Step 3: Implementar o componente**
+
+Crie `apps/web/src/features/crm/BlocoDaConversa.tsx`:
+
+```tsx
+import type { ConversationSummary, TimelineEntry } from "@e1p/shared-types";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api } from "../../lib/api";
+import { formatTime } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+
+/** Quantas falas cabem sem a ficha virar uma segunda tela de Conversas. */
+const ULTIMAS = 5;
+
+/**
+ * O teor da conversa na ficha 360° — uma JANELA, não um posto de trabalho.
+ *
+ * Mostra e leva para lá; responder continua sendo trabalho da tela de Conversas. A regra da
+ * janela de 24h da Meta e a escolha de template vivem lá, e duplicá-las aqui criaria um
+ * segundo lugar para o envio falhar de um jeito diferente.
+ *
+ * Não confundir com o `ClientTimeline` logo acima na ficha: aquele é a NARRATIVA do
+ * relacionamento (chegou, moveu, pagou, escreveu); este é o TEOR, o que foi dito.
+ */
+export default function BlocoDaConversa({ clientId }: { clientId: string }) {
+  const fuso = useFuso();
+  const [conversas, setConversas] = useState<ConversationSummary[]>([]);
+  const [mensagens, setMensagens] = useState<TimelineEntry[]>([]);
+  const [erro, setErro] = useState(false);
+  const [carregando, setCarregando] = useState(true);
+
+  const load = useCallback(async () => {
+    // Falha aqui NÃO pode derrubar a ficha — mesma postura do `ClientTimeline`, que degrada
+    // para um aviso em vez de levar junto cobranças, contratos e o resto da tela.
+    try {
+      const { data } = await api.get<ConversationSummary[]>(
+        `/whatsapp-conversations?client_id=${encodeURIComponent(clientId)}`,
+      );
+      const lista = Array.isArray(data) ? data : [];
+      setConversas(lista);
+      const recente = maisRecente(lista);
+      if (recente) {
+        const t = await api.get<TimelineEntry[]>(
+          `/whatsapp-conversations/${recente.chat_id}/timeline`,
+        );
+        setMensagens(Array.isArray(t.data) ? t.data.slice(-ULTIMAS) : []);
+      } else {
+        setMensagens([]);
+      }
+      setErro(false);
+    } catch {
+      setErro(true);
+      setConversas([]);
+      setMensagens([]);
+    } finally {
+      setCarregando(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (carregando) return <p className="py-4 text-sm text-neutral-400">Carregando conversa...</p>;
+  if (erro) {
+    return (
+      <p className="py-4 text-sm text-amber-700">
+        Não foi possível carregar a conversa.
+      </p>
+    );
+  }
+
+  const recente = maisRecente(conversas);
+  if (!recente) {
+    // Sem botão de "iniciar conversa": a janela de 24h da Meta não permite abrir conversa do
+    // nada, e um botão que sempre falha é pior que nenhum.
+    return <p className="py-4 text-center text-sm text-neutral-400">Nenhuma conversa no WhatsApp.</p>;
+  }
+
+  const outras = conversas.length - 1;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1.5">
+        {mensagens.length === 0 ? (
+          <p className="text-sm text-neutral-400">Conversa ainda sem mensagens.</p>
+        ) : (
+          mensagens.map((m, i) => (
+            <div
+              key={`${m.created_at}-${i}`}
+              className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm ${
+                m.direction === "out"
+                  ? "self-end bg-primary-50 text-neutral-800"
+                  : "self-start bg-neutral-100 text-neutral-700"
+              }`}
+            >
+              <p className="whitespace-pre-wrap">{m.text_body || `[${m.kind}]`}</p>
+              <p className="mt-0.5 text-[10px] text-neutral-400">{formatTime(m.created_at, fuso)}</p>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          to={`/conversas/${recente.chat_id}`}
+          className="text-sm font-medium text-primary-600 hover:text-primary-700"
+        >
+          Abrir conversa
+        </Link>
+        {/* Um contato pode ter MAIS DE UMA conversa (`@lid` + telefone — ver o comentário em
+            whatsapp_inbox/models.py). Mostrar só a mais recente sem dizer que há outra
+            esconderia mensagem do dono. */}
+        {outras > 0 && (
+          <Link to="/conversas" className="text-xs text-neutral-400 hover:text-neutral-600">
+            +{outras} outra conversa
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A conversa mais recente do contato — por data, não pela ordem em que a API devolveu. */
+function maisRecente(lista: ConversationSummary[]): ConversationSummary | null {
+  return lista.reduce<ConversationSummary | null>((melhor, c) => {
+    if (!melhor) return c;
+    if (!c.last_message_at) return melhor;
+    if (!melhor.last_message_at) return c;
+    return c.last_message_at > melhor.last_message_at ? c : melhor;
+  }, null);
+}
+```
+
+- [ ] **Step 4: Rodar e confirmar que passam**
+
+```bash
+pnpm --filter @e1p/web test -- BlocoDaConversa
+```
+
+Esperado: 5 passed. Se o texto "+1 outra conversa" falhar por causa da pluralização, ajuste a asserção do teste ou o texto — mas mantenha os dois batendo.
+
+- [ ] **Step 5: Pendurar o bloco na ficha**
+
+Em `apps/web/src/features/crm/ClientDetailPage.tsx`:
+
+Adicione `MessageCircle` ao import de `lucide-react` (linha 10) e importe o bloco junto dos outros imports locais:
+
+```tsx
+import BlocoDaConversa from "./BlocoDaConversa";
+```
+
+E insira a seção **logo depois** do bloco de Histórico (depois da linha 118), antes de Cobranças:
+
+```tsx
+      {/* Conversa vem depois do Histórico e antes do financeiro: o Histórico conta O QUE
+          aconteceu, a Conversa mostra O QUE FOI DITO, e só então vêm as seções operacionais.
+          O bloco carrega sozinho — não entra no `load()` da página, para que uma falha do
+          WhatsApp não segure a ficha inteira. */}
+      <Section icon={<MessageCircle size={16} />} title="Conversa">
+        <BlocoDaConversa clientId={id} />
+      </Section>
+```
+
+- [ ] **Step 6: Rodar a suíte de web inteira**
+
+```bash
+pnpm --filter @e1p/web test
+```
+
+Esperado: tudo verde.
+
+- [ ] **Step 7: Typecheck e lint**
+
+```bash
+pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/features/crm/BlocoDaConversa.tsx apps/web/src/features/crm/BlocoDaConversa.test.tsx apps/web/src/features/crm/ClientDetailPage.tsx
+git commit -m "feat: a ficha do contato mostra a conversa de WhatsApp"
+```
+
+---
+
+### Task 7: Fechamento — suíte inteira e a régua de 360px
+
+O card ganhou conteúdo na linha do nome e a ficha ganhou uma seção. A régua de 360px existe neste repo justamente porque teste estrutural (`toContain("flex-wrap")`) já deixou passar tela quebrada por duas sessões — layout só se prova medindo.
+
+**Files:**
+- Modify: `apps/web/e2e/crm-360.spec.ts` (se necessário, após verificar)
+
+- [ ] **Step 1: Rodar a suíte de API inteira, com `TZ=UTC`**
+
+```bash
+cd apps/api && TZ=UTC .venv/Scripts/python.exe -m pytest tests/ -q
+```
+
+Esperado: tudo verde. `TZ=UTC` porque a suíte deste repo já quebrou de madrugada três vezes por depender do relógio da máquina.
+
+- [ ] **Step 2: Rodar a suíte de web inteira**
+
+```bash
+pnpm --filter @e1p/web test && pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+- [ ] **Step 3: Atualizar a fixture do board**
+
+`apps/web/e2e/fixtures/crm.json` tem dois cards em `/crm/board`. Os objetos de cliente ali precisam do campo novo — e a fixture do repo é de **pior caso plausível**, então o card mais cheio (o `c2`, "Maria Aparecida Gonçalves de Souza", com duas tags) é o que ganha o ponto:
+
+- em `c1`, acrescente `"unread": false`
+- em `c2`, acrescente `"unread": true`
+
+- [ ] **Step 4: Medir o card com o ponto**
+
+Acrescente a `apps/web/e2e/crm-360.spec.ts`:
+
+```ts
+test("o ponto de mensagem esperando resposta não empurra o nome para fora", async ({ page }) => {
+  await page.goto("/crm");
+
+  // O ponto está no card MAIS CHEIO da fixture: nome longo + duas tags + alça de arrastar +
+  // botão de ficha. A linha do nome já era a mais disputada do card antes de ganhar inquilino.
+  const ponto = page.getByLabel("Mensagem esperando resposta");
+  await expect(ponto).toBeVisible();
+  await expect(ponto).toBeInViewport();
+
+  // O ponto tem `shrink-0`; quem cede é o nome, via `truncate`. A prova de que a divisão
+  // funciona é o ponto estar INTEIRO dentro do card — 8px de largura, não 3 amassados.
+  const caixaDoPonto = await ponto.boundingBox();
+  expect(caixaDoPonto?.width).toBeGreaterThanOrEqual(7);
+
+  // E nada da primeira coluna saiu da tela. Mesmo recorte `.w-72` e mesmo controle positivo
+  // do primeiro teste deste arquivo — sem o controle, um seletor que deixasse de casar
+  // aprovaria a tela para sempre.
+  expect(await textoForaDaTela(page, ".w-72")).toEqual([]);
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+});
+```
+
+- [ ] **Step 5: Medir o bloco de Conversa na ficha**
+
+Crie `apps/web/e2e/ficha-conversa-360.spec.ts` (arquivo próprio: a fixture é de outra tela e misturar as duas no `crm-360` obrigaria os testes de card a carregar mocks de conversa):
+
+```ts
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O bloco de Conversa da ficha 360° em 360px.
+ *
+ * O caso que estoura uma bolha de chat não é texto longo — é texto longo SEM ESPAÇO, que não
+ * tem onde quebrar. `max-w-[85%]` limita a caixa e não o conteúdo: sem `break-words` o texto
+ * transborda a bolha e leva a página junto. É por isso que a fixture abaixo tem uma URL
+ * gigante e uma sequência sem espaço, e não um lorem ipsum.
+ */
+const CONVERSA = {
+  chat_id: "chat-1",
+  kind: "direct",
+  title: "Ju",
+  phone: "554384035398",
+  client_id: "c1",
+  last_message_at: "2026-08-15T23:16:00Z",
+  last_message_preview: "Boa noite",
+  unread: false,
+};
+
+const fixtures = {
+  "/crm/clients/c1": {
+    id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: "554384035398",
+    document: null, gender: "unspecified", birthdate: null, notes: "", tags: [],
+    source: "whatsapp", stage_id: "s1", stage_entered_at: "2026-08-15T12:00:00Z",
+    created_at: "2026-08-15T12:00:00Z",
+  },
+  "/whatsapp-conversations/chat-1/timeline": [
+    {
+      source: "conversation", direction: "in", kind: "text",
+      text_body: "https://exemplo.com.br/orcamento/casamento-12-12-2026/detalhamento-completo-com-tudo",
+      media_attachment_id: null, purpose_label: null, sender_name: null,
+      created_at: "2026-08-15T23:10:00Z",
+    },
+    {
+      source: "conversation", direction: "out", kind: "text",
+      text_body: "Oi Ju! Aqui é do Doro Eventos. Recebemos seu contato e vamos te chamar pelo nosso número oficial.",
+      media_attachment_id: null, purpose_label: null, sender_name: null,
+      created_at: "2026-08-15T23:16:00Z",
+    },
+  ],
+  "/whatsapp-conversations": [CONVERSA],
+  // Mapeado de propósito: sem esta chave, o prefixo mais longo que casa é `/crm/clients/c1` e
+  // o `ClientTimeline` receberia o OBJETO do cliente onde espera `{entries, truncated}`. Ele
+  // degrada em vez de quebrar (`Array.isArray(data?.entries)`), mas o teste estaria medindo
+  // uma ficha sem Histórico — ou seja, uma tela mais curta que a real.
+  "/crm/clients/c1/timeline": { entries: [], truncated: false },
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, fixtures);
+});
+
+test("a conversa na ficha cabe em 360px, mesmo com texto sem espaço", async ({ page }) => {
+  await page.goto("/crm/clients/c1");
+
+  await expect(page.getByRole("link", { name: "Abrir conversa" })).toBeVisible();
+
+  // A PÁGINA não rola de lado. A ficha é uma coluna só — aqui, ao contrário do board, rolagem
+  // horizontal é defeito e não recurso.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // Varredura escopada à seção da conversa, com o controle positivo de sempre.
+  expect(await textoForaDaTela(page, "section, .rounded-2xl")).toEqual([]);
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});
+```
+
+⚠️ O seletor `"section, .rounded-2xl"` é um **chute** — ajuste-o para o que a ficha realmente usa depois de rodar (o `<Section>` de `ClientDetailPage` renderiza `div.rounded-2xl.bg-white`). O que **não** pode mudar é o par: varredura escopada **mais** o controle positivo. Um sem o outro não mede nada.
+
+- [ ] **Step 6: Rodar o e2e**
+
+```bash
+pnpm --filter @e1p/web e2e -- crm-360 ficha-conversa-360
+```
+
+Esperado: verde. Se o texto sem espaço estourar, o conserto é `break-words` na bolha de `BlocoDaConversa.tsx` — **não** afrouxe a medição.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/e2e/crm-360.spec.ts apps/web/e2e/ficha-conversa-360.spec.ts apps/web/e2e/fixtures/crm.json
+git commit -m "test: a regua de 360px mede o ponto no card e a conversa na ficha"
+```
+
+- [ ] **Step 8: Reportar**
+
+Rode `git log --oneline main..HEAD` e reporte ao dono:
+- os commits da onda;
+- a saída real das suítes (número de testes, não "passou");
+- que o push e o PR são do @devops — **não faça push**.
+
+---
+
+## Definição de pronto
+
+- [ ] `GET /whatsapp-conversations?client_id=X` devolve só as conversas daquele contato, e nunca grupo.
+- [ ] O teste de paridade entre `unread_client_ids` e `list_conversations` está verde.
+- [ ] `GET /crm/board` devolve `unread` booleano em todo card.
+- [ ] `/conversas/:chatId` abre a conversa; `/conversas` mostra a lista; id inválido avisa sem tela branca.
+- [ ] O card mostra o ponto quando há mensagem esperando resposta.
+- [ ] A ficha mostra as últimas mensagens, o link para a conversa, o aviso de conversa extra, o estado vazio honesto e degrada em falha de rede.
+- [ ] Suítes de API e web verdes; typecheck e lint limpos; régua de 360px verde.
+- [ ] Nenhum commit em `main`; nenhum push.

--- a/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
+++ b/docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md
@@ -33,11 +33,12 @@ pnpm --filter @e1p/web typecheck
 pnpm --filter @e1p/web lint
 ```
 
-**Antes de começar:** crie a branch de trabalho.
+**Antes de começar:** crie a branch de trabalho **a partir de `spec/crm-conversa-e-agenda-na-ficha`**, não de `main`. A spec e este plano vivem lá e ainda não foram mesclados (`main` é protegida e exige PR até para mudança só de documentação).
 
 ```bash
-git checkout main && git pull
+git checkout spec/crm-conversa-e-agenda-na-ficha
 git checkout -b feat/onda-1-conversa-na-ficha
+git log --oneline -2   # confirme que a spec e o plano estão no histórico
 ```
 
 ---

--- a/docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md
+++ b/docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md
@@ -1,0 +1,297 @@
+# A ficha do contato passa a falar com Conversas e com a Agenda
+
+**Data:** 2026-08-16
+**Status:** aprovado no brainstorming, aguardando plano de implementação
+
+## O problema
+
+O card do Kanban leva a uma ficha 360° que sabe de cobrança, contrato, orçamento, documento
+jurídico e funil — e não sabe de duas coisas que o dono usa o dia inteiro: a **conversa** que ele
+está tendo com aquela pessoa e o **compromisso** que ele marcou com ela.
+
+Os dois lados não estão no mesmo estágio:
+
+| Elo | Hoje |
+|---|---|
+| contato ↔ conversa | **Existe.** `whatsapp_chats.client_id` já aponta. A tela de Conversas até mostra o `ClientTimeline` do CRM na coluna da direita. Falta o caminho de volta: da ficha para a conversa. |
+| contato ↔ compromisso | **Não existe.** `agenda_events` não tem coluna de cliente. O nome que a Agenda mostra hoje é derivado da cobrança, por um caminho polimórfico via `external_ref`. |
+
+Consequência prática: para saber "o que está combinado com essa pessoa", o dono abre três telas e
+junta na cabeça. E no board ele não tem como ver quem está esperando resposta nem quem está
+parado no funil sem próximo passo marcado.
+
+## O que vamos construir
+
+**Sinal no card, conteúdo na ficha.**
+
+Na ficha (`/crm/clients/:id`), duas seções novas ao lado das que já existem:
+
+- **Conversa** — janela. Mostra as últimas mensagens e leva para Conversas para responder.
+- **Agenda** — ativa. Mostra os próximos compromissos e permite marcar um novo dali mesmo.
+
+No card do board (`/crm`), dois sinais:
+
+- ponto de **mensagem esperando resposta**, ao lado do nome;
+- uma linha que diz o **próximo compromisso** ou, na falta dele, que **não há próximo passo
+  marcado**.
+
+## Decisões tomadas
+
+| Decisão | Escolha | Por quê |
+|---|---|---|
+| Onde a integração mora | Sinal no card, conteúdo na ficha | O card tem 288px; cabe alerta, não conteúdo. |
+| Profundidade | Conversa é janela; Agenda é ativa | Responder WhatsApp tem janela de 24h e templates — regra que não pode viver em dois lugares. Marcar compromisso é o gesto que hoje não existe em lugar nenhum. |
+| Conversa vs. Histórico | Lado a lado | Histórico = a narrativa (chegou, moveu, pagou, escreveu). Conversa = o teor, as falas. |
+| Compromisso passado | Vai para o Histórico, não para o bloco | O bloco responde uma pergunta só: o que está marcado. O passado é assunto da linha do tempo, que já é read model cross-módulo. |
+| Vínculo Agenda↔contato | Coluna `client_id` própria | `external_ref` já é ponteiro polimórfico lido conforme o `kind`. Sobrecarregar viraria `WHERE source='crm' AND external_ref=X`, sem índice e sem garantia. |
+| Cardinalidade | Um cliente por evento | YAGNI. Reunião com dois clientes é rara e o campo `guests` já existe. |
+| Leitura | Cada módulo continua dono | Nenhuma regra de negócio duplicada. Fachada no CRM fica como otimização futura, se as requests doerem. |
+| Limpeza do router da Agenda | Entra nesta onda | O código polimórfico morre junto com o motivo dele existir — com teste comparando os dois caminhos antes da remoção. |
+| Entrega | Duas ondas | Onda 1 não toca no banco e pode ir para prod em dias. |
+
+### Abordagens descartadas
+
+**Fachada no CRM** (`GET /crm/clients/{id}/panorama`, tudo num payload). Uma request em vez de
+oito, e há precedente — `crm/timeline.py` já lê `quotes` e `receivables` na origem. Descartada
+por ora porque o CRM passaria a saber formatar conversa de WhatsApp, e aí janela de 24h, grupo
+que não é cliente e `@lid` não resolvido ganhariam um segundo lugar para dar errado.
+Reconsiderar se as 8 requests da ficha doerem.
+
+**Compromisso como entrada da linha do tempo, sem bloco.** Mais barato, mas o bloco precisa ser
+ativo (marcar) e o dono quer conversa separada do Histórico.
+
+---
+
+# Onda 1 — Conversa (sem migration)
+
+## API
+
+`GET /whatsapp-conversations` ganha o filtro opcional `client_id`. A implementação segue em
+`whatsapp_inbox/service.py`: é o módulo dono do vocabulário de conversa.
+
+Função nova no mesmo módulo, para o board:
+
+```python
+def unread_client_ids(db: Session) -> set[str]:
+    """Contatos com mensagem esperando resposta, para o card do Kanban."""
+```
+
+Agregada, uma query para o board inteiro — no molde do `crm_service.last_interaction_map`, que
+existe justamente porque valor derivado guardado dessincroniza.
+
+**Não** dá para reusar `list_conversations` aqui: ela carrega todas as mensagens do tenant em
+memória para achar a última de cada chat. A tela de Conversas tolera isso; o board, aberto a cada
+navegação, não.
+
+### O risco desta onda: duas definições de "não lida"
+
+A regra vive hoje inline dentro de `list_conversations`:
+
+```python
+unread = (
+    last_msg.direction == DIRECTION_IN
+    and (chat.last_read_at is None or last_msg.created_at > chat.last_read_at)
+)
+```
+
+Um agregado à parte cria uma segunda cópia dela. Elas divergem no primeiro ajuste que alguém
+fizer em uma só, e o sintoma é silencioso: o card diz "esperando resposta" com a caixa de entrada
+limpa.
+
+**Guarda:** as duas funções ficam no mesmo módulo, adjacentes, e um teste afirma que concordam
+sobre a mesma fixture:
+
+```python
+assert unread_client_ids(db) == {
+    c["client_id"] for c in list_conversations(db, tenant_id=t)
+    if c["unread"] and c["client_id"]
+}
+```
+
+A fixture precisa cobrir: chat sem `last_read_at`, chat lido depois da última mensagem, chat cuja
+última mensagem é `out`, grupo (que nunca tem `client_id`), e dois chats apontando para o mesmo
+cliente.
+
+## Ficha — bloco "Conversa"
+
+Nova seção em `ClientDetailPage`, usando o `<Section>` que já existe no arquivo. Últimas ~5
+mensagens em bolhas compactas e um botão que abre a conversa no lugar certo.
+
+**Um contato pode ter mais de uma conversa.** `whatsapp_chats.client_id` não tem unique, e o
+comentário no modelo explica: a mesma pessoa pode aparecer via `@lid` e via telefone, cada uma
+virando chat próprio. O bloco mostra a conversa **mais recente** por inteiro e, havendo outra, uma
+linha discreta "+1 outra conversa" que leva para Conversas. Fingir que é sempre uma esconderia
+mensagem do dono.
+
+Estado vazio: "Nenhuma conversa no WhatsApp." Sem botão de "iniciar conversa" — a janela de 24h da
+Meta não permite abrir conversa do nada, e um botão que sempre falha é pior que nenhum.
+
+O bloco degrada como o `ClientTimeline` já degrada: falha de carregamento vira aviso, não derruba
+a ficha.
+
+## Deep-link para a conversa
+
+Hoje `ConversasPage` guarda o chat selecionado em `useState` — não há como apontar para uma
+conversa de fora.
+
+- Rota nova: `/conversas/:chatId`.
+- `/conversas` continua válida (lista sem seleção), que é o que o menu lateral usa.
+- `chatId` inexistente ou de outro tenant: cai na lista com aviso, não em tela branca.
+
+Ganho colateral: o botão voltar do navegador e o link compartilhável passam a funcionar em
+Conversas, o que hoje não acontece.
+
+## Card do board — o ponto
+
+`build_board` passa a chamar `unread_client_ids`. `BoardClient` ganha `unread: bool`.
+
+Na tela: ponto ao lado do nome, mesma linguagem visual da lista de Conversas. Custo zero de
+altura — o card não cresce nesta onda.
+
+## Testes da Onda 1
+
+| Camada | O que prova |
+|---|---|
+| API | Filtro `client_id` na lista de conversas; grupo nunca aparece em conversa de cliente. |
+| API | **Paridade de "não lida"** entre `unread_client_ids` e `list_conversations` (fixture acima). |
+| API | `build_board` devolve `unread` correto, e o número de queries não cresce com a quantidade de cards. |
+| Web | Bloco de Conversa: com mensagens, vazio, com duas conversas, e com falha de rede. |
+| Web | Rota `/conversas/:chatId` seleciona a conversa; id inválido cai na lista. |
+| Web | Ponto no card aparece e some conforme o `unread`. |
+
+---
+
+# Onda 2 — Agenda (com migration)
+
+## Migration 0078
+
+```
+agenda_events.client_id  String(36)  nullable  indexed
+```
+
+**Sem FK**, seguindo o precedente de `whatsapp_chats.client_id`, que também é `String(36)` solto:
+a Agenda não deve ganhar dependência dura da tabela do CRM. Nullable é o caso normal — bloqueio de
+horário, prazo interno e conta a pagar não têm cliente.
+
+Nada muda em RLS: `agenda_events` já herda `TenantMixin` e a política é da tabela, não da coluna.
+
+### Backfill
+
+Todo evento `kind='cobranca_receber'` guarda no `external_ref` o id da cobrança, e a cobrança sabe
+de quem é. Um `UPDATE ... FROM charges` preenche o passado inteiro: na abertura, a ficha de um
+cliente antigo já mostra o histórico de compromissos sem nenhuma importação. Mesmo ganho retroativo
+que o `crm/timeline.py` descreve ao ler na origem.
+
+> ⚠️ **A armadilha da 0068 se aplica aqui, inteira.** O backfill roda como o papel dono
+> não-superusuário `e1p_app`, **sem** a GUC `app.current_tenant_id`. Sob `FORCE ROW LEVEL
+> SECURITY` o `UPDATE` seria filtrado a **zero linhas, em silêncio** — e o sintoma em produção não
+> seria erro de deploy, seria "a ficha não mostra compromisso nenhum". A RLS é desabilitada nas
+> **duas** tabelas na janela do backfill (`agenda_events` porque é o alvo, `charges` porque é a
+> fonte da subconsulta) e restaurada com ENABLE + FORCE logo depois. Mesmo padrão das 0046, 0066,
+> 0067 e 0068. DDL é transacional no Postgres e a migration roda offline, então não há janela de
+> exposição.
+
+O teste da migration segue o formato de `test_migration_0068_stage_order_rls.py`, que existe
+exatamente para provar que o `UPDATE` não foi filtrado a zero linhas.
+
+## API
+
+- `client_id` entra em `EventCreate`, `EventUpdate` e `EventOut`.
+- `GET /agenda/events` ganha o filtro `client_id`.
+- `receivables/service.py` passa a gravar `client_id` no evento que cria.
+- Função nova em `agenda/service.py`, para o board:
+
+```python
+def next_event_map(db: Session) -> dict[str, AgendaEvent]:
+    """Próximo compromisso por contato, para o card do Kanban."""
+```
+
+Agregada, uma query para o board inteiro. Ignora `status='cancelled'`.
+
+### Limpeza do router
+
+`agenda/router.py` hoje reconstrói o nome do cliente juntando `external_ref` de dois `kind`s
+diferentes, buscando cobranças e montando mapa. Com `client_id` populado isso vira um join direto.
+
+**Ordem obrigatória:** primeiro um teste que roda os dois caminhos sobre a mesma base e afirma que
+produzem o mesmo `client_name`; só depois a remoção do caminho antigo. Sem esse teste, um backfill
+que errasse uma linha faria a Agenda perder nome de cliente que ela hoje mostra — e ninguém
+perceberia.
+
+## Ficha — bloco "Agenda"
+
+Seção nova com os **próximos** compromissos e o botão **"Marcar com este cliente"**.
+
+O modal não é escrito do zero: `NewEventModal` já existe dentro de `AgendaPage.tsx`, **com o aviso
+de conflito de horário já resolvido**. Ele é extraído para `features/agenda/NewEventModal.tsx` e
+passa a receber `clientId` opcional. `AgendaPage.tsx` tem 723 linhas e o modal é ~175 delas — a
+extração deixa os dois arquivos menores e faz a checagem de conflito continuar existindo em um
+lugar só.
+
+Estado vazio: "Nenhum compromisso marcado", com o botão logo abaixo. É o estado mais importante do
+bloco — é ele que revela o contato que vai esfriar.
+
+## Compromisso passado vai para o Histórico
+
+`crm/timeline.py` ganha uma quarta fonte, ao lado de `facts`, `charges` e `quotes`: eventos de
+agenda já realizados, lidos na origem por `client_id`. Segue o mesmo `LIMITE_POR_FONTE` e a mesma
+regra de `truncated`.
+
+`kind` novo na saída — `agenda` — que precisa de entrada no mapa `APARENCIA` do `ClientTimeline`,
+porque o vocabulário é fechado e um `kind` sem tratamento cai no ícone neutro.
+
+> ⚠️ **Conserto de fuso, obrigatório nesta onda.** `ClientTimeline.quando()` formata com
+> `toLocaleString("pt-BR", ...)` **sem `timeZone`** — ou seja, no fuso do navegador. O comentário
+> ali diz "mesma convenção da ConversasPage", mas a ConversasPage foi corrigida exatamente disso: o
+> mesmo histórico quebrava os dias em pontos diferentes conforme a máquina que abrisse a tela.
+> Colocar compromissos com horário nessa lista sem consertar faria "reunião às 14h" aparecer em
+> hora errada. Passa a usar `useFuso()` + `lib/datetime`, como o resto do sistema.
+
+## Card do board — a linha do próximo passo
+
+`BoardClient` ganha `next_event_at` e `next_event_title`. Na tela, **uma linha só**: diz o próximo
+compromisso quando existe, e "sem próximo passo" quando não — são estados opostos da mesma
+pergunta e nunca aparecem juntos.
+
+O card fica com nome + selo de origem + tags + três linhas de rodapé ("na etapa desde", "última
+interação", próximo passo).
+
+> ⚠️ **Fuso.** "terça 14h" e a própria fronteira entre passado e futuro são calculados no fuso do
+> tenant — `hoje_do_tenant(db)` no back, `useFuso()` no front. É a classe de regressão que já
+> voltou três vezes neste repo. A suíte tem de rodar com `TZ=UTC` para o teste ter valor.
+
+## Testes da Onda 2
+
+| Camada | O que prova |
+|---|---|
+| Migration | Backfill sob RLS preencheu linhas (formato do `test_migration_0068_stage_order_rls.py`). |
+| Migration | Evento sem cobrança e conta a pagar continuam com `client_id` nulo. |
+| API | Filtro `client_id`; evento cancelado fora do `next_event_map`. |
+| API | **Paridade do router**: derivação antiga e join novo produzem o mesmo `client_name` — roda antes da remoção. |
+| API | `next_event_map` respeita o fuso do tenant na fronteira passado/futuro, com `TZ=UTC`. |
+| API | Linha do tempo inclui compromisso realizado e respeita `LIMITE_POR_FONTE`/`truncated`. |
+| Web | Bloco Agenda: com próximos, vazio, e criando compromisso (inclusive o caminho de conflito). |
+| Web | `NewEventModal` extraído continua funcionando na AgendaPage — sem regressão. |
+| Web | `ClientTimeline` formata no fuso do tenant. |
+| E2E 360px | `crm-360.spec.ts`: o card cresceu, então volta para a régua — medindo `boundingBox`, não procurando classe CSS. |
+
+---
+
+## Riscos, em ordem
+
+1. **Duas definições de "não lida"** (Onda 1). Divergência silenciosa. Mitigado pelo teste de
+   paridade.
+2. **Backfill filtrado a zero linhas pela RLS** (Onda 2). Falha silenciosa em produção, com
+   deploy verde. Mitigado pela janela de RLS e pelo teste de migration.
+3. **Limpeza do router antes de o backfill estar provado** (Onda 2). Perda de informação que hoje
+   funciona. Mitigado pela ordem obrigatória: teste de paridade primeiro, remoção depois.
+4. **Fuso no card e na linha do tempo.** Classe reincidente neste repo. Mitigado por rodar a
+   suíte com `TZ=UTC`.
+5. **Card mais alto** (Onda 2). Três linhas de rodapé em 288px. Mitigado pela régua de 360px.
+
+## O que fica de fora
+
+- Responder WhatsApp de dentro da ficha (janela de 24h e templates seguem só em Conversas).
+- Fachada `panorama` no CRM.
+- Evento com mais de um cliente.
+- Sinal de conversa em card de grupo — grupo não é contato do CRM, por decisão de 2026-08-04.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -254,9 +254,11 @@ export interface ClientTimelineOut {
   truncated: boolean;
 }
 
-/** `Client` do board, com a data da última interação (só o board calcula isso). */
+/** `Client` do board, com os sinais que só o board calcula. */
 export interface BoardClient extends Client {
   last_interaction_at: string | null;
+  /** Tem mensagem do contato esperando resposta. */
+  unread: boolean;
 }
 
 export interface BoardColumn {


### PR DESCRIPTION
## Onda 1 — a ficha do contato passa a falar com Conversas

A ficha 360° (`/crm/clients/:id`) sabia de cobrança, contrato, orçamento, documento jurídico e funil — e não sabia da conversa que o dono está tendo com aquela pessoa. Para responder "o que está combinado com esse contato", ele abria três telas e juntava na cabeça.

Esta onda liga fios que **já existiam** no banco (`whatsapp_chats.client_id`). **Sem migration.**

A Onda 2 (vínculo com a Agenda, que exige coluna nova e backfill) fica para um PR próprio — ver a spec.

### O que muda para o dono

- **Bloco "Conversa" na ficha** — as últimas mensagens e um botão que abre a conversa no lugar certo. É uma janela: responder continua sendo trabalho da tela de Conversas, onde a janela de 24h da Meta e os templates já vivem.
- **Ponto no card do Kanban** — quando o contato escreveu e ninguém respondeu.
- **A conversa tem URL própria** (`/conversas/:chatId`) — é assim que a ficha aponta para ela. De brinde, o botão voltar do navegador passou a funcionar na tela de Conversas.

### Decisões que valem revisão

**Duas expressões da mesma regra, de propósito.** `unread_client_ids` repete a regra de "não lida" que já existe dentro de `list_conversations`, porque aquela função materializa todas as mensagens do tenant e o board não pode pagar isso a cada navegação. As duas ficam coladas no mesmo módulo, desempatam por `(created_at, id)`, e um **teste de paridade** falha se alguém mexer numa e esquecer a outra.

**Um contato pode ter mais de uma conversa.** `@lid` e telefone viram chats separados. O bloco mostra a mais recente e avisa "+N outras conversas" — fingir que é sempre uma esconderia mensagem.

**Grupo nunca aparece.** `client_id` é nulo nele, por decisão de produto (2026-08-04).

**Estado vazio sem botão.** Não há "iniciar conversa": a janela de 24h da Meta não permite abrir conversa do nada, e um botão que sempre falha é pior que nenhum.

### Consertos que apareceram no caminho

- **A régua de 360px era cega.** `e2e/support/medidas.ts` media a **caixa** (`getBoundingClientRect`), não a **tinta**. Texto sem espaço vaza para fora da caixa sem alargá-la — exatamente a classe de estouro que a régua existe para pegar. Corrigido com `scrollWidth`, guardado contra falso positivo de `.truncate`, e com um teste que só esse ramo consegue pegar.
- **`ConversasPage` confundia "carregando" com "vazio".** Num tenant sem conversa nenhuma, qualquer link direto ficava permanentemente travado: sem aviso, lista escondida no celular, painel congelado em "Selecione uma conversa".
- **`chatId` inexistente montava o painel assim mesmo** — aviso de não-encontrada empilhado com uma caixa de mensagem funcional, pollando um 404 a cada 7s.
- **Consultas estreitadas.** O filtro por contato podava o resultado mas ainda carregava todas as mensagens do tenant; e a ficha baixava a conversa inteira para mostrar cinco balões (`get_timeline` ganhou `limit` opcional — o caminho sem limite, que a tela de Conversas usa, não mudou).

### Verificação

| Suíte | Resultado |
|---|---|
| API `pytest` (`TZ=UTC`) | 2126 passaram, 1 pulado |
| API `ruff` | limpo |
| Web `vitest` | 636 testes, 65 arquivos |
| `typecheck` / `lint` | limpos |
| Playwright 360px | 24 passaram |

`TZ=UTC` porque a suíte deste repo já quebrou de madrugada por depender do relógio da máquina.

### Sabidamente fora deste PR

- **Índice composto em `whatsapp_messages`.** A janela ordena por `(chat_id, created_at DESC, id DESC)`, então duas colunas ainda deixariam um sort — o índice certo é a tupla inteira, e vale medir antes de abrir migration.
- **Botão flutuante de Histórico com `chatId` inexistente.** Ainda aparece e abre gaveta com mensagem enganosa. Pré-existente; o conserto é gatear em `selected && !naoEncontrada`, como já se faz na lista e no painel.

### Documentos

- Spec: `docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md`
- Plano: `docs/superpowers/plans/2026-08-16-onda-1-conversa-na-ficha.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
