### PR TITLE
feat: o compromisso da Agenda sabe de quem e [Onda 2]

### DIFF
--- a/apps/api/app/modules/agenda/models.py
+++ b/apps/api/app/modules/agenda/models.py
@@ -75,4 +75,12 @@ class AgendaEvent(Base, TenantMixin, TimestampMixin):
     # Referência à entidade de origem (id do processo, fatura, contrato...).
     external_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
+    # De QUEM é este compromisso. Nullable é o caso normal: bloqueio de horário, prazo
+    # interno e conta a pagar não têm cliente. Sem FK e `String(36)`, como
+    # `whatsapp_chats.client_id` — a Agenda não deve ganhar dependência dura da tabela do CRM.
+    #
+    # Não confundir com `external_ref`: aquele é ponteiro POLIMÓRFICO, lido conforme o `kind`
+    # (id de cobrança, de conta a pagar...). Este é sempre um `clients.id`.
+    client_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
+
     created_by_ai: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/apps/api/app/modules/agenda/router.py
+++ b/apps/api/app/modules/agenda/router.py
@@ -82,13 +82,18 @@ def list_events(
     end: datetime | None = Query(default=None),
     kind: list[str] | None = Query(default=None),
     client_id: str | None = Query(default=None),
+    # Default `False`: preserva o comportamento de hoje da tela de Agenda, que lista TODO evento
+    # (cancelado incluso — o card mostra o status). A ficha 360° (`BlocoDaAgenda`) manda `true`
+    # explicitamente, para não impersonar um "próximo compromisso" com um evento cancelado.
+    exclude_cancelled: bool = Query(default=False),
     limit: int = Query(default=200, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     _user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> list[EventOut]:
     events = service.list_events(
-        db, start=start, end=end, kinds=kind, client_id=client_id, limit=limit, offset=offset
+        db, start=start, end=end, kinds=kind, client_id=client_id,
+        exclude_cancelled=exclude_cancelled, limit=limit, offset=offset,
     )
     return _events_out(db, events)
 

--- a/apps/api/app/modules/agenda/router.py
+++ b/apps/api/app/modules/agenda/router.py
@@ -75,12 +75,15 @@ def list_events(
     start: datetime | None = Query(default=None),
     end: datetime | None = Query(default=None),
     kind: list[str] | None = Query(default=None),
+    client_id: str | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     _user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
 ) -> list[EventOut]:
-    events = service.list_events(db, start=start, end=end, kinds=kind, limit=limit, offset=offset)
+    events = service.list_events(
+        db, start=start, end=end, kinds=kind, client_id=client_id, limit=limit, offset=offset
+    )
     return _events_out(db, events)
 
 

--- a/apps/api/app/modules/agenda/router.py
+++ b/apps/api/app/modules/agenda/router.py
@@ -19,34 +19,40 @@ from app.modules.agenda.schemas import (
 )
 from app.modules.crm.models import Client
 from app.modules.payables.models import Payable
-from app.modules.receivables.models import Charge
 
 
 def _events_out(db: Session, events: list[AgendaEvent]) -> list[EventOut]:
-    """Resolve o nome do cliente (cobrança) / fornecedor (conta a pagar) para o card."""
-    receber_refs = [
-        e.external_ref for e in events if e.kind == "cobranca_receber" and e.external_ref
-    ]
-    pagar_refs = [e.external_ref for e in events if e.kind == "cobranca_pagar" and e.external_ref]
+    """Resolve o nome exibido no card: cliente (vínculo direto) / fornecedor (derivação).
+
+    Os dois caminhos existem porque são coisas diferentes. Cliente é VÍNCULO: o evento carrega
+    `client_id` (Tasks 1/2 desta onda — backfill do passado + escrita no nascimento), então o nome
+    vem de um join direto por id, sem passar por `external_ref`/`Charge`. Fornecedor CONTINUA
+    sendo DERIVAÇÃO: conta a pagar não tem cliente e nunca terá `client_id` — o nome só existe
+    porque `Payable.supplier` é alcançável via `external_ref`. Remover este segundo caminho
+    apagaria o nome do fornecedor da tela da Agenda.
+    """
+    client_ids = {e.client_id for e in events if e.client_id}
     names: dict[str, str] = {}
-    if receber_refs:
-        charges = db.scalars(select(Charge).where(Charge.id.in_(receber_refs))).all()
-        client_ids = {c.client_id for c in charges if c.client_id}
-        cmap = {}
-        if client_ids:
-            rows = db.scalars(select(Client).where(Client.id.in_(client_ids)))
-            cmap = {c.id: c.name for c in rows}
-        for c in charges:
-            if c.client_id and c.client_id in cmap:
-                names[c.id] = cmap[c.client_id]
+    if client_ids:
+        rows = db.scalars(select(Client).where(Client.id.in_(client_ids)))
+        names = {c.id: c.name for c in rows}
+
+    pagar_refs = [e.external_ref for e in events if e.kind == "cobranca_pagar" and e.external_ref]
+    supplier_names: dict[str, str] = {}
     if pagar_refs:
         for p in db.scalars(select(Payable).where(Payable.id.in_(pagar_refs))):
             if p.supplier:
-                names[p.id] = p.supplier
+                supplier_names[p.id] = p.supplier
+
     out = []
     for e in events:
         eo = EventOut.model_validate(e)
-        eo.client_name = names.get(e.external_ref) if e.external_ref else None
+        if e.client_id:
+            eo.client_name = names.get(e.client_id)
+        elif e.external_ref:
+            eo.client_name = supplier_names.get(e.external_ref)
+        else:
+            eo.client_name = None
         out.append(eo)
     return out
 

--- a/apps/api/app/modules/agenda/router.py
+++ b/apps/api/app/modules/agenda/router.py
@@ -83,8 +83,10 @@ def list_events(
     kind: list[str] | None = Query(default=None),
     client_id: str | None = Query(default=None),
     # Default `False`: preserva o comportamento de hoje da tela de Agenda, que lista TODO evento
-    # (cancelado incluso — o card mostra o status). A ficha 360° (`BlocoDaAgenda`) manda `true`
-    # explicitamente, para não impersonar um "próximo compromisso" com um evento cancelado.
+    # (cancelado/feito incluso — o card mostra o status). A ficha 360° (`BlocoDaAgenda`) manda
+    # `true` explicitamente, para não impersonar um "próximo compromisso" com um evento cancelado
+    # OU JÁ FEITO. Nome mantido por compatibilidade de contrato de API; o filtro por trás exclui
+    # `TERMINAL_STATUSES` inteiro — ver o comentário em `agenda/service.py::list_events`.
     exclude_cancelled: bool = Query(default=False),
     limit: int = Query(default=200, ge=1, le=500),
     offset: int = Query(default=0, ge=0),

--- a/apps/api/app/modules/agenda/schemas.py
+++ b/apps/api/app/modules/agenda/schemas.py
@@ -35,6 +35,9 @@ class EventCreate(BaseModel):
     guests: list[str] = Field(default_factory=list)
     amount_cents: int | None = Field(default=None, ge=0)
     external_ref: str | None = None
+    # De quem é este compromisso (aponta para `clients.id`, sem FK — ver AgendaEvent.client_id).
+    # Opcional: bloqueio de horário, prazo interno e conta a pagar não têm contato.
+    client_id: str | None = None
 
     _aware = field_validator("starts_at", "ends_at")(_ensure_aware)
 
@@ -68,6 +71,8 @@ class EventUpdate(BaseModel):
     priority: str | None = None
     location: str | None = Field(default=None, max_length=255)
     meeting_url: str | None = Field(default=None, max_length=512)
+    # Reatribuir/desvincular o contato do evento (mesmo campo de EventCreate).
+    client_id: str | None = None
 
     @model_validator(mode="after")
     def _validate(self) -> EventUpdate:
@@ -110,7 +115,10 @@ class EventOut(BaseModel):
     external_ref: str | None
     # Id do evento espelhado no Google Calendar (quando o Meet foi gerado via OAuth). Story 4.1.
     google_event_id: str | None = None
-    # Nome do cliente (cobrança) ou fornecedor (conta a pagar) — resolvido no list/get.
+    # client_id é o VÍNCULO (aponta para clients.id, gravado no evento); client_name é o NOME
+    # já resolvido para exibição no card — vem de uma consulta à parte (cobrança/fornecedor),
+    # não da coluna do evento.
+    client_id: str | None = None
     client_name: str | None = None
     created_by_ai: bool
     created_at: datetime

--- a/apps/api/app/modules/agenda/schemas.py
+++ b/apps/api/app/modules/agenda/schemas.py
@@ -71,7 +71,9 @@ class EventUpdate(BaseModel):
     priority: str | None = None
     location: str | None = Field(default=None, max_length=255)
     meeting_url: str | None = Field(default=None, max_length=512)
-    # Reatribuir/desvincular o contato do evento (mesmo campo de EventCreate).
+    # Reatribuir o contato do evento (mesmo campo de EventCreate). `None` = campo OMITIDO, não
+    # "limpar o vínculo": `update_event` só grava quando `data.client_id is not None`, então dá
+    # para trocar A por B, mas não existe hoje um jeito de desvincular via PATCH.
     client_id: str | None = None
 
     @model_validator(mode="after")

--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -5,7 +5,7 @@ queries (Regra de Ouro nº 1). O tenant_id só é usado para CARIMBAR novas linh
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
@@ -98,6 +98,7 @@ def create_event(
         guests=data.guests,
         amount_cents=data.amount_cents,
         external_ref=data.external_ref,
+        client_id=data.client_id,
         created_by_ai=by_ai,
     )
     # Geração automática de Meet (Story 4.1): só quando é um evento de reunião, o usuário NÃO
@@ -130,6 +131,7 @@ def list_events(
     start: datetime | None = None,
     end: datetime | None = None,
     kinds: list[str] | None = None,
+    client_id: str | None = None,
     limit: int = DEFAULT_LIST_LIMIT,
     offset: int = 0,
 ) -> list[AgendaEvent]:
@@ -143,6 +145,11 @@ def list_events(
         stmt = stmt.where(AgendaEvent.starts_at <= end)
     if kinds:
         stmt = stmt.where(AgendaEvent.kind.in_(kinds))
+    if client_id is not None:
+        # Filtro da ficha 360°: só os compromissos DESTE contato. Evento sem client_id (bloqueio,
+        # prazo interno, conta a pagar) nunca casa — a coluna é nullable e `== client_id` não
+        # captura linhas NULL.
+        stmt = stmt.where(AgendaEvent.client_id == client_id)
     stmt = stmt.order_by(AgendaEvent.starts_at).limit(limit).offset(offset)
     return list(db.scalars(stmt).all())
 
@@ -192,6 +199,8 @@ def update_event(
         event.location = data.location
     if data.meeting_url is not None:
         event.meeting_url = data.meeting_url
+    if data.client_id is not None:
+        event.client_id = data.client_id
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="agenda.event.update", target=event.id,
         is_ai=by_ai,
@@ -266,3 +275,45 @@ def reschedule_event(
     db.commit()
     db.refresh(event)
     return event, conflicts
+
+
+def next_event_map(db: Session) -> dict[str, AgendaEvent]:
+    """Próximo compromisso por contato, para a linha do card do Kanban.
+
+    Consulta agregada, uma para o board inteiro — no molde de `crm_service.last_interaction_map`,
+    que existe justamente porque valor derivado guardado dessincroniza. O custo não cresce com
+    a quantidade de cards.
+
+    ⚠️ O corte é `ends_at >= agora`, NÃO `starts_at >= agora`. Evento de dia inteiro é ancorado
+    na meia-noite real do fuso do tenant (ver `create_event`), então às 15h o `starts_at` dele
+    já passou — filtrar pelo início esconderia o compromisso de HOJE, que é o mais relevante
+    que existe para o card. Pelo fim, ele aparece o dia todo e some quando acaba.
+
+    Cancelado fica de fora: não é próximo passo nenhum.
+
+    A sessão já chega escopada por RLS (mesma convenção de `list_events`).
+    """
+    agora = datetime.now(UTC)
+    # Mesmo padrão de `unread_client_ids` (whatsapp_inbox/service.py): `row_number()` particionado
+    # por contato, ordenado por (starts_at, id), ficando com rn == 1. O desempate por `id` não é
+    # decoração — dois eventos no mesmo instante fariam "o próximo" dançar entre chamadas sem ele.
+    # Sem SQL condicional por dialeto: roda igual em SQLite (teste) e Postgres (produção).
+    ranked = (
+        select(
+            AgendaEvent.id.label("id"),
+            func.row_number()
+            .over(
+                partition_by=AgendaEvent.client_id,
+                order_by=(AgendaEvent.starts_at, AgendaEvent.id),
+            )
+            .label("rn"),
+        )
+        .where(
+            AgendaEvent.client_id.is_not(None),
+            AgendaEvent.status != STATUS_CANCELLED,
+            AgendaEvent.ends_at >= agora,
+        )
+        .subquery()
+    )
+    stmt = select(AgendaEvent).join(ranked, ranked.c.id == AgendaEvent.id).where(ranked.c.rn == 1)
+    return {event.client_id: event for event in db.scalars(stmt).all()}

--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -132,6 +132,7 @@ def list_events(
     end: datetime | None = None,
     kinds: list[str] | None = None,
     client_id: str | None = None,
+    exclude_cancelled: bool = False,
     limit: int = DEFAULT_LIST_LIMIT,
     offset: int = 0,
 ) -> list[AgendaEvent]:
@@ -150,6 +151,13 @@ def list_events(
         # prazo interno, conta a pagar) nunca casa — a coluna é nullable e `== client_id` não
         # captura linhas NULL.
         stmt = stmt.where(AgendaEvent.client_id == client_id)
+    if exclude_cancelled:
+        stmt = stmt.where(AgendaEvent.status != STATUS_CANCELLED)
+    # Default `False`, ao contrário de `count_events` (default `True`): a tela de Agenda chama
+    # `list_events` sem este parâmetro e RENDERIZA todo evento, cancelado incluso (o card mostra
+    # o status); mudar o default aqui apagaria eventos cancelados do calendário sem ninguém pedir.
+    # É a ficha 360° (`BlocoDaAgenda`) que passa `exclude_cancelled=True` explicitamente — ver
+    # `router.py`.
     stmt = stmt.order_by(AgendaEvent.starts_at).limit(limit).offset(offset)
     return list(db.scalars(stmt).all())
 

--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -152,10 +152,18 @@ def list_events(
         # captura linhas NULL.
         stmt = stmt.where(AgendaEvent.client_id == client_id)
     if exclude_cancelled:
-        stmt = stmt.where(AgendaEvent.status != STATUS_CANCELLED)
+        # ⚠️ **O NOME do parâmetro ficou menor que o que ele faz** (achado da revisão final da
+        # Onda 2): exclui `TERMINAL_STATUSES` inteiro (`cancelled` E `done`), não só cancelado —
+        # um evento marcado `done` ANTES da hora não pode continuar aparecendo no bloco de
+        # "próximo compromisso" da ficha 360° como se ainda estivesse por vir. NÃO renomeado
+        # para `exclude_terminal` porque `exclude_cancelled` é também o nome do QUERY PARAM
+        # público (`GET /agenda/events?exclude_cancelled=true`, consumido por `BlocoDaAgenda.tsx`
+        # e pelos testes de `test_agenda_por_contato.py`) — o ganho de precisão do nome não paga
+        # o custo de uma migração de contrato de API só por isto. Este comentário é a correção.
+        stmt = stmt.where(AgendaEvent.status.not_in(TERMINAL_STATUSES))
     # Default `False`, ao contrário de `count_events` (default `True`): a tela de Agenda chama
-    # `list_events` sem este parâmetro e RENDERIZA todo evento, cancelado incluso (o card mostra
-    # o status); mudar o default aqui apagaria eventos cancelados do calendário sem ninguém pedir.
+    # `list_events` sem este parâmetro e RENDERIZA todo evento, cancelado/feito incluso (o card
+    # mostra o status); mudar o default aqui apagaria eventos do calendário sem ninguém pedir.
     # É a ficha 360° (`BlocoDaAgenda`) que passa `exclude_cancelled=True` explicitamente — ver
     # `router.py`.
     stmt = stmt.order_by(AgendaEvent.starts_at).limit(limit).offset(offset)
@@ -292,12 +300,20 @@ def next_event_map(db: Session) -> dict[str, AgendaEvent]:
     que existe justamente porque valor derivado guardado dessincroniza. O custo não cresce com
     a quantidade de cards.
 
-    ⚠️ O corte é `ends_at >= agora`, NÃO `starts_at >= agora`. Evento de dia inteiro é ancorado
-    na meia-noite real do fuso do tenant (ver `create_event`), então às 15h o `starts_at` dele
-    já passou — filtrar pelo início esconderia o compromisso de HOJE, que é o mais relevante
-    que existe para o card. Pelo fim, ele aparece o dia todo e some quando acaba.
+    ⚠️ O corte é `ends_at >= agora`, NÃO `starts_at >= agora`. Evento de dia inteiro tem `starts_at`
+    ancorado à MEIA-NOITE — mas em qual fuso depende de QUEM criou o evento, e as duas
+    convenções coexistem de propósito (achado da revisão final da Onda 2, não unificado aqui:
+    virar migration de dados está fora desta onda):
+      - `create_event` ancora na meia-noite REAL do fuso do TENANT (convertida p/ UTC via
+        `day_window_utc` — ver a docstring dele);
+      - `receivables.service.build_charge` (a população DOMINANTE que alimenta este mapa, já
+        que toda cobrança nasce com evento) ancora na meia-noite UTC CRUA — ver o comentário lá.
+    Nos dois casos, às 15h no fuso do tenant o `starts_at` já ficou no passado — filtrar pelo
+    início esconderia o compromisso de HOJE, que é o mais relevante que existe para o card.
+    Pelo fim, ele aparece o dia todo e some quando acaba, em QUALQUER das duas convenções.
 
-    Cancelado fica de fora: não é próximo passo nenhum.
+    Cancelado E feito ficam de fora (`TERMINAL_STATUSES`): nenhum dos dois é próximo passo — um
+    `done` adiantado pelo dono é tão "já resolvido" quanto um cancelado, para esta pergunta.
 
     A sessão já chega escopada por RLS (mesma convenção de `list_events`).
     """
@@ -318,7 +334,11 @@ def next_event_map(db: Session) -> dict[str, AgendaEvent]:
         )
         .where(
             AgendaEvent.client_id.is_not(None),
-            AgendaEvent.status != STATUS_CANCELLED,
+            # `TERMINAL_STATUSES`, não só `STATUS_CANCELLED` (achado da revisão final da Onda 2):
+            # um compromisso marcado `done` ANTES da hora (o dono adianta o status) não é "próximo
+            # passo" nenhum — ele já aconteceu, do ponto de vista de quem preenche o card. Cancelado
+            # e feito são os dois jeitos de um evento deixar de ser pendência.
+            AgendaEvent.status.not_in(TERMINAL_STATUSES),
             AgendaEvent.ends_at >= agora,
         )
         .subquery()

--- a/apps/api/app/modules/crm/router.py
+++ b/apps/api/app/modules/crm/router.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.core.facts import CRM_NOTA_CRIADA
 from app.core.tenancy import CurrentUser, get_tenant_db, require_module
+from app.modules.agenda import service as agenda_service
 from app.modules.crm import service, timeline
 from app.modules.crm.schemas import (
     Board,
@@ -46,6 +47,10 @@ def get_board(
     # Consulta agregada, uma para o board inteiro — o custo não cresce com a quantidade de
     # cards. Lida do módulo DONO da regra de "não lida" em vez de reimplementada aqui.
     esperando = inbox_service.unread_client_ids(db)
+    # Idem: uma consulta agregada para o board inteiro, dona da Agenda. Devolve o EVENTO
+    # inteiro (não uma tupla achatada) — aqui só extraímos `starts_at`/`title`, mas o mesmo
+    # mapa também alimenta o bloco da ficha 360°, que lê outros campos do mesmo agregado.
+    proximo = agenda_service.next_event_map(db)
     return Board(
         columns=[
             BoardColumn(
@@ -55,6 +60,8 @@ def get_board(
                         **ClientOut.model_validate(c).model_dump(),
                         last_interaction_at=ultimo.get(c.id),
                         unread=c.id in esperando,
+                        next_event_at=ev.starts_at if (ev := proximo.get(c.id)) else None,
+                        next_event_title=ev.title if ev else None,
                     )
                     for c in clients
                 ],

--- a/apps/api/app/modules/crm/router.py
+++ b/apps/api/app/modules/crm/router.py
@@ -85,6 +85,7 @@ def _board_client(
         unread=c.id in esperando,
         next_event_at=ev.starts_at if ev else None,
         next_event_title=ev.title if ev else None,
+        next_event_all_day=ev.all_day if ev else False,
     )
 
 

--- a/apps/api/app/modules/crm/router.py
+++ b/apps/api/app/modules/crm/router.py
@@ -1,13 +1,17 @@
 """Rotas do CRM & Funil Kanban. Exigem tenant autenticado + permissão ao módulo 'crm'."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
 from app.core.facts import CRM_NOTA_CRIADA
 from app.core.tenancy import CurrentUser, get_tenant_db, require_module
 from app.modules.agenda import service as agenda_service
+from app.modules.agenda.models import AgendaEvent
 from app.modules.crm import service, timeline
+from app.modules.crm.models import Client
 from app.modules.crm.schemas import (
     Board,
     BoardClient,
@@ -55,19 +59,32 @@ def get_board(
         columns=[
             BoardColumn(
                 stage=StageOut.model_validate(stage),
-                clients=[
-                    BoardClient(
-                        **ClientOut.model_validate(c).model_dump(),
-                        last_interaction_at=ultimo.get(c.id),
-                        unread=c.id in esperando,
-                        next_event_at=ev.starts_at if (ev := proximo.get(c.id)) else None,
-                        next_event_title=ev.title if ev else None,
-                    )
-                    for c in clients
-                ],
+                clients=[_board_client(c, ultimo, esperando, proximo) for c in clients],
             )
             for stage, clients in columns
         ]
+    )
+
+
+def _board_client(
+    c: Client,
+    ultimo: dict[str, datetime],
+    esperando: set[str],
+    proximo: dict[str, AgendaEvent],
+) -> BoardClient:
+    # Statement, não expressão dentro do comprehension de propósito: um walrus lendo `ev` em
+    # dois kwargs vizinhos só funciona hoje porque kwargs são avaliados na ordem em que estão
+    # escritos — trocar `next_event_at`/`next_event_title` de lugar, ou inserir um campo entre
+    # eles, não erra em lugar nenhum: silenciosamente lê o `ev` do card ANTERIOR do loop.
+    # Isolando a consulta ao mapa numa variável antes de montar o objeto, essa armadilha não
+    # existe — não "arrume" isto de volta para um walrus inline.
+    ev = proximo.get(c.id)
+    return BoardClient(
+        **ClientOut.model_validate(c).model_dump(),
+        last_interaction_at=ultimo.get(c.id),
+        unread=c.id in esperando,
+        next_event_at=ev.starts_at if ev else None,
+        next_event_title=ev.title if ev else None,
     )
 
 

--- a/apps/api/app/modules/crm/schemas.py
+++ b/apps/api/app/modules/crm/schemas.py
@@ -179,6 +179,12 @@ class BoardClient(ClientOut):
     # Tem mensagem do contato esperando resposta. Booleano e não contador: o card não tem
     # espaço para número, e "quantas" é pergunta da tela de Conversas.
     unread: bool = False
+    # Próximo compromisso do contato na Agenda — ou ausência dele, o sinal mais acionável do
+    # card (mostra quem vai esfriar sem nada marcado). Vêm de `agenda_service.next_event_map`,
+    # extraídos no router; `None` nos dois juntos significa "sem próximo passo", nunca um sem o
+    # outro.
+    next_event_at: datetime | None = None
+    next_event_title: str | None = None
 
 
 class BoardColumn(BaseModel):

--- a/apps/api/app/modules/crm/schemas.py
+++ b/apps/api/app/modules/crm/schemas.py
@@ -185,6 +185,12 @@ class BoardClient(ClientOut):
     # outro.
     next_event_at: datetime | None = None
     next_event_title: str | None = None
+    # Dia inteiro ou horário? O card precisa saber para escolher COMO formatar `next_event_at`:
+    # um evento all-day de `receivables` é ancorado na meia-noite UTC (não na do fuso do tenant,
+    # ver `agenda/service.py::next_event_map`), então formatar como INSTANTE (convertendo fuso)
+    # "volta" um dia em fuso negativo. `False` por padrão (sem próximo passo, o campo não importa
+    # — mas Pydantic não aceita `None` sem tornar o tipo opcional à toa).
+    next_event_all_day: bool = False
 
 
 class BoardColumn(BaseModel):

--- a/apps/api/app/modules/crm/timeline.py
+++ b/apps/api/app/modules/crm/timeline.py
@@ -13,7 +13,10 @@ histórico RETROATIVO: contatos que já existiam mostram as cobranças e os comp
 atrás sem nenhuma migration de dados.
 
 Só compromissos JÁ REALIZADOS entram aqui (`ends_at < agora`, excluído `cancelled`): o futuro
-é a pergunta do bloco de Agenda, não da timeline do contato — duas telas, duas perguntas.
+é a pergunta do bloco de Agenda, não da timeline do contato — duas telas, duas perguntas. E só
+os que a Agenda narra com EXCLUSIVIDADE: `cobranca_receber`/`cobranca_pagar` ficam de fora
+(`KINDS_FINANCEIROS_JA_NARRADOS`) porque a fonte `charges` já os conta como fato financeiro —
+sem a exclusão, cada cobrança apareceria DUAS vezes (o dinheiro e um compromisso fantasma).
 
 Fica fora de `service.py` porque é leitura cross-módulo (toca `receivables`, `quotes` e
 `agenda`), com responsabilidade distinta das regras de escrita do CRM.
@@ -26,9 +29,23 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.facts import Fact
-from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+from app.modules.agenda.models import (
+    KIND_COBRANCA_PAGAR,
+    KIND_COBRANCA_RECEBER,
+    STATUS_CANCELLED,
+    AgendaEvent,
+)
 from app.modules.quotes.models import Quote
 from app.modules.receivables.models import Charge
+
+# Kinds financeiros: todo `cobranca_receber`/`cobranca_pagar` já é narrado pela fonte `charges`
+# acima (título "Cobrança de R$ X — vence DD/MM/AAAA"). Desde a Task 2/3 da Onda 2, ESSES eventos
+# de Agenda também carregam `client_id` (backfill da 0078 + escrita em `receivables/service.py`),
+# então sem esta exclusão eles casariam de novo aqui e cada cobrança virava DOIS fatos na
+# timeline — o dinheiro (fonte `charges`) e um "Compromisso: A receber: Fulano" fantasma que o
+# dono nunca marcou. Achado da revisão final da onda: o financeiro já tem dono nesta tela; a
+# Agenda entra só com o que ela EXCLUSIVAMENTE sabe (atendimento, reunião, audiência...).
+KINDS_FINANCEIROS_JA_NARRADOS = {KIND_COBRANCA_RECEBER, KIND_COBRANCA_PAGAR}
 
 # Teto POR FONTE. A resposta declara `truncated` quando qualquer fonte bate nele — a tela
 # avisa em vez de fingir que aquilo é tudo.
@@ -126,6 +143,9 @@ def build(db: Session, *, client_id: str, limit: int = LIMITE_POR_FONTE) -> tupl
                 AgendaEvent.client_id == client_id,
                 AgendaEvent.ends_at < agora,
                 AgendaEvent.status != STATUS_CANCELLED,
+                # Ver `KINDS_FINANCEIROS_JA_NARRADOS` no topo do arquivo — a fonte `charges`
+                # acima já é dona de contar cobrança nesta timeline.
+                AgendaEvent.kind.not_in(KINDS_FINANCEIROS_JA_NARRADOS),
             )
             .order_by(AgendaEvent.starts_at.desc(), AgendaEvent.id.desc())
             .limit(limit + 1)

--- a/apps/api/app/modules/crm/timeline.py
+++ b/apps/api/app/modules/crm/timeline.py
@@ -3,16 +3,20 @@
 Mescla DUAS fontes com contratos diferentes:
 
 - **Persistida** — `facts`: os fatos narrativos (chegou, voltou, moveu, decidiu).
-- **Derivada** — `quotes` e `charges`: os fatos financeiros, lidos na ORIGEM.
+- **Derivada** — `quotes`, `charges` e `agenda_events`: os fatos financeiros e de compromisso,
+  lidos na ORIGEM.
 
-O financeiro não é copiado para `facts` de propósito. Guardar `amount_cents` em
-segundo lugar criaria uma segunda versão da verdade sobre dinheiro — a forma exata do bug que
+O financeiro e o compromisso não são copiados para `facts` de propósito. Guardar `amount_cents`
+ou `starts_at` em segundo lugar criaria uma segunda versão da verdade — a forma exata do bug que
 a Onda 0 do Epic 8 gastou uma onda inteira desfazendo. Ler da origem também traz de graça o
-histórico RETROATIVO: contatos que já existiam mostram as cobranças de meses atrás sem
-nenhuma migration de dados.
+histórico RETROATIVO: contatos que já existiam mostram as cobranças e os compromissos de meses
+atrás sem nenhuma migration de dados.
 
-Fica fora de `service.py` porque é leitura cross-módulo (toca `receivables` e `quotes`), com
-responsabilidade distinta das regras de escrita do CRM.
+Só compromissos JÁ REALIZADOS entram aqui (`ends_at < agora`, excluído `cancelled`): o futuro
+é a pergunta do bloco de Agenda, não da timeline do contato — duas telas, duas perguntas.
+
+Fica fora de `service.py` porque é leitura cross-módulo (toca `receivables`, `quotes` e
+`agenda`), com responsabilidade distinta das regras de escrita do CRM.
 """
 from __future__ import annotations
 
@@ -22,6 +26,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.facts import Fact
+from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
 from app.modules.quotes.models import Quote
 from app.modules.receivables.models import Charge
 
@@ -111,6 +116,30 @@ def build(db: Session, *, client_id: str, limit: int = LIMITE_POR_FONTE) -> tupl
             "title": f"Orçamento “{q.title}” — {_brl(q.total_cents)} ({q.status})",
             "body": q.notes, "actor": "sistema", "is_ai": False,
             "at": _instante(q.created_at),
+        })
+
+    agora = datetime.now(UTC)
+    compromissos = list(
+        db.scalars(
+            select(AgendaEvent)
+            .where(
+                AgendaEvent.client_id == client_id,
+                AgendaEvent.ends_at < agora,
+                AgendaEvent.status != STATUS_CANCELLED,
+            )
+            .order_by(AgendaEvent.starts_at.desc(), AgendaEvent.id.desc())
+            .limit(limit + 1)
+        ).all()
+    )
+    if len(compromissos) > limit:
+        truncated = True
+        compromissos = compromissos[:limit]
+    for ev in compromissos:
+        entradas.append({
+            "id": f"agenda:{ev.id}", "kind": "agenda",
+            "title": f"Compromisso: {ev.title}",
+            "body": ev.description, "actor": "sistema", "is_ai": False,
+            "at": _instante(ev.starts_at),
         })
 
     entradas.sort(key=lambda e: e["at"], reverse=True)

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -266,6 +266,9 @@ def build_charge(db: Session, *, tenant_id: str, actor: str, data: ChargeCreate)
         all_day=True,
         amount_cents=data.amount_cents,
         external_ref=charge.id,
+        # Sem isto, só o PASSADO (backfill da migration 0078) ficaria ligado ao contato — toda
+        # cobrança nova nasceria com evento órfão na Agenda (Task 2 da Onda 2).
+        client_id=data.client_id,
     )
     db.add(event)
     db.flush()  # popula event.id

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -253,6 +253,14 @@ def build_charge(db: Session, *, tenant_id: str, actor: str, data: ChargeCreate)
     who = client.name if client else (data.description or "cobrança")
 
     # Injeta o vencimento na Agenda (marcador, não ocupa horário).
+    #
+    # ⚠️ **Meia-noite UTC CRUA, e não a meia-noite do fuso do tenant** (achado da revisão final
+    # da Onda 2). `agenda/service.py::create_event` ancora eventos all-day na meia-noite REAL do
+    # fuso via `day_window_utc` — este ponto NÃO segue o mesmo caminho, e as duas convenções
+    # coexistem no sistema hoje. Unificar é migration de dados (reancorar todo `AgendaEvent`
+    # all-day já gravado), fora do escopo desta onda — o que ESTA onda corrigiu foi a EXIBIÇÃO
+    # (`BoardClient.next_event_all_day` em `crm/schemas.py` + `formatDay` no card do Kanban),
+    # não o armazenamento. Ver a nota espelhada em `agenda/service.py::next_event_map`.
     day_start = datetime.combine(data.due_date, time.min, tzinfo=UTC)
     event = AgendaEvent(
         tenant_id=tenant_id,
@@ -373,6 +381,7 @@ def reschedule_charge(
     if charge.agenda_event_id:
         ev = db.get(AgendaEvent, charge.agenda_event_id)
         if ev is not None:
+            # Mesma convenção (meia-noite UTC crua) de `build_charge` — ver o comentário lá.
             day_start = datetime.combine(due_date, time.min, tzinfo=UTC)
             ev.starts_at = day_start
             ev.ends_at = day_start.replace(hour=23, minute=59)
@@ -430,6 +439,7 @@ def update_charge(db: Session, *, charge_id: str, tenant_id: str, actor: str, da
     ev = db.get(AgendaEvent, charge.agenda_event_id) if charge.agenda_event_id else None
     if ev is not None:
         if data.due_date is not None:
+            # Mesma convenção (meia-noite UTC crua) de `build_charge` — ver o comentário lá.
             day_start = datetime.combine(charge.due_date, time.min, tzinfo=UTC)
             ev.starts_at = day_start
             ev.ends_at = day_start.replace(hour=23, minute=59)

--- a/apps/api/migrations/versions/0078_agenda_event_client.py
+++ b/apps/api/migrations/versions/0078_agenda_event_client.py
@@ -1,0 +1,69 @@
+"""Vínculo do compromisso com o contato: agenda_events.client_id
+
+Revision ID: 0078
+Revises: 0077
+Create Date: 2026-08-16
+
+A Agenda não sabia de que contato era um compromisso. O nome que a tela mostrava era
+DERIVADO da cobrança, por um caminho polimórfico via `external_ref` — que já está ocupado
+apontando para cobrança e para conta a pagar, conforme o `kind`.
+
+SEM FK, `String(36)`, seguindo o precedente de `whatsapp_chats.client_id`: a Agenda não deve
+ganhar dependência dura da tabela do CRM. Nullable é o caso NORMAL — bloqueio de horário,
+prazo interno e conta a pagar não têm cliente.
+
+⚠️ ARMADILHA QUE **SE APLICA** AQUI: esta migration FAZ BACKFILL. Ela roda como o papel dono
+não-superusuário `e1p_app`, **sem** a GUC `app.current_tenant_id`. Sob `FORCE ROW LEVEL
+SECURITY` o `UPDATE` seria filtrado a **ZERO LINHAS, EM SILÊNCIO** — e o sintoma em produção
+não seria erro de deploy, seria "a ficha não mostra compromisso nenhum". Por isso a RLS é
+desabilitada nas DUAS tabelas na janela do backfill (`agenda_events` porque é o ALVO,
+`charges` porque é a FONTE da subconsulta — a RLS filtra SELECT também) e restaurada com
+ENABLE + FORCE logo depois. Mesmo padrão da 0046, 0066, 0067 e 0068. DDL é transacional no
+Postgres e a migration roda offline, então não há janela de exposição.
+
+O backfill filtra por `kind='cobranca_receber'`. Sem esse filtro, um evento de conta a pagar
+cujo `external_ref` colidisse com o id de uma cobrança ganharia um dono errado — `external_ref`
+é ponteiro polimórfico, e o `kind` é o discriminador.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0078"
+down_revision: str | None = "0077"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("agenda_events", sa.Column("client_id", sa.String(36), nullable=True))
+    op.create_index(
+        "ix_agenda_events_client_id", "agenda_events", ["client_id"]
+    )
+
+    # --- backfill (ver a ARMADILHA no docstring: sem esta janela, tudo abaixo é no-op) ---
+    op.execute("ALTER TABLE agenda_events DISABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges DISABLE ROW LEVEL SECURITY")
+
+    op.execute(
+        """
+        UPDATE agenda_events AS e
+           SET client_id = c.client_id
+          FROM charges AS c
+         WHERE e.external_ref = c.id
+           AND e.kind = 'cobranca_receber'
+           AND c.client_id IS NOT NULL
+           AND e.tenant_id = c.tenant_id
+        """
+    )
+
+    op.execute("ALTER TABLE agenda_events ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE agenda_events FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges FORCE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agenda_events_client_id", table_name="agenda_events")
+    op.drop_column("agenda_events", "client_id")

--- a/apps/api/migrations/versions/0078_agenda_event_client.py
+++ b/apps/api/migrations/versions/0078_agenda_event_client.py
@@ -24,6 +24,13 @@ Postgres e a migration roda offline, então não há janela de exposição.
 O backfill filtra por `kind='cobranca_receber'`. Sem esse filtro, um evento de conta a pagar
 cujo `external_ref` colidisse com o id de uma cobrança ganharia um dono errado — `external_ref`
 é ponteiro polimórfico, e o `kind` é o discriminador.
+
+O `UPDATE` também filtra por `e.client_id IS NULL`: o backfill só preenche o que nunca foi
+preenchido. Sem essa cláusula, uma reexecução manual da SQL desta migration contra produção
+(coisa que já aconteceu na história deste projeto) apagaria em silêncio qualquer vínculo que o
+dono tivesse corrigido depois pela API — e a partir desta migration existe API para isso
+(`EventUpdate.client_id`). O `IS NULL` torna o backfill reentrante: rodar de novo é seguro
+porque só toca linha que ainda não tem dono.
 """
 from collections.abc import Sequence
 
@@ -36,13 +43,14 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
-def upgrade() -> None:
-    op.add_column("agenda_events", sa.Column("client_id", sa.String(36), nullable=True))
-    op.create_index(
-        "ix_agenda_events_client_id", "agenda_events", ["client_id"]
-    )
+def backfill_client_id() -> None:
+    """A janela de RLS + o UPDATE reentrante (ver ARMADILHA e `IS NULL` no docstring do módulo).
 
-    # --- backfill (ver a ARMADILHA no docstring: sem esta janela, tudo abaixo é no-op) ---
+    Extraído como função própria (em vez de inline em `upgrade()`) para que o teste de
+    idempotência (`test_backfill_nao_sobrescreve_vinculo_ja_existente`) possa reexecutar
+    exatamente este código — o mesmo que rodaria numa reexecução manual contra produção —
+    sem duplicar a SQL numa cópia que poderia divergir do que está de fato no arquivo.
+    """
     op.execute("ALTER TABLE agenda_events DISABLE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE charges DISABLE ROW LEVEL SECURITY")
 
@@ -55,6 +63,7 @@ def upgrade() -> None:
            AND e.kind = 'cobranca_receber'
            AND c.client_id IS NOT NULL
            AND e.tenant_id = c.tenant_id
+           AND e.client_id IS NULL
         """
     )
 
@@ -62,6 +71,16 @@ def upgrade() -> None:
     op.execute("ALTER TABLE agenda_events FORCE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE charges ENABLE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE charges FORCE ROW LEVEL SECURITY")
+
+
+def upgrade() -> None:
+    op.add_column("agenda_events", sa.Column("client_id", sa.String(36), nullable=True))
+    op.create_index(
+        "ix_agenda_events_client_id", "agenda_events", ["client_id"]
+    )
+
+    # --- backfill (ver a ARMADILHA no docstring: sem esta janela, tudo abaixo é no-op) ---
+    backfill_client_id()
 
 
 def downgrade() -> None:

--- a/apps/api/tests/test_agenda_por_contato.py
+++ b/apps/api/tests/test_agenda_por_contato.py
@@ -119,6 +119,59 @@ def test_evento_sem_client_id_nao_aparece_no_filtro(client: TestClient, headers)
     assert body[0]["client_id"] == cl["id"]
 
 
+# ── exclude_cancelled: achado da revisão do Task 6 ──────────────────────────────────────────
+# Histórico (`crm/timeline.py`) e `next_event_map` já excluem cancelado; `list_events` era o
+# único dos três que não tinha essa trava. `BlocoDaAgenda` (ficha 360°) pede `exclude_cancelled`
+# explicitamente para não impersonar um cancelado como "próximo compromisso"; a Agenda continua
+# sem passar o parâmetro, então o default tem que preservar o comportamento de hoje.
+
+
+def test_exclude_cancelled_filtra_o_cancelado_do_filtro_por_contato(client: TestClient, headers):
+    """A chamada que o `BlocoDaAgenda` faz: um evento futuro CANCELADO não pode aparecer."""
+    cl = client.post("/crm/clients", json={"name": "Cliente Cancelado"}, headers=headers).json()
+    created = client.post(
+        "/agenda/events",
+        json=_event(
+            client_id=cl["id"],
+            starts_at="2099-01-01T10:00:00+00:00", ends_at="2099-01-01T11:00:00+00:00",
+        ),
+        headers=headers,
+    ).json()["event"]
+    cancel = client.post(f"/agenda/events/{created['id']}/cancel", headers=headers)
+    assert cancel.status_code == 200
+
+    resp = client.get(
+        "/agenda/events",
+        params={"client_id": cl["id"], "exclude_cancelled": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_sem_exclude_cancelled_o_padrao_continua_devolvendo_o_cancelado(
+    client: TestClient, headers,
+):
+    """Default `False` é escolha de COMPATIBILIDADE, não descuido — a tela de Agenda (que não
+    manda o parâmetro) continua vendo todo evento, cancelado incluso, como sempre viu."""
+    cl = client.post("/crm/clients", json={"name": "Cliente Cancelado 2"}, headers=headers).json()
+    created = client.post(
+        "/agenda/events",
+        json=_event(
+            client_id=cl["id"],
+            starts_at="2099-01-01T10:00:00+00:00", ends_at="2099-01-01T11:00:00+00:00",
+        ),
+        headers=headers,
+    ).json()["event"]
+    client.post(f"/agenda/events/{created['id']}/cancel", headers=headers)
+
+    resp = client.get("/agenda/events", params={"client_id": cl["id"]}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["status"] == "cancelled"
+
+
 # ── receivables grava o vínculo no evento que ela cria ──────────────────────────────────────
 
 

--- a/apps/api/tests/test_agenda_por_contato.py
+++ b/apps/api/tests/test_agenda_por_contato.py
@@ -1,0 +1,199 @@
+"""Task 2 da Onda 2: a Agenda passa a falar de contato.
+
+Cobre três coisas: (1) `client_id` trafega em EventCreate/EventUpdate/EventOut e filtra
+`GET /agenda/events`; (2) uma cobrança criada em `receivables` já nasce com o evento LIGADO ao
+contato (não só o passado, que a Task 1 fez via backfill); (3) `next_event_map`, o agregado que
+vai alimentar a linha "próximo compromisso" do card do Kanban.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, day_window_utc, tenant_today
+from app.modules.agenda import service as agenda_service
+from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+
+REGISTER = {
+    "legal_name": "Agenda por Contato ME",
+    "document": "55666777000181",
+    "slug": "agendaporcontato",
+    "email": "dona@example.com",
+    "name": "Dona",
+    "password": "uma-senha-bem-forte",
+}
+
+TENANT_ID = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _event(**over):
+    base = {
+        "title": "Atendimento João",
+        "kind": "atendimento",
+        "starts_at": "2026-07-01T10:00:00+00:00",
+        "ends_at": "2026-07-01T11:00:00+00:00",
+    }
+    return {**base, **over}
+
+
+def _row(db: Session, *, client_id: str | None, starts_at: datetime, ends_at: datetime,
+         status: str = "scheduled", all_day: bool = False,
+         event_id: str | None = None) -> AgendaEvent:
+    """Cria um `AgendaEvent` direto pelo model (sem passar por `create_event`) — os testes de
+    `next_event_map` abaixo não precisam da checagem de conflito nem do vínculo com Google/Meet,
+    só de linhas na tabela com os campos que a consulta agregada lê."""
+    kwargs = dict(
+        tenant_id=TENANT_ID, title="Compromisso", kind="atendimento", status=status,
+        client_id=client_id, starts_at=starts_at, ends_at=ends_at, all_day=all_day,
+    )
+    if event_id is not None:
+        kwargs["id"] = event_id
+    row = AgendaEvent(**kwargs)
+    db.add(row)
+    db.commit()
+    return row
+
+
+# ── client_id em EventCreate/EventUpdate/EventOut e no filtro do GET ────────────────────────
+
+
+def test_cria_evento_com_client_id_e_le_de_volta(client: TestClient, headers):
+    cl = client.post("/crm/clients", json={"name": "Cliente Agenda"}, headers=headers).json()
+    resp = client.post("/agenda/events", json=_event(client_id=cl["id"]), headers=headers)
+    assert resp.status_code == 201, resp.text
+    created = resp.json()["event"]
+    assert created["client_id"] == cl["id"]
+
+    fetched = client.get(f"/agenda/events/{created['id']}", headers=headers)
+    assert fetched.status_code == 200
+    assert fetched.json()["client_id"] == cl["id"]
+
+
+def test_filtro_por_client_id_traz_so_os_daquele_contato(client: TestClient, headers):
+    a = client.post("/crm/clients", json={"name": "Contato A"}, headers=headers).json()
+    b = client.post("/crm/clients", json={"name": "Contato B"}, headers=headers).json()
+    client.post("/agenda/events", json=_event(client_id=a["id"]), headers=headers)
+    client.post(
+        "/agenda/events",
+        json=_event(
+            title="Evento B", client_id=b["id"],
+            starts_at="2026-07-02T10:00:00+00:00", ends_at="2026-07-02T11:00:00+00:00",
+        ),
+        headers=headers,
+    )
+
+    resp = client.get("/agenda/events", params={"client_id": a["id"]}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["client_id"] == a["id"]
+
+
+def test_evento_sem_client_id_nao_aparece_no_filtro(client: TestClient, headers):
+    cl = client.post("/crm/clients", json={"name": "Contato C"}, headers=headers).json()
+    client.post("/agenda/events", json=_event(client_id=cl["id"]), headers=headers)
+    client.post(
+        "/agenda/events",
+        json=_event(
+            title="Bloqueio sem contato", kind="bloqueio",
+            starts_at="2026-07-02T10:00:00+00:00", ends_at="2026-07-02T11:00:00+00:00",
+        ),
+        headers=headers,
+    )
+
+    resp = client.get("/agenda/events", params={"client_id": cl["id"]}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["client_id"] == cl["id"]
+
+
+# ── receivables grava o vínculo no evento que ela cria ──────────────────────────────────────
+
+
+def test_cobranca_criada_ja_nasce_com_client_id_no_evento(client: TestClient, db: Session, headers):
+    """`receivables` cria o evento da Agenda; ele tem que nascer ligado, não só o passado."""
+    cl = client.post("/crm/clients", json={"name": "Pagador Agenda"}, headers=headers).json()
+    due_date = (datetime.now(UTC).date() + timedelta(days=30)).isoformat()
+    charge = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 5000,
+            "due_date": due_date, "description": "Mensalidade", "client_id": cl["id"],
+        },
+        headers=headers,
+    ).json()
+
+    event = db.scalars(
+        select(AgendaEvent).where(AgendaEvent.external_ref == charge["id"])
+    ).first()
+    assert event is not None
+    assert event.client_id == cl["id"]
+
+
+# ── next_event_map: o agregado que alimenta a linha "próximo compromisso" do card ───────────
+
+
+def test_next_event_map_traz_o_mais_proximo_por_contato(db: Session):
+    agora = datetime.now(UTC)
+    perto = _row(
+        db, client_id="cli-1",
+        starts_at=agora + timedelta(hours=1), ends_at=agora + timedelta(hours=2),
+    )
+    _row(
+        db, client_id="cli-1",
+        starts_at=agora + timedelta(days=3), ends_at=agora + timedelta(days=3, hours=1),
+    )
+
+    mapa = agenda_service.next_event_map(db)
+    assert mapa["cli-1"].id == perto.id
+
+
+def test_next_event_map_ignora_cancelado(db: Session):
+    agora = datetime.now(UTC)
+    _row(
+        db, client_id="cli-2",
+        starts_at=agora + timedelta(hours=1), ends_at=agora + timedelta(hours=2),
+        status=STATUS_CANCELLED,
+    )
+    depois = _row(
+        db, client_id="cli-2",
+        starts_at=agora + timedelta(days=1), ends_at=agora + timedelta(days=1, hours=1),
+    )
+
+    mapa = agenda_service.next_event_map(db)
+    # O cancelado é o mais perto — se contasse, o mapa apontaria pra ele, não pro `depois`.
+    assert mapa["cli-2"].id == depois.id
+
+
+def test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje(db: Session):
+    """⚠️ O caso que uma implementação ingênua erra.
+
+    Evento de dia inteiro é ancorado na meia-noite REAL do fuso do tenant (ver
+    `agenda/service.create_event`). Às 15h, o `starts_at` dele já passou — filtrar por
+    `starts_at >= agora` esconderia o compromisso de HOJE, que é justamente o mais
+    relevante que o card poderia mostrar. O critério é `ends_at >= agora`.
+    """
+    # Mesma conversão que `create_event` faz no ramo `all_day` (`day_window_utc` sobre o dia
+    # calendário do tenant): a janela é [meia-noite local de HOJE, meia-noite local de AMANHÃ),
+    # em UTC. Por construção, `tenant_today(...)` é o dia que CONTÉM o instante atual — logo
+    # `starts_at` (a meia-noite de hoje) já ficou no passado assim que o dia começou, e
+    # `ends_at` (a meia-noite de amanhã) só chega no futuro. Uma implementação que corta por
+    # `starts_at >= agora` avaliaria essa condição como False e DESCARTARIA o evento; só o corte
+    # por `ends_at >= agora` o inclui — é exatamente essa diferença que este teste prova.
+    hoje = tenant_today(DEFAULT_TENANT_TIMEZONE)
+    starts_at, ends_at = day_window_utc(hoje, DEFAULT_TENANT_TIMEZONE)
+    evento = _row(db, client_id="cli-hoje", starts_at=starts_at, ends_at=ends_at, all_day=True)
+
+    mapa = agenda_service.next_event_map(db)
+    assert mapa["cli-hoje"].id == evento.id

--- a/apps/api/tests/test_agenda_por_contato.py
+++ b/apps/api/tests/test_agenda_por_contato.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm import Session
 from app.core.tz import DEFAULT_TENANT_TIMEZONE, day_window_utc, tenant_today
 from app.modules.agenda import service as agenda_service
 from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
-from app.modules.crm.models import Client
 from app.modules.receivables.models import Charge
 
 REGISTER = {
@@ -205,13 +204,15 @@ def test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje(db: Session):
 # ── metade das cobranças. A metade do fornecedor (payables) não tem client_id e fica. ───────
 
 
-def test_client_name_do_evento_e_o_mesmo_pelos_dois_caminhos(client: TestClient, db: Session,
-                                                               headers):
-    """A trava da limpeza: derivação antiga e join novo produzem o MESMO `client_name`.
+def test_cobranca_e_evento_concordam_no_client_id_ligado(client: TestClient, db: Session, headers):
+    """Checagem de base, NÃO a trava da limpeza: prova só que Tasks 1/2 ligaram os ids certos.
 
-    Roda ANTES da remoção do caminho velho. Se um backfill errasse uma linha, a Agenda
-    perderia um nome que hoje mostra — e ninguém perceberia, porque nenhum teste afirmava
-    que os dois caminhos concordam.
+    Faz dois lookups crus no banco (Charge.client_id e AgendaEvent.client_id) e afirma que
+    concordam — nunca chama `_events_out` nem bate no endpoint, então não exercita o join que
+    o router faz. `test_cobranca_criada_ja_nasce_com_client_id_no_evento` (acima) já cobre esse
+    mesmo fato de forma mais direta; este teste fica como reforço de que o vínculo é o MESMO id
+    dos dois lados, não como guarda da refatoração de `_events_out` — essa guarda é
+    `test_client_name_no_get_events_vem_do_join_direto`, abaixo, que bate no endpoint real.
     """
     cl = client.post("/crm/clients", json={"name": "Cliente Paridade"}, headers=headers).json()
     due_date = (datetime.now(UTC).date() + timedelta(days=30)).isoformat()
@@ -229,15 +230,33 @@ def test_client_name_do_evento_e_o_mesmo_pelos_dois_caminhos(client: TestClient,
     ).first()
     assert event is not None
 
-    # Caminho antigo: external_ref (charge["id"]) -> Charge -> Client.name.
     charge_row = db.get(Charge, charge["id"])
-    nome_antigo = db.get(Client, charge_row.client_id).name
+    assert charge_row.client_id == event.client_id
 
-    # Caminho novo: AgendaEvent.client_id -> Client.name (join direto, sem passar por Charge).
-    nome_novo = db.get(Client, event.client_id).name
 
-    assert nome_antigo is not None
-    assert nome_antigo == nome_novo
+def test_client_name_no_get_events_vem_do_join_direto(client: TestClient, headers):
+    """A trava real da limpeza: `GET /agenda/events` devolve o nome do cliente pelo endpoint.
+
+    Espelha `test_conta_a_pagar_continua_mostrando_o_fornecedor` (abaixo), mas para a metade
+    que FOI trocada por join direto. Bate no endpoint de verdade (não em `Client`/`Charge` crus),
+    então uma quebra em `_events_out` — por exemplo, um typo que troque `client_id` por
+    `external_ref` no join — apareceria aqui, não só numa checagem de banco que nem passa pelo
+    router.
+    """
+    cl = client.post("/crm/clients", json={"name": "Cliente Endpoint"}, headers=headers).json()
+    due_date = (datetime.now(UTC).date() + timedelta(days=30)).isoformat()
+    client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 5000,
+            "due_date": due_date, "description": "Mensalidade", "client_id": cl["id"],
+        },
+        headers=headers,
+    )
+
+    events = client.get("/agenda/events", headers=headers).json()
+    receber = next(e for e in events if e["kind"] == "cobranca_receber")
+    assert receber["client_name"] == "Cliente Endpoint"
 
 
 def test_conta_a_pagar_continua_mostrando_o_fornecedor(client: TestClient, headers):

--- a/apps/api/tests/test_agenda_por_contato.py
+++ b/apps/api/tests/test_agenda_por_contato.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from app.core.tz import DEFAULT_TENANT_TIMEZONE, day_window_utc, tenant_today
 from app.modules.agenda import service as agenda_service
-from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+from app.modules.agenda.models import STATUS_CANCELLED, STATUS_DONE, AgendaEvent
 from app.modules.receivables.models import Charge
 
 REGISTER = {
@@ -149,6 +149,33 @@ def test_exclude_cancelled_filtra_o_cancelado_do_filtro_por_contato(client: Test
     assert resp.json() == []
 
 
+def test_exclude_cancelled_tambem_filtra_o_done_adiantado(client: TestClient, db: Session, headers):
+    """Achado da revisão final da Onda 2: `TERMINAL_STATUSES` = {cancelled, done}, não só
+    cancelado. Um compromisso marcado `done` ANTES da hora (o dono adianta o status) não pode
+    continuar aparecendo no bloco de "próximos compromissos" da ficha 360° — já aconteceu, do
+    ponto de vista de quem olha o card."""
+    cl = client.post(
+        "/crm/clients", json={"name": "Cliente Done Adiantado"}, headers=headers
+    ).json()
+    agora = datetime.now(UTC)
+    db.add(
+        AgendaEvent(
+            tenant_id=cl["tenant_id"], title="Feito antes da hora", kind="atendimento",
+            status=STATUS_DONE, client_id=cl["id"],
+            starts_at=agora + timedelta(days=1), ends_at=agora + timedelta(days=1, hours=1),
+        )
+    )
+    db.commit()
+
+    resp = client.get(
+        "/agenda/events",
+        params={"client_id": cl["id"], "exclude_cancelled": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 def test_sem_exclude_cancelled_o_padrao_continua_devolvendo_o_cancelado(
     client: TestClient, headers,
 ):
@@ -228,6 +255,26 @@ def test_next_event_map_ignora_cancelado(db: Session):
     mapa = agenda_service.next_event_map(db)
     # O cancelado é o mais perto — se contasse, o mapa apontaria pra ele, não pro `depois`.
     assert mapa["cli-2"].id == depois.id
+
+
+def test_next_event_map_ignora_done_adiantado(db: Session):
+    """Irmã de `test_next_event_map_ignora_cancelado`: `done` ANTES da hora também não é
+    próximo passo. `TERMINAL_STATUSES = {cancelled, done}` — achado da revisão final da Onda 2,
+    que a implementação original só cobria a metade `cancelled`."""
+    agora = datetime.now(UTC)
+    _row(
+        db, client_id="cli-3",
+        starts_at=agora + timedelta(hours=1), ends_at=agora + timedelta(hours=2),
+        status=STATUS_DONE,
+    )
+    depois = _row(
+        db, client_id="cli-3",
+        starts_at=agora + timedelta(days=1), ends_at=agora + timedelta(days=1, hours=1),
+    )
+
+    mapa = agenda_service.next_event_map(db)
+    # O `done` adiantado é o mais perto — se contasse, o mapa apontaria pra ele, não pro `depois`.
+    assert mapa["cli-3"].id == depois.id
 
 
 def test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje(db: Session):

--- a/apps/api/tests/test_agenda_por_contato.py
+++ b/apps/api/tests/test_agenda_por_contato.py
@@ -17,6 +17,8 @@ from sqlalchemy.orm import Session
 from app.core.tz import DEFAULT_TENANT_TIMEZONE, day_window_utc, tenant_today
 from app.modules.agenda import service as agenda_service
 from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+from app.modules.crm.models import Client
+from app.modules.receivables.models import Charge
 
 REGISTER = {
     "legal_name": "Agenda por Contato ME",
@@ -197,3 +199,59 @@ def test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje(db: Session):
 
     mapa = agenda_service.next_event_map(db)
     assert mapa["cli-hoje"].id == evento.id
+
+
+# ── Task 3: _events_out — join direto substitui a derivação por external_ref, MAS só a ──────
+# ── metade das cobranças. A metade do fornecedor (payables) não tem client_id e fica. ───────
+
+
+def test_client_name_do_evento_e_o_mesmo_pelos_dois_caminhos(client: TestClient, db: Session,
+                                                               headers):
+    """A trava da limpeza: derivação antiga e join novo produzem o MESMO `client_name`.
+
+    Roda ANTES da remoção do caminho velho. Se um backfill errasse uma linha, a Agenda
+    perderia um nome que hoje mostra — e ninguém perceberia, porque nenhum teste afirmava
+    que os dois caminhos concordam.
+    """
+    cl = client.post("/crm/clients", json={"name": "Cliente Paridade"}, headers=headers).json()
+    due_date = (datetime.now(UTC).date() + timedelta(days=30)).isoformat()
+    charge = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 5000,
+            "due_date": due_date, "description": "Mensalidade", "client_id": cl["id"],
+        },
+        headers=headers,
+    ).json()
+
+    event = db.scalars(
+        select(AgendaEvent).where(AgendaEvent.external_ref == charge["id"])
+    ).first()
+    assert event is not None
+
+    # Caminho antigo: external_ref (charge["id"]) -> Charge -> Client.name.
+    charge_row = db.get(Charge, charge["id"])
+    nome_antigo = db.get(Client, charge_row.client_id).name
+
+    # Caminho novo: AgendaEvent.client_id -> Client.name (join direto, sem passar por Charge).
+    nome_novo = db.get(Client, event.client_id).name
+
+    assert nome_antigo is not None
+    assert nome_antigo == nome_novo
+
+
+def test_conta_a_pagar_continua_mostrando_o_fornecedor(client: TestClient, headers):
+    """A metade que NÃO morre. Conta a pagar não tem cliente; o nome vem de `payables.supplier`."""
+    resp = client.post(
+        "/payables/bills",
+        json={
+            "description": "Aluguel", "category": "Estrutura", "supplier": "Imobiliária Paridade",
+            "amount_cents": 250000, "due_date": "2099-08-05",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    events = client.get("/agenda/events", headers=headers).json()
+    pagar = next(e for e in events if e["kind"] == "cobranca_pagar")
+    assert pagar["client_name"] == "Imobiliária Paridade"

--- a/apps/api/tests/test_client_timeline.py
+++ b/apps/api/tests/test_client_timeline.py
@@ -1,5 +1,6 @@
-"""Timeline do contato: mescla o narrativo (`facts`) com o financeiro (charges/quotes)."""
-from datetime import date
+"""Timeline do contato: mescla o narrativo (`facts`) com o financeiro (charges/quotes) e,
+desde a Task 4 da Onda 2, o compromisso já realizado (agenda_events)."""
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -114,3 +115,71 @@ def test_truncated_quando_passa_do_teto(client: TestClient, headers, contato):
     corpo = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()
     assert corpo["truncated"] is True
     assert len(corpo["entries"]) == 100
+
+
+# ── Task 4 da Onda 2: a 4ª fonte — compromisso REALIZADO, lido de `agenda_events` ───────────
+
+
+def test_timeline_inclui_compromisso_realizado(client: TestClient, headers, contato):
+    """Compromisso que já aconteceu é fato do relacionamento — vive no Histórico, não no bloco."""
+    resp = client.post(
+        "/agenda/events",
+        json={
+            "title": "Sessão de fotos", "kind": "atendimento",
+            "starts_at": "2026-01-10T13:00:00+00:00", "ends_at": "2026-01-10T14:00:00+00:00",
+            "client_id": contato,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    entries = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()["entries"]
+    entrada = next(e for e in entries if e["kind"] == "agenda")
+    assert entrada["title"] == "Compromisso: Sessão de fotos"
+    assert entrada["actor"] == "sistema"
+
+
+def test_timeline_nao_inclui_compromisso_futuro(client: TestClient, headers, contato):
+    """O futuro é assunto do bloco de Agenda. Duas telas, duas perguntas."""
+    futuro = datetime.now(UTC) + timedelta(days=30)
+    resp = client.post(
+        "/agenda/events",
+        json={
+            "title": "Reunião ainda por vir", "kind": "reuniao",
+            "starts_at": futuro.isoformat(),
+            "ends_at": (futuro + timedelta(hours=1)).isoformat(),
+            "client_id": contato,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    entries = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()["entries"]
+    assert all(e["kind"] != "agenda" for e in entries)
+
+
+def test_timeline_de_agenda_respeita_o_limite_por_fonte(client: TestClient, headers, contato):
+    """Mesma regra das outras três fontes: `LIMITE_POR_FONTE` e `truncated`."""
+    base = datetime.now(UTC) - timedelta(days=365)
+    for i in range(101):
+        inicio = base + timedelta(hours=i)
+        resp = client.post(
+            "/agenda/events",
+            json={
+                "title": f"Atendimento {i}", "kind": "atendimento",
+                "starts_at": inicio.isoformat(),
+                "ends_at": (inicio + timedelta(minutes=30)).isoformat(),
+                "client_id": contato,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    corpo = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()
+    assert corpo["truncated"] is True
+    # A fonte por si só já corta em 100 (LIMITE_POR_FONTE); o corte global da timeline, que
+    # mescla com o fato "crm.lead.criado" do próprio contato, pode tirar mais uma — por isso o
+    # intervalo, em vez de um número fixo: o que este teste prova é que a Agenda nunca aparece
+    # acima do teto, não a aritmética exata da mescla final.
+    agenda_entries = [e for e in corpo["entries"] if e["kind"] == "agenda"]
+    assert 99 <= len(agenda_entries) <= 100

--- a/apps/api/tests/test_client_timeline.py
+++ b/apps/api/tests/test_client_timeline.py
@@ -185,6 +185,46 @@ def test_timeline_nao_inclui_compromisso_cancelado(client: TestClient, headers, 
     assert all(e["kind"] != "agenda" for e in entries)
 
 
+# ── Achado da revisão final da Onda 2: cobrança NÃO pode duplicar como compromisso fantasma ─
+
+
+def test_cobranca_via_api_nao_duplica_como_compromisso_na_timeline(
+    client: TestClient, headers, contato,
+):
+    """Vai pela rota real (`POST /receivables/charges`), não por um `Charge(...)` cru no banco.
+
+    `test_timeline_inclui_a_cobranca_sem_copiar_o_valor` semeia a `Charge` direto no banco —
+    isso NUNCA passa por `receivables.service.build_charge`, então o `AgendaEvent` gêmeo (que
+    `build_charge` cria, com o MESMO `client_id`) nunca chega a existir, e o teste não conseguia
+    enxergar o bug: a cobrança tinha que nascer pela rota de verdade para o evento fantasma
+    também nascer.
+
+    O vencimento é no PASSADO de propósito: só um evento com `ends_at < agora` entra nesta
+    timeline (é o corte de "já realizado"). Uma cobrança com vencimento futuro não provaria nada
+    — o filtro de data já a esconderia, kind ou não.
+    """
+    due_date = (datetime.now(UTC).date() - timedelta(days=5)).isoformat()
+    resp = client.post(
+        "/receivables/charges",
+        json={
+            "kind": "service", "method": "pix", "amount_cents": 30000,
+            "due_date": due_date, "description": "Consulta", "client_id": contato,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    entries = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()["entries"]
+
+    cobrancas = [e for e in entries if e["kind"] == "charge"]
+    assert len(cobrancas) == 1
+
+    # A trava real deste teste: NENHUM "Compromisso: A receber: ..." fantasma — a mesma
+    # cobrança não pode aparecer também como `kind == "agenda"`.
+    fantasmas = [e for e in entries if e["kind"] == "agenda"]
+    assert fantasmas == [], f"compromisso fantasma vazando na timeline: {fantasmas}"
+
+
 def test_timeline_de_agenda_respeita_o_limite_por_fonte(client: TestClient, headers, contato):
     """Mesma regra das outras três fontes: `LIMITE_POR_FONTE` e `truncated`."""
     base = datetime.now(UTC) - timedelta(days=365)

--- a/apps/api/tests/test_client_timeline.py
+++ b/apps/api/tests/test_client_timeline.py
@@ -158,6 +158,33 @@ def test_timeline_nao_inclui_compromisso_futuro(client: TestClient, headers, con
     assert all(e["kind"] != "agenda" for e in entries)
 
 
+def test_timeline_nao_inclui_compromisso_cancelado(client: TestClient, headers, contato):
+    """Cancelado não é fato: a timeline não pode dizer "você se encontrou" de um encontro
+    que não houve.
+
+    O evento é criado no PASSADO de propósito — `ends_at < agora` já seria motivo suficiente
+    para incluí-lo, então só o filtro de `status` pode estar segurando este teste. Um evento
+    cancelado no FUTURO não provaria nada: o filtro de data já bastaria para escondê-lo.
+    """
+    resp = client.post(
+        "/agenda/events",
+        json={
+            "title": "Consulta cancelada", "kind": "atendimento",
+            "starts_at": "2026-01-10T13:00:00+00:00", "ends_at": "2026-01-10T14:00:00+00:00",
+            "client_id": contato,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    event_id = resp.json()["event"]["id"]
+
+    cancel_resp = client.post(f"/agenda/events/{event_id}/cancel", headers=headers)
+    assert cancel_resp.status_code == 200, cancel_resp.text
+
+    entries = client.get(f"/crm/clients/{contato}/timeline", headers=headers).json()["entries"]
+    assert all(e["kind"] != "agenda" for e in entries)
+
+
 def test_timeline_de_agenda_respeita_o_limite_por_fonte(client: TestClient, headers, contato):
     """Mesma regra das outras três fontes: `LIMITE_POR_FONTE` e `truncated`."""
     base = datetime.now(UTC) - timedelta(days=365)

--- a/apps/api/tests/test_crm_board_proximo_passo.py
+++ b/apps/api/tests/test_crm_board_proximo_passo.py
@@ -1,0 +1,134 @@
+# apps/api/tests/test_crm_board_proximo_passo.py
+"""O board do Kanban devolve `next_event_at`/`next_event_title` por card — o outro lado da
+
+mesma pergunta que `unread` responde: o que está marcado com este contato, ou o aviso de que
+não há nada (o sinal mais acionável, quem vai esfriar). Irmão direto de
+`test_crm_board_nao_lida.py` — mesmo molde, inclusive o teste de contagem de consultas.
+"""
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.modules.agenda.models import STATUS_CANCELLED, AgendaEvent
+from app.modules.crm.models import Client
+
+REGISTER = {
+    "legal_name": "Estúdio Bia",
+    "document": "22333444000181",
+    "slug": "estudiobia",
+    "email": "bia@example.com",
+    "name": "Bia",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    """`/crm/board` é rota autenticada — sem isto tudo aqui é 401. Mesmo padrão de
+    `test_crm.py`."""
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _contato(client: TestClient, headers: dict[str, str], nome: str) -> str:
+    """Cria pela API, e não montando o modelo à mão.
+
+    O contato precisa nascer no tenant AUTENTICADO e na primeira etapa do funil — `POST
+    /crm/clients` faz as duas coisas (`create_client` chama `ensure_stages`). Um `Client(...)`
+    direto no banco com `tenant_id` inventado passaria em SQLite, onde não há RLS, e mediria
+    uma situação que não existe em produção.
+    """
+    resp = client.post("/crm/clients", json={"name": nome}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _compromisso(
+    db: Session, client_id: str, *, titulo: str = "Reunião de alinhamento",
+    status: str = "scheduled", em: timedelta = timedelta(hours=1),
+) -> AgendaEvent:
+    """Um `AgendaEvent` ligado ao contato, direto pelo model — no molde de `_row` em
+    `test_agenda_por_contato.py`. O `tenant_id` vem do próprio contato, como `_conversa_esperando`
+    faz para a mensagem de WhatsApp."""
+    contato = db.get(Client, client_id)
+    agora = datetime.now(UTC)
+    evento = AgendaEvent(
+        tenant_id=contato.tenant_id, title=titulo, kind="atendimento", status=status,
+        client_id=client_id, starts_at=agora + em, ends_at=agora + em + timedelta(hours=1),
+    )
+    db.add(evento)
+    db.commit()
+    return evento
+
+
+def _cards(payload: dict) -> dict[str, dict]:
+    return {c["id"]: c for col in payload["columns"] for c in col["clients"]}
+
+
+def test_board_traz_o_proximo_compromisso_do_contato(client, db, headers):
+    marcado = _contato(client, headers, "Tem compromisso")
+    sem_nada = _contato(client, headers, "Sem compromisso")
+    _compromisso(db, marcado, titulo="Reunião de alinhamento")
+
+    resp = client.get("/crm/board", headers=headers)
+    assert resp.status_code == 200
+    cards = _cards(resp.json())
+
+    assert cards[marcado]["next_event_title"] == "Reunião de alinhamento"
+    assert cards[marcado]["next_event_at"] is not None
+    assert cards[sem_nada]["next_event_at"] is None
+    assert cards[sem_nada]["next_event_title"] is None
+
+
+def test_board_nao_traz_compromisso_cancelado(client, db, headers):
+    """Cancelado não é próximo passo nenhum — mesma regra que `next_event_map` já aplica."""
+    contato = _contato(client, headers, "Só tem cancelado")
+    _compromisso(db, contato, titulo="Cancelado", status=STATUS_CANCELLED)
+
+    resp = client.get("/crm/board", headers=headers)
+    assert resp.status_code == 200
+    card = _cards(resp.json())[contato]
+
+    assert card["next_event_at"] is None
+    assert card["next_event_title"] is None
+
+
+def _consultas_do_board(client, headers, engine) -> int:
+    """Quantas consultas SQL um GET /crm/board dispara."""
+    from sqlalchemy import event
+
+    contador = []
+
+    def _antes(_conn, _cursor, statement, _params, _context, _many):
+        contador.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _antes)
+    try:
+        assert client.get("/crm/board", headers=headers).status_code == 200
+    finally:
+        event.remove(engine, "before_cursor_execute", _antes)
+    return len(contador)
+
+
+def test_board_nao_faz_uma_consulta_por_card_com_proximo_passo(client, db, headers):
+    """Mesma trava do `unread`: dobrar os cards não pode dobrar as consultas.
+
+    O jeito errado de implementar isto é perguntar pelo próximo evento por contato, dentro do
+    laço que monta as colunas. `next_event_map` existe para custar UMA consulta agregada,
+    igual `last_interaction_map` e `unread_client_ids` — e essa garantia só se prova medindo,
+    não lendo o JSON de resposta.
+    """
+    engine = db.get_bind()
+    for i in range(2):
+        _compromisso(db, _contato(client, headers, f"Contato {i}"))
+    com_2 = _consultas_do_board(client, headers, engine)
+
+    for i in range(2, 8):
+        _compromisso(db, _contato(client, headers, f"Contato {i}"))
+    com_8 = _consultas_do_board(client, headers, engine)
+
+    assert com_8 == com_2, (
+        f"{com_2} consultas com 2 cards e {com_8} com 8 — o custo está crescendo com os cards"
+    )

--- a/apps/api/tests/test_crm_board_proximo_passo.py
+++ b/apps/api/tests/test_crm_board_proximo_passo.py
@@ -82,6 +82,33 @@ def test_board_traz_o_proximo_compromisso_do_contato(client, db, headers):
     assert cards[sem_nada]["next_event_title"] is None
 
 
+def test_board_traz_next_event_all_day_do_compromisso(client, db, headers):
+    """Achado da revisão final da Onda 2: o card precisa saber SE o próximo passo é dia inteiro
+    para escolher como formatar a data (`next_event_all_day` — ver `CrmPage.tsx`).
+
+    Dois contatos: um com compromisso de HORÁRIO (`all_day=False`), outro de DIA INTEIRO
+    (`all_day=True`, o caso de uma cobrança gerada por `receivables`) — prova que o campo
+    reflete o evento de CADA card, não uma constante.
+    """
+    com_horario = _contato(client, headers, "Compromisso com horário")
+    _compromisso(db, com_horario, titulo="Reunião", status="scheduled")
+
+    dia_inteiro = _contato(client, headers, "Compromisso dia inteiro")
+    contato_row = db.get(Client, dia_inteiro)
+    agora = datetime.now(UTC)
+    evento_dia_inteiro = AgendaEvent(
+        tenant_id=contato_row.tenant_id, title="A receber: Fulana", kind="cobranca_receber",
+        status="scheduled", client_id=dia_inteiro, all_day=True,
+        starts_at=agora + timedelta(days=2), ends_at=agora + timedelta(days=2, hours=23),
+    )
+    db.add(evento_dia_inteiro)
+    db.commit()
+
+    cards = _cards(client.get("/crm/board", headers=headers).json())
+    assert cards[com_horario]["next_event_all_day"] is False
+    assert cards[dia_inteiro]["next_event_all_day"] is True
+
+
 def test_board_nao_traz_compromisso_cancelado(client, db, headers):
     """Cancelado não é próximo passo nenhum — mesma regra que `next_event_map` já aplica."""
     contato = _contato(client, headers, "Só tem cancelado")

--- a/apps/api/tests/test_migration_0078_agenda_client_rls.py
+++ b/apps/api/tests/test_migration_0078_agenda_client_rls.py
@@ -1,0 +1,269 @@
+"""Migration 0078 (backfill de `agenda_events.client_id`) sob RLS REAL.
+
+O fato que a suíte SQLite é estruturalmente incapaz de provar: **o backfill não é no-op.**
+`agenda_events` e `charges` têm FORCE ROW LEVEL SECURITY e a migration roda como o papel
+não-superusuário `e1p_app` sem GUC de tenant. Sem a janela de DISABLE/ENABLE o UPDATE
+afetaria zero linhas SEM ERRO NENHUM — e o sintoma em produção não seria falha de deploy,
+seria "a ficha do cliente não mostra compromisso nenhum", meses depois.
+
+Semeamos parando na 0077 e só então aplicamos a 0078: backfill sobre tabela vazia é
+indistinguível de backfill no-op, que é o bug que este arquivo existe para pegar.
+
+Marcado `rls_e2e`: NÃO roda no `pytest -q`; roda no job `cross-tenant-rls` do CI e
+localmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+
+_API_DIR = Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str, revision: str) -> None:
+    """Aplica migrations como `e1p_app`, parando na revisão pedida.
+
+    O teste precisa parar em `0077`, semear e só então aplicar a `0078` — senão o backfill
+    rodaria sobre tabela vazia, e backfill de tabela vazia é indistinguível de backfill
+    no-op (que é exatamente o bug que este arquivo existe para pegar).
+    """
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, revision)
+    finally:
+        settings.database_url = original_url
+
+
+_AGORA = datetime(2026, 8, 16, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture(scope="module")
+def ambiente():
+    """Sobe Postgres, migra até 0077, SEMEIA, e só então aplica a 0078.
+
+    A semente cobre os três casos do backfill num único tenant:
+      - `charge`: uma cobrança com `client_id` preenchido.
+      - `evento_cobranca`: `kind='cobranca_receber'`, `external_ref` = id da `charge` acima —
+        é o evento que o backfill DEVE ligar ao cliente.
+      - `evento_bloqueio`: sem `external_ref` — não tem de onde herdar dono, fica órfão.
+      - `payable`: uma conta a pagar cujo `id` é **deliberadamente igual ao `id` da charge**
+        (tabelas diferentes, sem FK — não há conflito de PK). Isso testa a armadilha real: se o
+        backfill não filtrasse por `kind`, a colisão de id ligaria `evento_pagar` ao cliente
+        errado.
+      - `evento_pagar`: `kind='cobranca_pagar'`, `external_ref` = esse id colidido — deve
+        continuar órfão porque o filtro `kind='cobranca_receber'` o exclui da UPDATE.
+    """
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url, "0077")
+
+        tenant_a = str(uuid4())
+        client_id = str(uuid4())
+        charge_id = str(uuid4())
+        payable_id = charge_id  # colisão DELIBERADA entre tabelas diferentes (ver docstring)
+
+        evento_cobranca_id = str(uuid4())
+        evento_bloqueio_id = str(uuid4())
+        evento_pagar_id = str(uuid4())
+
+        engine = create_engine(app_url, poolclass=NullPool)
+        with engine.begin() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :t, false)"), {"t": tenant_a}
+            )
+
+            # Cobrança com dono (client_id preenchido) — a FONTE do backfill.
+            conn.execute(
+                text(
+                    "INSERT INTO charges (id, tenant_id, client_id, kind, method, "
+                    "amount_cents, due_date) VALUES "
+                    "(:id, :t, :c, 'service', 'pix', 15000, '2026-07-01')"
+                ),
+                {"id": charge_id, "t": tenant_a, "c": client_id},
+            )
+
+            # Conta a pagar cujo id colide com o da charge acima (ver docstring da fixture).
+            conn.execute(
+                text(
+                    "INSERT INTO payables (id, tenant_id, amount_cents, due_date) VALUES "
+                    "(:id, :t, 8000, '2026-07-05')"
+                ),
+                {"id": payable_id, "t": tenant_a},
+            )
+
+            # Evento de cobrança a receber — DEVE ganhar client_id no backfill.
+            conn.execute(
+                text(
+                    "INSERT INTO agenda_events (id, tenant_id, title, kind, external_ref, "
+                    "starts_at, ends_at) VALUES "
+                    "(:id, :t, 'Vencimento', 'cobranca_receber', :ref, :ini, :fim)"
+                ),
+                {
+                    "id": evento_cobranca_id, "t": tenant_a, "ref": charge_id,
+                    "ini": _AGORA, "fim": _AGORA,
+                },
+            )
+
+            # Bloqueio de horário, sem external_ref — não tem de onde herdar dono.
+            conn.execute(
+                text(
+                    "INSERT INTO agenda_events (id, tenant_id, title, kind, "
+                    "starts_at, ends_at) VALUES "
+                    "(:id, :t, 'Fora do escritório', 'bloqueio', :ini, :fim)"
+                ),
+                {"id": evento_bloqueio_id, "t": tenant_a, "ini": _AGORA, "fim": _AGORA},
+            )
+
+            # Conta a pagar cujo external_ref colide com o id da charge — deve ficar órfão.
+            conn.execute(
+                text(
+                    "INSERT INTO agenda_events (id, tenant_id, title, kind, external_ref, "
+                    "starts_at, ends_at) VALUES "
+                    "(:id, :t, 'Aluguel', 'cobranca_pagar', :ref, :ini, :fim)"
+                ),
+                {
+                    "id": evento_pagar_id, "t": tenant_a, "ref": payable_id,
+                    "ini": _AGORA, "fim": _AGORA,
+                },
+            )
+        engine.dispose()
+
+        # AGORA a 0078 — o backfill encontra linhas de verdade.
+        _run_migrations_as_app(app_url, "0078")
+
+        yield {
+            "url": app_url,
+            "tenant_a": tenant_a,
+            "client_id": client_id,
+            "evento_cobranca_id": evento_cobranca_id,
+            "evento_bloqueio_id": evento_bloqueio_id,
+            "evento_pagar_id": evento_pagar_id,
+        }
+
+
+def _client_id_de(ambiente: dict, evento_id: str) -> str | None:
+    engine = create_engine(ambiente["url"], poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :t, false)"),
+                {"t": ambiente["tenant_a"]},
+            )
+            linha = conn.execute(
+                text("SELECT client_id FROM agenda_events WHERE id = :id"),
+                {"id": evento_id},
+            ).one()
+        return linha.client_id
+    finally:
+        engine.dispose()
+
+
+def test_backfill_liga_evento_de_cobranca_ao_cliente(ambiente):
+    """O caso que o backfill existe para resolver: evento antigo ganha dono."""
+    obtido = _client_id_de(ambiente, ambiente["evento_cobranca_id"])
+    assert obtido == ambiente["client_id"], (
+        f"evento de cobranca_receber deveria herdar client_id={ambiente['client_id']!r} "
+        f"da charge, veio {obtido!r}"
+    )
+
+
+def test_backfill_nao_e_no_op(ambiente):
+    """A asserção que só o Postgres com RLS pode fazer.
+
+    Se alguém remover a janela de DISABLE ROW LEVEL SECURITY, o UPDATE roda, não falha, e
+    afeta zero linhas. Este teste é a única coisa entre esse commit e a produção.
+    """
+    engine = create_engine(ambiente["url"], poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :t, false)"),
+                {"t": ambiente["tenant_a"]},
+            )
+            total = conn.execute(
+                text("SELECT COUNT(*) FROM agenda_events WHERE client_id IS NOT NULL")
+            ).scalar_one()
+        assert total >= 1, f"backfill foi no-op: {total} eventos com client_id não nulo"
+    finally:
+        engine.dispose()
+
+
+def test_backfill_nao_inventa_dono(ambiente):
+    """Evento sem cobrança e conta a PAGAR continuam órfãos — e devem."""
+    bloqueio = _client_id_de(ambiente, ambiente["evento_bloqueio_id"])
+    pagar = _client_id_de(ambiente, ambiente["evento_pagar_id"])
+    assert bloqueio is None, f"bloqueio sem external_ref não deveria ter dono, veio {bloqueio!r}"
+    assert pagar is None, (
+        f"cobranca_pagar cujo external_ref colide com o id de uma charge não deveria herdar "
+        f"dono (o filtro kind='cobranca_receber' deveria excluí-lo), veio {pagar!r}"
+    )
+
+
+@pytest.mark.parametrize("tabela", ["agenda_events", "charges"])
+def test_rls_foi_restaurada(ambiente, tabela):
+    """A janela do backfill DESLIGA a RLS das DUAS tabelas. Esquecer de religar abre uma
+    delas em produção.
+
+    `charges` entra aqui porque é a FONTE da subconsulta do backfill: ela precisa ser aberta
+    junto (a RLS filtra SELECT), e portanto precisa ser fechada junto.
+    """
+    engine = create_engine(ambiente["url"], poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            linha = conn.execute(
+                text(
+                    "SELECT relrowsecurity, relforcerowsecurity FROM pg_class "
+                    "WHERE relname = :t"
+                ),
+                {"t": tabela},
+            ).one()
+        assert linha.relrowsecurity is True, f"RLS de `{tabela}` ficou DESLIGADA após a 0078"
+        assert linha.relforcerowsecurity is True, f"FORCE de `{tabela}` não foi restaurado"
+    finally:
+        engine.dispose()

--- a/apps/api/tests/test_migration_0078_agenda_client_rls.py
+++ b/apps/api/tests/test_migration_0078_agenda_client_rls.py
@@ -14,6 +14,7 @@ localmente com Docker (`pytest -m rls_e2e`).
 """
 from __future__ import annotations
 
+import importlib.util
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -22,6 +23,8 @@ import pytest
 
 pytest.importorskip("testcontainers.postgres")
 
+from alembic.migration import MigrationContext  # noqa: E402
+from alembic.operations import Operations  # noqa: E402
 from sqlalchemy import create_engine, text  # noqa: E402
 from sqlalchemy.pool import NullPool  # noqa: E402
 from testcontainers.postgres import PostgresContainer  # noqa: E402
@@ -34,6 +37,7 @@ _APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container
 _DB_NAME = "e1pdb"
 
 _API_DIR = Path(__file__).resolve().parents[1]
+_MIGRATION_0078_PATH = _API_DIR / "migrations" / "versions" / "0078_agenda_event_client.py"
 
 
 def _bootstrap_rls_role(super_url: str) -> None:
@@ -87,6 +91,11 @@ def ambiente():
         errado.
       - `evento_pagar`: `kind='cobranca_pagar'`, `external_ref` = esse id colidido — deve
         continuar órfão porque o filtro `kind='cobranca_receber'` o exclui da UPDATE.
+      - `evento_corrigido`: mesmo formato de `evento_cobranca` (herda `client_id` da charge no
+        backfill inicial), mas **depois** da 0078 tem o `client_id` sobrescrito para `client_b`
+        — simulando o dono corrigindo o vínculo pela API (`EventUpdate.client_id`, que a partir
+        desta migration existe). A coluna não existe antes da 0078, por isso a correção só pode
+        ser aplicada DEPOIS que a migration cria a coluna, não junto da semente original.
     """
     with PostgresContainer(
         "postgres:16-alpine",
@@ -105,12 +114,14 @@ def ambiente():
 
         tenant_a = str(uuid4())
         client_id = str(uuid4())
+        client_b_id = str(uuid4())  # "dono corrigido" — ver evento_corrigido abaixo
         charge_id = str(uuid4())
         payable_id = charge_id  # colisão DELIBERADA entre tabelas diferentes (ver docstring)
 
         evento_cobranca_id = str(uuid4())
         evento_bloqueio_id = str(uuid4())
         evento_pagar_id = str(uuid4())
+        evento_corrigido_id = str(uuid4())
 
         engine = create_engine(app_url, poolclass=NullPool)
         with engine.begin() as conn:
@@ -172,19 +183,71 @@ def ambiente():
                     "ini": _AGORA, "fim": _AGORA,
                 },
             )
+
+            # Mesmo formato de evento_cobranca — vai herdar `client_id` (cliente A) no
+            # backfill inicial da 0078. Depois da migration, corrigimos para client_b (abaixo).
+            conn.execute(
+                text(
+                    "INSERT INTO agenda_events (id, tenant_id, title, kind, external_ref, "
+                    "starts_at, ends_at) VALUES "
+                    "(:id, :t, 'Consulta', 'cobranca_receber', :ref, :ini, :fim)"
+                ),
+                {
+                    "id": evento_corrigido_id, "t": tenant_a, "ref": charge_id,
+                    "ini": _AGORA, "fim": _AGORA,
+                },
+            )
         engine.dispose()
 
         # AGORA a 0078 — o backfill encontra linhas de verdade.
         _run_migrations_as_app(app_url, "0078")
 
+        # A coluna client_id só existe a partir daqui. Simula o dono corrigindo o vínculo
+        # pela API (EventUpdate.client_id) DEPOIS do backfill inicial ter rodado.
+        engine = create_engine(app_url, poolclass=NullPool)
+        with engine.begin() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :t, false)"), {"t": tenant_a}
+            )
+            conn.execute(
+                text("UPDATE agenda_events SET client_id = :b WHERE id = :id"),
+                {"b": client_b_id, "id": evento_corrigido_id},
+            )
+        engine.dispose()
+
         yield {
             "url": app_url,
             "tenant_a": tenant_a,
             "client_id": client_id,
+            "client_b_id": client_b_id,
             "evento_cobranca_id": evento_cobranca_id,
             "evento_bloqueio_id": evento_bloqueio_id,
             "evento_pagar_id": evento_pagar_id,
+            "evento_corrigido_id": evento_corrigido_id,
         }
+
+
+def _reexecutar_backfill(url: str) -> None:
+    """Reexecuta `backfill_client_id()` carregando o ARQUIVO REAL da migration 0078 — não uma
+    cópia da SQL — para que editar o arquivo (como no Step 6) mude o que este teste exercita.
+
+    Simula o cenário do achado do reviewer: alguém reexecutando a SQL da migration à mão contra
+    produção (já aconteceu na história deste projeto), depois que a Task 2 dá ao dono um jeito
+    de corrigir o vínculo pela API.
+    """
+    spec = importlib.util.spec_from_file_location("migration_0078_reexec", _MIGRATION_0078_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    engine = create_engine(url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                mod.backfill_client_id()
+    finally:
+        engine.dispose()
 
 
 def _client_id_de(ambiente: dict, evento_id: str) -> str | None:
@@ -242,6 +305,30 @@ def test_backfill_nao_inventa_dono(ambiente):
     assert pagar is None, (
         f"cobranca_pagar cujo external_ref colide com o id de uma charge não deveria herdar "
         f"dono (o filtro kind='cobranca_receber' deveria excluí-lo), veio {pagar!r}"
+    )
+
+
+def test_backfill_nao_sobrescreve_vinculo_ja_existente(ambiente):
+    """Reexecutar a SQL do backfill à mão não pode apagar uma correção que o dono já fez.
+
+    `evento_corrigido` herdou `client_id` de `client_id` (cliente A) no backfill original e foi
+    depois corrigido para `client_b` — como a Task 2 (`EventUpdate.client_id`) passa a permitir.
+    Sem a cláusula `AND e.client_id IS NULL`, reexecutar o backfill re-derivaria de `charges` e
+    apagaria a correção em silêncio, exatamente como uma reexecução manual contra produção faria
+    (já aconteceu na história deste projeto).
+    """
+    antes = _client_id_de(ambiente, ambiente["evento_corrigido_id"])
+    assert antes == ambiente["client_b_id"], (
+        f"pré-condição da fixture falhou: esperava client_b={ambiente['client_b_id']!r} "
+        f"antes da reexecução, veio {antes!r}"
+    )
+
+    _reexecutar_backfill(ambiente["url"])
+
+    depois = _client_id_de(ambiente, ambiente["evento_corrigido_id"])
+    assert depois == ambiente["client_b_id"], (
+        f"reexecução do backfill sobrescreveu a correção do dono: esperado "
+        f"client_b={ambiente['client_b_id']!r}, veio {depois!r}"
     )
 
 

--- a/apps/web/e2e/crm-360.spec.ts
+++ b/apps/web/e2e/crm-360.spec.ts
@@ -16,6 +16,11 @@ import { semearSessao } from "./support/sessao";
  * A fixture é de PIOR CASO PLAUSÍVEL: o rótulo mais comprido ("Integração") num card que também
  * tem o nome mais longo e duas tags, e o card de WhatsApp com o nome caindo no telefone cru —
  * que é como ele nasce quando o contato não tem `pushName`.
+ *
+ * [Onda 2, Task 8] O card ganhou uma TERCEIRA linha de rodapé: o próximo compromisso da Agenda
+ * (ou o aviso de que não há um). `c2` — o card mais cheio, já disputando espaço com nome, duas
+ * tags e o ponto de "esperando resposta" — é quem recebe o título de compromisso mais comprido
+ * plausível, para provar que a linha TRUNCA de verdade em vez de só não estourar por sorte.
  */
 test.beforeEach(async ({ page }) => {
   await semearSessao(page);
@@ -117,4 +122,37 @@ test("o ponto de mensagem esperando resposta não empurra o nome para fora", asy
 
   const { larguraDaPagina } = await medirPagina(page);
   expect(larguraDaPagina).toBe(360);
+});
+
+test("a linha do próximo passo trunca — de verdade — e não estoura a coluna", async ({ page }) => {
+  await page.goto("/crm");
+
+  // O card mais cheio (c2, `next_event_title` da fixture) recebe o compromisso mais comprido
+  // plausível: "Reunião de alinhamento do casamento 12/12". Não é escolhido por ACASO caber —
+  // é escolhido por FORÇAR a reticência. A prova de que ela ENGATOU é `scrollWidth >
+  // clientWidth` do próprio parágrafo (mesma régua de `.truncate` que a Onda 1 já usa em
+  // `medidas.ts`), não a ausência de estouro na página: um texto que apenas coubesse por sorte
+  // passaria nas DUAS provas e não provaria nada sobre o `truncate` em si.
+  const proximo = page.getByText(/^próximo: Reunião de alinhamento/);
+  await expect(proximo).toBeVisible();
+  const [scrollWidth, clientWidth] = await proximo.evaluate((el) => [el.scrollWidth, el.clientWidth]);
+  expect(scrollWidth).toBeGreaterThan(clientWidth);
+
+  // A PÁGINA continua sem rolar de lado, e nada da PRIMEIRA coluna (onde o card mora) sai da
+  // tela — mesmo recorte `.w-72` e mesmo controle positivo dos outros testes deste arquivo.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+  expect(await textoForaDaTela(page, ".w-72")).toEqual([]);
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});
+
+test("o card sem próximo passo avisa, sem estourar a coluna", async ({ page }) => {
+  await page.goto("/crm");
+
+  // c1 tem `next_event_at`/`next_event_title` nulos os dois — o estado "sem próximo passo" que
+  // a fixture exercita de propósito (ver comentário no topo do arquivo e em `crm.json`).
+  await expect(page.getByText("sem próximo passo")).toBeVisible();
+
+  expect(await textoForaDaTela(page, ".w-72")).toEqual([]);
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
 });

--- a/apps/web/e2e/ficha-agenda-360.spec.ts
+++ b/apps/web/e2e/ficha-agenda-360.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O bloco de Agenda da ficha 360° em 360px.
+ *
+ * `BlocoDaAgenda` (Onda 2, Task 6) é o irmão mais novo de `BlocoDaConversa` (Onda 1) — e o
+ * título do compromisso, ao contrário do nome do card do Kanban (`crm-360.spec.ts`), NÃO tem
+ * `truncate`: `<p className="text-sm font-medium text-neutral-800">{e.title}</p>` é texto de
+ * bloco cru. Um título comprido SEM espaço — sem onde quebrar — é o caso que estoura de
+ * verdade, não por elipse faltando e sim por ausência de `break-words`: o mesmo defeito que a
+ * bolha de chat da Conversa já tinha (ver o comentário em `ficha-conversa-360.spec.ts`).
+ */
+const EVENTO_CURTO = {
+  id: "ev-1",
+  tenant_id: "t1",
+  title: "Prova do vestido",
+  description: "",
+  kind: "atendimento",
+  status: "scheduled",
+  priority: "normal",
+  source: "manual",
+  starts_at: "2026-08-20T13:00:00Z",
+  ends_at: "2026-08-20T14:00:00Z",
+  all_day: false,
+  location: "",
+  meeting_url: null,
+  guests: [],
+  amount_cents: null,
+  external_ref: null,
+  google_event_id: null,
+  client_id: "c1",
+  client_name: "Ju",
+  created_by_ai: false,
+  created_at: "2026-08-15T10:00:00Z",
+};
+
+// Pior caso plausível: SEM espaço, hífen OU barra — mesma exigência de `ficha-conversa-360.spec.ts`.
+// Um `lorem ipsum` teria espaço sobrando; uma URL teria `/`, ponto de quebra válido por padrão
+// do navegador (UAX #14). Um compromisso de casamento com nome comprido de fornecedor grudado
+// é o cenário real: o dono digitando rápido, sem espaço entre as palavras.
+const EVENTO_SEM_ESPACO = {
+  id: "ev-2",
+  tenant_id: "t1",
+  title:
+    "ReuniaoDeAlinhamentoFinalDoCasamentoComTodosOsFornecedoresEEquipeCompletaUrgentissimo1234567890",
+  description: "",
+  kind: "atendimento",
+  status: "scheduled",
+  priority: "high",
+  source: "manual",
+  starts_at: "2026-08-22T13:00:00Z",
+  ends_at: "2026-08-22T14:00:00Z",
+  all_day: false,
+  location: "",
+  meeting_url: null,
+  guests: [],
+  amount_cents: null,
+  external_ref: null,
+  google_event_id: null,
+  client_id: "c1",
+  client_name: "Ju",
+  created_by_ai: false,
+  created_at: "2026-08-15T10:00:00Z",
+};
+
+const fixtures = {
+  "/crm/clients/c1": {
+    id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: "554384035398",
+    document: null, gender: "unspecified", birthdate: null, notes: "", tags: [],
+    source: "whatsapp", stage_id: "s1", stage_entered_at: "2026-08-15T12:00:00Z",
+    created_at: "2026-08-15T12:00:00Z",
+  },
+  // Mesmo motivo do `ficha-conversa-360.spec.ts`: sem esta chave, `/crm/clients/c1` (prefixo
+  // mais longo disponível) engoliria `/crm/clients/c1/timeline` e o `ClientTimeline` receberia
+  // o cliente onde espera `{entries, truncated}` — a ficha ficaria mais curta que a real.
+  "/crm/clients/c1/timeline": { entries: [], truncated: false },
+  // `BlocoDaAgenda` chama `GET /agenda/events?client_id=c1&start=...&exclude_cancelled=true`;
+  // o mock casa por PREFIXO de pathname (query descartada), então uma chave basta para as duas
+  // consultas que a página faz aqui.
+  "/agenda/events": [EVENTO_CURTO, EVENTO_SEM_ESPACO],
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, fixtures);
+});
+
+test("a agenda cabe em 360px, mesmo com um compromisso de título sem espaço", async ({ page }) => {
+  await page.goto("/crm/clients/c1");
+
+  await expect(page.getByText("Prova do vestido")).toBeVisible();
+
+  // O botão "Marcar com este cliente" fica AO LADO da lista, dentro da mesma seção — tem de
+  // estar INTEIRO dentro da tela, não só presente no DOM.
+  const marcar = page.getByRole("button", { name: "Marcar com este cliente" });
+  await expect(marcar).toBeVisible();
+  const caixaDoBotao = await marcar.boundingBox();
+  expect(caixaDoBotao).not.toBeNull();
+  expect(caixaDoBotao!.x).toBeGreaterThanOrEqual(0);
+  expect(caixaDoBotao!.x + caixaDoBotao!.width).toBeLessThanOrEqual(360);
+
+  // A PÁGINA não rola de lado — a ficha é coluna única, igual à Conversa.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // Varredura escopada à seção da Agenda. As OITO seções da ficha compartilham
+  // `rounded-2xl bg-white`, e `querySelector` devolve só a PRIMEIRA ocorrência do documento —
+  // aqui, o cabeçalho do cliente, não a Agenda. Por isso a seção ganhou
+  // `data-testid="secao-agenda"` (`ClientDetailPage.tsx`), mesmo motivo da Conversa.
+  expect(await textoForaDaTela(page, '[data-testid="secao-agenda"]')).toEqual([]);
+
+  // CONTROLE POSITIVO. A ficha, correta, não tem NENHUM corte em lugar nenhum da página — não
+  // existe conteúdo fora da tela por acidente para um seletor podre achar sozinho. Por isso o
+  // controle planta, só para o instante desta asserção, um texto sem filhos fora da tela: prova
+  // de que a função ENXERGA corte nesta página quando ele existe, e não que a fixture por acaso
+  // nunca produz um. Inline, some sozinho quando o Playwright fecha o contexto ao final do teste.
+  await page.evaluate(() => {
+    const marca = document.createElement("span");
+    marca.textContent = "marca de controle positivo";
+    marca.style.cssText = "position:absolute;left:9999px;top:0;white-space:nowrap;";
+    marca.setAttribute("data-marca-controle-positivo", "");
+    document.body.appendChild(marca);
+  });
+  expect(await textoForaDaTela(page, ".seletor-que-nao-existe")).not.toEqual([]);
+});
+
+test("o título sem espaço não vaza pela caixa do compromisso", async ({ page }) => {
+  // Prova direta do `scrollWidth` do PRÓPRIO parágrafo do título — não só a ausência de corte
+  // na varredura da seção. Mesma régua do `crm-360.spec.ts` para a linha de próximo passo do
+  // card, mas o SENTIDO da prova é o oposto: lá `scrollWidth > clientWidth` prova que a
+  // reticência ENGATOU (o `truncate` funcionando); aqui prova que o texto NÃO transbordou —
+  // porque este parágrafo não tem `truncate`, tem `break-words`: o conserto é ele quebrar a
+  // palavra, não escondê-la atrás de "...".
+  await page.goto("/crm/clients/c1");
+
+  const titulo = page.getByText(EVENTO_SEM_ESPACO.title.slice(0, 40), { exact: false });
+  await expect(titulo).toBeVisible();
+
+  const [scrollWidth, clientWidth] = await titulo.evaluate((el) => [el.scrollWidth, el.clientWidth]);
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 0.5);
+});

--- a/apps/web/e2e/fixtures/crm.json
+++ b/apps/web/e2e/fixtures/crm.json
@@ -27,7 +27,9 @@
             "stage_entered_at": "2026-08-13T12:00:00Z",
             "created_at": "2026-08-13T12:00:00Z",
             "last_interaction_at": "2026-08-13T12:00:00Z",
-            "unread": false
+            "unread": false,
+            "next_event_at": null,
+            "next_event_title": null
           },
           {
             "id": "c2",
@@ -45,7 +47,9 @@
             "stage_entered_at": "2026-08-12T09:30:00Z",
             "created_at": "2026-08-12T09:30:00Z",
             "last_interaction_at": "2026-08-14T18:45:00Z",
-            "unread": true
+            "unread": true,
+            "next_event_at": "2026-08-20T13:00:00Z",
+            "next_event_title": "Reunião de alinhamento do casamento 12/12"
           }
         ]
       },

--- a/apps/web/e2e/fixtures/crm.json
+++ b/apps/web/e2e/fixtures/crm.json
@@ -29,7 +29,8 @@
             "last_interaction_at": "2026-08-13T12:00:00Z",
             "unread": false,
             "next_event_at": null,
-            "next_event_title": null
+            "next_event_title": null,
+            "next_event_all_day": false
           },
           {
             "id": "c2",
@@ -49,7 +50,8 @@
             "last_interaction_at": "2026-08-14T18:45:00Z",
             "unread": true,
             "next_event_at": "2026-08-20T13:00:00Z",
-            "next_event_title": "Reunião de alinhamento do casamento 12/12"
+            "next_event_title": "Reunião de alinhamento do casamento 12/12",
+            "next_event_all_day": false
           }
         ]
       },

--- a/apps/web/src/features/agenda/AgendaPage.test.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.test.tsx
@@ -1,3 +1,4 @@
+import type { AgendaEvent } from "@e1p/shared-types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -94,5 +95,81 @@ describe("AgendaPage — Novo evento (Story 7.15, Task 2)", () => {
     // Modal permanece aberto e o botão volta a ficar habilitado (saving → false).
     expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Criar evento" })).toBeEnabled();
+  });
+});
+
+// Task 3 (Onda 2, limpeza do _events_out): `client_name` passou a vir de QUALQUER evento
+// com contato vinculado, não só cobranças (ver AgendaPage.tsx, `chipLabel`). O card do
+// calendário restringe o atalho "mostra o nome" aos kinds financeiros — os únicos cujo
+// título é auto-gerado pelo backend. Eventos "reunião"/"atendimento" mostram o título que o
+// dono digitou, mesmo linkados a um contato.
+function agendaEvent(overrides: Partial<AgendaEvent> = {}): AgendaEvent {
+  // "Hoje" no fuso fixo do runner (America/Sao_Paulo, ver vitest.config.ts) — mesmo fuso que
+  // `hojeDoTenant` usa quando não há sessão (fallback FUSO_PADRAO), então o evento cai dentro
+  // da grade do mês que a AgendaPage abre por padrão.
+  const now = new Date();
+  const at = (h: number) =>
+    new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, 0, 0).toISOString();
+  return {
+    id: "ev-1",
+    tenant_id: "t-1",
+    title: "Evento",
+    description: "",
+    kind: "atendimento",
+    status: "scheduled",
+    priority: "normal",
+    source: "manual",
+    starts_at: at(9),
+    ends_at: at(10),
+    all_day: false,
+    location: "",
+    meeting_url: null,
+    guests: [],
+    amount_cents: null,
+    external_ref: null,
+    google_event_id: null,
+    client_name: null,
+    created_by_ai: false,
+    created_at: at(8),
+    ...overrides,
+  };
+}
+
+function mockEvents(events: AgendaEvent[]) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/agenda/events") return Promise.resolve({ data: events } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+}
+
+describe("AgendaPage — chipLabel (Task 3, Onda 2): atalho de nome só para kinds financeiros", () => {
+  it("cobrança com client_name mostra o NOME no card, não o título auto-gerado", async () => {
+    mockEvents([
+      agendaEvent({
+        id: "ev-receber",
+        title: "A receber: cobrança gerada automaticamente",
+        kind: "cobranca_receber",
+        client_name: "Fulana da Silva",
+      }),
+    ]);
+    const { container } = renderPage();
+
+    await waitFor(() => expect(container.textContent).toContain("Fulana da Silva"));
+    expect(container.textContent).not.toContain("cobrança gerada automaticamente");
+  });
+
+  it("reunião com contato vinculado mostra o TÍTULO digitado, não o nome do contato", async () => {
+    mockEvents([
+      agendaEvent({
+        id: "ev-reuniao",
+        title: "Alinhamento do casamento 12/12",
+        kind: "reuniao",
+        client_name: "Cliente Vinculado",
+      }),
+    ]);
+    const { container } = renderPage();
+
+    await waitFor(() => expect(container.textContent).toContain("Alinhamento do casamento 12/12"));
+    expect(container.textContent).not.toContain("Cliente Vinculado");
   });
 });

--- a/apps/web/src/features/agenda/AgendaPage.test.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.test.tsx
@@ -128,6 +128,7 @@ function agendaEvent(overrides: Partial<AgendaEvent> = {}): AgendaEvent {
     amount_cents: null,
     external_ref: null,
     google_event_id: null,
+    client_id: null,
     client_name: null,
     created_by_ai: false,
     created_at: at(8),

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -195,8 +195,18 @@ function eventColor(e: AgendaEvent, hoje: string): string {
   return "bg-primary-100 text-primary-700";
 }
 const hhmm = (iso: string, tz: string) => formatTime(iso, tz);
-// Card: mostra o nome do cliente/fornecedor quando houver (cobranças/contas), senão o título.
-const chipLabel = (e: AgendaEvent) => e.client_name || e.title;
+// O atalho (nome no lugar do título) é só para os kinds FINANCEIROS. O título deles é
+// AUTO-GERADO pelo backend ("A receber: Fulano"), então mostrar o nome puro é um encurtamento
+// inofensivo — mesma informação, mais curta.
+// Desde que `client_id`/`client_name` passaram a ser resolvidos para QUALQUER kind com contato
+// vinculado (Onda 2, Task 3 — join direto em `_events_out`), uma reunião ou atendimento ligado a
+// um contato também ganhou `client_name`. Mas o título desses eventos foi DIGITADO pelo dono
+// ("Alinhamento do casamento 12/12") e carrega informação que o nome do contato não tem — no
+// calendário, que é o lugar de bater o olho e saber do que se trata, trocar por nome perderia
+// isso. Por isso a restrição por kind abaixo: NÃO simplificar de volta para `client_name || title`.
+const FINANCIAL_KINDS = new Set(["cobranca_receber", "cobranca_pagar"]);
+const chipLabel = (e: AgendaEvent) =>
+  FINANCIAL_KINDS.has(e.kind) && e.client_name ? e.client_name : e.title;
 // Eventos de dia inteiro (cobranças, contas a pagar, prazos) são gravados à meia-noite UTC:
 // casamos pela DATA do calendário (sem fuso) para não "voltar" um dia em fuso negativo.
 // Eventos com horário usam a data local normalmente.

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -1,29 +1,18 @@
-import type { AgendaEvent, Charge, CreateEventResult, Notification, Payable } from "@e1p/shared-types";
+import type { AgendaEvent, Charge, Notification, Payable } from "@e1p/shared-types";
 import { ChevronLeft, ChevronRight, MapPin, Sparkles, Users, Video } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Attachments from "../../components/Attachments";
-import Modal, { Field } from "../../components/Modal";
-import { api, apiErrorMessage, getGoogleStatus } from "../../lib/api";
+import Modal from "../../components/Modal";
+import { api } from "../../lib/api";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import { formatDateTime, formatDay, formatTime, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
-
-// Tipos de evento que geram Meet automaticamente quando o Google está conectado (Story 4.1).
-const MEET_KINDS = new Set(["reuniao", "atendimento", "audiencia"]);
+import NewEventModal from "./NewEventModal";
 
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 type View = "month" | "week" | "day";
-
-const KINDS = [
-  ["atendimento", "Atendimento"],
-  ["reuniao", "Reunião"],
-  ["audiencia", "Audiência"],
-  ["prazo", "Prazo"],
-  ["lembrete", "Lembrete"],
-  ["bloqueio", "Bloqueio"],
-] as const;
 
 const WEEKDAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
 
@@ -36,7 +25,9 @@ const addDays = (d: Date, n: number) => {
 };
 const startOfWeek = (d: Date) => addDays(d, -d.getDay()); // semana começa no domingo
 const sameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
-const ymd = (d: Date) =>
+// Exportado: `NewEventModal.tsx` (Onda 2, Task 5) também precisa converter a data pré-preenchida
+// pelo clique no calendário — helper compartilhado, não duplicado.
+export const ymd = (d: Date) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 /**
  * "Hoje" no fuso do TENANT, como `Date` local — a âncora da grade do calendário.
@@ -549,184 +540,6 @@ function EventDetailModal({ event, onClose }: { event: AgendaEvent; onClose: () 
             </div>
           </div>
         )}
-      </div>
-    </Modal>
-  );
-}
-
-function NewEventModal({
-  open,
-  initialDate,
-  onClose,
-  onCreated,
-}: {
-  open: boolean;
-  initialDate: Date | null;
-  onClose: () => void;
-  onCreated: () => void;
-}) {
-  const [title, setTitle] = useState("");
-  const [kind, setKind] = useState("atendimento");
-  const [allDay, setAllDay] = useState(false);
-  const [start, setStart] = useState("");
-  const [end, setEnd] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
-  const [location, setLocation] = useState("");
-  const [guests, setGuests] = useState("");
-  const [meetingUrl, setMeetingUrl] = useState("");
-  const [description, setDescription] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [conflict, setConflict] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [googleConnected, setGoogleConnected] = useState(false);
-
-  // Descobre se o Google está conectado (para a dica de "Meet automático"). Silencioso em falha.
-  useEffect(() => {
-    if (!open) return;
-    getGoogleStatus()
-      .then((s) => setGoogleConnected(s.connected))
-      .catch(() => setGoogleConnected(false));
-  }, [open]);
-
-  const autoMeet = googleConnected && MEET_KINDS.has(kind);
-
-  // pré-preenche a data ao abrir num dia do calendário
-  useEffect(() => {
-    if (open && initialDate) {
-      const d = ymd(initialDate);
-      setStartDate(d);
-      setEndDate(d);
-      setStart(`${d}T09:00`);
-      setEnd(`${d}T10:00`);
-    }
-  }, [open, initialDate]);
-
-  async function save() {
-    setError(null);
-    setConflict(null);
-    setSaving(true);
-    try {
-      // Eventos com horário: o input datetime-local devolve uma string "naive" (sem fuso,
-      // ex. "2026-07-13T09:00"). Enviá-la crua fazia o backend tratá-la como UTC (grava
-      // "...T09:00:00Z"), exibindo 3h a menos no fuso do Brasil (bug #23). new Date(x) a
-      // interpreta como horário LOCAL e .toISOString() serializa para UTC real (local→UTC).
-      // O ramo all_day é intencionalmente meia-noite UTC da data de calendário (ver CLAUDE.md
-      // §6.0) — NÃO converter, sob pena de reintroduzir o bug antigo de sumiço na agenda.
-      const starts_at = allDay ? `${startDate}T00:00:00` : new Date(start).toISOString();
-      const ends_at = allDay ? `${endDate || startDate}T23:59:00` : new Date(end).toISOString();
-      const { data } = await api.post<CreateEventResult>("/agenda/events", {
-        title,
-        kind,
-        all_day: allDay,
-        starts_at,
-        ends_at,
-        location,
-        meeting_url: meetingUrl || null,
-        guests: guests ? guests.split(",").map((g) => g.trim()) : [],
-        description,
-      });
-      if (data.conflicts.length > 0) {
-        setConflict(`⚠ Conflito de horário com: ${data.conflicts.map((c) => c.title).join(", ")}`);
-      }
-      onCreated();
-      if (data.conflicts.length === 0) onClose();
-    } catch (err) {
-      setError(apiErrorMessage(err));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  const valid = title && (allDay ? startDate : start && end);
-
-  return (
-    <Modal title="Novo evento" open={open} onClose={onClose}>
-      <div className="space-y-3">
-        <Field label="Título" value={title} onChange={setTitle} placeholder="Atendimento cliente" />
-        <div className="flex items-end gap-3">
-          <label className="flex-1">
-            <span className="mb-1 block text-xs font-medium text-neutral-600">Tipo</span>
-            <select
-              value={kind}
-              onChange={(e) => setKind(e.target.value)}
-              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
-            >
-              {KINDS.map(([v, l]) => (
-                <option key={v} value={v}>
-                  {l}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-2 pb-2 text-sm text-neutral-600">
-            <input type="checkbox" checked={allDay} onChange={(e) => setAllDay(e.target.checked)} />
-            Dia inteiro
-          </label>
-        </div>
-
-        {allDay ? (
-          <div className="flex gap-2">
-            <Field label="Data início" type="date" value={startDate} onChange={setStartDate} />
-            <Field label="Data fim" type="date" value={endDate} onChange={setEndDate} />
-          </div>
-        ) : (
-          <div className="flex gap-2">
-            <Field label="Início" type="datetime-local" value={start} onChange={setStart} />
-            <Field label="Fim" type="datetime-local" value={end} onChange={setEnd} />
-          </div>
-        )}
-
-        <Field label="Local" value={location} onChange={setLocation} placeholder="Escritório ou endereço" />
-        <div>
-          <span className="mb-1 block text-xs font-medium text-neutral-600">
-            Reunião (Google Meet / Zoom)
-          </span>
-          <div className="flex gap-2">
-            <input
-              value={meetingUrl}
-              onChange={(e) => setMeetingUrl(e.target.value)}
-              placeholder={
-                autoMeet ? "Deixe em branco para gerar o Meet automaticamente" : "Cole o link da reunião"
-              }
-              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
-            />
-            <a
-              href="https://meet.google.com/new"
-              target="_blank"
-              rel="noreferrer"
-              className="flex shrink-0 items-center gap-1 rounded-lg bg-primary-50 px-3 text-sm font-medium text-primary-700 hover:bg-primary-100"
-            >
-              <Video size={15} /> Meet
-            </a>
-          </div>
-          {autoMeet && !meetingUrl && (
-            <p className="mt-1 text-xs text-primary-600">
-              Um link do Meet será gerado automaticamente ao salvar (Google conectado).
-            </p>
-          )}
-        </div>
-        <Field label="Convidados (e-mails, separados por vírgula)" value={guests} onChange={setGuests} />
-        <label className="block">
-          <span className="mb-1 block text-xs font-medium text-neutral-600">Descrição</span>
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            rows={2}
-            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
-          />
-        </label>
-
-        {conflict && <p className="rounded-lg bg-amber-50 p-2 text-sm text-amber-700">{conflict}</p>}
-        {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
-
-        <button
-          onClick={save}
-          disabled={saving || !valid}
-          className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
-        >
-          {saving ? "Salvando..." : "Criar evento"}
-        </button>
       </div>
     </Modal>
   );

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -6,7 +6,7 @@ import Modal from "../../components/Modal";
 import { api } from "../../lib/api";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
-import { formatDateTime, formatDay, formatTime, today } from "../../lib/datetime";
+import { formatDateTime, formatDay, formatTime, localYmd, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
 import NewEventModal from "./NewEventModal";
 
@@ -25,18 +25,14 @@ const addDays = (d: Date, n: number) => {
 };
 const startOfWeek = (d: Date) => addDays(d, -d.getDay()); // semana começa no domingo
 const sameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
-// Exportado: `NewEventModal.tsx` (Onda 2, Task 5) também precisa converter a data pré-preenchida
-// pelo clique no calendário — helper compartilhado, não duplicado.
-export const ymd = (d: Date) =>
-  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 /**
  * "Hoje" no fuso do TENANT, como `Date` local — a âncora da grade do calendário.
  *
- * A grade inteira (`startOfDay`, `addDays`, `startOfWeek`, `ymd`) trabalha em `Date` local, e
- * isso é coerente: são posições numa grade, não instantes. O que NÃO podia continuar local era
- * o ponto de partida — `new Date()` num navegador em UTC começava a grade no dia errado.
- * Montamos o dia certo pelas PARTES, para que a `Date` resultante seja a meia-noite local desse
- * dia e toda a aritmética seguinte continue valendo.
+ * A grade inteira (`startOfDay`, `addDays`, `startOfWeek`, `localYmd` de `lib/datetime.ts`)
+ * trabalha em `Date` local, e isso é coerente: são posições numa grade, não instantes. O que NÃO
+ * podia continuar local era o ponto de partida — `new Date()` num navegador em UTC começava a
+ * grade no dia errado. Montamos o dia certo pelas PARTES, para que a `Date` resultante seja a
+ * meia-noite local desse dia e toda a aritmética seguinte continue valendo.
  */
 const hojeDoTenant = (tz: string) => {
   const [a, m, d] = today(tz).split("-").map(Number);
@@ -76,7 +72,7 @@ export default function AgendaPage() {
     // Fronteiras em UTC-date (meia-noite UTC da data do grid), não o local→UTC: assim os
     // eventos de dia inteiro (gravados à meia-noite UTC) não caem fora do range nas bordas.
     const { data } = await api.get<AgendaEvent[]>("/agenda/events", {
-      params: { start: `${ymd(start)}T00:00:00.000Z`, end: `${ymd(end)}T00:00:00.000Z`, limit: 500 },
+      params: { start: `${localYmd(start)}T00:00:00.000Z`, end: `${localYmd(end)}T00:00:00.000Z`, limit: 500 },
     });
     setEvents(data);
   }, [start, end]);
@@ -202,10 +198,10 @@ const chipLabel = (e: AgendaEvent) =>
 // casamos pela DATA do calendário (sem fuso) para não "voltar" um dia em fuso negativo.
 // Eventos com horário usam a data local normalmente.
 const eventYmd = (e: AgendaEvent) =>
-  e.all_day ? e.starts_at.slice(0, 10) : ymd(new Date(e.starts_at));
+  e.all_day ? e.starts_at.slice(0, 10) : localYmd(new Date(e.starts_at));
 const eventsOfDay = (events: AgendaEvent[], d: Date) =>
   events
-    .filter((e) => eventYmd(e) === ymd(d))
+    .filter((e) => eventYmd(e) === localYmd(d))
     .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at));
 
 function MonthGrid({
@@ -223,7 +219,7 @@ function MonthGrid({
 }) {
   const fuso = useFuso();
   const today = hojeDoTenant(fuso);
-  const hoje = ymd(today);
+  const hoje = localYmd(today);
   return (
     <div className="overflow-hidden rounded-2xl border border-neutral-100 bg-white">
       <div className="grid grid-cols-7 border-b border-neutral-100 text-center text-xs font-medium text-neutral-400">
@@ -291,7 +287,7 @@ function WeekView({
 }) {
   const fuso = useFuso();
   const today = hojeDoTenant(fuso);
-  const hoje = ymd(today);
+  const hoje = localYmd(today);
   return (
     <div className="grid grid-cols-7 gap-2">
       {days.map((d) => {
@@ -340,7 +336,7 @@ function DayView({
   onEventClick: (e: AgendaEvent) => void;
 }) {
   const fuso = useFuso();
-  const hoje = ymd(hojeDoTenant(fuso));
+  const hoje = localYmd(hojeDoTenant(fuso));
   const dayEvents = eventsOfDay(events, day);
   return (
     <div className="rounded-2xl border border-neutral-100 bg-white p-4">

--- a/apps/web/src/features/agenda/NewEventModal.test.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import NewEventModal from "./NewEventModal";
+
+// Onda 2, Task 5: extração do NewEventModal de AgendaPage.tsx para arquivo próprio, para que a
+// ficha 360° do contato (Task 6) reuse o mesmo modal em vez de reimplementar o aviso de conflito.
+// Rede sempre mockada (IV2): nenhum teste bate em /agenda real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  getGoogleStatus: vi.fn(() => Promise.resolve({ connected: false })),
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText("Título"), "Atendimento cliente");
+  fireEvent.change(screen.getByLabelText("Início"), { target: { value: "2026-08-01T09:00" } });
+  fireEvent.change(screen.getByLabelText("Fim"), { target: { value: "2026-08-01T10:00" } });
+  await user.click(screen.getByRole("button", { name: "Criar evento" }));
+}
+
+beforeEach(() => {
+  vi.mocked(api.post).mockReset();
+});
+
+describe("NewEventModal (Onda 2, Task 5)", () => {
+  it("envia client_id quando recebe um", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { conflicts: [] } } as never);
+
+    render(
+      <NewEventModal
+        open
+        initialDate={null}
+        onClose={() => {}}
+        onCreated={() => {}}
+        clientId="contato-123"
+      />,
+    );
+
+    await fillAndSubmit(user);
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/agenda/events",
+      expect.objectContaining({ client_id: "contato-123" }),
+    );
+  });
+
+  it("não envia client_id quando não recebe (evento solto, como na Agenda)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { conflicts: [] } } as never);
+
+    render(<NewEventModal open initialDate={null} onClose={() => {}} onCreated={() => {}} />);
+
+    await fillAndSubmit(user);
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/agenda/events",
+      expect.objectContaining({ client_id: null }),
+    );
+  });
+
+  it("mostra o aviso de conflito sem fechar o modal", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      data: { conflicts: [{ id: "ev-outro", title: "Reunião existente" }] },
+    } as never);
+    const onClose = vi.fn();
+
+    render(<NewEventModal open initialDate={null} onClose={onClose} onCreated={() => {}} />);
+
+    await fillAndSubmit(user);
+
+    expect(await screen.findByText(/Conflito de horário com: Reunião existente/)).toBeInTheDocument();
+    // O modal continua aberto: onClose NÃO é chamado quando há conflito (o dono decide).
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/agenda/NewEventModal.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.tsx
@@ -3,7 +3,7 @@ import { Video } from "lucide-react";
 import { useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage, getGoogleStatus } from "../../lib/api";
-import { ymd } from "./AgendaPage";
+import { localYmd } from "../../lib/datetime";
 
 // Tipos de evento que geram Meet automaticamente quando o Google está conectado (Story 4.1).
 const MEET_KINDS = new Set(["reuniao", "atendimento", "audiencia"]);
@@ -61,7 +61,7 @@ export default function NewEventModal({
   // pré-preenche a data ao abrir num dia do calendário
   useEffect(() => {
     if (open && initialDate) {
-      const d = ymd(initialDate);
+      const d = localYmd(initialDate);
       setStartDate(d);
       setEndDate(d);
       setStart(`${d}T09:00`);

--- a/apps/web/src/features/agenda/NewEventModal.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.tsx
@@ -1,0 +1,201 @@
+import type { CreateEventResult } from "@e1p/shared-types";
+import { Video } from "lucide-react";
+import { useEffect, useState } from "react";
+import Modal, { Field } from "../../components/Modal";
+import { api, apiErrorMessage, getGoogleStatus } from "../../lib/api";
+import { ymd } from "./AgendaPage";
+
+// Tipos de evento que geram Meet automaticamente quando o Google está conectado (Story 4.1).
+const MEET_KINDS = new Set(["reuniao", "atendimento", "audiencia"]);
+
+const KINDS = [
+  ["atendimento", "Atendimento"],
+  ["reuniao", "Reunião"],
+  ["audiencia", "Audiência"],
+  ["prazo", "Prazo"],
+  ["lembrete", "Lembrete"],
+  ["bloqueio", "Bloqueio"],
+] as const;
+
+export default function NewEventModal({
+  open,
+  initialDate,
+  onClose,
+  onCreated,
+  clientId,
+}: {
+  open: boolean;
+  initialDate: Date | null;
+  onClose: () => void;
+  onCreated: () => void;
+  /** Quando presente, o evento nasce ligado a este contato. A ficha 360° usa isto; a tela de
+   *  Agenda não passa nada e segue criando evento solto. */
+  clientId?: string;
+}) {
+  const [title, setTitle] = useState("");
+  const [kind, setKind] = useState("atendimento");
+  const [allDay, setAllDay] = useState(false);
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [location, setLocation] = useState("");
+  const [guests, setGuests] = useState("");
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [googleConnected, setGoogleConnected] = useState(false);
+
+  // Descobre se o Google está conectado (para a dica de "Meet automático"). Silencioso em falha.
+  useEffect(() => {
+    if (!open) return;
+    getGoogleStatus()
+      .then((s) => setGoogleConnected(s.connected))
+      .catch(() => setGoogleConnected(false));
+  }, [open]);
+
+  const autoMeet = googleConnected && MEET_KINDS.has(kind);
+
+  // pré-preenche a data ao abrir num dia do calendário
+  useEffect(() => {
+    if (open && initialDate) {
+      const d = ymd(initialDate);
+      setStartDate(d);
+      setEndDate(d);
+      setStart(`${d}T09:00`);
+      setEnd(`${d}T10:00`);
+    }
+  }, [open, initialDate]);
+
+  async function save() {
+    setError(null);
+    setConflict(null);
+    setSaving(true);
+    try {
+      // Eventos com horário: o input datetime-local devolve uma string "naive" (sem fuso,
+      // ex. "2026-07-13T09:00"). Enviá-la crua fazia o backend tratá-la como UTC (grava
+      // "...T09:00:00Z"), exibindo 3h a menos no fuso do Brasil (bug #23). new Date(x) a
+      // interpreta como horário LOCAL e .toISOString() serializa para UTC real (local→UTC).
+      // O ramo all_day é intencionalmente meia-noite UTC da data de calendário (ver CLAUDE.md
+      // §6.0) — NÃO converter, sob pena de reintroduzir o bug antigo de sumiço na agenda.
+      const starts_at = allDay ? `${startDate}T00:00:00` : new Date(start).toISOString();
+      const ends_at = allDay ? `${endDate || startDate}T23:59:00` : new Date(end).toISOString();
+      const { data } = await api.post<CreateEventResult>("/agenda/events", {
+        title,
+        kind,
+        all_day: allDay,
+        starts_at,
+        ends_at,
+        location,
+        meeting_url: meetingUrl || null,
+        guests: guests ? guests.split(",").map((g) => g.trim()) : [],
+        description,
+        client_id: clientId ?? null,
+      });
+      if (data.conflicts.length > 0) {
+        setConflict(`⚠ Conflito de horário com: ${data.conflicts.map((c) => c.title).join(", ")}`);
+      }
+      onCreated();
+      if (data.conflicts.length === 0) onClose();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const valid = title && (allDay ? startDate : start && end);
+
+  return (
+    <Modal title="Novo evento" open={open} onClose={onClose}>
+      <div className="space-y-3">
+        <Field label="Título" value={title} onChange={setTitle} placeholder="Atendimento cliente" />
+        <div className="flex items-end gap-3">
+          <label className="flex-1">
+            <span className="mb-1 block text-xs font-medium text-neutral-600">Tipo</span>
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            >
+              {KINDS.map(([v, l]) => (
+                <option key={v} value={v}>
+                  {l}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 pb-2 text-sm text-neutral-600">
+            <input type="checkbox" checked={allDay} onChange={(e) => setAllDay(e.target.checked)} />
+            Dia inteiro
+          </label>
+        </div>
+
+        {allDay ? (
+          <div className="flex gap-2">
+            <Field label="Data início" type="date" value={startDate} onChange={setStartDate} />
+            <Field label="Data fim" type="date" value={endDate} onChange={setEndDate} />
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            <Field label="Início" type="datetime-local" value={start} onChange={setStart} />
+            <Field label="Fim" type="datetime-local" value={end} onChange={setEnd} />
+          </div>
+        )}
+
+        <Field label="Local" value={location} onChange={setLocation} placeholder="Escritório ou endereço" />
+        <div>
+          <span className="mb-1 block text-xs font-medium text-neutral-600">
+            Reunião (Google Meet / Zoom)
+          </span>
+          <div className="flex gap-2">
+            <input
+              value={meetingUrl}
+              onChange={(e) => setMeetingUrl(e.target.value)}
+              placeholder={
+                autoMeet ? "Deixe em branco para gerar o Meet automaticamente" : "Cole o link da reunião"
+              }
+              className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+            />
+            <a
+              href="https://meet.google.com/new"
+              target="_blank"
+              rel="noreferrer"
+              className="flex shrink-0 items-center gap-1 rounded-lg bg-primary-50 px-3 text-sm font-medium text-primary-700 hover:bg-primary-100"
+            >
+              <Video size={15} /> Meet
+            </a>
+          </div>
+          {autoMeet && !meetingUrl && (
+            <p className="mt-1 text-xs text-primary-600">
+              Um link do Meet será gerado automaticamente ao salvar (Google conectado).
+            </p>
+          )}
+        </div>
+        <Field label="Convidados (e-mails, separados por vírgula)" value={guests} onChange={setGuests} />
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Descrição</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
+          />
+        </label>
+
+        {conflict && <p className="rounded-lg bg-amber-50 p-2 text-sm text-amber-700">{conflict}</p>}
+        {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
+
+        <button
+          onClick={save}
+          disabled={saving || !valid}
+          className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
+        >
+          {saving ? "Salvando..." : "Criar evento"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
@@ -58,9 +58,36 @@ describe("BlocoDaAgenda", () => {
 
     // O corte é no SERVIDOR via `start=`, não uma filtragem client-side depois do fetch — o
     // gap desta task era exatamente isto (ler o router em vez de inventar filtro no front).
+    // `exclude_cancelled=true` também vai na URL: este bloco é o único dos três lugares que
+    // "sabem" o que é próximo (Histórico, next_event_map, este) que não excluía cancelado por
+    // padrão — pedir explicitamente evita impersonar um "próximo compromisso" cancelado.
     const url = vi.mocked(api.get).mock.calls[0][0] as string;
     expect(url).toContain("/agenda/events?client_id=cli-1");
     expect(url).toContain("start=");
+    expect(url).toContain("exclude_cancelled=true");
+  });
+
+  it("mostra o evento de dia inteiro de hoje, mesmo com starts_at já no passado", async () => {
+    // Espelha `test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje` no backend: um evento de
+    // dia inteiro é ancorado na meia-noite REAL do fuso do tenant, então às 15h seu `starts_at`
+    // já ficou no passado — só o corte por `ends_at >= agora` (aplicado pelo SERVIDOR) o inclui.
+    // Este teste prova que o BLOCO não reintroduz um corte por `starts_at` no cliente: se a API
+    // devolve o evento, o bloco tem que renderizá-lo, não escondê-lo de novo.
+    mockar([
+      evento({
+        id: "ev-hoje-dia-inteiro",
+        title: "Compromisso de hoje",
+        all_day: true,
+        starts_at: "2026-08-16T00:00:00Z",
+        ends_at: "2026-08-17T00:00:00Z",
+      }),
+    ]);
+    renderBloco();
+
+    expect(await screen.findByText("Compromisso de hoje")).toBeInTheDocument();
+    // Dia inteiro formata pela STRING (`formatDay`), sem `Date` — nunca `formatDateTime`, que
+    // trataria a meia-noite UTC como um instante e converteria para o fuso do tenant.
+    expect(screen.getByText("16/08/2026")).toBeInTheDocument();
   });
 
   it("estado vazio diz que não há compromisso e oferece marcar", async () => {

--- a/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import BlocoDaAgenda from "./BlocoDaAgenda";
+
+// Task 6 (Onda 2): o bloco reusa o `NewEventModal` da Task 5 — por isso o mock de `api` também
+// precisa de `getGoogleStatus` (o modal a chama ao abrir) e `apiErrorMessage`, do mesmo jeito que
+// `NewEventModal.test.tsx` já faz.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  getGoogleStatus: vi.fn(() => Promise.resolve({ connected: false })),
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+
+const evento = (over: Record<string, unknown> = {}) => ({
+  id: "ev-1", tenant_id: "t1", title: "Atendimento", description: "", kind: "atendimento",
+  status: "scheduled", priority: "normal", source: "manual",
+  starts_at: "2026-08-20T13:00:00Z", ends_at: "2026-08-20T14:00:00Z",
+  all_day: false, location: "", meeting_url: null, guests: [], amount_cents: null,
+  external_ref: null, google_event_id: null, client_id: "cli-1", client_name: null,
+  created_by_ai: false, created_at: "2026-08-15T10:00:00Z",
+  ...over,
+});
+
+function mockar(eventos: unknown[]) {
+  vi.mocked(api.get).mockResolvedValue({ data: eventos } as never);
+}
+
+const renderBloco = () => render(<BlocoDaAgenda clientId="cli-1" />);
+
+// Mesmo motivo do `beforeEach` em `BlocoDaConversa.test.tsx`: `mockReset()` devolve o próprio
+// mock, e um corpo de expressão única faria o Vitest tratar esse retorno como hook de limpeza
+// pós-teste, chamando `api.get()` sem `url` depois de cada teste.
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+  vi.mocked(api.post).mockReset();
+});
+
+describe("BlocoDaAgenda", () => {
+  it("lista os próximos compromissos, do mais próximo para o mais distante", async () => {
+    mockar([
+      evento({ id: "ev-perto", title: "Atendimento amanhã", starts_at: "2026-08-16T13:00:00Z" }),
+      evento({ id: "ev-longe", title: "Reunião semana que vem", starts_at: "2026-08-22T13:00:00Z" }),
+    ]);
+    renderBloco();
+
+    expect(await screen.findByText("Atendimento amanhã")).toBeInTheDocument();
+    const itens = screen.getAllByRole("listitem");
+    expect(itens).toHaveLength(2);
+    // A ordem em que o servidor devolve (mais próximo primeiro) é preservada, sem reordenar
+    // no cliente — o bloco confia no `ORDER BY starts_at` do `list_events`.
+    expect(itens[0]).toHaveTextContent("Atendimento amanhã");
+    expect(itens[1]).toHaveTextContent("Reunião semana que vem");
+
+    // O corte é no SERVIDOR via `start=`, não uma filtragem client-side depois do fetch — o
+    // gap desta task era exatamente isto (ler o router em vez de inventar filtro no front).
+    const url = vi.mocked(api.get).mock.calls[0][0] as string;
+    expect(url).toContain("/agenda/events?client_id=cli-1");
+    expect(url).toContain("start=");
+  });
+
+  it("estado vazio diz que não há compromisso e oferece marcar", async () => {
+    // ⚠️ Este é o estado MAIS IMPORTANTE do bloco: é ele que revela o contato que vai esfriar.
+    mockar([]);
+    renderBloco();
+
+    expect(await screen.findByText("Nenhum compromisso marcado")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /marcar com este cliente/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("abre o modal de marcar e, ao criar, recarrega a lista", async () => {
+    const user = userEvent.setup();
+    mockar([]);
+    vi.mocked(api.post).mockResolvedValue({ data: { conflicts: [] } } as never);
+    renderBloco();
+
+    await screen.findByText("Nenhum compromisso marcado");
+    await user.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+    expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
+
+    // Depois de abrir, a próxima chamada a `GET /agenda/events` já devolve o evento recém-criado
+    // — é isso que prova que a lista recarregou, e não só que o modal fechou.
+    mockar([evento({ id: "ev-novo", title: "Atendimento cliente" })]);
+
+    await user.type(screen.getByLabelText("Título"), "Atendimento cliente");
+    fireEvent.change(screen.getByLabelText("Início"), { target: { value: "2026-08-20T09:00" } });
+    fireEvent.change(screen.getByLabelText("Fim"), { target: { value: "2026-08-20T10:00" } });
+    await user.click(screen.getByRole("button", { name: "Criar evento" }));
+
+    // O evento nasce ligado a ESTE contato — mesmo vínculo que a Task 5 testou no modal isolado.
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/agenda/events",
+      expect.objectContaining({ client_id: "cli-1" }),
+    );
+    expect(await screen.findByText("Atendimento cliente")).toBeInTheDocument();
+    // Sem conflito, o modal fecha sozinho — o heading "Novo evento" some.
+    expect(screen.queryByRole("heading", { name: "Novo evento" })).not.toBeInTheDocument();
+  });
+
+  it("formata o horário no fuso do tenant", async () => {
+    // 13:00 UTC em America/Sao_Paulo (UTC-3, sem horário de verão) é 10:00 — se o bloco usasse
+    // o fuso do NAVEGADOR (headless roda em UTC) o teste pegaria "13:00" em vez de "10:00".
+    mockar([evento({ starts_at: "2026-08-20T13:00:00Z" })]);
+    renderBloco();
+
+    expect(await screen.findByText("20/08/2026 10:00")).toBeInTheDocument();
+  });
+
+  it("falha de rede vira aviso, não derruba a ficha", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("caiu"));
+    renderBloco();
+
+    expect(await screen.findByText(/não foi possível carregar a agenda/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/crm/BlocoDaAgenda.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.tsx
@@ -71,7 +71,11 @@ export default function BlocoDaAgenda({ clientId }: { clientId: string }) {
         <ul className="divide-y divide-neutral-100">
           {eventos.map((e) => (
             <li key={e.id} className="py-2.5">
-              <p className="text-sm font-medium text-neutral-800">{e.title}</p>
+              {/* `break-words`: o título vem de digitação livre e pode chegar sem espaço, hífen
+                  ou barra (o dono grudando o nome de um fornecedor, por exemplo) — sem quebra de
+                  palavra o texto vaza a caixa em vez de quebrar linha (achado da régua de 360px,
+                  Onda 2 Task 8: `forcaFora` de 439px com um título assim). */}
+              <p className="break-words text-sm font-medium text-neutral-800">{e.title}</p>
               {/* Dia inteiro é DATA DE CALENDÁRIO (gravada à meia-noite UTC): formata pela
                   string, sem `Date`, para não "voltar" um dia em fuso negativo. Com horário é
                   INSTANTE: converte para o fuso do tenant — nunca `localYmd` aqui (ver a nota

--- a/apps/web/src/features/crm/BlocoDaAgenda.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.tsx
@@ -1,0 +1,100 @@
+import type { AgendaEvent } from "@e1p/shared-types";
+import { CalendarPlus } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import { formatDateTime, formatDay } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+import NewEventModal from "../agenda/NewEventModal";
+
+/**
+ * O que está MARCADO com este contato — irmão do `BlocoDaConversa` (o que foi DITO) e do
+ * `ClientTimeline` (o que ACONTECEU). Três perguntas diferentes, três blocos diferentes.
+ *
+ * É o bloco ATIVO da ficha: só mostra o FUTURO (o passado já vive no Histórico, Task 4) e traz o
+ * botão "Marcar com este cliente" para o dono agir sem sair da tela. O estado vazio é o mais
+ * importante dos dois — "Nenhum compromisso marcado" é o sinal de um contato esfriando no funil.
+ */
+export default function BlocoDaAgenda({ clientId }: { clientId: string }) {
+  const fuso = useFuso();
+  const [eventos, setEventos] = useState<AgendaEvent[]>([]);
+  const [erro, setErro] = useState(false);
+  const [carregando, setCarregando] = useState(true);
+  const [open, setOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    // Falha aqui NÃO pode derrubar a ficha — mesma postura do `BlocoDaConversa`: degrada para um
+    // aviso em vez de levar junto Cobranças, Contratos e o resto da tela.
+    try {
+      // `start=agora` filtra no SERVIDOR (`list_events`: `ends_at >= start`), o mesmo critério do
+      // `next_event_map` que alimenta o card do Kanban — inclui o evento de dia inteiro de HOJE
+      // (cujo `starts_at` já ficou no passado à meia-noite, mas `ends_at` ainda não). Um corte
+      // client-side por `starts_at >= agora` reintroduziria esse bug. O backend já devolve
+      // ordenado por `starts_at` ascendente (mais próximo primeiro); nada a reordenar aqui.
+      const agora = new Date().toISOString();
+      const { data } = await api.get<AgendaEvent[]>(
+        `/agenda/events?client_id=${encodeURIComponent(clientId)}&start=${encodeURIComponent(agora)}`,
+      );
+      setEventos(Array.isArray(data) ? data : []);
+      setErro(false);
+    } catch {
+      setErro(true);
+      setEventos([]);
+    } finally {
+      setCarregando(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (carregando) return <p className="py-4 text-sm text-neutral-400">Carregando agenda...</p>;
+  if (erro) {
+    return (
+      <p className="py-4 text-sm text-amber-700">
+        Não foi possível carregar a agenda.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {eventos.length === 0 ? (
+        <p className="py-2 text-center text-sm text-neutral-400">Nenhum compromisso marcado</p>
+      ) : (
+        <ul className="divide-y divide-neutral-100">
+          {eventos.map((e) => (
+            <li key={e.id} className="py-2.5">
+              <p className="text-sm font-medium text-neutral-800">{e.title}</p>
+              {/* Dia inteiro é DATA DE CALENDÁRIO (gravada à meia-noite UTC): formata pela
+                  string, sem `Date`, para não "voltar" um dia em fuso negativo. Com horário é
+                  INSTANTE: converte para o fuso do tenant — nunca `localYmd` aqui (ver a nota
+                  do próprio helper em `lib/datetime.ts`). */}
+              <p className="text-xs text-neutral-400">
+                {e.all_day ? formatDay(e.starts_at) : formatDateTime(e.starts_at, fuso)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center justify-center gap-1.5 rounded-pill bg-primary-50 py-2 text-sm font-semibold text-primary-600 hover:bg-primary-100"
+      >
+        <CalendarPlus size={14} /> Marcar com este cliente
+      </button>
+
+      {/* Reusa o `NewEventModal` da Task 5 — ele já cuida do aviso de conflito, mantendo-se
+          aberto quando a API reporta sobreposição para o dono decidir. `onCreated` só recarrega
+          a lista; o próprio modal chama `onClose` quando não há conflito. */}
+      <NewEventModal
+        open={open}
+        initialDate={null}
+        onClose={() => setOpen(false)}
+        onCreated={load}
+        clientId={clientId}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/crm/BlocoDaAgenda.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.tsx
@@ -30,9 +30,15 @@ export default function BlocoDaAgenda({ clientId }: { clientId: string }) {
       // (cujo `starts_at` já ficou no passado à meia-noite, mas `ends_at` ainda não). Um corte
       // client-side por `starts_at >= agora` reintroduziria esse bug. O backend já devolve
       // ordenado por `starts_at` ascendente (mais próximo primeiro); nada a reordenar aqui.
+      //
+      // `exclude_cancelled=true`: este bloco é o único dos três (Histórico, next_event_map e
+      // este) que ainda deixava um compromisso CANCELADO se passar por "próximo compromisso" —
+      // e é exatamente o sinal que o estado vazio existe para revelar (contato esfriando sem
+      // próximo passo). O default do endpoint é `false` (a tela de Agenda continua mostrando
+      // cancelados no calendário); aqui pedimos explicitamente o filtro.
       const agora = new Date().toISOString();
       const { data } = await api.get<AgendaEvent[]>(
-        `/agenda/events?client_id=${encodeURIComponent(clientId)}&start=${encodeURIComponent(agora)}`,
+        `/agenda/events?client_id=${encodeURIComponent(clientId)}&start=${encodeURIComponent(agora)}&exclude_cancelled=true`,
       );
       setEventos(Array.isArray(data) ? data : []);
       setErro(false);

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -7,7 +7,8 @@ import type {
   Quote,
 } from "@e1p/shared-types";
 import {
-  ArrowLeft, FileSignature, FileText, Gavel, History, MessageCircle, Pencil, Receipt, Workflow,
+  ArrowLeft, CalendarDays, FileSignature, FileText, Gavel, History, MessageCircle, Pencil,
+  Receipt, Workflow,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -15,6 +16,7 @@ import { api, apiErrorMessage } from "../../lib/api";
 import { formatDate, formatDay } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
 import { rotaDaCobranca } from "../cobrancas/rota";
+import BlocoDaAgenda from "./BlocoDaAgenda";
 import BlocoDaConversa from "./BlocoDaConversa";
 import ClientTimeline from "./ClientTimeline";
 import { hojeISO } from "../financeiro/contas";
@@ -127,6 +129,16 @@ export default function ClientDetailPage() {
           e a régua de 360px precisa de um recorte que aponte só para esta. */}
       <Section icon={<MessageCircle size={16} />} title="Conversa" testId="secao-conversa">
         <BlocoDaConversa clientId={id} />
+      </Section>
+
+      {/* Agenda vem depois da Conversa e antes do operacional: a ficha conta uma história — o
+          que aconteceu (Histórico), o que foi dito (Conversa), o que está marcado (Agenda), e só
+          então o operacional (Cobranças, Contratos...). Bloco ATIVO, não só narrativo: mostra o
+          FUTURO e deixa marcar sem sair da ficha. Carrega sozinho, fora do `load()` da página,
+          pelo mesmo motivo do `BlocoDaConversa`: uma falha da Agenda não pode derrubar Cobranças
+          e o resto da tela. */}
+      <Section icon={<CalendarDays size={16} />} title="Agenda">
+        <BlocoDaAgenda clientId={id} />
       </Section>
 
       {/* Cobranças */}

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -137,7 +137,11 @@ export default function ClientDetailPage() {
           FUTURO e deixa marcar sem sair da ficha. Carrega sozinho, fora do `load()` da página,
           pelo mesmo motivo do `BlocoDaConversa`: uma falha da Agenda não pode derrubar Cobranças
           e o resto da tela. */}
-      <Section icon={<CalendarDays size={16} />} title="Agenda">
+      {/* `testId`: mesma razão da Conversa — as OITO seções da ficha compartilham
+          `rounded-2xl bg-white`, e `querySelector` devolve só a PRIMEIRA ocorrência do
+          documento (o cabeçalho do cliente). Sem recorte próprio, a régua de 360px mediria o
+          cabeçalho em vez da Agenda. */}
+      <Section icon={<CalendarDays size={16} />} title="Agenda" testId="secao-agenda">
         <BlocoDaAgenda clientId={id} />
       </Section>
 
@@ -362,7 +366,8 @@ function Section({
   icon: React.ReactNode;
   title: string;
   children: React.ReactNode;
-  /** Opcional: só a seção de Conversa precisa hoje, para a régua de 360px conseguir recortá-la. */
+  /** Opcional: Conversa e Agenda precisam, para a régua de 360px conseguir recortá-las —
+   *  as duas compartilham `rounded-2xl bg-white` com as outras seis seções da ficha. */
   testId?: string;
 }) {
   return (

--- a/apps/web/src/features/crm/ClientTimeline.test.tsx
+++ b/apps/web/src/features/crm/ClientTimeline.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import ClientTimeline from "./ClientTimeline";
 
@@ -8,6 +8,8 @@ vi.mock("../../lib/api", () => ({
   api: { get: vi.fn(), post: vi.fn() },
   apiErrorMessage: (e: unknown) => String(e),
 }));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
 
 const ENTRADA = {
   id: "1", kind: "crm.lead.criado", title: "Chegou pelo site", body: "",
@@ -81,5 +83,62 @@ describe("ClientTimeline", () => {
 
     render(<ClientTimeline clientId="c1" />);
     expect(await screen.findByText(/nenhum registro/i)).toBeInTheDocument();
+  });
+
+  describe("fuso do tenant, não da máquina", () => {
+    const TZ_ORIGINAL = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = TZ_ORIGINAL;
+    });
+
+    it("formata no fuso do tenant, não no do navegador", async () => {
+      // `vitest.config.ts` fixa TZ=America/Sao_Paulo pra suíte inteira — o MESMO fuso do
+      // tenant mockado acima, então rodar isto com o `TZ` padrão faria o `quando()` ANTIGO
+      // (sem `timeZone`, no relógio da máquina) acertar por coincidência: máquina e tenant
+      // dariam o mesmo resultado, e o teste passaria mesmo sem o conserto. Pra provar a
+      // correção de verdade, este teste simula a MÁQUINA em outro fuso (a viagem/servidor
+      // headless que o comentário original da ConversasPage descrevia) e confirma que a tela
+      // ignora o relógio dela e usa sempre o fuso do tenant, vindo de `useFuso()`.
+      process.env.TZ = "Asia/Tokyo";
+
+      const ENTRADA = {
+        id: "9", kind: "agenda", title: "Compromisso: Reunião", body: "",
+        actor: "sistema", is_ai: false, at: "2026-08-16T23:30:00Z",
+      };
+      vi.mocked(api.get).mockResolvedValue({
+        data: { entries: [ENTRADA], truncated: false },
+      } as never);
+
+      render(<ClientTimeline clientId="c1" />);
+      await screen.findByTestId("timeline-title");
+
+      // Fuso do tenant (America/Sao_Paulo, UTC-3): 23:30 UTC vira 20:30 do MESMO dia 16/08.
+      expect(screen.getByText("16/08/2026 20:30")).toBeInTheDocument();
+      // O `quando()` antigo, no relógio da MÁQUINA (Tóquio, UTC+9), teria mostrado
+      // 17/08/2026 08:30 — um dia adiante e 12h de diferença. Isso NÃO pode aparecer.
+      expect(screen.queryByText("17/08/2026 08:30")).not.toBeInTheDocument();
+    });
+  });
+
+  it("compromisso realizado tem identidade visual própria, não o ícone neutro", async () => {
+    // O vocabulário de `kind` em APARENCIA é FECHADO: um `kind` sem entrada ali cai no
+    // `NEUTRO` (`bg-neutral-100`). Este teste prova que "agenda" TEM entrada própria (mesma
+    // família visual das outras fontes derivadas, `bg-sky-50`) — se o mapa esquecesse
+    // "agenda", o compromisso realizado ficaria indistinguível de um `kind` desconhecido.
+    const COMPROMISSO = {
+      id: "7", kind: "agenda", title: "Compromisso: Sessão de fotos", body: "",
+      actor: "sistema", is_ai: false, at: "2026-08-10T14:00:00Z",
+    };
+    vi.mocked(api.get).mockResolvedValue({
+      data: { entries: [COMPROMISSO], truncated: false },
+    } as never);
+
+    render(<ClientTimeline clientId="c1" />);
+    const titulo = await screen.findByTestId("timeline-title");
+    const item = titulo.closest("li");
+
+    expect(item?.querySelector(".bg-sky-50")).not.toBeNull();
+    expect(item?.querySelector(".bg-neutral-100")).toBeNull();
   });
 });

--- a/apps/web/src/features/crm/ClientTimeline.tsx
+++ b/apps/web/src/features/crm/ClientTimeline.tsx
@@ -1,11 +1,13 @@
 import type { ClientTimelineEntry, ClientTimelineOut } from "@e1p/shared-types";
 import {
-  ArrowRightLeft, FileText, MessageSquarePlus, Receipt, RotateCcw,
+  ArrowRightLeft, CalendarDays, FileText, MessageSquarePlus, Receipt, RotateCcw,
   Sparkles, UserPlus, Workflow,
 } from "lucide-react";
 import type { JSX } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
+import { formatDateTime } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
 
 /** Ícone e cor por tipo de fato. Um `kind` novo vindo de um backend mais recente cai no
  *  neutro em vez de sumir da tela. */
@@ -17,24 +19,18 @@ const APARENCIA: Record<string, { icon: JSX.Element; cor: string }> = {
   "crm.lead.reaberto": { icon: <RotateCcw size={14} />, cor: "bg-amber-50 text-amber-700" },
   "crm.nota.criada": { icon: <MessageSquarePlus size={14} />, cor: "bg-emerald-50 text-emerald-700" },
   "crm.funil.inscrito": { icon: <Workflow size={14} />, cor: "bg-neutral-100 text-neutral-600" },
-  // Estes três NÃO mudam: são gerados por `crm/timeline.py` a partir de `quotes`/`charges`,
-  // lidos na origem, e nunca passaram pela tabela persistida.
+  // Estes quatro NÃO mudam: são gerados por `crm/timeline.py` a partir de `quotes`/`charges`/
+  // `agenda_events`, lidos na origem, e nunca passaram pela tabela persistida.
   quote: { icon: <FileText size={14} />, cor: "bg-sky-50 text-sky-700" },
   charge: { icon: <Receipt size={14} />, cor: "bg-sky-50 text-sky-700" },
   payment: { icon: <Receipt size={14} />, cor: "bg-emerald-50 text-emerald-700" },
+  agenda: { icon: <CalendarDays size={14} />, cor: "bg-sky-50 text-sky-700" },
 };
 
 const NEUTRO = { icon: <Sparkles size={14} />, cor: "bg-neutral-100 text-neutral-600" };
 
-/** `at` é um INSTANTE (timestamptz), não uma data de negócio — formata no fuso local, mesma
- *  convenção da ConversasPage (e o oposto da regra all-day da Agenda). */
-const quando = (iso: string) =>
-  new Date(iso).toLocaleString("pt-BR", {
-    day: "2-digit", month: "2-digit", year: "numeric",
-    hour: "2-digit", minute: "2-digit",
-  });
-
 export default function ClientTimeline({ clientId }: { clientId: string }) {
+  const fuso = useFuso();
   const [entries, setEntries] = useState<ClientTimelineEntry[]>([]);
   const [truncated, setTruncated] = useState(false);
   const [nota, setNota] = useState("");
@@ -129,7 +125,7 @@ export default function ClientTimeline({ clientId }: { clientId: string }) {
                     <p className="whitespace-pre-wrap text-sm text-neutral-600">{e.body}</p>
                   )}
                   <p className="text-[11px] text-neutral-400">
-                    {quando(e.at)}
+                    {formatDateTime(e.at, fuso)}
                     {e.is_ai && " · IA"}
                   </p>
                 </div>

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -204,7 +204,7 @@ describe("CrmPage — ponto de mensagem esperando resposta", () => {
         gender: "unspecified", birthdate: null, notes: "", tags: [], source: "whatsapp",
         stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
         stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
-        unread, next_event_at: null, next_event_title: null,
+        unread, next_event_at: null, next_event_title: null, next_event_all_day: false,
       }],
     }],
   });
@@ -227,7 +227,9 @@ describe("CrmPage — a linha do próximo passo", () => {
   // Próximo compromisso e a AUSÊNCIA dele são estados opostos da mesma pergunta: nunca os dois
   // juntos. `nextEventAt: null` exercita o card sem nada marcado (o caso mais acionável, quem
   // vai esfriar); com data, exercita o card que já tem o próximo passo escrito.
-  const boardCom = (nextEventAt: string | null, nextEventTitle: string | null): Board => ({
+  const boardCom = (
+    nextEventAt: string | null, nextEventTitle: string | null, allDay = false,
+  ): Board => ({
     columns: [{
       stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
       clients: [{
@@ -236,6 +238,7 @@ describe("CrmPage — a linha do próximo passo", () => {
         stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
         stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
         unread: false, next_event_at: nextEventAt, next_event_title: nextEventTitle,
+        next_event_all_day: allDay,
       }],
     }],
   });
@@ -263,5 +266,53 @@ describe("CrmPage — a linha do próximo passo", () => {
     renderPage();
     await screen.findByText(/próximo: Reunião de alinhamento em 20\/08/i);
     expect(screen.queryByText("sem próximo passo")).not.toBeInTheDocument();
+  });
+});
+
+describe("CrmPage — próximo passo de dia inteiro não 'volta' um dia (achado da revisão final)", () => {
+  // `receivables/service.py::build_charge` ancora o evento de cobrança à MEIA-NOITE UTC (não na
+  // meia-noite do fuso do tenant, ao contrário de `agenda/service.py::create_event`). O teste
+  // roda sem `AuthContext` ao redor (`renderPage` só empacota Router + PageActions), e
+  // `useFuso()` cai no fallback `FUSO_PADRAO = "America/Sao_Paulo"` (UTC−3) quando o contexto
+  // é `null` — o cenário exato do achado: "2026-08-22T00:00:00Z" em UTC−3 é 21/08 21h. Formatar
+  // como INSTANTE (`formatDateShort`, que converte fuso) imprimiria "21/08"; o card tem que
+  // usar `formatDay` (lê a string, sem conversão) e mostrar "22/08" — a data real do vencimento.
+  const boardComProximo = (
+    nextEventAt: string, nextEventTitle: string, allDay: boolean,
+  ): Board => ({
+    columns: [{
+      stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
+      clients: [{
+        id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: null, document: null,
+        gender: "unspecified", birthdate: null, notes: "", tags: [], source: "whatsapp",
+        stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
+        stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
+        unread: false, next_event_at: nextEventAt, next_event_title: nextEventTitle,
+        next_event_all_day: allDay,
+      }],
+    }],
+  });
+
+  it("cobrança vencendo dia 22 mostra 22/08 no card, não 21/08", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: boardComProximo("2026-08-22T00:00:00Z", "A receber: Fulana", true),
+    } as never);
+    renderPage();
+    expect(
+      await screen.findByText(/próximo: A receber: Fulana em 22\/08/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/em 21\/08/i)).not.toBeInTheDocument();
+  });
+
+  it("compromisso COM horário continua convertendo para o fuso do tenant (formatDateShort)", async () => {
+    // Contraste: `all_day: false` não pode passar a usar `formatDay` por engano — um evento com
+    // horário É um instante de verdade, e tem que continuar convertendo fuso.
+    vi.mocked(api.get).mockResolvedValue({
+      data: boardComProximo("2026-08-20T14:00:00Z", "Reunião de alinhamento", false),
+    } as never);
+    renderPage();
+    expect(
+      await screen.findByText(/próximo: Reunião de alinhamento em 20\/08/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -204,7 +204,7 @@ describe("CrmPage — ponto de mensagem esperando resposta", () => {
         gender: "unspecified", birthdate: null, notes: "", tags: [], source: "whatsapp",
         stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
         stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
-        unread,
+        unread, next_event_at: null, next_event_title: null,
       }],
     }],
   });
@@ -220,5 +220,48 @@ describe("CrmPage — ponto de mensagem esperando resposta", () => {
     renderPage();
     expect(await screen.findByText("Ju")).toBeInTheDocument();
     expect(screen.queryByLabelText("Mensagem esperando resposta")).not.toBeInTheDocument();
+  });
+});
+
+describe("CrmPage — a linha do próximo passo", () => {
+  // Próximo compromisso e a AUSÊNCIA dele são estados opostos da mesma pergunta: nunca os dois
+  // juntos. `nextEventAt: null` exercita o card sem nada marcado (o caso mais acionável, quem
+  // vai esfriar); com data, exercita o card que já tem o próximo passo escrito.
+  const boardCom = (nextEventAt: string | null, nextEventTitle: string | null): Board => ({
+    columns: [{
+      stage: { id: "s1", name: "Entrada", position: 0, is_won: false, is_lost: false },
+      clients: [{
+        id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: null, document: null,
+        gender: "unspecified", birthdate: null, notes: "", tags: [], source: "whatsapp",
+        stage_id: "s1", created_at: "2026-08-15T12:00:00Z",
+        stage_entered_at: "2026-08-15T12:00:00Z", last_interaction_at: null,
+        unread: false, next_event_at: nextEventAt, next_event_title: nextEventTitle,
+      }],
+    }],
+  });
+
+  it("mostra o próximo compromisso quando existe", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: boardCom("2026-08-20T14:00:00Z", "Reunião de alinhamento"),
+    } as never);
+    renderPage();
+    expect(
+      await screen.findByText(/próximo: Reunião de alinhamento em 20\/08/i),
+    ).toBeInTheDocument();
+  });
+
+  it("diz 'sem próximo passo' quando não existe", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: boardCom(null, null) } as never);
+    renderPage();
+    expect(await screen.findByText("sem próximo passo")).toBeInTheDocument();
+  });
+
+  it("nunca mostra os dois ao mesmo tempo", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: boardCom("2026-08-20T14:00:00Z", "Reunião de alinhamento"),
+    } as never);
+    renderPage();
+    await screen.findByText(/próximo: Reunião de alinhamento em 20\/08/i);
+    expect(screen.queryByText("sem próximo passo")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
-import { formatDateShort } from "../../lib/datetime";
+import { formatDateShort, formatDay } from "../../lib/datetime";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { rotuloDaOrigem } from "./origem";
 import { usePrimaryAction } from "../../store/pageActions";
@@ -246,7 +246,15 @@ function Card({ client, stageId }: { client: BoardClient; stageId: string }) {
         {client.next_event_at ? (
           <p className="truncate text-[10px] text-neutral-400">
             próximo: {client.next_event_title} em{" "}
-            {formatDateShort(client.next_event_at, fuso)}
+            {/* Mesma distinção que `BlocoDaAgenda` já faz: dia inteiro é DATA DE CALENDÁRIO
+                (cobrança de `receivables` grava à meia-noite UTC, não na do fuso do tenant —
+                `formatDay` lê a string sem converter fuso, então não "volta" um dia). Com
+                horário é INSTANTE de verdade: aí sim converte para o fuso do tenant. Achado da
+                revisão final da Onda 2 — antes disto o card usava `formatDateShort` sempre, e
+                uma cobrança vencendo dia 22 aparecia como 21 em fuso negativo. */}
+            {client.next_event_all_day
+              ? formatDay(client.next_event_at)
+              : formatDateShort(client.next_event_at, fuso)}
           </p>
         ) : (
           <p className="text-[10px] text-neutral-400">sem próximo passo</p>

--- a/apps/web/src/features/crm/CrmPage.tsx
+++ b/apps/web/src/features/crm/CrmPage.tsx
@@ -240,6 +240,17 @@ function Card({ client, stageId }: { client: BoardClient; stageId: string }) {
             última interação: {formatDateShort(client.last_interaction_at, fuso)}
           </p>
         )}
+        {/* Próximo passo e a AUSÊNCIA dele são estados opostos da mesma pergunta e nunca
+            aparecem juntos — por isso uma linha só, e não duas. O aviso de "sem próximo passo"
+            é o mais acionável do card: mostra quem vai esfriar. */}
+        {client.next_event_at ? (
+          <p className="truncate text-[10px] text-neutral-400">
+            próximo: {client.next_event_title} em{" "}
+            {formatDateShort(client.next_event_at, fuso)}
+          </p>
+        ) : (
+          <p className="text-[10px] text-neutral-400">sem próximo passo</p>
+        )}
       </div>
       <button
         onClick={() => navigate(`/crm/clients/${client.id}`)}

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -105,3 +105,21 @@ export function formatDay(ymd: string | null | undefined): string {
 export function today(tz: string, now: Date = new Date()): string {
   return now.toLocaleDateString("en-CA", { timeZone: fusoValido(tz) });
 }
+
+/**
+ * `Date` → `"YYYY-MM-DD"` pelas partes LOCAIS do objeto — fuso da MÁQUINA, não do tenant.
+ *
+ * Único helper deste módulo que NÃO recebe `tz`, e de propósito: ele não formata um instante
+ * (`starts_at`, `created_at`), formata a posição de uma grade de calendário já construída em
+ * `Date` locais (`AgendaPage.tsx`: `startOfDay`/`addDays`/`startOfWeek`), cuja âncora (`hoje`) já
+ * foi resolvida no fuso do tenant por `today()`/`hojeDoTenant` antes de entrar nessa aritmética.
+ * Formatar essas posições pelas partes locais do `Date` é coerente com essa aritmética.
+ *
+ * Pela mesma razão, `localYmd` NÃO é seguro para formatar um instante vindo da API
+ * (`new Date(iso)` interpretado no fuso do NAVEGADOR, não do tenant) — para isso use
+ * `formatDate`/`formatDay` acima. Movida de `AgendaPage.tsx` (Onda 2, Task 5) sem mudar
+ * comportamento: era local a ela, agora é compartilhada com `NewEventModal.tsx`.
+ */
+export function localYmd(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}

--- a/docs/superpowers/plans/2026-08-16-onda-2-agenda-na-ficha.md
+++ b/docs/superpowers/plans/2026-08-16-onda-2-agenda-na-ficha.md
@@ -1,0 +1,710 @@
+# Onda 2 — Agenda na ficha do contato: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Um compromisso da Agenda passa a saber de que contato é. A ficha 360° mostra os próximos compromissos daquele contato e permite marcar um novo dali mesmo; o card do Kanban diz qual é o próximo passo — ou avisa que não há nenhum.
+
+**Architecture:** Coluna nova `agenda_events.client_id` (nullable, indexada, sem FK) com backfill retroativo a partir das cobranças. Cada módulo continua dono do seu dado: a Agenda expõe filtro e agregado, o CRM consome. O modal de criação não é reescrito — é extraído do `AgendaPage` e passa a aceitar `clientId`, para a checagem de conflito continuar existindo em um lugar só.
+
+**Tech Stack:** FastAPI + SQLAlchemy + Alembic + Pydantic (Python 3.12); React + TypeScript + Vite + Tailwind; pytest (API, SQLite + testcontainers/Postgres para RLS), Vitest + Testing Library (web), Playwright (e2e).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md` — seção "Onda 2".
+
+## Global Constraints
+
+- **Worktree:** `F:/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda`, branch `feat/onda-2-agenda-na-ficha`. Existe um checkout irmão em `F:/Projetos/e1p/escritorio-1-pessoa` (sem `.claude/worktrees/...`) — **nunca** edite nem commite lá.
+- **Nunca commitar em `main`; nunca `git push`; nunca `gh pr create`.** São exclusivos do @devops.
+- **Rodar tudo em primeiro plano.** Nunca em background, nunca com monitor, nunca poll. Dois implementadores da Onda 1 perderam o turno assim.
+- **Fuso:** todo instante exibido usa o fuso do TENANT — `useFuso()` + `lib/datetime` no front, `tenant_timezone(db)` no back. `toLocaleString` sem `timeZone` é regressão conhecida.
+- **Dinheiro em centavos inteiros.** Nunca float.
+- **Comentário em português**, explicando o *porquê*.
+- **`ruff check .` é gate de CI** (`.github/workflows/ci.yml:47` roda `ruff check . && pytest` dentro da imagem) — lint quebrado derruba o build antes de qualquer teste. Limite de 100 colunas.
+- Rede sempre mockada em teste de web.
+
+**Comandos (verificados neste worktree):**
+
+```bash
+# API — cwd no apps/api DO WORKTREE, interpretador do checkout principal
+cd /f/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda/apps/api
+/f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check .
+TZ=UTC /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -q     # ~8min
+# Testes de RLS/migration (Docker 29.6.1 disponível; roda em ~10s)
+/f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -m rls_e2e -q
+
+# Web — da raiz do worktree
+cd /f/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda
+pnpm --filter @e1p/web test && pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+pnpm --filter @e1p/web e2e
+```
+
+> ⚠️ `pytest -q` **exclui** o marcador `rls_e2e` no CI (`-m 'not rls_e2e'`) e o teste da migration vive nele. Rodar só `pytest -q` **não** exercita o backfill. Toda tarefa que toca a migration roda os dois.
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade | Ação |
+|---|---|---|
+| `apps/api/migrations/versions/0078_agenda_event_client.py` | Coluna + backfill sob janela de RLS | Criar |
+| `apps/api/tests/test_migration_0078_agenda_client_rls.py` | Prova que o backfill não é no-op | Criar |
+| `apps/api/app/modules/agenda/models.py` | `client_id` | Modificar |
+| `apps/api/app/modules/agenda/schemas.py` | `client_id` em Create/Update/Out | Modificar |
+| `apps/api/app/modules/agenda/service.py` | Grava `client_id`; `next_event_map` | Modificar |
+| `apps/api/app/modules/agenda/router.py` | Filtro `client_id`; limpeza do `_events_out` | Modificar |
+| `apps/api/app/modules/receivables/service.py` | Passa a gravar `client_id` no evento | Modificar |
+| `apps/api/app/modules/crm/timeline.py` | 4ª fonte: compromissos realizados | Modificar |
+| `apps/api/app/modules/crm/router.py` | Board consome `next_event_map` | Modificar |
+| `apps/api/app/modules/crm/schemas.py` | `next_event_at` / `next_event_title` | Modificar |
+| `packages/shared-types/src/index.ts` | Espelho dos campos novos | Modificar |
+| `apps/web/src/features/agenda/NewEventModal.tsx` | Modal extraído, aceita `clientId` | Criar |
+| `apps/web/src/features/agenda/AgendaPage.tsx` | Passa a importar o modal | Modificar |
+| `apps/web/src/features/crm/BlocoDaAgenda.tsx` | Próximos compromissos + "Marcar" | Criar |
+| `apps/web/src/features/crm/ClientDetailPage.tsx` | Hospeda o bloco | Modificar |
+| `apps/web/src/features/crm/ClientTimeline.tsx` | Fuso do tenant + `kind: agenda` | Modificar |
+| `apps/web/src/features/crm/CrmPage.tsx` | Linha do próximo passo | Modificar |
+| `apps/web/e2e/ficha-agenda-360.spec.ts` | Régua | Criar |
+
+**Ordem e dependências:** T1 → T2 → T3 (a limpeza exige o backfill provado). T2 → T7, T8. T6 → T7. T4+T5 tocam os mesmos dois arquivos e vão juntas.
+
+**Antes de começar:**
+
+```bash
+cd /f/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda
+git branch --show-current   # deve imprimir feat/onda-2-agenda-na-ficha
+```
+
+---
+
+### Task 1: Migration 0078 — a coluna e o passado
+
+**Files:**
+- Create: `apps/api/migrations/versions/0078_agenda_event_client.py`
+- Create: `apps/api/tests/test_migration_0078_agenda_client_rls.py`
+- Modify: `apps/api/app/modules/agenda/models.py`
+
+**Interfaces:**
+- Produces: `AgendaEvent.client_id: str | None` (indexado, sem FK). Consumido por todas as tarefas seguintes.
+
+- [ ] **Step 1: Escrever o teste da migration (vai falhar)**
+
+Crie `apps/api/tests/test_migration_0078_agenda_client_rls.py`. Ele segue a estrutura de `test_migration_0068_stage_order_rls.py` — **leia aquele arquivo primeiro** e reuse os helpers `_bootstrap_rls_role` e `_run_migrations_as_app` copiando-os (são módulos de teste independentes; a duplicação é a convenção existente).
+
+```python
+"""Migration 0078 (backfill de `agenda_events.client_id`) sob RLS REAL.
+
+O fato que a suíte SQLite é estruturalmente incapaz de provar: **o backfill não é no-op.**
+`agenda_events` e `charges` têm FORCE ROW LEVEL SECURITY e a migration roda como o papel
+não-superusuário `e1p_app` sem GUC de tenant. Sem a janela de DISABLE/ENABLE o UPDATE
+afetaria zero linhas SEM ERRO NENHUM — e o sintoma em produção não seria falha de deploy,
+seria "a ficha do cliente não mostra compromisso nenhum", meses depois.
+
+Semeamos parando na 0077 e só então aplicamos a 0078: backfill sobre tabela vazia é
+indistinguível de backfill no-op, que é o bug que este arquivo existe para pegar.
+
+Marcado `rls_e2e`: NÃO roda no `pytest -q`; roda no job `cross-tenant-rls` do CI e
+localmente com Docker (`pytest -m rls_e2e`).
+"""
+```
+
+Três testes:
+
+```python
+def test_backfill_liga_evento_de_cobranca_ao_cliente(...):
+    """O caso que o backfill existe para resolver: evento antigo ganha dono."""
+    # Semeie parando na 0077: um tenant, um client, uma charge com client_id,
+    # e um agenda_event kind='cobranca_receber' com external_ref = charge.id.
+    # Aplique a 0078. Afirme que o evento agora tem client_id igual ao da charge.
+
+def test_backfill_nao_e_no_op(...):
+    """A asserção que só o Postgres com RLS pode fazer.
+
+    Se alguém remover a janela de DISABLE ROW LEVEL SECURITY, o UPDATE roda, não falha, e
+    afeta zero linhas. Este teste é a única coisa entre esse commit e a produção.
+    """
+    # Idem acima, mas afirme explicitamente COUNT(*) de eventos com client_id NÃO NULO >= 1.
+
+def test_backfill_nao_inventa_dono(...):
+    """Evento sem cobrança e conta a PAGAR continuam órfãos — e devem."""
+    # Semeie um evento kind='bloqueio' sem external_ref e um kind='cobranca_pagar' cujo
+    # external_ref aponta para um payable. Afirme que ambos ficam com client_id NULL.
+```
+
+> ⚠️ O terceiro teste importa mais do que parece: `_events_out` no router resolve **dois** vínculos — cliente (via `charges`) e **fornecedor** (via `payables`). Um backfill que casasse `external_ref` sem filtrar por `kind` ligaria um evento de conta a pagar ao id de uma cobrança que por acaso colidisse. Filtrar por `kind='cobranca_receber'` é obrigatório.
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_migration_0078_agenda_client_rls.py -m rls_e2e -v
+```
+
+Esperado: FAIL — a revisão 0078 não existe.
+
+- [ ] **Step 3: Escrever a migration**
+
+Crie `apps/api/migrations/versions/0078_agenda_event_client.py`. **Leia a 0068 primeiro** — ela é o modelo da janela de RLS e o docstring dela explica a armadilha.
+
+```python
+"""Vínculo do compromisso com o contato: agenda_events.client_id
+
+Revision ID: 0078
+Revises: 0077
+Create Date: 2026-08-16
+
+A Agenda não sabia de que contato era um compromisso. O nome que a tela mostrava era
+DERIVADO da cobrança, por um caminho polimórfico via `external_ref` — que já está ocupado
+apontando para cobrança e para conta a pagar, conforme o `kind`.
+
+SEM FK, `String(36)`, seguindo o precedente de `whatsapp_chats.client_id`: a Agenda não deve
+ganhar dependência dura da tabela do CRM. Nullable é o caso NORMAL — bloqueio de horário,
+prazo interno e conta a pagar não têm cliente.
+
+⚠️ ARMADILHA QUE **SE APLICA** AQUI: esta migration FAZ BACKFILL. Ela roda como o papel dono
+não-superusuário `e1p_app`, **sem** a GUC `app.current_tenant_id`. Sob `FORCE ROW LEVEL
+SECURITY` o `UPDATE` seria filtrado a **ZERO LINHAS, EM SILÊNCIO** — e o sintoma em produção
+não seria erro de deploy, seria "a ficha não mostra compromisso nenhum". Por isso a RLS é
+desabilitada nas DUAS tabelas na janela do backfill (`agenda_events` porque é o ALVO,
+`charges` porque é a FONTE da subconsulta — a RLS filtra SELECT também) e restaurada com
+ENABLE + FORCE logo depois. Mesmo padrão da 0046, 0066, 0067 e 0068. DDL é transacional no
+Postgres e a migration roda offline, então não há janela de exposição.
+
+O backfill filtra por `kind='cobranca_receber'`. Sem esse filtro, um evento de conta a pagar
+cujo `external_ref` colidisse com o id de uma cobrança ganharia um dono errado — `external_ref`
+é ponteiro polimórfico, e o `kind` é o discriminador.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0078"
+down_revision: str | None = "0077"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("agenda_events", sa.Column("client_id", sa.String(36), nullable=True))
+    op.create_index(
+        "ix_agenda_events_client_id", "agenda_events", ["client_id"]
+    )
+
+    # --- backfill (ver a ARMADILHA no docstring: sem esta janela, tudo abaixo é no-op) ---
+    op.execute("ALTER TABLE agenda_events DISABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges DISABLE ROW LEVEL SECURITY")
+
+    op.execute(
+        """
+        UPDATE agenda_events AS e
+           SET client_id = c.client_id
+          FROM charges AS c
+         WHERE e.external_ref = c.id
+           AND e.kind = 'cobranca_receber'
+           AND c.client_id IS NOT NULL
+           AND e.tenant_id = c.tenant_id
+        """
+    )
+
+    op.execute("ALTER TABLE agenda_events ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE agenda_events FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE charges FORCE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agenda_events_client_id", table_name="agenda_events")
+    op.drop_column("agenda_events", "client_id")
+```
+
+> ⚠️ Confirme o nome real da tabela de cobranças (`charges`) e da coluna de tenant lendo `apps/api/app/modules/receivables/models.py` antes de rodar. O `AND e.tenant_id = c.tenant_id` é cinto de segurança: com a RLS desligada, nada mais impede um cruzamento entre tenants se dois ids colidissem.
+
+- [ ] **Step 4: Adicionar o campo ao modelo**
+
+Em `apps/api/app/modules/agenda/models.py`, dentro de `AgendaEvent`, logo abaixo de `external_ref`:
+
+```python
+    # De QUEM é este compromisso. Nullable é o caso normal: bloqueio de horário, prazo
+    # interno e conta a pagar não têm cliente. Sem FK e `String(36)`, como
+    # `whatsapp_chats.client_id` — a Agenda não deve ganhar dependência dura da tabela do CRM.
+    #
+    # Não confundir com `external_ref`: aquele é ponteiro POLIMÓRFICO, lido conforme o `kind`
+    # (id de cobrança, de conta a pagar...). Este é sempre um `clients.id`.
+    client_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
+```
+
+- [ ] **Step 5: Rodar o teste de migration**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_migration_0078_agenda_client_rls.py -m rls_e2e -v
+```
+
+Esperado: 3 passed.
+
+- [ ] **Step 6: Provar que o teste discrimina**
+
+Copie a migration (`cp`, **nunca** `git checkout`/`git stash` — há trabalho não commitado), remova as quatro linhas de `DISABLE`/`ENABLE`/`FORCE`, rode de novo e confirme que `test_backfill_nao_e_no_op` **FALHA**. Restaure e confirme que volta a passar. Reporte os dois resultados.
+
+Se passar sem a janela, o teste não está medindo o que promete e precisa de outra construção.
+
+- [ ] **Step 7: Suítes e lint**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check .
+cd apps/api && TZ=UTC /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -q
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -m rls_e2e -q
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/migrations/versions/0078_agenda_event_client.py apps/api/tests/test_migration_0078_agenda_client_rls.py apps/api/app/modules/agenda/models.py
+git commit -m "feat: o compromisso da Agenda sabe de que contato e (migration 0078)"
+```
+
+---
+
+### Task 2: A API da Agenda passa a falar de contato
+
+**Files:**
+- Modify: `apps/api/app/modules/agenda/schemas.py`, `service.py`, `router.py`
+- Modify: `apps/api/app/modules/receivables/service.py` (por volta da linha 257)
+- Test: `apps/api/tests/test_agenda_por_contato.py` (criar)
+
+**Interfaces:**
+- Consumes: `AgendaEvent.client_id` da Task 1.
+- Produces: `GET /agenda/events?client_id=<id>`; `client_id` em `EventCreate`/`EventUpdate`/`EventOut`; `next_event_map(db) -> dict[str, AgendaEvent]`.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+Crie `apps/api/tests/test_agenda_por_contato.py`. Use o padrão de fixture `headers` de `tests/test_agenda.py` — **leia aquele arquivo** para copiar a forma de autenticar e criar eventos pela API.
+
+Cobrir:
+
+```python
+def test_cria_evento_com_client_id_e_le_de_volta(client, headers): ...
+def test_filtro_por_client_id_traz_so_os_daquele_contato(client, headers): ...
+def test_evento_sem_client_id_nao_aparece_no_filtro(client, headers): ...
+def test_cobranca_criada_ja_nasce_com_client_id_no_evento(client, db, headers):
+    """`receivables` cria o evento da Agenda; ele tem que nascer ligado, não só o passado."""
+
+def test_next_event_map_traz_o_mais_proximo_por_contato(db): ...
+def test_next_event_map_ignora_cancelado(db): ...
+def test_next_event_map_inclui_evento_de_dia_inteiro_de_hoje(db):
+    """⚠️ O caso que uma implementação ingênua erra.
+
+    Evento de dia inteiro é ancorado na meia-noite REAL do fuso do tenant (ver
+    `agenda/service.create_event`). Às 15h, o `starts_at` dele já passou — filtrar por
+    `starts_at >= agora` esconderia o compromisso de HOJE, que é justamente o mais
+    relevante para o card. O critério é `ends_at >= agora`.
+    """
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_agenda_por_contato.py -v
+```
+
+- [ ] **Step 3: Schemas**
+
+Em `apps/api/app/modules/agenda/schemas.py`, adicione `client_id: str | None = None` a `EventCreate`, a `EventUpdate` e a `EventOut` (esta última já tem `client_name`; o campo novo fica logo acima dele, com um comentário distinguindo os dois: `client_id` é o vínculo, `client_name` é o nome resolvido para o card).
+
+- [ ] **Step 4: Service**
+
+Em `create_event`, passe `client_id=data.client_id` ao construir o `AgendaEvent`. Em `update_event`, trate `client_id` como os demais campos opcionais (leia como o arquivo já faz com os outros antes de escrever).
+
+Adicione, ao fim de `service.py`:
+
+```python
+def next_event_map(db: Session) -> dict[str, AgendaEvent]:
+    """Próximo compromisso por contato, para a linha do card do Kanban.
+
+    Consulta agregada, uma para o board inteiro — no molde de `crm_service.last_interaction_map`,
+    que existe justamente porque valor derivado guardado dessincroniza. O custo não cresce com
+    a quantidade de cards.
+
+    ⚠️ O corte é `ends_at >= agora`, NÃO `starts_at >= agora`. Evento de dia inteiro é ancorado
+    na meia-noite real do fuso do tenant (ver `create_event`), então às 15h o `starts_at` dele
+    já passou — filtrar pelo início esconderia o compromisso de HOJE, que é o mais relevante
+    que existe para o card. Pelo fim, ele aparece o dia todo e some quando acaba.
+
+    Cancelado fica de fora: não é próximo passo nenhum.
+
+    A sessão já chega escopada por RLS (mesma convenção de `list_events`).
+    """
+```
+
+Implemente com `row_number()` particionado por `client_id`, ordenado por `(starts_at, id)`, ficando com `rn == 1` — mesmo padrão que a Onda 1 usou em `unread_client_ids`, e pelo mesmo motivo: sem desempate por `id`, dois eventos no mesmo instante fazem "o próximo" dançar entre chamadas. Sem SQL condicional por dialeto.
+
+- [ ] **Step 5: Router — o filtro**
+
+Em `list_events` (`router.py`), acrescente `client_id: str | None = Query(default=None)` e repasse ao service, que filtra na consulta.
+
+- [ ] **Step 6: `receivables` grava o vínculo**
+
+Em `apps/api/app/modules/receivables/service.py`, no `AgendaEvent(...)` por volta da linha 257, acrescente:
+
+```python
+        client_id=data.client_id,
+```
+
+com um comentário curto dizendo que sem isto só o passado (o backfill da 0078) ficaria ligado e todo evento novo nasceria órfão.
+
+- [ ] **Step 7: Rodar, lint, commit**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_agenda_por_contato.py -v
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check .
+cd apps/api && TZ=UTC /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -q
+```
+
+```bash
+git add apps/api/app/modules/agenda apps/api/app/modules/receivables/service.py apps/api/tests/test_agenda_por_contato.py
+git commit -m "feat: eventos da Agenda filtram por contato e nascem ligados a ele"
+```
+
+---
+
+### Task 3: A limpeza do `_events_out` — teste de paridade ANTES da remoção
+
+`agenda/router.py::_events_out` reconstrói o nome do cliente por um caminho polimórfico: junta `external_ref` de dois `kind`s, busca cobranças, monta mapa. Com `client_id` populado, a metade das cobranças vira um join direto.
+
+> ⚠️ **Só metade morre.** `_events_out` resolve DOIS vínculos: cliente (via `charges`) e **fornecedor** (via `payables`, `p.supplier`). Conta a pagar não tem cliente e nunca terá `client_id`. A derivação via `payables` **fica**. Remover as duas apagaria o nome do fornecedor da tela da Agenda.
+
+**Files:**
+- Modify: `apps/api/app/modules/agenda/router.py:25-49`
+- Test: `apps/api/tests/test_agenda_por_contato.py` (acrescentar)
+
+- [ ] **Step 1: Escrever o teste de paridade (deve passar JÁ, antes de qualquer mudança)**
+
+```python
+def test_client_name_do_evento_e_o_mesmo_pelos_dois_caminhos(client, db, headers):
+    """A trava da limpeza: derivação antiga e join novo produzem o MESMO `client_name`.
+
+    Roda ANTES da remoção do caminho velho. Se um backfill errasse uma linha, a Agenda
+    perderia um nome que hoje mostra — e ninguém perceberia, porque nenhum teste afirmava
+    que os dois caminhos concordam.
+    """
+    # Crie uma cobrança com cliente (o que gera o evento da Agenda com client_id e external_ref).
+    # Calcule o nome pelos DOIS caminhos sobre a mesma base:
+    #   antigo: external_ref -> Charge -> Client.name
+    #   novo:   AgendaEvent.client_id -> Client.name
+    # Afirme que são iguais, e que não são None.
+
+def test_conta_a_pagar_continua_mostrando_o_fornecedor(client, db, headers):
+    """A metade que NÃO morre. Conta a pagar não tem cliente; o nome vem de `payables.supplier`."""
+```
+
+- [ ] **Step 2: Rodar — os dois devem passar antes da mudança**
+
+Se `test_client_name_..._dois_caminhos` já falhar aqui, **pare e reporte**: significa que o backfill ou o `receivables` não estão ligando corretamente, e a limpeza não pode prosseguir.
+
+- [ ] **Step 3: Trocar a metade das cobranças por join direto**
+
+Reescreva `_events_out` para resolver o nome do cliente por `AgendaEvent.client_id` (uma consulta a `Client` com os ids do lote), mantendo intacto o ramo `pagar_refs` → `Payable.supplier`. Atualize o docstring para dizer que os dois caminhos existem porque são coisas diferentes: cliente é vínculo direto, fornecedor é derivação e continua sendo.
+
+- [ ] **Step 4: Rodar de novo — os mesmos testes, agora contra o código novo**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_agenda_por_contato.py tests/test_agenda.py -v
+```
+
+Ambos os testes de paridade continuam verdes; se o do fornecedor cair, você removeu a metade errada.
+
+- [ ] **Step 5: Suíte inteira, lint, commit**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check . && TZ=UTC /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -q
+git add apps/api/app/modules/agenda/router.py apps/api/tests/test_agenda_por_contato.py
+git commit -m "refactor: o nome do cliente na Agenda vem do vinculo, nao da derivacao"
+```
+
+---
+
+### Task 4: O compromisso realizado entra no Histórico — e o fuso do `ClientTimeline`
+
+**Files:**
+- Modify: `apps/api/app/modules/crm/timeline.py`
+- Modify: `apps/web/src/features/crm/ClientTimeline.tsx`
+- Test: `apps/api/tests/test_client_timeline.py` (acrescentar), `apps/web/src/features/crm/ClientTimeline.test.tsx` (acrescentar)
+
+**Interfaces:**
+- Produces: entradas com `kind: "agenda"` no `GET /crm/clients/{id}/timeline`.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+API — acrescente a `tests/test_client_timeline.py`:
+
+```python
+def test_timeline_inclui_compromisso_realizado(...):
+    """Compromisso que já aconteceu é fato do relacionamento — vive no Histórico, não no bloco."""
+
+def test_timeline_nao_inclui_compromisso_futuro(...):
+    """O futuro é assunto do bloco de Agenda. Duas telas, duas perguntas."""
+
+def test_timeline_de_agenda_respeita_o_limite_por_fonte(...):
+    """Mesma regra das outras três fontes: `LIMITE_POR_FONTE` e `truncated`."""
+```
+
+Web — acrescente a `ClientTimeline.test.tsx`:
+
+```tsx
+it("formata no fuso do tenant, não no do navegador", async () => {
+  // Uma entrada às 23:30 UTC deve aparecer como 20:30 em America/Sao_Paulo (UTC-3),
+  // e a DATA deve ser a do dia anterior — que é o ponto: sem o fuso, a entrada aparece
+  // no dia errado. Mocke `useFuso` para "America/Sao_Paulo".
+});
+
+it("compromisso realizado tem identidade visual própria, não o ícone neutro", async () => {
+  // O vocabulário de `kind` é FECHADO: um `kind` sem entrada em APARENCIA cai no neutro.
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+- [ ] **Step 3: A 4ª fonte no `timeline.py`**
+
+Em `apps/api/app/modules/crm/timeline.py`, acrescente `AgendaEvent` ao lado de `Fact`, `Charge` e `Quote`, seguindo o padrão exato das outras três (mesmo `LIMITE_POR_FONTE`, mesma marcação de `truncated`, mesma normalização por `_instante`).
+
+Só compromissos **já realizados** entram: filtre por `ends_at < agora` e por `status != 'cancelled'`. Título no formato do resto do arquivo — algo como `f"Compromisso: {e.title}"` —, `kind` = `"agenda"`, `actor` = `"sistema"`.
+
+Atualize o docstring do módulo: hoje ele fala em DUAS fontes derivadas (`quotes` e `charges`); passam a ser três, e a razão é a mesma — ler na origem em vez de copiar para `facts`.
+
+- [ ] **Step 4: A aparência do `kind` novo, e o conserto do fuso**
+
+Em `apps/web/src/features/crm/ClientTimeline.tsx`:
+
+Acrescente ao mapa `APARENCIA` uma entrada para `agenda`, com ícone `CalendarDays` do `lucide-react` e cor coerente com as demais fontes derivadas (`quote` e `charge` usam `bg-sky-50 text-sky-700`).
+
+E conserte o fuso. A função `quando()` hoje é:
+
+```tsx
+const quando = (iso: string) =>
+  new Date(iso).toLocaleString("pt-BR", {
+    day: "2-digit", month: "2-digit", year: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
+```
+
+Sem `timeZone`, isso formata no relógio do NAVEGADOR. O comentário acima dela diz "mesma convenção da ConversasPage" — mas a ConversasPage foi corrigida exatamente disso, e o comentário dela explica por quê: o mesmo histórico quebrava os dias em pontos diferentes conforme a máquina que abrisse a tela. Passe a usar `useFuso()` + `lib/datetime`, como o resto do sistema, e reescreva o comentário para dizer a verdade.
+
+> Isto vira obrigatório agora, e não antes, porque esta tarefa coloca compromisso **com horário** nessa lista: "reunião às 14h" aparecendo às 11h para quem abrir de outro fuso é errado de um jeito que o dono percebe.
+
+- [ ] **Step 5: Rodar, lint, commit**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/test_client_timeline.py -v && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check .
+cd /f/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda && pnpm --filter @e1p/web test -- ClientTimeline && pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+```bash
+git add apps/api/app/modules/crm/timeline.py apps/api/tests/test_client_timeline.py apps/web/src/features/crm/ClientTimeline.tsx apps/web/src/features/crm/ClientTimeline.test.tsx
+git commit -m "feat: compromisso realizado entra no Historico, e ele passa a usar o fuso do tenant"
+```
+
+---
+
+### Task 5: Extrair o `NewEventModal`
+
+`AgendaPage.tsx` tem 723 linhas e o modal ocupa ~175 delas (a partir da 547). Ele já resolve o aviso de conflito de horário; a ficha vai reusá-lo em vez de reimplementar.
+
+**Files:**
+- Create: `apps/web/src/features/agenda/NewEventModal.tsx`
+- Modify: `apps/web/src/features/agenda/AgendaPage.tsx`
+- Test: `apps/web/src/features/agenda/NewEventModal.test.tsx` (criar)
+
+**Interfaces:**
+- Produces: `<NewEventModal open initialDate onClose onCreated clientId? />`. Consumido pela Task 6.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+```tsx
+it("envia client_id quando recebe um", async () => { /* afirma o corpo do POST /agenda/events */ });
+it("não envia client_id quando não recebe", async () => { /* a Agenda continua criando evento solto */ });
+it("mostra o aviso de conflito sem fechar o modal", async () => {
+  // O comportamento que NÃO pode se perder na extração: com conflitos, avisa e mantém aberto.
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+- [ ] **Step 3: Mover, não reescrever**
+
+Recorte o componente `NewEventModal` de `AgendaPage.tsx` para `NewEventModal.tsx`, **sem alterar a lógica**. Leve junto o que ele usa e que hoje vive no escopo do arquivo (`KINDS`, `MEET_KINDS`, `ymd`, `getGoogleStatus`, `Field`, `Modal`) — importando de onde já vêm ou movendo o que for exclusivo dele. Se algum helper for compartilhado com o resto do `AgendaPage`, **não duplique**: exporte-o de um lado e importe do outro.
+
+Acrescente a prop opcional:
+
+```tsx
+  /** Quando presente, o evento nasce ligado a este contato. A ficha 360° usa isto; a tela de
+   *  Agenda não passa nada e segue criando evento solto. */
+  clientId?: string;
+```
+
+e inclua `client_id: clientId ?? null` no corpo do `POST /agenda/events`.
+
+- [ ] **Step 4: `AgendaPage` importa em vez de declarar**
+
+Confirme que a página segue funcionando exatamente como antes — os testes existentes de `AgendaPage.test.tsx` são a rede.
+
+- [ ] **Step 5: Rodar tudo, lint, commit**
+
+```bash
+pnpm --filter @e1p/web test && pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+```
+
+Esperado: a suíte inteira verde, incluindo `AgendaPage`. Uma regressão ali significa que a extração levou junto algo que ficou faltando.
+
+```bash
+git add apps/web/src/features/agenda/
+git commit -m "refactor: NewEventModal em arquivo proprio, aceitando clientId"
+```
+
+---
+
+### Task 6: O bloco "Agenda" na ficha
+
+**Files:**
+- Create: `apps/web/src/features/crm/BlocoDaAgenda.tsx`, `BlocoDaAgenda.test.tsx`
+- Modify: `apps/web/src/features/crm/ClientDetailPage.tsx`
+
+**Interfaces:**
+- Consumes: `GET /agenda/events?client_id=` (Task 2), `<NewEventModal clientId>` (Task 5).
+
+O bloco é **ativo**: mostra os **próximos** compromissos e traz "Marcar com este cliente". O passado NÃO aparece aqui — ele vive no Histórico (Task 4). Duas telas, duas perguntas.
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+```tsx
+it("lista os próximos compromissos, do mais próximo para o mais distante", ...);
+it("estado vazio diz que não há compromisso e oferece marcar", ...);
+// ⚠️ Este é o estado MAIS IMPORTANTE do bloco: é ele que revela o contato que vai esfriar.
+it("abre o modal de marcar e, ao criar, recarrega a lista", ...);
+it("formata o horário no fuso do tenant", ...);
+it("falha de rede vira aviso, não derruba a ficha", ...);
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+- [ ] **Step 3: Implementar**
+
+Arquivo próprio: `ClientDetailPage.tsx` já tem sete seções. Siga a postura do `BlocoDaConversa` (criado na Onda 1) — **leia-o**: carrega sozinho fora do `load()` da página, degrada para aviso em falha, e não derruba a ficha. Os dois devem parecer irmãos.
+
+Estado vazio: "Nenhum compromisso marcado", com o botão logo abaixo.
+
+- [ ] **Step 4: Pendurar na ficha**
+
+Em `ClientDetailPage.tsx`, insira a seção logo **depois** de Conversa e antes de Cobranças — a ficha conta uma história: o que aconteceu (Histórico), o que foi dito (Conversa), o que está marcado (Agenda), e então o operacional. Use `<Section icon={<CalendarDays size={16} />} title="Agenda">`.
+
+- [ ] **Step 5: Rodar tudo, lint, commit**
+
+---
+
+### Task 7: A linha do próximo passo no card
+
+**Files:**
+- Modify: `apps/api/app/modules/crm/schemas.py`, `apps/api/app/modules/crm/router.py`
+- Modify: `packages/shared-types/src/index.ts`
+- Modify: `apps/web/src/features/crm/CrmPage.tsx`
+- Test: `apps/api/tests/test_crm_board_proximo_passo.py` (criar), `CrmPage.test.tsx` (acrescentar)
+
+- [ ] **Step 1: Escrever os testes (vão falhar)**
+
+API — no molde de `tests/test_crm_board_nao_lida.py` (criado na Onda 1; **leia-o**, inclusive o teste de contagem de consultas, que deve ganhar um irmão aqui):
+
+```python
+def test_board_traz_o_proximo_compromisso_do_contato(client, db, headers): ...
+def test_board_nao_traz_compromisso_cancelado(client, db, headers): ...
+def test_board_nao_faz_uma_consulta_por_card_com_proximo_passo(client, db, headers):
+    """Mesma trava do `unread`: dobrar os cards não pode dobrar as consultas."""
+```
+
+Web:
+
+```tsx
+it("mostra o próximo compromisso quando existe", ...);
+it("diz 'sem próximo passo' quando não existe", ...);
+it("nunca mostra os dois ao mesmo tempo", ...);
+```
+
+- [ ] **Step 2: Rodar e confirmar que falham**
+
+- [ ] **Step 3: Backend**
+
+`BoardClient` ganha `next_event_at: datetime | None` e `next_event_title: str | None`, com o mesmo comentário de vizinhança que `unread` já tem (campos que só o board calcula). O `get_board` chama `next_event_map(db)` **uma vez**, ao lado de `last_interaction_map` e `unread_client_ids`.
+
+Note a diferença de forma: `next_event_map` devolve `dict[str, AgendaEvent]` — o evento inteiro —, e o router extrai os dois campos ao montar cada `BoardClient` (`ev.starts_at` e `ev.title`, ou `None` quando o contato não está no mapa). Devolver o objeto, e não uma tupla já achatada, é o que permite o bloco da ficha e o card lerem coisas diferentes do mesmo agregado sem uma segunda consulta.
+
+- [ ] **Step 4: Tipo compartilhado**
+
+`packages/shared-types/src/index.ts`, em `BoardClient`: `next_event_at: string | null` e `next_event_title: string | null`.
+
+- [ ] **Step 5: O card**
+
+Em `CrmPage.tsx`, dentro de `Card`, **uma linha só** abaixo de "última interação":
+
+```tsx
+        {/* Próximo passo e a AUSÊNCIA dele são estados opostos da mesma pergunta e nunca
+            aparecem juntos — por isso uma linha só, e não duas. O aviso de "sem próximo passo"
+            é o mais acionável do card: mostra quem vai esfriar. */}
+```
+
+Renderize o título e a data no fuso do tenant (`useFuso()` + `formatDateShort`) quando houver; senão, o aviso em tom discreto.
+
+- [ ] **Step 6: Rodar tudo (API + web), lint, typecheck, commit**
+
+---
+
+### Task 8: Fechamento — suítes completas e a régua de 360px
+
+O card ganhou uma **terceira** linha de rodapé e a ficha uma oitava seção. A régua de 360px foi afiada na Onda 1 (`e2e/support/medidas.ts` passou a medir a tinta, não a caixa) — ela agora enxerga estouro que antes passava.
+
+**Files:**
+- Modify: `apps/web/e2e/crm-360.spec.ts`, `apps/web/e2e/fixtures/crm.json`
+- Create: `apps/web/e2e/ficha-agenda-360.spec.ts`
+
+- [ ] **Step 1: Todas as suítes, em primeiro plano**
+
+```bash
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m ruff check .
+cd apps/api && TZ=UTC /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -q
+cd apps/api && /f/Projetos/e1p/escritorio-1-pessoa/apps/api/.venv/Scripts/python.exe -m pytest tests/ -m rls_e2e -q
+cd /f/Projetos/e1p/escritorio-1-pessoa/.claude/worktrees/onda-2-agenda
+pnpm --filter @e1p/web test && pnpm --filter @e1p/web typecheck && pnpm --filter @e1p/web lint
+pnpm --filter @e1p/web e2e
+```
+
+- [ ] **Step 2: A fixture ganha o próximo passo**
+
+Em `apps/web/e2e/fixtures/crm.json`, acrescente `next_event_at` e `next_event_title` aos dois cards: o card mais cheio (`c2`) recebe um **título longo e plausível** de compromisso — "Reunião de alinhamento do casamento 12/12" —, e `c1` recebe `null` nos dois, exercitando o "sem próximo passo". Pior caso plausível, como manda a casa.
+
+- [ ] **Step 3: Medir o card de três linhas**
+
+Acrescente a `crm-360.spec.ts` uma medição no estilo do arquivo: o card com o título longo de compromisso não estoura a coluna, com varredura escopada em `.w-72` **e o controle positivo** (`.seletor-que-nao-existe`) — sem o par, a varredura vira um passe permanente que não mede nada.
+
+- [ ] **Step 4: Medir o bloco de Agenda na ficha**
+
+Crie `ficha-agenda-360.spec.ts` no molde de `ficha-conversa-360.spec.ts` (Onda 1). Dê à seção um `data-testid` próprio pelo mesmo motivo que a Conversa ganhou o dela: `querySelector` devolve só o primeiro casamento e as oito seções da ficha compartilham `.rounded-2xl.bg-white`, então um seletor de classe mediria o cabeçalho do cliente.
+
+Inclua o caso que estoura de verdade: um compromisso com título longo **sem espaços**, e o botão "Marcar com este cliente" ao lado da lista.
+
+Se algo estourar, o conserto é no CSS do componente — **nunca** afrouxar a medição.
+
+- [ ] **Step 5: Commit e reportar**
+
+Reporte ao dono os commits, a saída real de cada suíte (números, não "passou"), e que push e PR são do @devops.
+
+---
+
+## Definição de pronto
+
+- [ ] `agenda_events.client_id` existe, indexada, e o backfill ligou o passado — provado sob Postgres real com RLS.
+- [ ] O teste da migration falha quando a janela de RLS é removida (discriminação demonstrada).
+- [ ] Evento novo de cobrança nasce ligado ao contato.
+- [ ] `GET /agenda/events?client_id=` filtra; `next_event_map` ignora cancelado e inclui o dia-inteiro de hoje.
+- [ ] O nome do cliente na Agenda vem do vínculo; o do fornecedor continua vindo da conta a pagar.
+- [ ] Compromisso realizado aparece no Histórico; futuro não.
+- [ ] `ClientTimeline` formata no fuso do tenant.
+- [ ] `NewEventModal` mora em arquivo próprio, aceita `clientId`, e a tela de Agenda não regrediu.
+- [ ] A ficha mostra os próximos compromissos e marca um novo dali.
+- [ ] O card diz o próximo passo — ou avisa que não há.
+- [ ] Todas as suítes verdes, incluindo `rls_e2e` e a régua de 360px.
+- [ ] Nenhum commit em `main`; nenhum push.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -267,6 +267,11 @@ export interface BoardClient extends Client {
   /** Próximo compromisso do contato na Agenda — `null` nos dois junto significa "sem próximo passo". */
   next_event_at: string | null;
   next_event_title: string | null;
+  /** `next_event_at` é dia inteiro ou tem horário? Determina COMO formatar: dia inteiro usa
+   *  `formatDay` (lê a data da string, sem fuso — `receivables` ancora à meia-noite UTC, não
+   *  na do fuso do tenant); com horário usa `formatDateShort` (converte o instante para o fuso).
+   *  Mesma distinção que `BlocoDaAgenda` já faz com `AgendaEvent.all_day`. */
+  next_event_all_day: boolean;
 }
 
 export interface BoardColumn {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -264,6 +264,9 @@ export interface BoardClient extends Client {
   last_interaction_at: string | null;
   /** Tem mensagem do contato esperando resposta. */
   unread: boolean;
+  /** Próximo compromisso do contato na Agenda — `null` nos dois junto significa "sem próximo passo". */
+  next_event_at: string | null;
+  next_event_title: string | null;
 }
 
 export interface BoardColumn {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -184,6 +184,11 @@ export interface AgendaEvent {
   external_ref: string | null;
   /** Id do evento espelhado no Google Calendar (quando o Meet foi gerado via OAuth). */
   google_event_id: string | null;
+  /** De quem é este compromisso (aponta para `clients.id`). `null` para bloqueio de horário,
+   *  prazo interno e conta a pagar — nunca têm contato (espelha `EventOut.client_id` em
+   *  `agenda/schemas.py`). Gap deixado pela Task 2/3 desta onda: o backend já devolvia o campo,
+   *  mas o tipo compartilhado não o declarava — a ficha 360° (Task 6) é a primeira consumidora. */
+  client_id: string | null;
   /** Nome do cliente (cobrança) ou fornecedor (conta a pagar), resolvido no list/get. */
   client_name: string | null;
   created_by_ai: boolean;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -189,7 +189,14 @@ export interface AgendaEvent {
    *  `agenda/schemas.py`). Gap deixado pela Task 2/3 desta onda: o backend já devolvia o campo,
    *  mas o tipo compartilhado não o declarava — a ficha 360° (Task 6) é a primeira consumidora. */
   client_id: string | null;
-  /** Nome do cliente (cobrança) ou fornecedor (conta a pagar), resolvido no list/get. */
+  /** Nome resolvido para exibição no card, no list/get — não da coluna do evento. Desde a
+   *  Task 3 (Onda 2), o join direto por `client_id` resolve o NOME DO CONTATO para QUALQUER
+   *  evento vinculado (reunião, atendimento, cobrança...), não só cobrança/conta a pagar; a
+   *  metade sem `client_id` — conta a pagar — continua resolvendo o fornecedor por
+   *  `external_ref` (ver `agenda/router.py::_events_out`). `chipLabel` (AgendaPage.tsx) usa
+   *  isto como ATALHO só para os kinds financeiros, justamente porque o título deles já é
+   *  auto-gerado ("A receber: Fulano") — não confundir a restrição de exibição com a origem
+   *  do dado, que é ampla. */
   client_name: string | null;
   created_by_ai: boolean;
   created_at: string;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -239,7 +239,7 @@ export interface ClientTimelineEntry {
   id: string;
   kind:
     | "lead_created" | "lead_return" | "stage_move" | "reopened" | "note" | "funnel"
-    | "quote" | "charge" | "payment";
+    | "quote" | "charge" | "payment" | "agenda";
   title: string;
   body: string;
   actor: string;


### PR DESCRIPTION
## Onda 2 — o compromisso passa a saber de quem é

Fecha o par iniciado no #116. A Onda 1 ligou a ficha às Conversas com fios que já existiam no banco; esta cria o vínculo que **não existia**: um evento de Agenda não sabia de que contato era.

O nome que a Agenda mostrava até agora era *derivado* — reconstruído por um caminho polimórfico via `external_ref`, que já estava ocupado apontando ora para cobrança, ora para conta a pagar, conforme o `kind`.

### ⚠️ Contém migration com backfill

**0078** adiciona `agenda_events.client_id` (nullable, indexada, sem FK) e preenche o passado a partir das cobranças. Ver a seção de deploy no fim.

### O que muda para o dono

- **Bloco "Agenda" na ficha** — os próximos compromissos daquele contato, e o botão "Marcar com este cliente" que cria o evento já vinculado, sem sair da página.
- **Linha de próximo passo no card do Kanban** — diz o que está marcado, ou avisa que **não há nada marcado**. O aviso é o mais acionável dos dois: mostra quem vai esfriar no funil.
- **Compromisso realizado entra no Histórico** — o passado vira parte da história do relacionamento; o futuro fica no bloco. Duas telas, duas perguntas.

### Decisões que valem revisão

**O backfill é reentrante.** `AND e.client_id IS NULL` no `UPDATE`: como esta onda dá ao dono a capacidade de corrigir um vínculo errado pela API, um re-run manual da migration contra produção não pode apagar essa correção.

**Só metade da derivação morreu.** `_events_out` resolvia dois vínculos: cliente (via cobrança) e **fornecedor** (via conta a pagar). Conta a pagar não tem cliente e nunca terá — essa metade continua derivando.

**A regra de "cancelado" vive em quatro lugares, com a mesma expressão.** Histórico, `next_event_map`, `list_events` e o bloco. A revisão final confirmou que são compatíveis entre si.

**O corte do "próximo" é `ends_at >= agora`, não `starts_at`.** Evento de dia inteiro é ancorado na meia-noite do fuso do tenant, então às 15h o início dele já passou — filtrar pelo começo esconderia o compromisso de **hoje**, que é o mais relevante que existe para o card.

### Defeitos que a revisão final pegou, e que valem saber

**O Histórico ia duplicar toda cobrança do passado.** Como todo evento de cobrança passou a ter `client_id`, a nova fonte da linha do tempo listava cada cobrança duas vezes: a entrada de dinheiro e um "Compromisso: A receber: Fulano" que ninguém marcou. Em toda ficha, no dia do deploy, ainda consumindo o teto de 100 entradas. Corrigido excluindo os kinds financeiros — o dinheiro já é narrado pela fonte de cobranças.

**O card mostrava o dia anterior.** `receivables` ancora o evento da cobrança na meia-noite **UTC**; o card convertia para o fuso do tenant e imprimia 21/08 para uma cobrança que vence 22/08 — e ela sumia da linha de próximo passo às 21h do próprio dia. Corrigido dando `next_event_all_day` ao card, que passa a usar a mesma convenção do bloco e do detalhe do evento. **A ancoragem no `receivables` NÃO foi mexida**: existem duas convenções de all-day convivendo (`create_event` ancora no fuso do tenant, `receivables` em UTC) e unificá-las é migration de dados, fora desta onda.

### Verificação

| Suíte | Resultado |
|---|---|
| API `pytest` (`TZ=UTC`) | 2155 passaram, 1 pulado |
| API `rls_e2e` (Postgres real via testcontainers) | 63 passaram |
| API `ruff` | limpo |
| Web `vitest` | 654 testes, 67 arquivos |
| `typecheck` / `lint` | limpos |
| Playwright 360px | 28 passaram |

A régua de 360px pegou mais um estouro real: um título de compromisso sem espaços vazava 755px no bloco de Agenda. Corrigido no CSS, nunca afrouxando a medição.

### Sabidamente fora deste PR

- **`exclude_cancelled` subdiz o que faz** — agora exclui `cancelled` **e** `done`. Documentado nos dois pontos de uso; renomear é barato (≈5 call sites) e vale um follow-up.
- **`count_events` diverge** — tem seu próprio `exclude_cancelled` que ainda filtra só `cancelled`. Três funções no mesmo módulo, um nome, dois significados.
- **O bloco manda o `now` do navegador** como `start`. Com relógio do cliente torto, um compromisso pode aparecer nas duas superfícies ou em nenhuma.
- **Duas convenções de all-day** (tenant midnight vs UTC midnight), descritas acima.

### Deploy

A migration faz backfill sob `FORCE ROW LEVEL SECURITY`, desabilitando a RLS de `agenda_events` e `charges` na janela e restaurando com ENABLE + FORCE — mesmo padrão das 0046/0066/0067/0068. Sem essa janela o `UPDATE` seria filtrado a **zero linhas em silêncio**: deploy verde, dado não migrado, sintoma meses depois.

Isso é provado, não presumido: `tests/test_migration_0078_agenda_client_rls.py` roda contra Postgres real e fica **vermelho** quando a janela é removida. Confirmado por duas pessoas diferentes na revisão.

### Documentos

- Spec: `docs/superpowers/specs/2026-08-16-crm-conversa-e-agenda-na-ficha-design.md`
- Plano: `docs/superpowers/plans/2026-08-16-onda-2-agenda-na-ficha.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
