### PR TITLE
feat: a agenda vem antes do formulário ao marcar com o cliente

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1807,9 +1807,214 @@ contato quando na verdade tinha uma etiqueta a mais em alguns.
   exibir o valor cru **em silêncio**; um `export type ClientSource` em `shared-types` trocaria isso
   por erro de TypeScript. E o padrão `rounded-pill` inline já passou de **7 ocorrências**
   (`Attachments.tsx:79` é quase idêntico ao selo novo) sem nunca virar um `<Pill>` — este diff
-  seguiu a convenção local, não a piorou. **Acessibilidade:** a distinção origem × tag é por cor e
-  posição; o texto difere e o selo tem `title`, então não é codificação puramente cromática, mas
-  não há forma nem ícone separando os dois.
+  seguiu a convenção local, não a piorou.
+  ⚠️ **"7 ocorrências" ficou defasado: são 190**, em ~50 arquivos de `apps/web/src` (contado em
+  2026-08-18). O número importa porque é ele que decide a dívida: "7" se lê como *ainda não vale um
+  componente*, e **190** se lê como *isto é o design system, e ele não foi declarado*. Enquanto o
+  número estiver errado, a dívida vai ser adiada com razão aparente.
+  **Acessibilidade:** a distinção origem × tag é por cor e posição; o texto difere e o selo tem
+  `title`, então não é codificação puramente cromática, mas não há forma nem ícone separando os
+  dois.
+
+### Marcar compromisso: a agenda vem antes do formulário (2026-08-18)
+
+O botão "Marcar com este cliente" da ficha 360° abria o `NewEventModal` com `initialDate={null}`:
+o dono escolhia data e hora **sem ver o próprio calendário** e só descobria a colisão depois de
+salvar, pelo aviso de conflito. Agora o passo 1 é a disponibilidade; o formulário só aparece com
+data e hora já decididas. **Zero backend, zero migration** — reusa `GET /agenda/events`.
+
+- [x] **`features/agenda/grade.ts`** — a aritmética de calendário saiu de dentro do `AgendaPage.tsx`
+  (`startOfDay`, `addDays`, `startOfWeek`, `sameDay`, `hojeDoTenant`, `eventYmd`, `eventsOfDay`,
+  `gradeDoMes`) e virou módulo compartilhado. Refactor puro, sem mudança de comportamento: os dois
+  calendários passam a nascer da MESMA matemática, e é assim que um deles não começa a semana num
+  dia diferente do outro.
+- [x] **`faixasLivres(eventos, dia, fuso, agora)`** — blocos de 1h entre `HORA_ABERTURA` (8) e
+  `HORA_FECHAMENTO` (18). **A janela é FIXA de propósito:** não existe expediente configurável no
+  backend, e inventar um (migration + endpoint + tela) para oferecer atalhos de horário seria
+  construir um épico para resolver um clique. O botão "Outro horário" é a válvula de escape.
+  - ⚠️ **`all_day` NÃO ocupa faixa.** Cobrança, conta a pagar e prazo são **todos** de dia inteiro;
+    se ocupassem, todo dia com uma parcela vencendo apareceria cheio — o oposto do que o seletor
+    existe para mostrar. Elas aparecem só na lista "já marcado" do dia. Tem teste; não "corrija".
+  - Cancelado não ocupa (mesma postura do `exclude_cancelled` do `BlocoDaAgenda`); no dia de hoje,
+    faixa que já começou some.
+- ⚠️ **`eventosDoDia` é IRMÃO de `eventsOfDay`, e a diferença é o ponto.** Aquele agrupa por
+  `localYmd(new Date(iso))` — o fuso do **navegador**, convenção antiga do `AgendaPage`, mantida
+  intacta. O novo agrupa pelo fuso do **tenant** (§6.0), porque as faixas livres já são calculadas
+  lá: se as duas listas discordassem sobre a que dia pertence um compromisso das 23h, o seletor
+  ofereceria uma faixa livre logo abaixo do compromisso que a ocupa. Uniformizar os dois é decisão
+  separada, e mexe no `AgendaPage`.
+- [x] **`NewEventModal` ganhou `initialHour?: number | null`** — ausente mantém o 09:00–10:00 de
+  quem clicou num dia da Agenda sem dizer a que horas. `AgendaPage` não passa nada e segue idêntico.
+- [x] **O seletor NÃO recebe `clientId`** — disponibilidade é a agenda do **dono** inteira, não os
+  compromissos daquele contato. Filtrar por contato mostraria um mês vazio para quem está com a
+  semana lotada. O `clientId` continua indo ao `NewEventModal`, que é quem vincula.
+- [x] **O aviso de conflito do `NewEventModal` continua valendo** e não virou redundância: a agenda
+  pode mudar entre abrir o mês e salvar, e o seletor não conhece compromisso fora de 08–18h.
+- ⚠️ **A grade de 7 colunas NÃO alcança 44px de alvo tocável em 360px, e a exceção está escrita no
+  teste.** Sete células de 44px pedem 308px + vãos; a caixa do modal oferece **280px** de área útil
+  — é aritmeticamente impossível sem quebrar o calendário em duas linhas por semana. A rede da grade
+  é uma altura mínima medida (36px); o recorte segue a postura já documentada do
+  `modal-conta-360.spec.ts` para os campos de 38px: **a exceção fica escrita, não escondida num
+  filtro**.
+- [x] **O aceite em ~360px foi MEDIDO antes do merge, e achou quatro defeitos reais**
+  (`apps/web/e2e/ficha-marcar-360.spec.ts`): navegação de mês com **30×30px**, "Hoje" com **26px**,
+  as faixas de horário com **32px** e "Outro horário" com **38px** — todos abaixo do mínimo tocável,
+  e nenhum deles visível numa asserção de classe CSS. Corrigidos com `min-h-[44px]`; o padding
+  cresce, a fonte não.
+  - ⚠️ **O spec congela o relógio** (`page.clock.setFixedTime`). Sem isso ele é bomba-relógio: o
+    seletor abre no mês CORRENTE, e em setembro "20 de agosto" simplesmente não está na grade.
+  - O localizador do título longo é **escopado ao seletor**: o mesmo texto está na lista do
+    `BlocoDaAgenda`, atrás do modal, e o Playwright recusa dois elementos em modo estrito.
+#### O que o passo 3 do §5 achou — e a suíte estava VERDE o tempo todo
+
+Os três papéis de QA rodaram sobre o código já verde (675 testes, 31 do gate de 360px, `tsc` e
+`eslint` limpos) e o veredito do caça-bugs foi **FAIL**. Vale registrar o que nenhum gate mecânico
+pegou:
+
+- ⚠️ **Trocar de mês deixava o dia selecionado ÓRFÃO — e um dia lotado passava a exibir dez faixas
+  livres.** `irPara` mexia só em `anchor`; `eventos` virava a lista do mês novo e o painel de baixo
+  continuava escrito *"15 de outubro"*, agora sobre uma janela que não cobre mais aquela data.
+  Dois cliques, sem nada de exótico, e o seletor oferecia horário em cima de um compromisso
+  existente — **o oposto exato do que a feature existe para fazer**, sem nem a célula selecionada
+  na tela para denunciar. O `dia` agora acompanha o mês (voltar ao mês corrente reencontra HOJE;
+  qualquer outro começa no dia 1).
+  - O teste `"busca os eventos do mês novo ao navegar"` passava por cima disso porque aferia só os
+    PARÂMETROS da requisição, nunca o que a tela mostra depois. **Asserção sobre o pedido não é
+    asserção sobre a resposta.**
+- ⚠️ **A faixa era ESCOLHIDA no fuso do tenant e GRAVADA no fuso do navegador.** `grade.ts` inteiro
+  fala em fuso do tenant, de propósito; aí a hora atravessava a fronteira como string ingênua e o
+  `new Date(...)` do `save()` a reinterpretava na máquina de quem abriu a tela. Medido: tenant em
+  São Paulo com navegador em Manaus → o dono aponta 14:00 e o evento nasce às 15:00. É a família
+  §6.0, reintroduzida **na costura entre dois componentes que, isolados, estavam certos**.
+  `instanteNoFuso` (em `grade.ts`, com duas passadas por causa de horário de verão) resolve a hora
+  de parede no instante real, e `paraInputLocal` a devolve na linguagem do `datetime-local`. Com os
+  dois fusos iguais — o caso normal — o resultado é byte a byte o de antes.
+- ⚠️ **Densidade da grade custava 342 ms a 3,3 s de main thread por render.** `eventosDoDia(...)`
+  por CÉLULA varria a lista 42 vezes, e `today()` constrói dois `Intl.DateTimeFormat` descartáveis
+  por chamada (~200 µs medidos). Com 50 eventos no mês — trivial, porque cada cobrança e cada conta
+  a pagar viram um `agenda_events` — a tela travava a cada toque num dia, no aparelho de 360px que
+  a feature declara atender. `densidadePorDia` faz uma passada por evento, memoizada.
+- ⚠️ **`vi.setSystemTime` + `useFuso` mockado com o MESMO fuso do runner tornam o teste de fuso
+  incapaz de falhar.** O `vitest.config.ts` fixa `TZ: "America/Sao_Paulo"`; enquanto o fuso do
+  tenant nos testes for esse mesmo, ler o instante pelo fuso do tenant e lê-lo pelas partes locais
+  do `Date` dão o mesmo resultado. **Cinco de cinco mutações no coração do `grade.ts` sobreviveram
+  aos 11 testes verdes**, incluindo trocar `today(fuso, ...)` por `localYmd(new Date(...))` — no
+  teste literalmente chamado *"agrupa pelo dia do TENANT, não pelo do navegador"*. É a família do
+  `toContain("flex-wrap")` do §5.1, e a produção estava CERTA: o que faltava era um teste capaz de
+  dizer isso. Agora há `FUSO_DISTANTE = "Asia/Tokyo"` (12h à frente do runner), e as mutações
+  morrem.
+  - **A regra que fica: um teste sobre fuso do tenant que roda com o fuso do tenant igual ao da
+    máquina não testa fuso nenhum.** Vale para todo `vi.mock("../../store/auth")` da suíte.
+- **Compromisso que atravessa a meia-noite** não ocupava nada do dia seguinte (o plantão 22h→09h
+  deixava as 08h do dia 11 oferecidas). `intervaloNoDia` tem três ramos por isso.
+- **Na hora cheia exata** a faixa que começa AGORA era oferecida — o corte virou `<=`. O único
+  teste de corte usava 14:30, que passa com `<` e com `<=`; **só a hora cheia separa os dois**.
+- ⚠️ **O `NewEventModal` fica MONTADO o tempo todo e só reescreve as datas ao abrir.** `allDay`,
+  título, descrição e o aviso de conflito sobreviviam entre aberturas — e um "Dia inteiro" herdado
+  faz o `save()` **descartar em silêncio** a hora que o dono acabou de apontar na faixa livre.
+  Corrigido com `key`, como o `NewBillModal` já havia pago; o `seq` no `key` existe porque
+  reescolher exatamente o mesmo dia e hora repetiria a chave. **A primeira abertura de cada sessão
+  sempre funciona** — é o que esconde o defeito num teste manual apressado.
+- **Corrida na troca de mês**: dois toques rápidos e a resposta do mês antigo chegando por último
+  sobrescrevia a do mês visível. Guarda de sequência por `useRef` no `load`.
+
+Duplicações que o dedup separou entre **introduzidas por este changeset** e herdadas — as três
+introduzidas foram fechadas: `paramsDaGrade` (a regra da fronteira UTC-date vivia num comentário
+copiado em dois arquivos, e regra que mora em comentário duplicado é regra que deriva),
+`src/test/fixtures/agenda.ts` + `e2e/support/fixtures.ts` (o literal de 21 campos ia para seis
+lugares, e as cópias de e2e nem eram tipadas), e `horaCheia`/`lib/texto.ts`.
+
+#### A segunda rodada — o QA reprovou a PRÓPRIA correção, e três consertos estavam sem prova
+
+Reverificados por mutação, os nove consertos morrem quando desfeitos (cada um derruba o teste que
+o cobre). Mas a rodada achou mais quatro coisas, e a primeira é a mais instrutiva do PR inteiro:
+
+- ⚠️ **A correção do fuso INTRODUZIU um bug de fuso.** `offsetEmMinutos` calculava o offset pelo
+  truque comum — `new Date(x.toLocaleString("en-US", { timeZone: … }))` dos dois lados, subtrai, e
+  o fuso da máquina se cancela. Ele cancela **exceto** quando as duas strings caem em lados opostos
+  da virada de horário de verão **do NAVEGADOR**: aí sobram 60 minutos. Medido varrendo 16.643
+  combinações de (fuso do tenant × dia × hora):
+
+  | fuso da MÁQUINA | quebras com `new Date(string)` | quebras com `formatToParts` |
+  |---|---|---|
+  | `America/New_York` | **52** | 0 |
+  | `Australia/Sydney` | **29** | 0 |
+  | `Europe/Dublin` | **23** | 0 |
+  | `America/Sao_Paulo` | 0 | 0 |
+
+  A última linha é o ponto: **sob o fuso que o `vitest.config.ts` fixa, as duas implementações são
+  indistinguíveis.** Nenhum teste desta suíte poderia pegar isso — a prova teve de ser uma
+  varredura fora do runner. Hoje `offsetEmMinutos` usa `formatToParts` + `Date.UTC` e **não
+  constrói `Date` a partir de string em lugar nenhum**; a ausência é a funcionalidade.
+  - O Brasil não tem horário de verão e o produto é brasileiro — mas `tenants.timezone` aceita
+    qualquer zona IANA, e **o fuso do navegador é de quem ABRE a tela, não de quem configurou o
+    tenant**.
+- ⚠️ **`densidadePorDia` nasceu sem rede.** Devolver um `Map` vazio — as bolinhas do calendário
+  sumindo inteiras, que é o sinal que faz o dono escolher em que dia clicar — passava em **41 de
+  41** testes. Foi o helper criado pela correção de performance, exatamente o padrão que a primeira
+  rodada tinha acabado de gastar uma rodada eliminando. **Correção nova é código novo, e código
+  novo nasce com teste.**
+- ⚠️ **O teste de horário de verão era decorativo.** O caso escolhido (`America/New_York`,
+  01/11/2026, 14:00) acerta já na primeira aproximação — a transição às 06:00Z fica antes da parede
+  das 14:00Z —, então a segunda passada de `instanteNoFuso` nunca era exercitada e uma
+  implementação de passada única passava. **A zona e a data não são intercambiáveis:** o caso que
+  separa as duas é a LESTE de Greenwich (`Australia/Sydney`, 04/04/2026, 16:00). Há agora um
+  invariante varrendo 7 zonas × 4 datas de virada × 10 horas.
+- **Dois ramos de `intervaloNoDia` estavam descobertos** — o compromisso que começa DENTRO da
+  janela e vara a noite (o teste existente usava 22:00, fora de 08–18, e por isso não distinguia),
+  e o que cobre o dia do meio por fora. Sem eles, uma viagem de 9 a 12 deixava os dias 10 e 11 100%
+  livres.
+- **A régua estava cega para metade do modal.** `data-testid="seletor-horario"` vivia no `children`
+  do `Modal`, então cabeçalho e rodapé ficavam FORA de `textoForaDaTela` — e a varredura devolvia
+  lista vazia enquanto um nome de contato sem espaço empurrava o botão "Fechar" para **x=698 numa
+  viewport de 360**. O `scrollWidth` da página continuava 360, porque a caixa tem `overflow-y-auto`:
+  o mesmo disfarce que `medidas.ts` documenta para o `main.overflow-x-hidden`.
+  - `Modal` ganhou `testId` (na CAIXA, com a razão escrita na prop) e o `<h2>` ganhou
+    `min-w-0 break-words` + `shrink-0` no botão. **O conserto é do `Modal`, não do seletor:** o
+    detalhe de evento da Agenda (`AgendaPage.tsx`, `<Modal title={event.title}>`) tinha a mesma
+    exposição. **Todo modal medido pela régua deve receber `testId`, nunca um `<div>` interno.**
+- **Performance, medida de novo:** a densidade caiu ~10× (135 ms → 14 ms com 50 eventos), mas o
+  ramo do meia-noite encareceu `faixasLivres` em 4× — `intervaloNoDia` formatava as horas de TODO
+  evento da janela de 42 dias antes de descobrir que 97% deles não encostam no dia. Agora as duas
+  datas vêm primeiro e a saída acontece antes de qualquer `formatTime`; `doDia` e `livres` também
+  passaram a ser memoizados, senão cada toque num dia repagava a varredura inteira.
+- **`limit: 500` deixou de ser silencioso.** É o teto do endpoint e não há campo de total, então
+  bater nele corta a CAUDA do mês (o backend ordena por `starts_at`) e aqueles dias apareceriam sem
+  bolinha e com as dez faixas livres — a lista incompleta virando uma DECISÃO. Não paginamos:
+  quando `length` bate no teto, a tela **diz que não sabe**.
+
+Duas dívidas de teste também fecharam: `vi.useRealTimers()` saiu do corpo para um `afterEach` (no
+corpo, uma asserção que falha antes dele vaza fake timers e transforma uma falha em cascata), e o
+comentário que dizia *"headless roda em UTC"* foi corrigido — `vitest.config.ts` fixa
+`America/Sao_Paulo` desde sempre, e era essa crença que sustentava a asserção incapaz de falhar da
+primeira rodada.
+
+- **Dívida:** a grade não tem navegação por teclado (setas entre dias) — hoje é clique/toque e
+  `Tab`. E não há atalho para "próximo horário livre", que resolveria o caso do dono que só quer o
+  primeiro encaixe possível, sem escolher dia.
+- **Dívida:** `eventosDoDia` (fuso do tenant) e `eventsOfDay` (fuso do navegador) são coerentes
+  DENTRO de cada tela e discordam ENTRE elas — com navegador ≠ tenant, um compromisso das 23h30
+  aparece num dia no seletor da ficha e no dia seguinte no calendário da Agenda. Uniformizar mexe
+  em `MonthGrid`/`WeekView`/`DayView` e pede regressão própria.
+- **Dívida:** `lib/datetime.ts` documenta duas espécies (instante e data de calendário) e falta a
+  terceira que este changeset tornou inegável — **posição de grade** (`Date` local, sem `tz`). São
+  6 call sites de `toLocaleDateString` direto entre `AgendaPage` e `EscolherHorario`, e
+  `formatWeekday` já existe com exatamente o bag de opções que dois deles remontam à mão — **com
+  zero consumidores**, e `noUnusedLocals` não pega export não usado: enquanto ele estiver lá, morto
+  e invisível a qualquer busca por uso, é ele que faz a próxima pessoa escrever o 7º
+  `toLocaleDateString`. Enquanto isso, a afirmação do §6.0 ("a ÚNICA porta de formatação") tem seis
+  exceções.
+  ⚠️ **Quando essa dívida for aberta, `instanteNoFuso` e `offsetEmMinutos` vão junto.** Eles vivem
+  em `grade.ts` provisoriamente — nasceram da grade, mas produzem e manipulam INSTANTE, que pela
+  contabilidade do repo é matéria de `lib/datetime.ts`. Deixá-los lá depois da mudança faria
+  `grade.ts` virar o segundo módulo de fuso do frontend, e a porta única deixaria de ser única
+  também nesse eixo. O cabeçalho do `grade.ts` já diz isso.
+- **Dívida:** a mesma regra de 44px aparece com duas grafias no `EscolherHorario` — `min-h-[44px]`
+  (4×) e `h-11 w-11` (2×, a navegação de mês). São 12 ocorrências de `min-h-[44px]` no app;
+  `packages/design-tokens` já é dono do `rounded-pill`, e um `minHeight: { toque: "44px" }` no
+  preset daria `min-h-toque` greppável. E a nota do `rounded-pill` neste arquivo diz **7
+  ocorrências** quando a contagem real é **190** — o erro de 27× faz a dívida se ler como "ainda
+  não vale um componente".
 
 ## Vima: o Registro de Fatos e o briefing (PRs #85 e #90, 2026-08-06/07)
 

