### PR TITLE
docs: o job frontend ja e required check — quatro arquivos paravam de dizer isso (#122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,24 @@
 # e garante o isolamento RLS num Postgres real (testcontainers).
 # Story 6.2: adiciona `secret-scan` (gitleaks) e `sast-semgrep` como gates de segurança.
 #
-# Gate obrigatório: se qualquer job falhar, o workflow fica vermelho. Para que isso
-# BLOQUEIE merge/deploy de fato, @devops deve habilitar branch protection em
-# GitHub → Settings → Branches → "Require status checks to pass" marcando
-# `test-in-prod-image` e `cross-tenant-rls` (follow-up fora do escopo de código — Task 5).
+# Gate obrigatório: se qualquer job falhar, o workflow fica vermelho — e isso BLOQUEIA o
+# merge. Os CINCO jobs deste arquivo são required checks em `main`, conjunto verificado em
+# 2026-08-18: `test-in-prod-image`, `cross-tenant-rls`, `secret-scan`, `sast-semgrep` e
+# `frontend`. Push direto em `main` é rejeitado (GH006); toda mudança passa por PR.
+# Para reconferir o conjunto SEM ser admin do repositório, a receita está no CLAUDE.md §5.1 —
+# a rota óbvia (`/branches/main/protection`) responde 404 para quem não é admin, e esse 404 é
+# indistinguível de "branch não protegida": não o leia como resposta.
 #
-# Story 6.2 — gates OBSERVÁVEIS primeiro, bloqueantes depois: `secret-scan` e
-# `sast-semgrep` seguem O MESMO modelo — hoje aparecem no PR (check vermelho quando
-# acham algo), mas NÃO impedem merge porque ainda não estão em "Require status checks
-# to pass". A promoção para bloqueante é um follow-up de @devops (mesma tela de branch
-# protection acima), a ser feito após um período de observação sem falso positivo
-# excessivo — assim ninguém trava merge por falso positivo no dia 1. NÃO usamos
-# `continue-on-error` (deixaria o check sempre verde e tornaria a promoção via branch
-# protection um no-op) — o mecanismo de "não-bloqueante" é a AUSÊNCIA do check na lista
-# de required, igual aos dois jobs acima.
+# O PADRÃO desta casa — gates OBSERVÁVEIS primeiro, bloqueantes depois — está CONCLUÍDO para
+# estes cinco, e foi assim que os cinco chegaram a required: um gate novo entra rodando e
+# aparecendo no PR (check vermelho quando acha algo) mas FORA da lista de required; roda um
+# período de observação; e só é promovido a bloqueante depois de se mostrar sem falso positivo
+# excessivo — assim ninguém trava merge por falso positivo no dia 1. Gate novo daqui pra frente
+# nasce assim (é o caso do job de mutação noturna, issue #121).
+#
+# NÃO usamos `continue-on-error` para obter a fase observável: ele deixaria o check sempre
+# verde e tornaria a promoção via branch protection um no-op. O mecanismo de "não-bloqueante"
+# é a AUSÊNCIA do check na lista de required — nunca `continue-on-error`.
 name: CI
 
 on:
@@ -97,7 +101,7 @@ jobs:
   # O CLI/binário gitleaks é MIT, sem registro nem EULA (mesma engine, cobertura
   # idêntica): custo zero de verdade + zero fricção operacional/legal (Regra de Ouro nº 4).
   # O padrão `docker run` é o mesmo já usado por `test-in-prod-image` neste arquivo.
-  # Observável, não bloqueante — ver o cabeçalho (branch protection é o gate de merge).
+  # Required check em `main` (verificado em 2026-08-18) — chegou lá pela promoção do cabeçalho.
   secret-scan:
     runs-on: ubuntu-latest
     steps:
@@ -134,7 +138,7 @@ jobs:
   # (p/typescript, p/react, p/owasp-top-ten) — não o pack genérico p/ci (mais ruidoso).
   # Escaneia SÓ apps/web (TS/React): o backend Python já é coberto por `ruff` no job
   # test-in-prod-image; SAST Python (p/python) fica como follow-up, não é escopo do AC2.
-  # Observável, não bloqueante — ver o cabeçalho.
+  # Required check em `main` (verificado em 2026-08-18) — ver o cabeçalho.
   sast-semgrep:
     runs-on: ubuntu-latest
     steps:
@@ -160,12 +164,12 @@ jobs:
   # assim que seis telas mergearam com "validação em ~360px não foi feita" e três PRs de correção
   # em campo foram pagos (#56, #58, #89).
   #
-  # Observável primeiro, bloqueante depois — MESMO modelo de `secret-scan`/`sast-semgrep` deste
-  # arquivo: o job aparece no PR e fica vermelho quando acha algo, mas só IMPEDE merge quando
-  # @devops o acrescentar em "Require status checks to pass" (GitHub → Settings → Branches).
-  # Sem esse passo a régua mede e não barra — e foi a ausência de barreira, não a de conhecimento,
-  # que deixou seis telas passarem. NÃO usamos `continue-on-error` (deixaria o check sempre verde
-  # e tornaria a promoção via branch protection um no-op).
+  # Percorreu o MESMO caminho de `secret-scan`/`sast-semgrep` — observável primeiro, bloqueante
+  # depois (ver cabeçalho) — e a promoção JÁ ACONTECEU: `frontend` é required check em `main`,
+  # verificado em 2026-08-18. A régua agora mede E barra. Foi a ausência de barreira, não a de
+  # conhecimento, que deixou seis telas passarem; é essa repetição que a barreira hoje impede.
+  # NÃO usamos `continue-on-error` (deixaria o check sempre verde e tornaria a promoção via
+  # branch protection um no-op).
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,21 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   Node** (é a mesma lacuna que o comentário no topo dele descreve para o jsdom). **Dívida:** o teste
   continua sensível à versão do Node, e o CI hoje exercita só a versão dos desenvolvedores — não o
   piso `>=22` que o repositório promete suportar.
-  **Dívida:** ele é **observável, não bloqueante**, até @devops o acrescentar em "Require status
-  checks to pass" (mesmo modelo de `secret-scan`/`sast-semgrep`). Enquanto isso, a régua **mede e não
-  barra** — e foi a ausência de barreira, não a de conhecimento, que deixou seis telas passarem.
+- ✅ **O job `frontend` BARRA o merge — a dívida de 2026-08-10 está fechada (issue #122).** Conjunto
+  obrigatório de `main`, **verificado em 2026-08-18**: `test-in-prod-image`, `cross-tenant-rls`,
+  `secret-scan`, `sast-semgrep` e **`frontend`**. A régua mede **e barra**. Ela já estava na
+  configuração antes desta data — o que faltava era alguém conseguir LER a configuração, não mudá-la.
+  **Como reler sem ser admin** (o dono é o único admin, e reabrir isso à mão custou uma issue):
+  `GET /branches/main/protection` responde **404 tanto para "branch não protegida" quanto para "seu
+  token não é admin"**, e `repository.branchProtectionRules` do GraphQL devolve `totalCount: 0` pelo
+  mesmo motivo — **nenhum dos dois é resposta**, os dois são o silêncio da falta de permissão. Quem
+  tem só `push` lê pelo `refUpdateRule`, que é a projeção não-admin da mesma regra:
+  ```bash
+  gh api graphql -f query='query { repository(owner:"educacaocriativa", name:"escritorio-1-pessoa")
+    { ref(qualifiedName:"refs/heads/main") { refUpdateRule { requiredStatusCheckContexts } } } }'
+  ```
+  Confirmação cruzada: `/branches/main` traz `"protected": true`, e `/rules/branches/main` volta `[]`
+  — ou seja, a proteção é **branch protection clássica**, não ruleset; procurar em Rules não acha.
 
 ## 6. Estado atual / roadmap
 - [x] Fundação do monorepo, docs, agentes de QA, CI local.
@@ -352,8 +364,7 @@ Medidos num **clone novo** (worktree limpa, `pnpm install`, nada mais), eram coi
 - [x] **`pnpm lint` não rodava em NENHUM job do CI**, e é essa a explicação de por que o NBSP
   sobreviveu do #102 até aqui: `ci.yml` tinha typecheck, vitest e o gate de 360px, e nada de
   `eslint`. O job `frontend` ganhou a etapa **Lint** (antes do typecheck, que é a mais rápida das
-  quatro). Ela é **observável, não bloqueante**, como o resto do job — a dívida de tornar
-  `frontend` um required check segue com @devops (§5.1).
+  quatro). Ela **barra o merge** como o resto do job: `frontend` é required check em `main` (§5.1).
 
 > **A regra que fica:** gate vermelho no SEU checkout não é, por si, dívida do repositório.
 > *"Vermelho aqui"* e *"vermelho num clone novo"* são afirmações diferentes, e distinguir as duas

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -132,7 +132,7 @@
 
 ## 9. CI e branch protection (Story 3.2)
 - [x] CI já existe e roda de verdade (`test-in-prod-image` + `cross-tenant-rls`) — validado na PR #7
-- [ ] Habilitar branch protection em GitHub → Settings → Branches → marcar os 2 checks como obrigatórios (transforma o CI num gate real, hoje só reporta status)
+- [x] Branch protection habilitada — o CI é gate real, não só status. Conjunto obrigatório de `main` verificado em **2026-08-18**: `test-in-prod-image`, `cross-tenant-rls`, `secret-scan`, `sast-semgrep` e `frontend` (os 5 jobs do `ci.yml`). Push direto é rejeitado (GH006). Para reconferir sem ser admin: receita no CLAUDE.md §5.1
 - [ ] (Fora do escopo atual) CD automático — deploy hoje é `git pull` + rebuild manual na VPS
 
 ## 10. Staging (Story 3.1)

--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -451,9 +451,10 @@ White-label por subdomínio (`joaosilva.e1p.com`). O certificado curinga exige T
 - **Wildcard na Topologia B (Traefik compartilhado):** a emissão real do cert curinga depende
   de config externa em `/opt/infra/proxy/` (certresolver DNS-01/Cloudflare) — ver §10.3.
 - **CI** já existe (`.github/workflows/ci.yml`, Story 3.2): testa a imagem de produção e o
-  isolamento RLS a cada push/PR na `main`. **Pendente (@devops):** habilitar branch protection
-  em GitHub → Settings → Branches marcando `test-in-prod-image` e `cross-tenant-rls` como checks
-  obrigatórios (transforma o workflow num gate que BLOQUEIA merge, não só um status vermelho).
+  isolamento RLS a cada push/PR na `main`. Branch protection está **habilitada** e o workflow
+  BLOQUEIA merge: os 5 jobs são checks obrigatórios (conjunto verificado em **2026-08-18** —
+  `test-in-prod-image`, `cross-tenant-rls`, `secret-scan`, `sast-semgrep`, `frontend`); push
+  direto em `main` é rejeitado (GH006). Receita para reconferir sem admin: CLAUDE.md §5.1.
   **CD (deploy automático)** ainda não existe — o deploy segue `git pull` + rebuild manual na VPS.
 - Monitoramento/alertas: **implementado** na Story 3.4 com Uptime Kuma self-hosted —
   ver **§9**. (Migração para observabilidade gerenciada na AWS Fase B fica para quando o


### PR DESCRIPTION
## O que muda

Só documentação. **Nenhuma alteração de configuração no GitHub, nenhum código de produção.**

A #122 pedia para @devops acrescentar o job `frontend` em *Require status checks to pass*. Ele **já estava lá**. O que faltava não era a mudança — era conseguir **ler** a configuração.

Conjunto obrigatório de `main`, verificado em **2026-08-18**:

```
test-in-prod-image · cross-tenant-rls · secret-scan · sast-semgrep · frontend
```

Ou seja, os cinco jobs do `ci.yml`. A régua de 360px mede **e barra**.

## Por que ninguém conseguia verificar

`GET /branches/main/protection` responde **404 tanto para "branch não protegida" quanto para "seu token não é admin"**, e `repository.branchProtectionRules` do GraphQL devolve `totalCount: 0` pelo mesmo motivo. **Nenhum dos dois é resposta** — os dois são o silêncio da falta de permissão, e a issue leu o 404 como possível "não protegida".

Quem tem só `push` lê pelo `refUpdateRule`, a projeção não-admin da mesma regra:

```bash
gh api graphql -f query='query { repository(owner:"educacaocriativa", name:"escritorio-1-pessoa")
  { ref(qualifiedName:"refs/heads/main") { refUpdateRule { requiredStatusCheckContexts } } } }'
```

Confirmação cruzada: `/branches/main` traz `"protected": true` (já desmentia o 404), e `/rules/branches/main` volta `[]` — a proteção é **branch protection clássica**, não ruleset; procurar em *Rules* não acha. A receita ficou escrita no §5.1 para a issue não renascer.

## O alcance era maior que a issue

A mesma dívida já resolvida estava escrita em **quatro arquivos**, e o pior não era o `ci.yml`:

| Arquivo | O que dizia |
|---|---|
| `CLAUDE.md` §5.1 | a nota de dívida de 2026-08-10 + uma **segunda ocorrência** no bullet do `pnpm lint` |
| `.github/workflows/ci.yml` | 5 pontos pedindo a promoção — e não só do `frontend`: `secret-scan` e `sast-semgrep` **também** já são obrigatórios |
| `docs/GO-LIVE-CHECKLIST.md` §9 | um checkbox **aberto**: `[ ] Habilitar branch protection (hoje só reporta status)` |
| `docs/HOSTINGER-DEPLOY.md` | `**Pendente (@devops):** habilitar branch protection...` |

O do `GO-LIVE-CHECKLIST` é o que mais incomodava: uma lista de prontidão de produção afirmando que o gate não existia.

## O que foi deliberadamente preservado

- **O raciocínio "observável primeiro, bloqueante depois"** virou padrão **concluído** no cabeçalho do `ci.yml`, não foi apagado junto com a pendência. É o mecanismo que os cinco jobs percorreram, e é como o job noturno de mutação (#121) vai nascer.
- **A nota sobre `continue-on-error`** continua: o mecanismo de não-bloqueante é a ausência do check na lista de required, nunca `continue-on-error`.
- **Registro histórico intacto:** `docs/plans/2026-08-10-divida-360px.md`, os PRDs dos Epics 6 e 7 e as duas menções a "4 checks" descrevem a janela em que o `frontend` ainda não existia. Eram verdade na data em que foram escritas; reescrever apagaria a trilha.

## Verificação

`ci.yml` mudou **só comentário** — provado por parse, não por leitura: o YAML das duas versões desserializa em objetos **idênticos**.

```
python: yaml.safe_load(antes) == yaml.safe_load(depois)  ->  True
jobs: cross-tenant-rls, frontend, sast-semgrep, secret-scan, test-in-prod-image
```

## Achado incidental, não corrigido aqui

O `ci.yml` justifica usar o CLI do gitleaks em vez da Action porque *"este repo é da org educacaocriativa"*. `owner.type` é **`User`** — a premissa está errada. A decisão continua certa por outro motivo (o CLI é MIT, sem registro nem EULA), só o porquê escrito está errado. Issue própria.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)