--- a/apps/web/e2e/ficha-marcar-360.spec.ts
+++ b/apps/web/e2e/ficha-marcar-360.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { alvosPequenos, medirPagina, textoForaDaTela } from "./support/medidas";
+import { agendaEvent as evento } from "./support/fixtures";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O seletor de horário ("Marcar com este cliente") em 360px.
+ *
+ * É o controle mais denso que a ficha 360° ganhou: uma grade de SETE colunas dentro de um modal.
+ * Sete colunas é a única forma do calendário que não dá para negociar — e é exatamente o tipo de
+ * layout que passa numa asserção de classe CSS (`grid-cols-7` está lá!) enquanto some pela borda
+ * da tela do dono. Aqui tudo é medido em pixel.
+ */
+
+
+const fixtures = {
+  "/crm/clients/c1": {
+    id: "c1", tenant_id: "t1", name: "Ju", email: null, phone: "554384035398",
+    document: null, gender: "unspecified", birthdate: null, notes: "", tags: [],
+    source: "whatsapp", stage_id: "s1", stage_entered_at: "2026-08-15T12:00:00Z",
+    created_at: "2026-08-15T12:00:00Z",
+  },
+  "/crm/clients/c1/timeline": { entries: [], truncated: false },
+  // Pior caso plausível para o PAINEL DO DIA: um título sem espaço nenhum, do mesmo naipe do que
+  // `ficha-agenda-360.spec.ts` usa na lista — só que aqui ele divide a linha com a coluna de
+  // horário, e sobra menos largura para quebrar.
+  "/agenda/events": [
+    evento(),
+    evento({
+      id: "ev-2",
+      title:
+        "ReuniaoDeAlinhamentoFinalDoCasamentoComTodosOsFornecedoresEEquipeCompletaUrgentissimo1234567890",
+      starts_at: "2026-08-20T18:00:00Z",
+      ends_at: "2026-08-20T19:00:00Z",
+    }),
+  ],
+};
+
+test.beforeEach(async ({ page }) => {
+  // Relógio congelado em 18/08/2026 09:00 (fuso do tenant). Sem isto o spec é uma bomba-relógio:
+  // o seletor abre no mês CORRENTE, e em setembro "20 de agosto" simplesmente não está na grade.
+  await page.clock.setFixedTime(new Date("2026-08-18T12:00:00Z"));
+  await semearSessao(page);
+  await mockarApi(page, fixtures);
+  await page.goto("/crm/clients/c1");
+  await page.getByRole("button", { name: "Marcar com este cliente" }).click();
+  await expect(page.getByRole("heading", { name: "Marcar com Ju" })).toBeVisible();
+});
+
+test("a grade de sete colunas cabe inteira em 360px", async ({ page }) => {
+  // A página não passa a rolar de lado só porque o modal abriu.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // Cada coluna da grade tem de estar INTEIRA dentro da tela — a de sábado é a que morre
+  // primeiro quando a conta de largura não fecha.
+  for (const rotulo of ["Dom", "Sáb"]) {
+    const caixa = await page.getByText(rotulo, { exact: true }).first().boundingBox();
+    expect(caixa).not.toBeNull();
+    expect(caixa!.x).toBeGreaterThanOrEqual(0);
+    expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
+  }
+
+  // Nenhum texto do seletor sai pela borda do que o recorta.
+  expect(await textoForaDaTela(page, '[data-testid="seletor-horario"]')).toEqual([]);
+});
+
+test("as faixas de horário e a saída de escape ficam alcançáveis", async ({ page }) => {
+  await page.getByRole("button", { name: /20 de agosto/ }).click();
+
+  // O compromisso que já existe é a informação que faltava — e o título sem espaço tem de
+  // QUEBRAR dentro da caixa, não vazar por ela (o painel do dia não tem `truncate`).
+  // Escopado ao seletor: o MESMO título também está na lista do `BlocoDaAgenda`, atrás do modal
+  // — sem o recorte, o localizador casa dois elementos e o Playwright recusa em modo estrito.
+  const titulo = page
+    .getByTestId("seletor-horario")
+    .getByText("ReuniaoDeAlinhamentoFinal", { exact: false });
+  await expect(titulo).toBeVisible();
+  const [scrollWidth, clientWidth] = await titulo.evaluate((el) => [el.scrollWidth, el.clientWidth]);
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 0.5);
+
+  // A faixa livre é o alvo do dedo: tem de caber na tela e ser tocável.
+  const faixa = page.getByRole("button", { name: "09:00–10:00" });
+  await expect(faixa).toBeVisible();
+  const caixaDaFaixa = await faixa.boundingBox();
+  expect(caixaDaFaixa!.x + caixaDaFaixa!.width).toBeLessThanOrEqual(360);
+
+  // "Outro horário" mora na barra fixa do rodapé justamente para nunca sair da tela: sem ele um
+  // dia cheio, ou uma agenda que não carregou, vira beco sem saída. Mede-se que ele está DENTRO
+  // dos 740px de altura da viewport, não só presente no DOM.
+  const escape = page.getByRole("button", { name: "Outro horário" });
+  const caixaDoEscape = await escape.boundingBox();
+  expect(caixaDoEscape).not.toBeNull();
+  expect(caixaDoEscape!.y + caixaDoEscape!.height).toBeLessThanOrEqual(740);
+});
+
+test("os botões de ação do seletor respeitam o mínimo tocável", async ({ page }) => {
+  await page.getByRole("button", { name: /20 de agosto/ }).click();
+
+  // Recorte deliberado: as células da GRADE ficam de fora desta asserção. Sete colunas de 44px
+  // pedem 308px + vãos, e a caixa do modal em 360px oferece 280px de área útil — 44px por célula
+  // é aritmeticamente impossível sem quebrar o calendário em duas linhas por semana. É a mesma
+  // postura documentada do `modal-conta-360.spec.ts` para os campos de 38px: a exceção fica
+  // escrita, não escondida. O que ESTE teste protege são os alvos que dão para honrar — as faixas
+  // de horário, o "Outro horário" e a navegação de mês —, e a grade tem sua própria rede: a
+  // altura mínima medida abaixo.
+  const pequenos = (await alvosPequenos(page, 44, ".fixed.inset-0.z-50")).filter(
+    (a) => a.descricao.startsWith("button") && !a.descricao.includes("aspect-square"),
+  );
+  expect(pequenos).toEqual([]);
+
+  // A rede da grade: célula quadrada de pelo menos 36px. Abaixo disso o dedo erra o dia, e o
+  // erro é caro — marca o compromisso no dia errado sem aviso nenhum.
+  const celula = await page.getByRole("button", { name: /20 de agosto/ }).boundingBox();
+  expect(celula!.height).toBeGreaterThanOrEqual(36);
+  expect(celula!.width).toBeGreaterThanOrEqual(36);
+});
+
+test("nome de contato sem espaço não empurra o 'Fechar' para fora da tela", async ({ page }) => {
+  // O cabeçalho e o rodapé do `Modal` ficavam FORA da varredura: o `data-testid` estava no
+  // `children`, então a régua media o miolo e dava tudo certo enquanto o `<h2>` do título
+  // empurrava o botão "Fechar" 327px para fora dos 360. E o `scrollWidth` da PÁGINA continua 360
+  // porque a caixa tem `overflow-y-auto` — o mesmo disfarce que `medidas.ts` documenta para o
+  // `main.overflow-x-hidden`. `name` aceita 255 chars no backend; sem espaço é o pior caso real.
+  await page.getByRole("button", { name: /fechar/i }).click();
+  await page.route("**/api/crm/clients/c1", async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({ ...fixtures["/crm/clients/c1"], name: "MariaEduardaDeAlmeidaFonsecaRodriguesDosSantosNascimentoJunior" }),
+    }),
+  );
+  await page.goto("/crm/clients/c1");
+  await page.getByRole("button", { name: "Marcar com este cliente" }).click();
+
+  const fechar = page.getByRole("button", { name: /fechar/i });
+  const caixa = await fechar.boundingBox();
+  expect(caixa).not.toBeNull();
+  expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
+
+  // E a varredura agora enxerga a CAIXA inteira do modal, não só o miolo.
+  expect(await textoForaDaTela(page, '[data-testid="seletor-horario"]')).toEqual([]);
+});

--- a/apps/web/e2e/support/fixtures.ts
+++ b/apps/web/e2e/support/fixtures.ts
@@ -1,0 +1,25 @@
+import type { AgendaEvent } from "@e1p/shared-types";
+import { agendaEvent as base } from "../../src/test/fixtures/agenda";
+
+/**
+ * Payload de `AgendaEvent` para os specs de layout — na forma real de `packages/shared-types`.
+ *
+ * DERIVA da fixture de `src/`, e não a copia: `apps/web/tsconfig.json` é único e inclui
+ * `["src", "e2e", "playwright.config.ts"]`, então os dois lados compartilham compilador, `strict`
+ * e `paths` — não havia barreira nenhuma, e uma segunda lista dos 21 campos só devolveria o
+ * problema que a extração veio resolver.
+ *
+ * O que muda aqui são os VALORES, e isso é a régua de 360px falando (§5.1): as fixtures de layout
+ * são de **pior caso plausível** — título de casamento, contato vinculado —, porque dado curto
+ * sempre cabe e medir com ele é medir uma tela que não existe.
+ */
+export const agendaEvent = (over: Partial<AgendaEvent> = {}): AgendaEvent =>
+  base({
+    title: "Prova do vestido",
+    starts_at: "2026-08-20T13:00:00Z",
+    ends_at: "2026-08-20T14:00:00Z",
+    client_id: "c1",
+    client_name: "Ju",
+    created_at: "2026-08-15T10:00:00Z",
+    ...over,
+  });

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -7,11 +7,22 @@ export default function Modal({
   onClose,
   children,
   footer,
+  testId,
 }: {
   title: string;
   open: boolean;
   onClose: () => void;
   children: ReactNode;
+  /**
+   * `data-testid` na CAIXA do modal — cabeçalho e rodapé inclusive.
+   *
+   * ⚠️ Existe por causa da régua de 360px. Pôr o recorte no conteúdo (`children`) deixa título e
+   * barra de ação FORA da varredura de `textoForaDaTela`, e foi exatamente assim que um título
+   * comprido empurrando o "Fechar" 338px para fora da tela passou por uma medição que devolveu
+   * lista vazia. Todo modal medido pela régua deve receber `testId` aqui, nunca num `<div>`
+   * interno.
+   */
+  testId?: string;
   /**
    * Ação primária do modal. Vive numa barra `sticky bottom-0` DENTRO da caixa que rola, para que
    * ela nunca saia da tela enquanto o dono preenche o formulário. **Opcional**: modal que não
@@ -31,15 +42,21 @@ export default function Modal({
       onClick={onClose}
     >
       <div
+        data-testid={testId}
         className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-2xl bg-white p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-bold text-neutral-800">{title}</h2>
+        <div className="mb-4 flex items-start justify-between gap-2">
+          {/* `min-w-0 break-words`: o título é digitação livre — nome de contato, título de evento
+              — e `name` aceita 255 chars no backend. Sem os dois, um nome colado sem espaço não
+              tem onde quebrar, o `<h2>` cresce e empurra o "Fechar" para fora da tela: medido em
+              698px numa viewport de 360. O `shrink-0` no botão é a outra metade — sem ele o
+              flex o espreme antes de deixar o título quebrar. */}
+          <h2 className="min-w-0 break-words text-lg font-bold text-neutral-800">{title}</h2>
           <button
             onClick={onClose}
             aria-label="Fechar"
-            className="-mr-2 flex h-11 w-11 items-center justify-center rounded-pill text-neutral-400 hover:text-neutral-700"
+            className="-mr-2 flex h-11 w-11 shrink-0 items-center justify-center rounded-pill text-neutral-400 hover:text-neutral-700"
           >
             <X size={20} />
           </button>

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -6,40 +6,26 @@ import Modal from "../../components/Modal";
 import { api } from "../../lib/api";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
-import { formatDateTime, formatDay, formatTime, localYmd, today } from "../../lib/datetime";
+import { formatDateTime, formatDay, formatTime, localYmd } from "../../lib/datetime";
+import { sentenceCase } from "../../lib/texto";
+import {
+  WEEKDAYS,
+  addDays,
+  eventYmd,
+  eventsOfDay,
+  gradeDoMes,
+  paramsDaGrade,
+  hojeDoTenant,
+  sameDay,
+  startOfDay,
+  startOfWeek,
+} from "./grade";
 import { useFuso } from "../../store/auth";
 import NewEventModal from "./NewEventModal";
 
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 type View = "month" | "week" | "day";
-
-const WEEKDAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
-
-// ── helpers de data (sem lib) ──────────────────────────
-const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
-const addDays = (d: Date, n: number) => {
-  const r = startOfDay(d);
-  r.setDate(r.getDate() + n);
-  return r;
-};
-const startOfWeek = (d: Date) => addDays(d, -d.getDay()); // semana começa no domingo
-const sameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
-/**
- * "Hoje" no fuso do TENANT, como `Date` local — a âncora da grade do calendário.
- *
- * A grade inteira (`startOfDay`, `addDays`, `startOfWeek`, `localYmd` de `lib/datetime.ts`)
- * trabalha em `Date` local, e isso é coerente: são posições numa grade, não instantes. O que NÃO
- * podia continuar local era o ponto de partida — `new Date()` num navegador em UTC começava a
- * grade no dia errado. Montamos o dia certo pelas PARTES, para que a `Date` resultante seja a
- * meia-noite local desse dia e toda a aritmética seguinte continue valendo.
- */
-const hojeDoTenant = (tz: string) => {
-  const [a, m, d] = today(tz).split("-").map(Number);
-  return new Date(a, m - 1, d);
-};
-// só a primeira letra maiúscula (ex.: "junho de 2026" -> "Junho de 2026")
-const sentenceCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 
 function rangeFor(view: View, anchor: Date): { start: Date; end: Date; days: Date[] } {
   if (view === "day") {
@@ -50,11 +36,7 @@ function rangeFor(view: View, anchor: Date): { start: Date; end: Date; days: Dat
     const days = Array.from({ length: 7 }, (_, i) => addDays(s, i));
     return { start: s, end: addDays(s, 7), days };
   }
-  // month: grade de 6 semanas a partir do domingo anterior ao dia 1
-  const first = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
-  const gridStart = startOfWeek(first);
-  const days = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
-  return { start: gridStart, end: addDays(gridStart, 42), days };
+  return gradeDoMes(anchor);
 }
 
 export default function AgendaPage() {
@@ -69,10 +51,8 @@ export default function AgendaPage() {
   const { start, end, days } = useMemo(() => rangeFor(view, anchor), [view, anchor]);
 
   const load = useCallback(async () => {
-    // Fronteiras em UTC-date (meia-noite UTC da data do grid), não o local→UTC: assim os
-    // eventos de dia inteiro (gravados à meia-noite UTC) não caem fora do range nas bordas.
     const { data } = await api.get<AgendaEvent[]>("/agenda/events", {
-      params: { start: `${localYmd(start)}T00:00:00.000Z`, end: `${localYmd(end)}T00:00:00.000Z`, limit: 500 },
+      params: paramsDaGrade(start, end),
     });
     setEvents(data);
   }, [start, end]);
@@ -194,15 +174,6 @@ const hhmm = (iso: string, tz: string) => formatTime(iso, tz);
 const FINANCIAL_KINDS = new Set(["cobranca_receber", "cobranca_pagar"]);
 const chipLabel = (e: AgendaEvent) =>
   FINANCIAL_KINDS.has(e.kind) && e.client_name ? e.client_name : e.title;
-// Eventos de dia inteiro (cobranças, contas a pagar, prazos) são gravados à meia-noite UTC:
-// casamos pela DATA do calendário (sem fuso) para não "voltar" um dia em fuso negativo.
-// Eventos com horário usam a data local normalmente.
-const eventYmd = (e: AgendaEvent) =>
-  e.all_day ? e.starts_at.slice(0, 10) : localYmd(new Date(e.starts_at));
-const eventsOfDay = (events: AgendaEvent[], d: Date) =>
-  events
-    .filter((e) => eventYmd(e) === localYmd(d))
-    .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at));
 
 function MonthGrid({
   days,

--- a/apps/web/src/features/agenda/EscolherHorario.test.tsx
+++ b/apps/web/src/features/agenda/EscolherHorario.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { localYmd } from "../../lib/datetime";
+import EscolherHorario from "./EscolherHorario";
+import { gradeDoMes } from "./grade";
+import { agendaEvent } from "../../test/fixtures/agenda";
+
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  getGoogleStatus: vi.fn(() => Promise.resolve({ connected: false })),
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+
+
+
+// O dia base deste arquivo é quinta 15/10/2026 às 09:00 do tenant (12:00Z), não o 10/10 da
+// fixture compartilhada.
+const evento = (over: Record<string, unknown> = {}) =>
+  agendaEvent({
+    title: "Alinhamento do casamento",
+    starts_at: "2026-10-15T12:00:00Z",
+    ends_at: "2026-10-15T13:00:00Z",
+    ...over,
+  } as never);
+
+function mockar(eventos: unknown[] = []) {
+  vi.mocked(api.get).mockResolvedValue({ data: eventos } as never);
+}
+
+const abrir = (onEscolher = vi.fn()) => {
+  render(<EscolherHorario open nome="Loana" onClose={() => {}} onEscolher={onEscolher} />);
+  return onEscolher;
+};
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+  // "Agora" fixo: 10/10/2026 09:00 no fuso do tenant. Sem isto, os testes de faixa livre
+  // mudariam de resultado conforme o dia em que a suíte roda.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date("2026-10-10T12:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("EscolherHorario", () => {
+  it("mostra a disponibilidade do dia escolhido antes de qualquer formulário", async () => {
+    mockar([evento()]);
+    abrir();
+
+    await userEvent.click(await screen.findByRole("button", { name: /15 de outubro/ }));
+
+    // O compromisso que já existe aparece — é a informação que o dono não tinha ao abrir o
+    // formulário direto.
+    expect(screen.getByText("Alinhamento do casamento")).toBeInTheDocument();
+    // E a faixa que ele tomou some da oferta.
+    expect(screen.queryByRole("button", { name: "09:00–10:00" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "10:00–11:00" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "08:00–09:00" })).toBeInTheDocument();
+  });
+
+  it("devolve o dia e a hora ao clicar numa faixa livre", async () => {
+    mockar([evento()]);
+    const onEscolher = abrir();
+
+    await userEvent.click(await screen.findByRole("button", { name: /15 de outubro/ }));
+    await userEvent.click(screen.getByRole("button", { name: "14:00–15:00" }));
+
+    expect(onEscolher).toHaveBeenCalledTimes(1);
+    const [dia, hora] = onEscolher.mock.calls[0];
+    expect(localYmd(dia as Date)).toBe("2026-10-15");
+    expect(hora).toBe(14);
+  });
+
+  it("devolve o dia sem hora quando o dono pede outro horário", async () => {
+    mockar([]);
+    const onEscolher = abrir();
+
+    await userEvent.click(await screen.findByRole("button", { name: /15 de outubro/ }));
+    await userEvent.click(screen.getByRole("button", { name: /outro horário/i }));
+
+    const [dia, hora] = onEscolher.mock.calls[0];
+    expect(localYmd(dia as Date)).toBe("2026-10-15");
+    expect(hora).toBeNull();
+  });
+
+  it("no dia de hoje, não oferece horário que já passou", async () => {
+    mockar([]);
+    abrir();
+
+    // Hoje (10/10) já vem selecionado; são 09:00 EM PONTO no fuso do tenant. A faixa das 09h
+    // não tem mais nem um minuto de antecedência, então some junto com as que já correram.
+    await waitFor(() => expect(vi.mocked(api.get)).toHaveBeenCalled());
+
+    expect(screen.queryByRole("button", { name: "08:00–09:00" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "09:00–10:00" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "10:00–11:00" })).toBeInTheDocument();
+  });
+
+  it("avisa quando o dia não tem mais faixa livre, sem tirar a saída de escape", async () => {
+    // 11:00Z–21:00Z = 08:00–18:00: a janela inteira tomada.
+    mockar([evento({ starts_at: "2026-10-15T11:00:00Z", ends_at: "2026-10-15T21:00:00Z" })]);
+    abrir();
+
+    await userEvent.click(await screen.findByRole("button", { name: /15 de outubro/ }));
+
+    expect(screen.getByText(/sem horário livre/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /outro horário/i })).toBeInTheDocument();
+  });
+
+  it("busca os eventos do mês novo ao navegar", async () => {
+    mockar([]);
+    abrir();
+    await waitFor(() => expect(vi.mocked(api.get)).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole("button", { name: /mês seguinte/i }));
+
+    const novembro = gradeDoMes(new Date(2026, 10, 1));
+    await waitFor(() =>
+      expect(vi.mocked(api.get)).toHaveBeenLastCalledWith(
+        "/agenda/events",
+        expect.objectContaining({
+          params: expect.objectContaining({ start: `${localYmd(novembro.start)}T00:00:00.000Z` }),
+        }),
+      ),
+    );
+  });
+
+  it("ao trocar de mês, o painel do dia acompanha em vez de opinar sobre um dia fora da janela", async () => {
+    // O defeito: `irPara` mexia só no mês da grade. O painel de baixo continuava escrito
+    // "15 de outubro" enquanto `eventos` já era a lista de NOVEMBRO — então um dia lotado
+    // aparecia com as dez faixas livres, e clicar numa delas marcava em cima de um compromisso.
+    // Sem pista visual nenhuma: a célula selecionada nem existe na grade nova.
+    mockar([evento({ starts_at: "2026-10-10T11:00:00Z", ends_at: "2026-10-10T21:00:00Z" })]);
+    abrir();
+
+    // Hoje (10/10) vem selecionado e está cheio de ponta a ponta.
+    await waitFor(() => expect(screen.getByText(/sem horário livre/i)).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /mês seguinte/i }));
+
+    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(/novembro/i);
+    expect(screen.getByRole("heading", { level: 4 })).not.toHaveTextContent(/outubro/i);
+  });
+
+  it("resposta atrasada de um mês antigo não sobrescreve a do mês visível", async () => {
+    const deNovembro = evento({
+      id: "ev-nov",
+      title: "Compromisso de novembro",
+      starts_at: "2026-11-16T12:00:00Z",
+      ends_at: "2026-11-16T13:00:00Z",
+    });
+    let entregarOutubro = () => {};
+    vi.mocked(api.get)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            entregarOutubro = () => resolve({ data: [evento()] } as never);
+          }) as never,
+      )
+      .mockImplementationOnce(() => Promise.resolve({ data: [deNovembro] } as never));
+
+    abrir();
+    await userEvent.click(screen.getByRole("button", { name: /mês seguinte/i }));
+    await waitFor(() => expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(/novembro/i));
+
+    // Só AGORA a requisição de outubro responde — fora de ordem, como uma rede lenta faria.
+    entregarOutubro();
+
+    await userEvent.click(screen.getByRole("button", { name: /16 de novembro/ }));
+    expect(screen.getByText("Compromisso de novembro")).toBeInTheDocument();
+    expect(screen.queryByText("Alinhamento do casamento")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/agenda/EscolherHorario.tsx
+++ b/apps/web/src/features/agenda/EscolherHorario.tsx
@@ -1,0 +1,273 @@
+import type { AgendaEvent } from "@e1p/shared-types";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Modal from "../../components/Modal";
+import { api } from "../../lib/api";
+import { formatTime, localYmd } from "../../lib/datetime";
+import { sentenceCase } from "../../lib/texto";
+import { useFuso } from "../../store/auth";
+import {
+  HORA_ABERTURA,
+  HORA_FECHAMENTO,
+  WEEKDAYS,
+  densidadePorDia,
+  eventosDoDia,
+  faixasLivres,
+  gradeDoMes,
+  horaCheia,
+  hojeDoTenant,
+  paramsDaGrade,
+  sameDay,
+} from "./grade";
+
+/**
+ * "Quando dá?" ANTES de "o que é?".
+ *
+ * O botão "Marcar com este cliente" da ficha 360° abria o formulário de evento direto: o dono
+ * escolhia data e hora sem ver o próprio calendário, e só descobria a colisão depois de salvar,
+ * pelo aviso de conflito do `NewEventModal`. Este seletor inverte a ordem — mostra o mês, o que
+ * já está marcado no dia e as faixas que sobraram; o formulário só aparece com data e hora já
+ * decididas.
+ *
+ * Não recebe `clientId` de propósito: disponibilidade é a agenda do DONO inteira, não os
+ * compromissos deste contato. Filtrar por contato mostraria um mês vazio para quem está com a
+ * semana lotada.
+ */
+export default function EscolherHorario({
+  open,
+  nome,
+  onClose,
+  onEscolher,
+}: {
+  open: boolean;
+  /** Nome do contato, só para o título. */
+  nome: string;
+  onClose: () => void;
+  /** `hora` é a hora cheia escolhida, ou `null` quando o dono pediu "Outro horário". */
+  onEscolher: (dia: Date, hora: number | null) => void;
+}) {
+  const fuso = useFuso();
+  const [anchor, setAnchor] = useState(() => hojeDoTenant(fuso));
+  const [dia, setDia] = useState(() => hojeDoTenant(fuso));
+  const [eventos, setEventos] = useState<AgendaEvent[]>([]);
+  const [erro, setErro] = useState(false);
+  const [parcial, setParcial] = useState(false);
+
+  const { start, end, days } = useMemo(() => gradeDoMes(anchor), [anchor]);
+
+  // Guarda de sequência: aqui o refetch é dirigido por MARTELADA do usuário (dois toques rápidos
+  // em "Mês seguinte"), e nada garante que as respostas cheguem na ordem em que foram pedidas. Sem
+  // isto, a resposta de um mês antigo chegando por último sobrescreve a do mês visível — e a tela
+  // volta a opinar sobre disponibilidade com a lista errada, que é o defeito que o `dia` seguindo
+  // o mês (abaixo) acabou de fechar pelo outro lado.
+  const pedido = useRef(0);
+
+  const load = useCallback(async () => {
+    const meu = ++pedido.current;
+    try {
+      const { data } = await api.get<AgendaEvent[]>("/agenda/events", {
+        params: paramsDaGrade(start, end),
+      });
+      if (meu !== pedido.current) return;
+      const lista = Array.isArray(data) ? data : [];
+      setEventos(lista);
+      // `limit` é o TETO do endpoint (`le=500`) e não há campo de total: batendo nele, a CAUDA do
+      // mês é cortada (o backend ordena por `starts_at`) e aqueles dias apareceriam sem bolinha e
+      // com as dez faixas livres — a lista incompleta virando uma DECISÃO de agendamento, em
+      // silêncio nas duas pontas. Não paginamos; dizemos que não sabemos.
+      setParcial(lista.length >= paramsDaGrade(start, end).limit);
+      setErro(false);
+    } catch {
+      // Sem a agenda não há disponibilidade a mostrar — mas o dono ainda precisa conseguir
+      // marcar. Degrada para o aviso + "Outro horário", nunca para uma tela morta.
+      if (meu !== pedido.current) return;
+      setErro(true);
+      setEventos([]);
+      setParcial(false);
+    }
+  }, [start, end]);
+
+  useEffect(() => {
+    if (open) load();
+  }, [open, load]);
+
+  // Memoizados pela mesma razão da densidade: sem isto, todo toque num dia paga a varredura
+  // inteira da janela de 42 dias de novo.
+  const doDia = useMemo(() => eventosDoDia(eventos, dia, fuso), [eventos, dia, fuso]);
+  const livres = useMemo(() => faixasLivres(eventos, dia, fuso), [eventos, dia, fuso]);
+  const hoje = hojeDoTenant(fuso);
+  // Uma passada por EVENTO, não uma por célula × evento. `today()` constrói dois
+  // `Intl.DateTimeFormat` descartáveis por chamada (~200 µs), e a grade tem 42 células: com 50
+  // eventos no mês — trivial num mês com parcelas e contas recorrentes, que viram um
+  // `agenda_events` cada — o custo por render passava de 340 ms, e ele se repetia a cada toque
+  // num dia. No aparelho de 360px que a feature declara atender, isso é a tela travando.
+  const densidade = useMemo(() => densidadePorDia(eventos, fuso), [eventos, fuso]);
+
+  // O dia selecionado ACOMPANHA o mês. Sem isto, `eventos` passava a ser a lista do mês novo
+  // enquanto o painel de baixo continuava escrito "15 de outubro" — um dia lotado aparecia com as
+  // dez faixas livres, sem nem a célula selecionada na tela para denunciar, e clicar numa faixa
+  // marcava em cima de um compromisso existente. Era o oposto exato do que o seletor existe para
+  // fazer. Voltar para o mês corrente reencontra HOJE; qualquer outro mês começa no dia 1.
+  function irPara(dir: number) {
+    const novo = new Date(anchor.getFullYear(), anchor.getMonth() + dir, 1);
+    setAnchor(novo);
+    setDia(novo.getMonth() === hoje.getMonth() && novo.getFullYear() === hoje.getFullYear() ? hoje : novo);
+  }
+
+  return (
+    <Modal
+      title={`Marcar com ${nome}`}
+      open={open}
+      testId="seletor-horario"
+      onClose={onClose}
+      footer={
+        // Na barra fixa do rodapé porque é a saída de escape: em 360px a lista de faixas empurra
+        // o botão para fora da tela, e sem ele um dia cheio vira um beco sem saída.
+        <button
+          onClick={() => onEscolher(dia, null)}
+          className="min-h-[44px] w-full rounded-pill border border-neutral-200 bg-white text-sm font-semibold text-neutral-600 hover:bg-neutral-50"
+        >
+          Outro horário
+        </button>
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <button
+              aria-label="Mês anterior"
+              onClick={() => irPara(-1)}
+              className="flex h-11 w-11 items-center justify-center rounded-lg text-neutral-500 hover:bg-neutral-100"
+            >
+              <ChevronLeft size={18} />
+            </button>
+            <button
+              aria-label="Mês seguinte"
+              onClick={() => irPara(1)}
+              className="flex h-11 w-11 items-center justify-center rounded-lg text-neutral-500 hover:bg-neutral-100"
+            >
+              <ChevronRight size={18} />
+            </button>
+          </div>
+          <h3 className="text-sm font-bold text-neutral-800">{tituloDoMes(anchor)}</h3>
+          <button
+            onClick={() => {
+              setAnchor(hoje);
+              setDia(hoje);
+            }}
+            className="min-h-[44px] rounded-pill border border-neutral-200 px-3 text-xs text-neutral-600 hover:bg-neutral-50"
+          >
+            Hoje
+          </button>
+        </div>
+
+        {erro && (
+          <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            Não foi possível carregar a agenda — escolha o horário no formulário.
+          </p>
+        )}
+
+        {!erro && parcial && (
+          <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            Mês muito cheio: a agenda pode estar incompleta aqui. Confira antes de confirmar.
+          </p>
+        )}
+
+        <div>
+          <div className="grid grid-cols-7 text-center text-[10px] font-medium text-neutral-400">
+            {WEEKDAYS.map((w) => (
+              <div key={w} className="py-1">
+                {w}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-0.5">
+            {days.map((d) => {
+              const noMes = d.getMonth() === anchor.getMonth();
+              const ocupacao = densidade.get(localYmd(d)) ?? 0;
+              const escolhido = sameDay(d, dia);
+              return (
+                <button
+                  key={d.toISOString()}
+                  aria-label={rotuloDoDia(d)}
+                  aria-pressed={escolhido}
+                  onClick={() => setDia(d)}
+                  className={`flex aspect-square flex-col items-center justify-center rounded-lg text-xs transition ${
+                    escolhido
+                      ? "bg-primary-500 font-bold text-white"
+                      : noMes
+                        ? "text-neutral-700 hover:bg-neutral-100"
+                        : "text-neutral-300 hover:bg-neutral-50"
+                  } ${!escolhido && sameDay(d, hoje) ? "ring-1 ring-primary-300" : ""}`}
+                >
+                  <span className="tabular-nums">{d.getDate()}</span>
+                  {/* Só a densidade, não o título: o mês inteiro cabe em 360px porque cada dia
+                      gasta 3px de altura para dizer "tem coisa aqui". O que é fica no painel
+                      abaixo, para o dia que o dono escolheu. */}
+                  <span className="mt-0.5 flex h-1 items-center gap-0.5">
+                    {Array.from({ length: Math.min(ocupacao, 3) }, (_, i) => (
+                      <span
+                        key={i}
+                        className={`h-1 w-1 rounded-full ${escolhido ? "bg-white/70" : "bg-primary-300"}`}
+                      />
+                    ))}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="border-t border-neutral-100 pt-3">
+          <h4 className="text-sm font-semibold text-neutral-800">{rotuloCompleto(dia)}</h4>
+
+          {doDia.length > 0 && (
+            <ul className="mt-2 space-y-1">
+              {doDia.map((e) => (
+                <li key={e.id} className="flex gap-2 text-xs text-neutral-500">
+                  <span className="w-24 shrink-0 tabular-nums">
+                    {e.all_day
+                      ? "Dia inteiro"
+                      : `${formatTime(e.starts_at, fuso)}–${formatTime(e.ends_at, fuso)}`}
+                  </span>
+                  {/* `break-words`: título é digitação livre e pode vir sem espaço nenhum —
+                      mesma razão da lista do `BlocoDaAgenda`. */}
+                  <span className="min-w-0 break-words text-neutral-700">{e.title}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {livres.length === 0 ? (
+            <p className="mt-3 text-sm text-neutral-400">
+              Sem horário livre entre {horaCheia(HORA_ABERTURA)} e {horaCheia(HORA_FECHAMENTO)}{" "}
+              neste dia.
+            </p>
+          ) : (
+            <div className="mt-3 grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+              {livres.map((f) => (
+                <button
+                  key={f.hora}
+                  onClick={() => onEscolher(dia, f.hora)}
+                  className="min-h-[44px] rounded-pill bg-primary-50 text-xs font-semibold tabular-nums text-primary-600 hover:bg-primary-100"
+                >
+                  {f.inicio}–{f.fim}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+const tituloDoMes = (d: Date) =>
+  sentenceCase(d.toLocaleDateString("pt-BR", { month: "long", year: "numeric" }));
+
+/** O nome acessível da célula: "15 de outubro" — o número sozinho não diz de que mês é. */
+const rotuloDoDia = (d: Date) =>
+  d.toLocaleDateString("pt-BR", { day: "numeric", month: "long" });
+
+const rotuloCompleto = (d: Date) =>
+  sentenceCase(d.toLocaleDateString("pt-BR", { weekday: "long", day: "2-digit", month: "long" }));

--- a/apps/web/src/features/agenda/NewEventModal.test.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.test.tsx
@@ -7,6 +7,11 @@ import NewEventModal from "./NewEventModal";
 // Onda 2, Task 5: extração do NewEventModal de AgendaPage.tsx para arquivo próprio, para que a
 // ficha 360° do contato (Task 6) reuse o mesmo modal em vez de reimplementar o aviso de conflito.
 // Rede sempre mockada (IV2): nenhum teste bate em /agenda real.
+// O fuso do TENANT é trocável por teste: o `vitest.config.ts` fixa o fuso da MÁQUINA em
+// America/Sao_Paulo, e é justamente a diferença entre os dois que este arquivo precisa exercitar.
+let fusoDoTenant = "America/Sao_Paulo";
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+
 vi.mock("../../lib/api", () => ({
   api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
   publicApi: { post: vi.fn() },
@@ -27,6 +32,7 @@ async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
 
 beforeEach(() => {
   vi.mocked(api.post).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("NewEventModal (Onda 2, Task 5)", () => {
@@ -83,5 +89,58 @@ describe("NewEventModal (Onda 2, Task 5)", () => {
     // O modal continua aberto: onClose NÃO é chamado quando há conflito (o dono decide).
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
+  });
+
+  it("pré-preenche 09:00–10:00 ao abrir num dia, sem hora escolhida", () => {
+    render(
+      <NewEventModal
+        open
+        initialDate={new Date(2026, 9, 10)}
+        onClose={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Início")).toHaveValue("2026-10-10T09:00");
+    expect(screen.getByLabelText("Fim")).toHaveValue("2026-10-10T10:00");
+  });
+
+  it("pré-preenche a hora escolhida no seletor, e a seguinte no fim", () => {
+    render(
+      <NewEventModal
+        open
+        initialDate={new Date(2026, 9, 10)}
+        initialHour={14}
+        onClose={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Início")).toHaveValue("2026-10-10T14:00");
+    expect(screen.getByLabelText("Fim")).toHaveValue("2026-10-10T15:00");
+  });
+
+  it("a hora escolhida é a hora do TENANT, mesmo com o navegador em outro fuso", () => {
+    // O seletor decide as faixas no fuso do tenant; o `<input type="datetime-local">` fala no fuso
+    // do NAVEGADOR. Entregar "14:00" como string ingênua fazia `new Date(...)` reinterpretá-la na
+    // máquina de quem abriu a tela — o dono viajando marcava 15:00 achando que marcava 14:00.
+    // Tenant em Tóquio (UTC+9), runner em São Paulo (UTC−3): 14:00 em Tóquio é 05:00Z, que o
+    // navegador escreve como 02:00 do mesmo dia.
+    fusoDoTenant = "Asia/Tokyo";
+
+    render(
+      <NewEventModal
+        open
+        initialDate={new Date(2026, 9, 10)}
+        initialHour={14}
+        onClose={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+
+    const inicio = screen.getByLabelText("Início") as HTMLInputElement;
+    expect(inicio).toHaveValue("2026-10-10T02:00");
+    // O que importa não é a string e sim o INSTANTE que ela produz na hora de salvar.
+    expect(new Date(inicio.value).toISOString()).toBe("2026-10-10T05:00:00.000Z");
   });
 });

--- a/apps/web/src/features/agenda/NewEventModal.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.tsx
@@ -4,9 +4,19 @@ import { useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage, getGoogleStatus } from "../../lib/api";
 import { localYmd } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+import { instanteNoFuso } from "./grade";
 
 // Tipos de evento que geram Meet automaticamente quando o Google está conectado (Story 4.1).
 const MEET_KINDS = new Set(["reuniao", "atendimento", "audiencia"]);
+
+/**
+ * Instante -> o que o `<input type="datetime-local">` espera: `"YYYY-MM-DDTHH:mm"` nas partes
+ * LOCAIS do navegador. E o inverso exato do `new Date(valor)` que o `save()` faz, entao o
+ * instante que entra e o instante que sai.
+ */
+const paraInputLocal = (d: Date) =>
+  `${localYmd(d)}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 
 const KINDS = [
   ["atendimento", "Atendimento"],
@@ -20,12 +30,16 @@ const KINDS = [
 export default function NewEventModal({
   open,
   initialDate,
+  initialHour,
   onClose,
   onCreated,
   clientId,
 }: {
   open: boolean;
   initialDate: Date | null;
+  /** Hora cheia escolhida no `EscolherHorario` (14 => 14:00–15:00). Ausente = 09:00–10:00, o
+   *  default de quem clicou num dia da Agenda sem dizer a que horas. */
+  initialHour?: number | null;
   onClose: () => void;
   onCreated: () => void;
   /** Quando presente, o evento nasce ligado a este contato. A ficha 360° usa isto; a tela de
@@ -47,6 +61,7 @@ export default function NewEventModal({
   const [conflict, setConflict] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [googleConnected, setGoogleConnected] = useState(false);
+  const fuso = useFuso();
 
   // Descobre se o Google está conectado (para a dica de "Meet automático"). Silencioso em falha.
   useEffect(() => {
@@ -58,16 +73,24 @@ export default function NewEventModal({
 
   const autoMeet = googleConnected && MEET_KINDS.has(kind);
 
-  // pré-preenche a data ao abrir num dia do calendário
+  // Pré-preenche a data ao abrir num dia do calendário — e a HORA quando ela veio junto.
+  //
+  // ⚠️ A hora é de PAREDE DO TENANT, não do navegador. O seletor decide as faixas no fuso do
+  // tenant (`faixasLivres`) e o `<input type="datetime-local">` fala no fuso da máquina: escrever
+  // `"14:00"` direto fazia o `new Date(...)` do `save()` reinterpretá-la localmente, e um dono com
+  // o navegador em outro fuso marcava um horário diferente do que apontou na tela — a família §6.0
+  // do CLAUDE.md, na costura entre os dois componentes. Quando os dois fusos coincidem (o caso
+  // normal) o resultado é byte a byte o de antes.
   useEffect(() => {
     if (open && initialDate) {
       const d = localYmd(initialDate);
       setStartDate(d);
       setEndDate(d);
-      setStart(`${d}T09:00`);
-      setEnd(`${d}T10:00`);
+      const h = initialHour ?? 9;
+      setStart(paraInputLocal(instanteNoFuso(initialDate, h * 60, fuso)));
+      setEnd(paraInputLocal(instanteNoFuso(initialDate, (h + 1) * 60, fuso)));
     }
-  }, [open, initialDate]);
+  }, [open, initialDate, initialHour, fuso]);
 
   async function save() {
     setError(null);

--- a/apps/web/src/features/agenda/grade.test.ts
+++ b/apps/web/src/features/agenda/grade.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+import { formatTime, localYmd } from "../../lib/datetime";
+import {
+  HORA_ABERTURA,
+  HORA_FECHAMENTO,
+  densidadePorDia,
+  eventosDoDia,
+  faixasLivres,
+  instanteNoFuso,
+} from "./grade";
+import { agendaEvent as evento } from "../../test/fixtures/agenda";
+
+const FUSO = "America/Sao_Paulo"; // UTC−3: 12:00Z = 09:00 na tela
+
+// ⚠️ O `vitest.config.ts` fixa `TZ: "America/Sao_Paulo"` para a suíte inteira. Enquanto o fuso do
+// TENANT nos testes for esse mesmo, ler o instante pelo fuso do tenant e lê-lo pelas partes locais
+// do `Date` produz o MESMO resultado — e um teste chamado "agrupa pelo fuso do tenant" passa mesmo
+// com a produção lendo o fuso do NAVEGADOR. É a família do `toContain("flex-wrap")` que o CLAUDE.md
+// §5.1 documenta: asserção estruturalmente incapaz de falhar.
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner: sob ele os dois caminhos
+// discordam, e é por isso que os testes deste fuso existem.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+
+
+// Sábado 10/10/2026 — o dia que o dono clicou na grade.
+const DIA = new Date(2026, 9, 10);
+// Um "agora" bem distante do DIA, para que o corte do passado não interfira nos casos que não
+// são sobre ele.
+const ONTEM = new Date("2026-10-01T12:00:00Z");
+
+const horas = (fx: { hora: number }[]) => fx.map((f) => f.hora);
+
+describe("eventosDoDia", () => {
+  it("agrupa pelo dia do TENANT, não pelo do navegador", () => {
+    // 02:00Z de 11/10 ainda é 23:00 de 10/10 em UTC−3 — o compromisso é da noite de sábado.
+    const noturno = evento({ starts_at: "2026-10-11T02:00:00Z", ends_at: "2026-10-11T03:00:00Z" });
+
+    expect(eventosDoDia([noturno], DIA, FUSO)).toHaveLength(1);
+    expect(eventosDoDia([noturno], new Date(2026, 9, 11), FUSO)).toHaveLength(0);
+  });
+
+  it("usa o fuso do tenant mesmo quando ele discorda do fuso da MÁQUINA", () => {
+    // 23:00Z de 10/10 é 08:00 de 11/10 em Tóquio e 20:00 de 10/10 em São Paulo (o fuso do runner).
+    // Só quem lê pelo fuso do TENANT põe este compromisso no dia 11.
+    const e = evento({ starts_at: "2026-10-10T23:00:00Z", ends_at: "2026-10-11T00:00:00Z" });
+
+    expect(eventosDoDia([e], new Date(2026, 9, 11), FUSO_DISTANTE)).toHaveLength(1);
+    expect(eventosDoDia([e], DIA, FUSO_DISTANTE)).toHaveLength(0);
+  });
+
+  it("mantém o de dia inteiro na data de calendário dele, sem fuso", () => {
+    const cobranca = evento({
+      kind: "cobranca_receber",
+      all_day: true,
+      starts_at: "2026-10-10T00:00:00Z",
+      ends_at: "2026-10-10T23:59:00Z",
+    });
+
+    expect(eventosDoDia([cobranca], DIA, FUSO)).toHaveLength(1);
+  });
+
+  it("ordena do mais cedo para o mais tarde", () => {
+    const tarde = evento({ id: "tarde", starts_at: "2026-10-10T18:00:00Z", ends_at: "2026-10-10T19:00:00Z" });
+    const cedo = evento({ id: "cedo", starts_at: "2026-10-10T12:00:00Z", ends_at: "2026-10-10T13:00:00Z" });
+
+    expect(eventosDoDia([tarde, cedo], DIA, FUSO).map((e) => e.id)).toEqual(["cedo", "tarde"]);
+  });
+});
+
+describe("faixasLivres", () => {
+  it("oferece a janela inteira de 08h a 18h quando o dia está vazio", () => {
+    const fx = faixasLivres([], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+    expect(fx[0]).toMatchObject({ inicio: "08:00", fim: "09:00" });
+    expect(fx[9]).toMatchObject({ inicio: "17:00", fim: "18:00" });
+  });
+
+  it("esconde a faixa tomada por um compromisso do dia", () => {
+    // 12:00Z–13:00Z = 09:00–10:00 no fuso do tenant.
+    const fx = faixasLivres([evento()], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).not.toContain(9);
+    expect(horas(fx)).toContain(8);
+    expect(horas(fx)).toContain(10);
+  });
+
+  it("derruba as duas faixas que um compromisso atravessa pela metade", () => {
+    // 09:30–10:30 encosta em 09h e em 10h: nenhuma das duas cabe inteira.
+    const fx = faixasLivres(
+      [evento({ starts_at: "2026-10-10T12:30:00Z", ends_at: "2026-10-10T13:30:00Z" })],
+      DIA,
+      FUSO,
+      ONTEM,
+    );
+
+    expect(horas(fx)).not.toContain(9);
+    expect(horas(fx)).not.toContain(10);
+    expect(horas(fx)).toContain(11);
+  });
+
+  it("não deixa um compromisso de dia inteiro travar o dia", () => {
+    // Cobrança, conta a pagar e prazo são TODOS `all_day`. Se ocupassem, todo dia com uma
+    // parcela vencendo apareceria cheio — o oposto do que este seletor existe para mostrar.
+    const fx = faixasLivres(
+      [evento({ kind: "cobranca_receber", all_day: true, starts_at: "2026-10-10T00:00:00Z", ends_at: "2026-10-10T23:59:00Z" })],
+      DIA,
+      FUSO,
+      ONTEM,
+    );
+
+    expect(horas(fx)).toHaveLength(10);
+  });
+
+  it("não deixa um compromisso cancelado travar a faixa", () => {
+    const fx = faixasLivres([evento({ status: "cancelled" })], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).toContain(9);
+  });
+
+  it("ignora compromisso de outro dia", () => {
+    const fx = faixasLivres(
+      [evento({ starts_at: "2026-10-11T12:00:00Z", ends_at: "2026-10-11T13:00:00Z" })],
+      DIA,
+      FUSO,
+      ONTEM,
+    );
+
+    expect(horas(fx)).toHaveLength(10);
+  });
+
+  it("no dia de hoje, some a faixa que já começou", () => {
+    // 17:30Z = 14:30 no fuso do tenant: 14h já correu, 15h ainda dá.
+    const agora = new Date("2026-10-10T17:30:00Z");
+
+    const fx = faixasLivres([], DIA, FUSO, agora);
+
+    expect(horas(fx)).toEqual([15, 16, 17]);
+  });
+
+  it("marca a hora pelo fuso do tenant, não pelas partes locais do Date", () => {
+    // Em Tóquio o compromisso é das 08:00 às 09:00 do dia 11; em São Paulo (fuso do runner) ele
+    // seria 20:00 do dia 10. Ler pelas partes locais do `Date` não derrubaria a faixa das 08h.
+    const fx = faixasLivres(
+      [evento({ starts_at: "2026-10-10T23:00:00Z", ends_at: "2026-10-11T00:00:00Z" })],
+      new Date(2026, 9, 11),
+      FUSO_DISTANTE,
+      ONTEM,
+    );
+
+    expect(horas(fx)).not.toContain(8);
+    expect(horas(fx)).toContain(9);
+  });
+
+  it("o compromisso que atravessa a meia-noite ocupa a manhã do dia seguinte", () => {
+    // 22:00 do dia 10 até 09:00 do dia 11, no fuso do tenant. O plantão acabou às 9h: as 08h do
+    // dia 11 estão TOMADAS, e oferecê-las é oferecer um choque.
+    const virada = evento({ starts_at: "2026-10-11T01:00:00Z", ends_at: "2026-10-11T12:00:00Z" });
+
+    const fx = faixasLivres([virada], new Date(2026, 9, 11), FUSO, ONTEM);
+
+    expect(horas(fx)).not.toContain(8);
+    expect(horas(fx)).toContain(9);
+  });
+
+  it("o compromisso que vara a noite ocupa até o fim do dia em que COMEÇOU", () => {
+    // 14:00 do dia 10 até 09:00 do dia 11. O teste irmão (acima) usa 22:00, que está fora da
+    // janela 08–18 e por isso não distingue "ocupa até a meia-noite" de "ocupa até o ends_at":
+    // sem um caso DENTRO da janela, o ramo do dia de início passa sem prova.
+    const virada = evento({ starts_at: "2026-10-10T17:00:00Z", ends_at: "2026-10-11T12:00:00Z" });
+
+    const fx = faixasLivres([virada], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).toEqual([8, 9, 10, 11, 12, 13]);
+  });
+
+  it("o compromisso de vários dias deixa o dia do MEIO inteiramente ocupado", () => {
+    // Uma viagem do dia 9 ao dia 12, com horário. O dia 10 não é nem o começo nem o fim — sem o
+    // ramo do meio ele apareceria 100% livre. Criável na tela: os dois `datetime-local` do
+    // formulário não impedem intervalo de vários dias.
+    const viagem = evento({ starts_at: "2026-10-09T15:00:00Z", ends_at: "2026-10-12T15:00:00Z" });
+
+    expect(faixasLivres([viagem], DIA, FUSO, ONTEM)).toEqual([]);
+  });
+
+  it("na hora cheia exata, a faixa que começa AGORA já não é oferecida", () => {
+    // Borda: às 14:00:00 em ponto a faixa das 14h não tem mais nem um minuto de antecedência.
+    // O caso de 14:30 (acima) passa com `<` e com `<=`; só a hora cheia separa os dois.
+    const fx = faixasLivres([], DIA, FUSO, new Date("2026-10-10T17:00:00Z"));
+
+    expect(horas(fx)).toEqual([15, 16, 17]);
+  });
+
+  it("compromisso com horário ilegível não apaga o resto do dia", () => {
+    // Inalcançável pela API (`ends_at` é NOT NULL e validado), e é justamente por isso que o
+    // modo de falha importa: uma linha estranha não pode varrer nove faixas em silêncio. O
+    // aviso de conflito do `NewEventModal` continua sendo a rede.
+    const fx = faixasLivres([evento({ ends_at: "" })], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).toHaveLength(10);
+  });
+
+  it("devolve vazio quando o dia está cheio de ponta a ponta", () => {
+    const fx = faixasLivres(
+      [evento({ starts_at: "2026-10-10T11:00:00Z", ends_at: "2026-10-10T21:00:00Z" })],
+      DIA,
+      FUSO,
+      ONTEM,
+    );
+
+    expect(fx).toEqual([]);
+  });
+});
+
+describe("densidadePorDia", () => {
+  // Ela existe por CUSTO (substituiu uma varredura de 42x no grid) e alimenta as bolinhas que
+  // dizem "tem coisa aqui" — o sinal que faz o dono escolher em que dia clicar. Sem estes testes
+  // ela podia devolver um mapa vazio e a suite inteira continuava verde.
+  it("conta por dia, no fuso do tenant", () => {
+    const mapa = densidadePorDia(
+      [
+        evento(),
+        evento({ id: "b", starts_at: "2026-10-10T18:00:00Z", ends_at: "2026-10-10T19:00:00Z" }),
+        evento({ id: "c", starts_at: "2026-10-11T18:00:00Z", ends_at: "2026-10-11T19:00:00Z" }),
+      ],
+      FUSO,
+    );
+
+    expect(mapa.get("2026-10-10")).toBe(2);
+    expect(mapa.get("2026-10-11")).toBe(1);
+    expect(mapa.get("2026-10-12")).toBeUndefined();
+  });
+
+  it("concorda com eventosDoDia, inclusive quando o fuso do tenant discorda da MÁQUINA", () => {
+    // 23:00Z do dia 10 é 08:00 do dia 11 em Tóquio. As bolinhas da grade e a lista do painel têm
+    // de apontar para o MESMO dia — senão o dono clica no dia com bolinha e não acha nada lá.
+    const e = evento({ starts_at: "2026-10-10T23:00:00Z", ends_at: "2026-10-11T00:00:00Z" });
+    const onze = new Date(2026, 9, 11);
+
+    expect(densidadePorDia([e], FUSO_DISTANTE).get("2026-10-11")).toBe(1);
+    expect(densidadePorDia([e], FUSO_DISTANTE).get("2026-10-10")).toBeUndefined();
+    expect(eventosDoDia([e], onze, FUSO_DISTANTE)).toHaveLength(1);
+  });
+
+  it("conta o de dia inteiro pela data de calendário dele", () => {
+    const cobranca = evento({
+      all_day: true,
+      starts_at: "2026-10-10T00:00:00Z",
+      ends_at: "2026-10-10T23:59:00Z",
+    });
+
+    expect(densidadePorDia([cobranca], FUSO).get("2026-10-10")).toBe(1);
+  });
+});
+
+describe("instanteNoFuso", () => {
+  it("resolve a hora de parede do tenant no instante certo", () => {
+    // 14:00 em São Paulo (UTC−3) é 17:00Z. É este instante que vai para a API — e é por isso que
+    // a faixa oferecida não pode virar uma string ingênua reinterpretada no fuso do NAVEGADOR.
+    expect(instanteNoFuso(DIA, 14 * 60, FUSO).toISOString()).toBe("2026-10-10T17:00:00.000Z");
+  });
+
+  it("resolve a mesma hora de parede num fuso adiantado", () => {
+    // 14:00 em Tóquio (UTC+9) é 05:00Z do MESMO dia.
+    expect(instanteNoFuso(DIA, 14 * 60, FUSO_DISTANTE).toISOString()).toBe("2026-10-10T05:00:00.000Z");
+  });
+
+  it("acerta o instante do outro lado de uma virada de horário de verão", () => {
+    // ⚠️ A zona e a data NÃO são intercambiáveis, e a primeira versão deste teste era decorativa:
+    // com `America/New_York` em 01/11 a transição (06:00Z) cai ANTES da parede das 14:00Z, então
+    // a primeira aproximação já acerta e a segunda passada nunca é exercitada — uma implementação
+    // de passada única passava neste teste.
+    // Sydney (a LESTE de Greenwich) em 04/04/2026 é o caso que separa as duas: 16:00 locais são
+    // 05:00Z, e a conta de uma passada só devolveria 06:00Z (17:00 na tela).
+    expect(instanteNoFuso(new Date(2026, 3, 4), 16 * 60, "Australia/Sydney").toISOString()).toBe(
+      "2026-04-04T05:00:00.000Z",
+    );
+    // A virada de outubro, no sentido oposto.
+    expect(instanteNoFuso(new Date(2026, 9, 3), 17 * 60, "Australia/Sydney").toISOString()).toBe(
+      "2026-10-03T07:00:00.000Z",
+    );
+    // E o caso original, que continua valendo como não-membro (acerta com uma ou duas passadas).
+    expect(instanteNoFuso(new Date(2026, 10, 1), 14 * 60, "America/New_York").toISOString()).toBe(
+      "2026-11-01T19:00:00.000Z",
+    );
+  });
+
+  it("a hora de parede volta a ser a MESMA hora quando lida no fuso do tenant", () => {
+    // O invariante que amarra `instanteNoFuso` ao resto: o que sai tem de ser lido de volta como a
+    // hora que entrou. Varre zonas com e sem horário de verão, dos dois lados de Greenwich, em
+    // datas de virada — é o que impediria uma implementação de offset que dependa do fuso da
+    // MÁQUINA de passar despercebida sob um runner sem horário de verão.
+    const zonas = [
+      "America/Sao_Paulo",
+      "Asia/Tokyo",
+      "Australia/Sydney",
+      "Pacific/Auckland",
+      "America/New_York",
+      "Europe/Lisbon",
+      "Asia/Kathmandu",
+    ];
+    const dias = [new Date(2026, 3, 4), new Date(2026, 9, 3), new Date(2026, 10, 1), new Date(2026, 5, 15)];
+
+    for (const zona of zonas) {
+      for (const dia of dias) {
+        for (let h = HORA_ABERTURA; h < HORA_FECHAMENTO; h++) {
+          const lido = formatTime(instanteNoFuso(dia, h * 60, zona).toISOString(), zona);
+          expect(`${zona} ${localYmd(dia)} ${h}h -> ${lido}`).toBe(
+            `${zona} ${localYmd(dia)} ${h}h -> ${String(h).padStart(2, "0")}:00`,
+          );
+        }
+      }
+    }
+  });
+});

--- a/apps/web/src/features/agenda/grade.ts
+++ b/apps/web/src/features/agenda/grade.ts
@@ -1,0 +1,296 @@
+import type { AgendaEvent } from "@e1p/shared-types";
+import { formatTime, fusoValido, localYmd, today } from "../../lib/datetime";
+
+/**
+ * A aritmética de calendário da Agenda — em sua maior parte POSIÇÕES numa grade, não instantes.
+ *
+ * Vive fora do `AgendaPage.tsx` porque o seletor de horário da ficha 360° (`EscolherHorario`)
+ * precisa exatamente da mesma matemática. Duplicar `startOfWeek`/`addDays` em dois lugares é
+ * como um dos dois calendários acaba começando a semana num dia diferente do outro.
+ *
+ * ⚠️ **`instanteNoFuso` e `offsetEmMinutos` são a exceção, e estão aqui provisoriamente.** Eles
+ * produzem e manipulam INSTANTE, que pela contabilidade do repo é matéria de `lib/datetime.ts`.
+ * Ficaram juntos da grade porque nascem dela (a hora de parede vem de `faixasLivres`), mas quando
+ * a terceira espécie — "posição de grade" — for aberta naquele módulo, estes dois vão junto:
+ * senão `grade.ts` vira o segundo módulo de fuso do frontend e a porta única deixa de ser única
+ * também nesse eixo. Ver a dívida registrada no CLAUDE.md.
+ */
+
+// ── posições na grade ──────────────────────────────────
+export const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+export const addDays = (d: Date, n: number) => {
+  const r = startOfDay(d);
+  r.setDate(r.getDate() + n);
+  return r;
+};
+export const startOfWeek = (d: Date) => addDays(d, -d.getDay()); // semana começa no domingo
+export const sameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
+
+/**
+ * "Hoje" no fuso do TENANT, como `Date` local — a âncora da grade do calendário.
+ *
+ * A grade inteira (`startOfDay`, `addDays`, `startOfWeek`, `localYmd`) trabalha em `Date` local,
+ * e isso é coerente: são posições numa grade, não instantes. O que NÃO podia continuar local era
+ * o ponto de partida — `new Date()` num navegador em UTC começava a grade no dia errado.
+ * Montamos o dia certo pelas PARTES, para que a `Date` resultante seja a meia-noite local desse
+ * dia e toda a aritmética seguinte continue valendo.
+ */
+export const hojeDoTenant = (tz: string) => {
+  const [a, m, d] = today(tz).split("-").map(Number);
+  return new Date(a, m - 1, d);
+};
+
+export const WEEKDAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+/**
+ * A grade de 6 semanas do mês de `anchor`, começando no domingo anterior ao dia 1 — 42 células,
+ * sempre. `start`/`end` são as fronteiras para pedir os eventos à API.
+ */
+export function gradeDoMes(anchor: Date): { start: Date; end: Date; days: Date[] } {
+  const first = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
+  const gridStart = startOfWeek(first);
+  const days = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+  return { start: gridStart, end: addDays(gridStart, 42), days };
+}
+
+/**
+ * Eventos de dia inteiro (cobranças, contas a pagar, prazos) são gravados à meia-noite UTC:
+ * casamos pela DATA do calendário (sem fuso) para não "voltar" um dia em fuso negativo.
+ * Eventos com horário usam a data local normalmente.
+ */
+export const eventYmd = (e: AgendaEvent) =>
+  e.all_day ? e.starts_at.slice(0, 10) : localYmd(new Date(e.starts_at));
+
+export const eventsOfDay = (events: AgendaEvent[], d: Date) =>
+  events
+    .filter((e) => eventYmd(e) === localYmd(d))
+    .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at));
+
+// ── faixas livres do dia ───────────────────────────────
+
+/**
+ * A janela de trabalho assumida pelo seletor de horário. É FIXA de propósito: não existe
+ * expediente configurável no backend, e inventar um (migration + endpoint + tela) para oferecer
+ * atalhos de horário seria construir um épico para resolver um clique. O botão "Outro horário"
+ * do seletor é a válvula de escape para tudo que cai fora daqui.
+ */
+export const HORA_ABERTURA = 8;
+export const HORA_FECHAMENTO = 18;
+
+export type Faixa = { hora: number; inicio: string; fim: string };
+
+/** `14` => `"14:00"`. O `% 24` faz `24` virar `"00:00"` — meia-noite, não "24:00". */
+export const horaCheia = (h: number) => `${String(h % 24).padStart(2, "0")}:00`;
+
+const hhmm = (minutos: number) => horaCheia(Math.floor(minutos / 60));
+
+const emMinutos = (hhmmStr: string) => {
+  const [h, m] = hhmmStr.split(":").map(Number);
+  return h * 60 + m;
+};
+
+/** "Que dia é este instante, no fuso do tenant?" — a pergunta tem quatro lugares que a fazem. */
+const diaDoInstante = (iso: string, fuso: string) => today(fuso, new Date(iso));
+
+/** A data do evento no fuso do TENANT. Dia inteiro é data de calendário: não passa por fuso. */
+const diaDoEvento = (e: AgendaEvent, fuso: string) =>
+  e.all_day ? e.starts_at.slice(0, 10) : diaDoInstante(e.starts_at, fuso);
+
+/**
+ * Os eventos de `dia`, agrupados pelo fuso do TENANT.
+ *
+ * Irmão de `eventsOfDay`, e a diferença é o ponto: aquele agrupa por `localYmd(new Date(iso))`,
+ * isto é, pelo fuso do NAVEGADOR — convenção antiga do `AgendaPage`, correta na prática porque o
+ * dono abre a tela na própria cidade. Aqui não dá para conviver com o desvio: as faixas livres
+ * já são calculadas no fuso do tenant, e as duas listas precisam concordar sobre a que dia um
+ * compromisso das 23h pertence, senão o seletor mostra uma faixa livre logo abaixo do
+ * compromisso que a ocupa.
+ */
+export function eventosDoDia(eventos: AgendaEvent[], dia: Date, fuso: string): AgendaEvent[] {
+  const ymd = localYmd(dia);
+  return eventos
+    .filter((e) => diaDoEvento(e, fuso) === ymd)
+    .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at));
+}
+
+/**
+ * Quantos compromissos cada dia tem, no fuso do tenant — `YYYY-MM-DD` → contagem.
+ *
+ * Existe por CUSTO, não por elegância: a grade tem 42 células, e perguntar a cada uma "quantos
+ * eventos são seus?" varre a lista inteira 42 vezes. Como `today()` constrói dois
+ * `Intl.DateTimeFormat` descartáveis por chamada, isso vira centenas de milissegundos de main
+ * thread travada por render num mês movimentado — e o render se repete a cada toque num dia.
+ */
+export function densidadePorDia(eventos: AgendaEvent[], fuso: string): Map<string, number> {
+  const porDia = new Map<string, number>();
+  for (const e of eventos) {
+    const ymd = diaDoEvento(e, fuso);
+    porDia.set(ymd, (porDia.get(ymd) ?? 0) + 1);
+  }
+  return porDia;
+}
+
+/**
+ * Os parâmetros de `GET /agenda/events` para uma janela de grade.
+ *
+ * Fronteiras em UTC-date (meia-noite UTC da data do grid), NÃO o local→UTC: assim os eventos de
+ * dia inteiro (gravados à meia-noite UTC) não caem fora do range nas bordas. Mora aqui porque os
+ * dois calendários — a tela de Agenda e o seletor da ficha — pedem o mesmo mês, e a regra vivia
+ * num comentário copiado nos dois arquivos. Regra que mora em comentário duplicado é regra que
+ * deriva.
+ */
+export const paramsDaGrade = (start: Date, end: Date) => ({
+  start: `${localYmd(start)}T00:00:00.000Z`,
+  end: `${localYmd(end)}T00:00:00.000Z`,
+  limit: 500,
+});
+
+type Intervalo = { inicio: number; fim: number };
+
+/**
+ * O trecho de `ymd` que este compromisso ocupa, em minutos do fuso do tenant — ou `null` quando
+ * ele não encosta no dia.
+ *
+ * Os três ramos existem porque um compromisso pode ATRAVESSAR a meia-noite: um plantão das 22h às
+ * 9h começa num dia e termina no outro. Filtrar só pelo dia de `starts_at` (o que `eventosDoDia`
+ * faz, e está certo para LISTAR) deixaria a manhã do dia seguinte inteiramente livre na oferta,
+ * em cima de um compromisso existente.
+ *
+ * Horário ilegível devolve `null` em vez de ocupar até a meia-noite: uma linha estranha não pode
+ * varrer nove faixas em silêncio, e o aviso de conflito do `NewEventModal` continua sendo a rede.
+ */
+function intervaloNoDia(e: AgendaEvent, ymd: string, fuso: string): Intervalo | null {
+  // As duas datas primeiro, e a saída antes de qualquer `formatTime`: numa janela de 42 dias, 97%
+  // dos eventos não encostam no dia pedido, e formatá-los era o termo dominante do custo.
+  const diaInicio = diaDoInstante(e.starts_at, fuso);
+  const diaFim = diaDoInstante(e.ends_at, fuso);
+  if (ymd < diaInicio || diaFim < ymd) return null;
+  if (diaInicio < ymd && ymd < diaFim) return { inicio: 0, fim: 24 * 60 };
+
+  const minInicio = emMinutos(formatTime(e.starts_at, fuso));
+  const minFim = emMinutos(formatTime(e.ends_at, fuso));
+  if (!Number.isFinite(minInicio) || !Number.isFinite(minFim)) return null;
+
+  if (diaInicio === ymd) return { inicio: minInicio, fim: diaFim === ymd ? minFim : 24 * 60 };
+  return { inicio: 0, fim: minFim };
+}
+
+/**
+ * A hora de parede `minutos` do dia `dia`, no fuso do TENANT, como instante real.
+ *
+ * Existe porque a faixa oferecida é decidida no fuso do tenant e o `<input type="datetime-local">`
+ * do formulário fala no fuso do NAVEGADOR: entregar `"14:00"` como string ingênua faria
+ * `new Date(...)` reinterpretá-la na máquina de quem abriu a tela, e um dono viajando marcaria
+ * 15:00 achando que marcou 14:00 — a família §6.0 do CLAUDE.md, na costura entre os dois.
+ *
+ * Duas passadas de propósito: o offset usado na primeira aproximação pode não ser o offset do
+ * instante resultante quando o dia tem virada de horário de verão.
+ */
+export function instanteNoFuso(dia: Date, minutos: number, fuso: string): Date {
+  const parede = Date.UTC(dia.getFullYear(), dia.getMonth(), dia.getDate(), 0, minutos);
+  const aproximado = new Date(parede - offsetEmMinutos(fuso, new Date(parede)) * 60_000);
+  return new Date(parede - offsetEmMinutos(fuso, aproximado) * 60_000);
+}
+
+/**
+ * Quantos minutos o fuso está à frente do UTC NAQUELE instante (negativo a oeste de Greenwich).
+ *
+ * ⚠️ **Sem `new Date(string)` em lugar nenhum, e a ausência é a funcionalidade.** O truque comum —
+ * `new Date(x.toLocaleString("en-US", { timeZone: … }))` dos dois lados e subtrair — parece
+ * cancelar o fuso da MÁQUINA, e cancela, exceto quando as duas strings caem em lados opostos da
+ * virada de horário de verão **do navegador**: aí sobram 60 minutos. Medido antes do conserto: com
+ * a máquina em `America/New_York`, 52 combinações de (fuso do tenant × dia × hora) devolviam a
+ * hora errada — um tenant em Sydney via a faixa "08:00" virar 09:00 no formulário, nos dois dias
+ * do ano em que os EUA viram o relógio. O produto é brasileiro e o Brasil não tem horário de
+ * verão, mas `tenants.timezone` aceita qualquer zona IANA, e o fuso do NAVEGADOR é de quem abre a
+ * tela, não de quem configurou o tenant.
+ *
+ * `formatToParts` lê as partes de parede direto no fuso alvo, e `Date.UTC` as remonta sem passar
+ * por parser nenhum: o fuso da máquina não entra na conta em momento algum.
+ */
+function offsetEmMinutos(fuso: string, instante: Date): number {
+  const partes: Record<string, string> = {};
+  for (const { type, value } of formatadorDe(fusoValido(fuso)).formatToParts(instante)) {
+    partes[type] = value;
+  }
+  const comoSeFosseUtc = Date.UTC(
+    Number(partes.year),
+    Number(partes.month) - 1,
+    Number(partes.day),
+    // `hour12: false` produz "24" para a meia-noite em alguns ambientes; `% 24` normaliza.
+    Number(partes.hour) % 24,
+    Number(partes.minute),
+    Number(partes.second),
+  );
+  // As partes têm resolução de SEGUNDO: truncar o instante evita um resto de milissegundos virar
+  // um offset quebrado.
+  return (comoSeFosseUtc - Math.floor(instante.getTime() / 1000) * 1000) / 60_000;
+}
+
+/**
+ * Um `Intl.DateTimeFormat` por fuso, reaproveitado.
+ *
+ * Construir um custa ~90 µs, e `instanteNoFuso` chama `offsetEmMinutos` duas vezes por faixa
+ * oferecida. O `Map` é global de propósito: o conjunto de fusos vivos numa sessão é UM (o do
+ * tenant), então não há o que expurgar.
+ */
+const FORMATADORES = new Map<string, Intl.DateTimeFormat>();
+const formatadorDe = (tz: string) => {
+  const existente = FORMATADORES.get(tz);
+  if (existente) return existente;
+  const novo = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  FORMATADORES.set(tz, novo);
+  return novo;
+};
+
+/**
+ * Os blocos de 1h ainda livres em `dia`, no fuso do tenant.
+ *
+ * Três exclusões deliberadas, cada uma um jeito diferente de errar:
+ * - **`all_day` não ocupa.** Cobrança, conta a pagar e prazo são TODOS de dia inteiro; se
+ *   ocupassem, todo dia com uma parcela vencendo apareceria cheio — o oposto do que o seletor
+ *   existe para mostrar.
+ * - **Cancelado não ocupa.** Mesma postura do `BlocoDaAgenda`, que pede `exclude_cancelled`.
+ * - **No dia de hoje, o que já começou some.** Oferecer 09:00 às 11h da manhã é oferecer erro.
+ *
+ * Tudo é comparado em minutos DO FUSO DO TENANT (`formatTime`), nunca pelas partes locais de um
+ * `Date` — `localYmd`/`getHours()` sobre um instante da API leem o fuso do NAVEGADOR e trocariam
+ * as faixas de lugar num notebook em viagem ou num headless em UTC.
+ */
+export function faixasLivres(
+  eventos: AgendaEvent[],
+  dia: Date,
+  fuso: string,
+  agora: Date = new Date(),
+): Faixa[] {
+  const ymd = localYmd(dia);
+
+  const ocupado = eventos
+    .filter((e) => !e.all_day && e.status !== "cancelled")
+    .map((e) => intervaloNoDia(e, ymd, fuso))
+    .filter((i): i is Intervalo => i !== null);
+
+  // −1 em qualquer outro dia: nada do passado a cortar.
+  const corte = today(fuso, agora) === ymd ? emMinutos(formatTime(agora.toISOString(), fuso)) : -1;
+
+  const livres: Faixa[] = [];
+  for (let h = HORA_ABERTURA; h < HORA_FECHAMENTO; h++) {
+    const inicio = h * 60;
+    const fim = inicio + 60;
+    // `<=`: às 14:00:00 em ponto a faixa das 14h não tem mais nem um minuto de
+    // antecedência. Com `<` estrito ela seria oferecida, contra a própria regra acima.
+    if (inicio <= corte) continue;
+    if (ocupado.some((o) => o.inicio < fim && o.fim > inicio)) continue;
+    livres.push({ hora: h, inicio: hhmm(inicio), fim: hhmm(fim) });
+  }
+  return livres;
+}

--- a/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import BlocoDaAgenda from "./BlocoDaAgenda";
 
@@ -30,7 +30,7 @@ function mockar(eventos: unknown[]) {
   vi.mocked(api.get).mockResolvedValue({ data: eventos } as never);
 }
 
-const renderBloco = () => render(<BlocoDaAgenda clientId="cli-1" />);
+const renderBloco = () => render(<BlocoDaAgenda clientId="cli-1" nome="Loana" />);
 
 // Mesmo motivo do `beforeEach` em `BlocoDaConversa.test.tsx`: `mockReset()` devolve o próprio
 // mock, e um corpo de expressão única faria o Vitest tratar esse retorno como hook de limpeza
@@ -38,6 +38,12 @@ const renderBloco = () => render(<BlocoDaAgenda clientId="cli-1" />);
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
   vi.mocked(api.post).mockReset();
+});
+
+// Em `afterEach`, não no corpo do teste: se uma asserção falhar antes do `useRealTimers()`, os
+// fake timers vazam para os testes seguintes e uma falha vira cascata de falhas sem relação.
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("BlocoDaAgenda", () => {
@@ -101,24 +107,46 @@ describe("BlocoDaAgenda", () => {
     ).toBeInTheDocument();
   });
 
-  it("abre o modal de marcar e, ao criar, recarrega a lista", async () => {
-    const user = userEvent.setup();
+  it("mostra a agenda antes do formulário — o formulário não abre no primeiro clique", async () => {
+    // O gap que este bloco tinha: "Marcar com este cliente" abria o formulário direto, e o dono
+    // escolhia a data sem ver o próprio calendário. Agora a disponibilidade vem primeiro.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-16T12:00:00Z"));
+    mockar([]);
+    renderBloco();
+
+    await screen.findByText("Nenhum compromisso marcado");
+    await userEvent.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+
+    expect(screen.getByRole("heading", { name: "Marcar com Loana" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Novo evento" })).not.toBeInTheDocument();
+  });
+
+  it("escolher um horário abre o formulário já preenchido e, ao criar, recarrega a lista", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-16T12:00:00Z"));
     mockar([]);
     vi.mocked(api.post).mockResolvedValue({ data: { conflicts: [] } } as never);
     renderBloco();
 
     await screen.findByText("Nenhum compromisso marcado");
-    await user.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+    await userEvent.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /20 de agosto/ }));
+    await userEvent.click(screen.getByRole("button", { name: "10:00–11:00" }));
+
+    // O seletor sai de cena e o formulário entra com a escolha já feita — o dono não redigita
+    // a data que acabou de apontar no calendário.
     expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Marcar com Loana" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Início")).toHaveValue("2026-08-20T10:00");
+    expect(screen.getByLabelText("Fim")).toHaveValue("2026-08-20T11:00");
 
     // Depois de abrir, a próxima chamada a `GET /agenda/events` já devolve o evento recém-criado
     // — é isso que prova que a lista recarregou, e não só que o modal fechou.
     mockar([evento({ id: "ev-novo", title: "Atendimento cliente" })]);
 
-    await user.type(screen.getByLabelText("Título"), "Atendimento cliente");
-    fireEvent.change(screen.getByLabelText("Início"), { target: { value: "2026-08-20T09:00" } });
-    fireEvent.change(screen.getByLabelText("Fim"), { target: { value: "2026-08-20T10:00" } });
-    await user.click(screen.getByRole("button", { name: "Criar evento" }));
+    await userEvent.type(screen.getByLabelText("Título"), "Atendimento cliente");
+    await userEvent.click(screen.getByRole("button", { name: "Criar evento" }));
 
     // O evento nasce ligado a ESTE contato — mesmo vínculo que a Task 5 testou no modal isolado.
     expect(vi.mocked(api.post)).toHaveBeenCalledWith(
@@ -131,8 +159,12 @@ describe("BlocoDaAgenda", () => {
   });
 
   it("formata o horário no fuso do tenant", async () => {
-    // 13:00 UTC em America/Sao_Paulo (UTC-3, sem horário de verão) é 10:00 — se o bloco usasse
-    // o fuso do NAVEGADOR (headless roda em UTC) o teste pegaria "13:00" em vez de "10:00".
+    // 13:00 UTC em America/Sao_Paulo (UTC−3, sem horário de verão) é 10:00.
+    // ⚠️ Este teste NÃO distingue fuso do tenant de fuso do navegador, e o comentário anterior
+    // dizia que sim ("headless roda em UTC"): `vitest.config.ts` fixa `TZ: "America/Sao_Paulo"`
+    // para a suíte inteira, e o mock de `useFuso` devolve o mesmo valor — com os dois iguais, os
+    // dois caminhos dão o mesmo resultado. Quem quiser essa prova use um fuso de tenant DIFERENTE
+    // do runner, como `grade.test.ts` faz com `FUSO_DISTANTE`.
     mockar([evento({ starts_at: "2026-08-20T13:00:00Z" })]);
     renderBloco();
 
@@ -144,5 +176,35 @@ describe("BlocoDaAgenda", () => {
     renderBloco();
 
     expect(await screen.findByText(/não foi possível carregar a agenda/i)).toBeInTheDocument();
+  });
+
+  it("o formulário nasce limpo a cada escolha — 'Dia inteiro' de uma vez anterior não engole a hora nova", async () => {
+    // O `NewEventModal` fica MONTADO o tempo todo e guarda estado próprio. `allDay`, título e
+    // aviso de conflito nunca eram resetados: o dono marcava "Dia inteiro" uma vez e, na próxima
+    // vez que apontasse uma faixa livre, o `save()` descartava `start`/`end` em silêncio e criava
+    // um evento sem horário. É o defeito que o `NewBillModal` já pagou com `key` (CLAUDE.md).
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-16T12:00:00Z"));
+    mockar([]);
+    renderBloco();
+
+    await screen.findByText("Nenhum compromisso marcado");
+    await userEvent.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /20 de agosto/ }));
+    await userEvent.click(screen.getByRole("button", { name: "10:00–11:00" }));
+
+    await userEvent.type(screen.getByLabelText("Título"), "rascunho abandonado");
+    await userEvent.click(screen.getByLabelText("Dia inteiro"));
+    expect(screen.getByLabelText("Dia inteiro")).toBeChecked();
+
+    // Desiste e recomeça.
+    await userEvent.click(screen.getByRole("button", { name: /fechar/i }));
+    await userEvent.click(screen.getByRole("button", { name: /marcar com este cliente/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /21 de agosto/ }));
+    await userEvent.click(screen.getByRole("button", { name: "14:00–15:00" }));
+
+    expect(screen.getByLabelText("Dia inteiro")).not.toBeChecked();
+    expect(screen.getByLabelText("Título")).toHaveValue("");
+    expect(screen.getByLabelText("Início")).toHaveValue("2026-08-21T14:00");
   });
 });

--- a/apps/web/src/features/crm/BlocoDaAgenda.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { api } from "../../lib/api";
 import { formatDateTime, formatDay } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
+import EscolherHorario from "../agenda/EscolherHorario";
 import NewEventModal from "../agenda/NewEventModal";
 
 /**
@@ -14,12 +15,21 @@ import NewEventModal from "../agenda/NewEventModal";
  * botão "Marcar com este cliente" para o dono agir sem sair da tela. O estado vazio é o mais
  * importante dos dois — "Nenhum compromisso marcado" é o sinal de um contato esfriando no funil.
  */
-export default function BlocoDaAgenda({ clientId }: { clientId: string }) {
+export default function BlocoDaAgenda({ clientId, nome }: { clientId: string; nome: string }) {
   const fuso = useFuso();
   const [eventos, setEventos] = useState<AgendaEvent[]>([]);
   const [erro, setErro] = useState(false);
   const [carregando, setCarregando] = useState(true);
-  const [open, setOpen] = useState(false);
+  // Dois passos, dois estados: primeiro o dono vê a agenda (`escolhendo`), depois preenche o
+  // formulário (`escolha`). `escolha` guardar o dia (e a hora, quando veio de uma faixa) é o que
+  // faz o formulário nascer preenchido.
+  const [escolhendo, setEscolhendo] = useState(false);
+  // `seq` é o que faz o `key` do formulário MUDAR a cada escolha — inclusive quando o dono
+  // reescolhe exatamente o mesmo dia e a mesma hora. Sem ele, a chave se repetiria e o React
+  // reusaria a instância suja.
+  const [escolha, setEscolha] = useState<{ dia: Date; hora: number | null; seq: number } | null>(
+    null,
+  );
 
   const load = useCallback(async () => {
     // Falha aqui NÃO pode derrubar a ficha — mesma postura do `BlocoDaConversa`: degrada para um
@@ -89,19 +99,42 @@ export default function BlocoDaAgenda({ clientId }: { clientId: string }) {
       )}
 
       <button
-        onClick={() => setOpen(true)}
+        onClick={() => setEscolhendo(true)}
         className="flex w-full items-center justify-center gap-1.5 rounded-pill bg-primary-50 py-2 text-sm font-semibold text-primary-600 hover:bg-primary-100"
       >
         <CalendarPlus size={14} /> Marcar com este cliente
       </button>
 
-      {/* Reusa o `NewEventModal` da Task 5 — ele já cuida do aviso de conflito, mantendo-se
-          aberto quando a API reporta sobreposição para o dono decidir. `onCreated` só recarrega
-          a lista; o próprio modal chama `onClose` quando não há conflito. */}
+      {/* Passo 1 — "quando dá?". Mostra o mês do dono e as faixas livres do dia. Só depois de
+          uma escolha o formulário aparece: era aqui que o dono marcava às cegas. */}
+      <EscolherHorario
+        open={escolhendo}
+        nome={nome}
+        onClose={() => setEscolhendo(false)}
+        onEscolher={(dia, hora) => {
+          setEscolha((anterior) => ({ dia, hora, seq: (anterior?.seq ?? 0) + 1 }));
+          setEscolhendo(false);
+        }}
+      />
+
+      {/* Passo 2 — reusa o `NewEventModal` da Task 5, que já cuida do aviso de conflito,
+          mantendo-se aberto quando a API reporta sobreposição para o dono decidir. `onCreated`
+          só recarrega a lista; o próprio modal chama `onClose` quando não há conflito.
+          O aviso de conflito continua importando mesmo com o seletor na frente: a agenda pode ter
+          mudado entre abrir o mês e salvar, e o seletor não conhece compromisso fora de 08–18h. */}
+      {/* ⚠️ O `key` NÃO é enfeite. O `NewEventModal` fica montado o tempo todo e guarda estado
+          próprio; só `startDate`/`start`/`end` são reescritos ao abrir. `allDay`, título,
+          descrição, convidados e o aviso de conflito sobreviviam de uma abertura para a outra — e
+          um "Dia inteiro" herdado faz o `save()` DESCARTAR a hora que o dono acabou de apontar na
+          faixa livre, em silêncio. É o mesmo defeito que o `NewBillModal` já pagou com `key`, e a
+          primeira abertura de cada sessão sempre funciona, o que é o que o esconde num teste
+          manual apressado. */}
       <NewEventModal
-        open={open}
-        initialDate={null}
-        onClose={() => setOpen(false)}
+        key={escolha?.seq ?? 0}
+        open={escolha !== null}
+        initialDate={escolha?.dia ?? null}
+        initialHour={escolha?.hora ?? null}
+        onClose={() => setEscolha(null)}
         onCreated={load}
         clientId={clientId}
       />

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -142,7 +142,7 @@ export default function ClientDetailPage() {
           documento (o cabeçalho do cliente). Sem recorte próprio, a régua de 360px mediria o
           cabeçalho em vez da Agenda. */}
       <Section icon={<CalendarDays size={16} />} title="Agenda" testId="secao-agenda">
-        <BlocoDaAgenda clientId={id} />
+        <BlocoDaAgenda clientId={id} nome={client.name} />
       </Section>
 
       {/* Cobranças */}

--- a/apps/web/src/lib/texto.ts
+++ b/apps/web/src/lib/texto.ts
@@ -1,0 +1,11 @@
+/**
+ * Operações de texto que não pertencem a nenhum domínio.
+ *
+ * Existe pelo mesmo motivo de `lib/pluralize.ts`, que é um módulo de três linhas: um one-liner
+ * repetido em quatro arquivos é quatro chances de alguém "melhorar" um deles. Não mora em
+ * `lib/datetime.ts` de propósito — o contrato estreito daquele módulo ("data e hora, e as duas
+ * espécies não se misturam") é justamente o que o torna cobrável.
+ */
+
+/** `"junho de 2026"` → `"Junho de 2026"`. Só a primeira letra, sem tocar no resto. */
+export const sentenceCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);

--- a/apps/web/src/test/fixtures/agenda.ts
+++ b/apps/web/src/test/fixtures/agenda.ts
@@ -1,0 +1,35 @@
+import type { AgendaEvent } from "@e1p/shared-types";
+
+/**
+ * Um `AgendaEvent` completo, para os testes que precisam de um sem se importar com os 21 campos.
+ *
+ * Existe porque o literal já vivia copiado em vários specs: o 22º campo do tipo obrigaria uma
+ * edição por cópia, e as cópias dos testes de e2e nem eram TIPADAS — o TypeScript não avisaria.
+ * Tipado como `AgendaEvent` de propósito: é o que faz o compilador cobrar o campo novo aqui, uma
+ * vez, em vez de deixar cada spec descobrir sozinho em runtime.
+ */
+export const agendaEvent = (over: Partial<AgendaEvent> = {}): AgendaEvent =>
+  ({
+    id: "ev-1",
+    tenant_id: "t1",
+    title: "Atendimento",
+    description: "",
+    kind: "atendimento",
+    status: "scheduled",
+    priority: "normal",
+    source: "manual",
+    starts_at: "2026-10-10T12:00:00Z",
+    ends_at: "2026-10-10T13:00:00Z",
+    all_day: false,
+    location: "",
+    meeting_url: null,
+    guests: [],
+    amount_cents: null,
+    external_ref: null,
+    google_event_id: null,
+    client_id: null,
+    client_name: null,
+    created_by_ai: false,
+    created_at: "2026-10-01T10:00:00Z",
+    ...over,
+  }) as AgendaEvent;


### PR DESCRIPTION
## O que muda

O botão **"Marcar com este cliente"** da ficha 360° abria o formulário de evento direto: o dono escolhia data e hora **sem ver o próprio calendário** e só descobria a colisão depois de salvar, pelo aviso de conflito. Agora o passo 1 é a disponibilidade — grade do mês com marcadores de ocupação, o que já está marcado no dia escolhido, e as faixas livres de 1h entre 08:00 e 18:00 — e o formulário só aparece com data e hora decididas.

**Zero backend, zero migration.** Reusa `GET /agenda/events`.

## Decisões que valem revisão

- **Evento de dia inteiro NÃO ocupa faixa.** Cobrança, conta a pagar e prazo são todos `all_day`; se ocupassem, todo dia com uma parcela vencendo apareceria cheio — o oposto do que o seletor existe para mostrar. Tem teste fixando isso.
- **O seletor não recebe `clientId`** — disponibilidade é a agenda do dono inteira, não os compromissos daquele contato.
- **A janela 08–18h é fixa** e `Outro horário` é a válvula de escape. Expediente configurável seria migration + endpoint + tela para resolver um clique.
- **A grade de 7 colunas não alcança 44px de alvo tocável em 360px** — 7 × 44 = 308px + vãos contra 280px de área útil no modal. A exceção está escrita dentro do teste, com uma rede própria (altura mínima medida de 36px), no padrão já documentado do `modal-conta-360.spec.ts`.

## O que o QA achou — com a suíte 100% verde

Dois ciclos de `regression-tester` / `bug-hunter` / `dedup-checker`. O caça-bugs deu **FAIL** no primeiro e **CONCERNS** no segundo; tudo abaixo foi corrigido com teste que falhou antes.

| Defeito | Consequência |
|---|---|
| Trocar de mês deixava o dia selecionado órfão | Um dia **lotado** passava a exibir as dez faixas livres; clicar marcava em cima de um compromisso |
| Faixa escolhida no fuso do tenant, gravada no fuso do navegador | Dono aponta 14:00 e o evento nasce às 15:00 |
| **A correção acima introduziu um bug de fuso próprio** | `new Date(toLocaleString(...))` quebrava na virada de horário de verão da MÁQUINA |
| Densidade da grade em O(42 × N) | 342 ms a 3,3 s de main thread travada por render |
| `allDay` residual do `NewEventModal` | Descartava **em silêncio** a hora recém-escolhida |
| Compromisso atravessando a meia-noite | Não ocupava a manhã do dia seguinte |
| Régua de 360px cega para cabeçalho/rodapé do `Modal` | Nome sem espaço empurrava o "Fechar" para **x=698 numa tela de 360**, e a varredura devolvia lista vazia |

### O achado que mais importa

`offsetEmMinutos` calculava o offset com `new Date(x.toLocaleString(..., { timeZone }))` dos dois lados. Cancela o fuso da máquina — **exceto** quando as duas strings caem em lados opostos da virada de horário de verão do navegador. Varredura de 16.643 combinações:

| fuso da MÁQUINA | com `new Date(string)` | com `formatToParts` |
|---|---|---|
| `America/New_York` | **52 quebras** | 0 |
| `Australia/Sydney` | **29** | 0 |
| `Europe/Dublin` | **23** | 0 |
| `America/Sao_Paulo` | 0 | 0 |

A última linha é o ponto: **sob o fuso que o `vitest.config.ts` fixa, as duas implementações são indistinguíveis** — nenhum teste desta suíte poderia pegar isso.

### E os testes que passavam sem provar nada

- **5 de 5 mutações no coração do `grade.ts` sobreviviam** aos 11 testes verdes, incluindo trocar o fuso do tenant pelo do navegador — no teste literalmente chamado *"agrupa pelo dia do TENANT, não pelo do navegador"*. Causa: `TZ` do runner **igual** ao fuso mockado. Agora há `FUSO_DISTANTE = "Asia/Tokyo"`, e as mutações morrem.
- `densidadePorDia` podia devolver mapa vazio — as bolinhas do calendário sumindo inteiras — e passava em **41 de 41**.
- O teste de horário de verão era decorativo: o caso escolhido acertava já na primeira aproximação, então a segunda passada nunca era exercitada.

## Verificação

- **693 testes** `vitest` (69 arquivos)
- **32 medições** no gate de 360px, 4 delas novas
- `tsc --noEmit` e `eslint --max-warnings 0` limpos
- Consertos verificados **por mutação** (cópia de arquivo, nunca `git checkout`): cada um derruba o teste que o cobre

## Dívidas registradas no CLAUDE.md

Cinco, com número: `eventosDoDia` × `eventsOfDay` discordando entre telas quando navegador ≠ tenant; a "terceira espécie" (posição de grade) faltando em `lib/datetime.ts`, com `instanteNoFuso`/`offsetEmMinutos` marcados para migrar junto; o token de 44px; navegação por teclado na grade; e a contagem de `rounded-pill`, que estava registrada como 7 e são **190**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
