### PR TITLE
feat: contas a pagar abre no que se deve, e para de cortar o futuro em silencio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,80 @@ caso — ela exige saber de antemão quantas vezes vai repetir e supõe valor fi
   `pnpm typecheck` e `pnpm lint` já falhavam antes deste diff.~~ **FECHADOS em 2026-08-12**, num PR
   separado só disso — e **só UM dos dois era defeito do repositório.** Ver a seção logo abaixo.
 
+## Financeiro: o recorte da lista de Contas a Pagar (2026-08-18)
+
+> Spec: `docs/superpowers/specs/2026-08-18-contas-a-pagar-recorte-design.md` ·
+> Plano: `docs/superpowers/plans/2026-08-18-contas-a-pagar-recorte.md`
+
+A tela era uma lista única, sem filtro, ordenada por vencimento **crescente** — a conta mais antiga
+já paga ocupava a primeira linha. E, como recorrência aqui é **materializada** (`create_payable`
+grava N linhas reais ligadas por `recurrence_group`), a lista crescia sozinha sem o dono lançar
+nada.
+
+- [x] ⚠️ **O defeito mais grave não era a rolagem: era o truncamento silencioso.**
+  `list_payables` tinha `limit=200` fixo e o router **não expunha** `limit`/`offset`. Com a
+  ordenação crescente, a rota devolvia as **200 mais antigas** — passando de 200 contas, o que
+  sumia da tela era o **futuro, ainda por pagar**. Sem aviso, sem contagem, sem sintoma. O teste
+  `test_teto_de_200_nao_engole_o_futuro` reprova o código antigo e é a régua da entrega.
+- [x] **`GET /payables/bills` devolve `{items, total}`**, não lista nua, e aceita `status`
+  (**repetível**), `from`, `to`, `q`, `cost_center_id`, `chart_account_id`, `order`, `limit`,
+  `offset`. O `total` é o do recorte inteiro: é ele que sustenta o **"Mostrando 50 de 213"**, que
+  aparece SEMPRE e não só quando trunca. O pecado antigo não era ter teto — era o teto não se
+  anunciar.
+- [x] **A tela abre em "o que eu devo"**: `status ∈ (open, scheduled)`, **sem piso de data** e com
+  teto no fim do mês seguinte. ⚠️ **O "sem piso" é deliberado.** Atrasado vence no passado; um
+  `from` na visão padrão esconderia exatamente a conta mais urgente que existe. Travado por
+  `test_from_ausente_nao_engole_atrasado_antigo` e pelo teste de front do recorte padrão.
+- [x] **A ordenação segue a intenção do filtro:** em aberto/agendada `asc`; pago/cancelado `desc`
+  (histórico se lê do mais recente para trás). A direção é decidida no front (`filtros.ts`) e vai
+  explícita na query — o backend obedece e valida, não adivinha.
+- ⚠️ **`list_payables` e `count_payables` compartilham `_filtros()`. Não duplique o `where`.**
+  Divergindo, a tela anuncia um `total` que a própria lista não confirma: nada quebra, o rodapé só
+  passa a mentir. `test_total_sempre_casa_com_a_lista` cobre sete combinações de filtro.
+- ⚠️ **O `q` escapa `%` e `_` antes do `ilike`.** Sem isso, digitar `%` casa com tudo e a busca
+  parece funcionar enquanto não filtra nada — defeito sem sintoma. A implementação ingênua passa em
+  todos os outros testes e falha só em `test_q_escapa_curinga_do_like`.
+- ⚠️ **`from` é palavra reservada em Python:** o parâmetro é `due_from` com `alias="from"`.
+- [x] **`POST /payables/bills/{id}/reactivate`** — conta cancelada volta para `open` **com o
+  vencimento original**. Reativada depois do prazo, nasce **Atrasada**, que é o que ela é: empurrar
+  a data para hoje apagaria o vencimento contratado e a Projeção/DRE passariam a contar uma data
+  que nunca existiu.
+  - ⚠️ **Não é `/reverse`, e a separação é de significado.** `reverse` quer dizer *"esta saída não
+    vai acontecer"* e seu trabalho é **apagar o movimento bancário**; `cancel_payable` só aceita
+    conta em aberto, que nunca teve movimento nenhum. Fundir os dois obrigaria um
+    `if status == canceled: pula tudo` no meio da lógica mais delicada do arquivo.
+- [x] **`pagar/filtros.ts`** — estado do filtro, puro e sem DOM (12 testes). ⚠️ **`fimDoMesSeguinte`
+  faz aritmética de string, nunca `new Date`:** o dia já chega no fuso do tenant (`today(useFuso())`)
+  e reconstruir um `Date` devolveria o cálculo ao fuso do navegador — em UTC−3, das 21h à meia-noite
+  o horizonte pularia um dia (regra §6.0).
+- [x] **`GanchoDaVima` desceu para DEPOIS da tabela.** Acima do título ele ocupava ~200px da
+  primeira dobra e empurrava a lista para fora da tela.
+- [x] **Centro de custo e Categoria ficam atrás de "Mais filtros" SÓ no celular** — e isso foi
+  **medido, não suposto**. Com os cinco controles na mesma linha, em 360px a barra refluía em cinco
+  linhas, ocupava ~300px e jogava a tabela para `y=765`, fora da dobra de 740px. Recolhidos:
+  `y=653`. De `sm` para cima os cinco aparecem juntos. `e2e/pagar-360.spec.ts` mede por
+  `boundingBox`, nunca por classe CSS.
+- ⚠️ **BUG DE INTEGRAÇÃO ACHADO E CORRIGIDO: o axios serializava `status[]=open`.** O FastAPI
+  declara `status: list[str] | None = Query(default=None)` e só reconhece a forma **repetida**
+  (`status=open&status=scheduled`); com colchetes ele não vê o parâmetro, recebe `None` e devolve a
+  lista **sem filtro nenhum** — a tela pediria "o que eu devo" e receberia pago e cancelado junto,
+  sem erro e sem sintoma. Corrigido com `paramsSerializer: { indexes: null }` nos **dois** clientes
+  de `lib/api.ts`.
+  - ⚠️ **Nenhuma camada de teste pegava isso, e vale entender por quê:** o pytest monta a URL crua
+    já na forma certa, o vitest assere o objeto `params` **antes** de serializar, e o gate de layout
+    recebe payload fixo seja qual for a query. Só medir a URL real fecha a fresta — é o que
+    `e2e/pagar-contrato.spec.ts` faz, e é o único lugar do projeto onde axios de verdade roda.
+- **A busca da barra de cima CONTINUA DESLIGADA** (`AppShell.tsx`, `<input>` sem `onChange` — o
+  próprio código diz *"é decoração até alguém ligá-la"*). **Não é regressão e não é bug**: é o
+  Projeto B, ainda sem spec. Registrado aqui para a próxima sessão não gastar tempo procurando um
+  defeito que não existe. O filtro de texto de Contas a Pagar é o primitivo que ele vai reusar.
+- **Dívida:** `receivables.cancel_charge` tem o mesmo beco sem saída — cobrança cancelada também
+  não volta. Fora de escopo (não foi pedido e dobraria a superfície de teste); a rota seria
+  `POST /receivables/charges/{id}/reactivate`, com a mesma forma do `reactivate_payable`.
+- **Dívida:** sem índice para o `ilike` sobre `description`/`supplier`. Com alguns milhares de
+  linhas por tenant, já cortadas pela RLS, roda sem. `pg_trgm` é o gatilho quando incomodar —
+  otimização especulativa agora.
+
 ## Os dois gates herdados de `main` — e a diferença entre "vermelho aqui" e "vermelho num clone novo"
 
 O parágrafo acima registrava `pnpm lint` e `pnpm typecheck` como duas dívidas irmãs de `main`.

--- a/apps/api/app/modules/payables/router.py
+++ b/apps/api/app/modules/payables/router.py
@@ -237,6 +237,22 @@ def cancel_bill(
     return _out(db, p)
 
 
+@router.post("/bills/{payable_id}/reactivate", response_model=PayableOut)
+def reactivate_bill(
+    payable_id: str,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> PayableOut:
+    """Conta cancelada volta para 'A pagar'. Rota própria — ver `service.reactivate_payable`."""
+    try:
+        p = service.reactivate_payable(
+            db, payable_id=payable_id, tenant_id=user.tenant_id, actor=user.user_id
+        )
+    except service.PayableError as e:
+        raise _err(e) from e
+    return _out(db, p)
+
+
 @router.post("/bills/{payable_id}/reverse", response_model=PayableOut)
 def reverse_bill(
     payable_id: str,

--- a/apps/api/app/modules/payables/router.py
+++ b/apps/api/app/modules/payables/router.py
@@ -73,6 +73,13 @@ def categories(
 @router.get("/bills", response_model=PayablesPageOut)
 def list_bills(
     status: list[str] | None = Query(default=None),
+    # `from`/`to` são as palavras naturais na URL; `from` é reservada em Python, daí o alias.
+    due_from: date_type | None = Query(default=None, alias="from"),
+    due_to: date_type | None = Query(default=None, alias="to"),
+    q: str | None = Query(default=None, max_length=120),
+    cost_center_id: str | None = Query(default=None),
+    chart_account_id: str | None = Query(default=None),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     _user: CurrentUser = Depends(_guard),
@@ -81,10 +88,20 @@ def list_bills(
     # Fuso resolvido UMA vez para a página inteira: `_out` por linha faria uma consulta de perfil
     # por conta (N+1). Mesmo cuidado da listagem de `receivables`.
     hoje = hoje_do_tenant(db)
-    itens = service.list_payables(db, status=status, limit=limit, offset=offset)
+    # O recorte vai como dict ÚNICO para buscar e contar: esquecer um argumento em uma das duas
+    # chamadas reproduz, pela porta da rota, a divergência que `_filtros` existe para impedir.
+    recorte = dict(
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
+    itens = service.list_payables(db, order=order, limit=limit, offset=offset, **recorte)
     return PayablesPageOut(
         items=[service.payable_out(p, hoje) for p in itens],
-        total=service.count_payables(db, status=status),
+        total=service.count_payables(db, **recorte),
     )
 
 

--- a/apps/api/app/modules/payables/router.py
+++ b/apps/api/app/modules/payables/router.py
@@ -14,6 +14,7 @@ from app.modules.payables.schemas import (
     PayableOut,
     PayablePayIn,
     PayablePaymentUpdate,
+    PayablesPageOut,
     PayablesPaidBeforeOut,
     PayablesSummary,
     PayableUpdate,
@@ -69,18 +70,22 @@ def categories(
     return service.list_categories(db)
 
 
-@router.get("/bills", response_model=list[PayableOut])
+@router.get("/bills", response_model=PayablesPageOut)
 def list_bills(
-    status: str | None = Query(default=None),
+    status: list[str] | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
     _user: CurrentUser = Depends(_guard),
     db: Session = Depends(get_tenant_db),
-) -> list[PayableOut]:
-    # Fuso resolvido UMA vez para a lista inteira: `_out` por linha faria uma consulta de perfil
+) -> PayablesPageOut:
+    # Fuso resolvido UMA vez para a página inteira: `_out` por linha faria uma consulta de perfil
     # por conta (N+1). Mesmo cuidado da listagem de `receivables`.
     hoje = hoje_do_tenant(db)
-    return [
-        service.payable_out(p, hoje) for p in service.list_payables(db, status=status)
-    ]
+    itens = service.list_payables(db, status=status, limit=limit, offset=offset)
+    return PayablesPageOut(
+        items=[service.payable_out(p, hoje) for p in itens],
+        total=service.count_payables(db, status=status),
+    )
 
 
 @router.get("/bills/paid-before", response_model=PayablesPaidBeforeOut)

--- a/apps/api/app/modules/payables/schemas.py
+++ b/apps/api/app/modules/payables/schemas.py
@@ -205,3 +205,15 @@ class PaymentQueueOut(BaseModel):
     # 60 dias continua sendo um compromisso, e escondê-lo é a omissão que o AC7 combate.
     agendadas: list[PayableOut] = []
     summary: PaymentQueueSummary
+
+
+class PayablesPageOut(BaseModel):
+    """Uma página da listagem de contas a pagar — `items` + o `total` REAL do recorte.
+
+    O `total` não é enfeite: sem ele a tela não consegue dizer "mostrando 50 de 213", e o
+    truncamento volta a ser silencioso — que foi exatamente o defeito que esta spec corrigiu.
+    Ele conta o recorte inteiro, ignorando `limit`/`offset`.
+    """
+
+    items: list[PayableOut]
+    total: int

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -322,14 +322,36 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     return p
 
 
+def _filtros(stmt, *, status: list[str] | None = None):
+    """Construtor ÚNICO do predicado da listagem — usado por `list_payables` E `count_payables`.
+
+    ⚠️ **Não duplique este `where` do outro lado.** Dois blocos copiados divergem na primeira
+    manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
+    quebra, o rodapé só passa a mentir. É um modo de falha discreto e caro de achar.
+    """
+    if status:
+        stmt = stmt.where(Payable.status.in_(status))
+    return stmt
+
+
 def list_payables(
-    db: Session, *, status: str | None = None, limit: int = 200, offset: int = 0
+    db: Session,
+    *,
+    status: list[str] | None = None,
+    limit: int = 200,
+    offset: int = 0,
 ) -> list[Payable]:
     limit = max(1, min(limit, 500))
-    stmt = select(Payable).order_by(Payable.due_date)
-    if status:
-        stmt = stmt.where(Payable.status == status)
+    # Desempate por `id`: sem ele, contas com o MESMO vencimento podem trocar de posição entre
+    # duas consultas e o `offset` passa a repetir ou pular linha entre páginas.
+    stmt = _filtros(select(Payable), status=status).order_by(Payable.due_date, Payable.id)
     return list(db.scalars(stmt.limit(limit).offset(max(0, offset))).all())
+
+
+def count_payables(db: Session, *, status: list[str] | None = None) -> int:
+    """Quantas contas o recorte tem, ignorando `limit`/`offset`."""
+    stmt = _filtros(select(func.count()).select_from(Payable), status=status)
+    return int(db.scalar(stmt) or 0)
 
 
 def _today(db: Session, *, now: datetime | None = None) -> date:

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -322,15 +322,52 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     return p
 
 
-def _filtros(stmt, *, status: list[str] | None = None):
+def _escapa_curinga(termo: str) -> str:
+    """Neutraliza `%` e `_` para que o texto do usuário seja tratado como TEXTO no `ilike`.
+
+    Sem isto, buscar `%` casa com todas as linhas e a busca parece funcionar enquanto não filtra
+    nada — o pior tipo de defeito de busca, porque não tem sintoma.
+    """
+    return termo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _filtros(
+    stmt,
+    *,
+    status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+):
     """Construtor ÚNICO do predicado da listagem — usado por `list_payables` E `count_payables`.
 
     ⚠️ **Não duplique este `where` do outro lado.** Dois blocos copiados divergem na primeira
     manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
     quebra, o rodapé só passa a mentir. É um modo de falha discreto e caro de achar.
+
+    `due_from` é opcional **e a tela não o manda na visão padrão, de propósito**: atrasado tem
+    vencimento no passado, então qualquer piso de data esconde a conta mais urgente que existe.
     """
     if status:
         stmt = stmt.where(Payable.status.in_(status))
+    if due_from is not None:
+        stmt = stmt.where(Payable.due_date >= due_from)
+    if due_to is not None:
+        stmt = stmt.where(Payable.due_date <= due_to)
+    if q:
+        alvo = f"%{_escapa_curinga(q)}%"
+        stmt = stmt.where(
+            or_(
+                Payable.description.ilike(alvo, escape="\\"),
+                Payable.supplier.ilike(alvo, escape="\\"),
+            )
+        )
+    if cost_center_id:
+        stmt = stmt.where(Payable.cost_center_id == cost_center_id)
+    if chart_account_id:
+        stmt = stmt.where(Payable.chart_account_id == chart_account_id)
     return stmt
 
 
@@ -338,19 +375,52 @@ def list_payables(
     db: Session,
     *,
     status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+    order: str = "asc",
     limit: int = 200,
     offset: int = 0,
 ) -> list[Payable]:
     limit = max(1, min(limit, 500))
+    stmt = _filtros(
+        select(Payable),
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
     # Desempate por `id`: sem ele, contas com o MESMO vencimento podem trocar de posição entre
     # duas consultas e o `offset` passa a repetir ou pular linha entre páginas.
-    stmt = _filtros(select(Payable), status=status).order_by(Payable.due_date, Payable.id)
+    coluna = Payable.due_date.desc() if order == "desc" else Payable.due_date.asc()
+    stmt = stmt.order_by(coluna, Payable.id)
     return list(db.scalars(stmt.limit(limit).offset(max(0, offset))).all())
 
 
-def count_payables(db: Session, *, status: list[str] | None = None) -> int:
+def count_payables(
+    db: Session,
+    *,
+    status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+) -> int:
     """Quantas contas o recorte tem, ignorando `limit`/`offset`."""
-    stmt = _filtros(select(func.count()).select_from(Payable), status=status)
+    stmt = _filtros(
+        select(func.count()).select_from(Payable),
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
     return int(db.scalar(stmt) or 0)
 
 

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -805,6 +805,34 @@ def cancel_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str) 
     return p
 
 
+def reactivate_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str) -> Payable:
+    """Devolve uma conta CANCELADA para 'open', com o vencimento original intacto.
+
+    ⚠️ **Não é `reverse`, e a separação é de significado, não de estilo.** `reverse` quer dizer
+    *"esta saída não vai acontecer"*, e o trabalho dele é APAGAR o movimento bancário. Reativar
+    quer dizer o oposto: *"esta saída volta a ser esperada"*. E como `cancel_payable` só aceita
+    conta em aberto, aqui **não existe movimento bancário nem evento de Agenda para desfazer** —
+    cancelar nunca criou nem removeu nenhum dos dois. Fundir os dois verbos obrigaria um
+    `if status == canceled: pula tudo` no meio da lógica mais delicada do arquivo, e é assim que
+    um dos dois caminhos deixa de receber a próxima correção.
+
+    **O vencimento não se reescreve.** Reativada depois do prazo, a conta volta Atrasada — porque é
+    o que ela é. Empurrar a data para hoje apagaria o vencimento que o dono de fato contratou, e a
+    Projeção e o DRE passariam a contar uma data que nunca existiu. Ela nasce editável (`open`),
+    então corrigir a data continua sendo um gesto disponível, só não imposto.
+    """
+    p = db.scalar(select(Payable).where(Payable.id == payable_id).with_for_update())
+    if p is None:
+        raise PayableError("Conta não encontrada", 404)
+    if p.status != STATUS_CANCELED:
+        raise PayableError("Só contas canceladas podem ser reativadas", 409)
+    p.status = STATUS_OPEN
+    audit.record(db, tenant_id=tenant_id, actor=actor, action="payable.reactivate", target=p.id)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
 def reverse_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str) -> Payable:
     """Estorna uma conta paga **ou agendada**: volta para 'open', limpa paid_at, reabre a edição,
     devolve o evento vinculado na Agenda para pendente (desfaz o `done` de mark_paid) — e

--- a/apps/api/tests/test_bank_contagem_dupla.py
+++ b/apps/api/tests/test_bank_contagem_dupla.py
@@ -211,7 +211,7 @@ def test_tarifa_de_dois_reais_e_noventa_passa_sem_aviso(client: TestClient, head
     )
     assert resp.status_code == 201, resp.text
     assert resp.json()["operation_nature"] == "tarifa_bancaria"
-    assert client.get("/payables/bills", headers=headers).json() == []
+    assert client.get("/payables/bills", headers=headers).json()["items"] == []
 
 
 def test_entrada_com_payable_de_mesmo_valor_nao_dispara(client: TestClient, headers, account):

--- a/apps/api/tests/test_financial_intelligence_dre.py
+++ b/apps/api/tests/test_financial_intelligence_dre.py
@@ -324,7 +324,7 @@ def test_AC14_dre_IDENTICA_campo_a_campo_com_e_sem_conta_agendada(client: TestCl
     antes = _dre(client, headers)
 
     conta = _conta_bancaria_814(client, headers)
-    bill = client.get("/payables/bills", headers=headers).json()[0]
+    bill = client.get("/payables/bills", headers=headers).json()["items"][0]
     _agendar_814(client, headers, bill["id"], conta["id"])
 
     assert _dre(client, headers) == antes, (

--- a/apps/api/tests/test_financial_intelligence_profitability.py
+++ b/apps/api/tests/test_financial_intelligence_profitability.py
@@ -547,7 +547,7 @@ def test_AC14_lucratividade_IDENTICA_com_e_sem_conta_agendada(client: TestClient
         },
         headers=headers,
     ).json()
-    bill = client.get("/payables/bills", headers=headers).json()[0]
+    bill = client.get("/payables/bills", headers=headers).json()["items"][0]
     futuro = datetime.now(UTC).date() + timedelta(days=20)
     resp = client.post(
         f"/payables/bills/{bill['id']}/pay",

--- a/apps/api/tests/test_payables.py
+++ b/apps/api/tests/test_payables.py
@@ -101,7 +101,7 @@ def test_recurring_generates_occurrences(client: TestClient, headers):
         json=_bill(due_date="2026-08-05", recurrence="monthly", recurrence_count=3),
         headers=headers,
     )
-    bills = client.get("/payables/bills", headers=headers).json()
+    bills = client.get("/payables/bills", headers=headers).json()["items"]
     assert len(bills) == 3  # 3 contas geradas
     dues = sorted(b["due_date"] for b in bills)
     assert dues == ["2026-08-05", "2026-09-05", "2026-10-05"]  # vencimentos mensais
@@ -276,7 +276,7 @@ def test_recurring_payable_competence_advances(client: TestClient, headers):
                    recurrence="monthly", recurrence_count=3),
         headers=headers,
     )
-    bills = client.get("/payables/bills", headers=headers).json()
+    bills = client.get("/payables/bills", headers=headers).json()["items"]
     comps = sorted(b["competence_date"] for b in bills)
     assert comps == ["2026-08-01", "2026-09-01", "2026-10-01"]
 

--- a/apps/api/tests/test_payables_listagem.py
+++ b/apps/api/tests/test_payables_listagem.py
@@ -83,3 +83,96 @@ def test_pagina_nao_repete_nem_pula_conta(client: TestClient, headers):
         vistos.extend(item["id"] for item in pagina["items"])
     assert len(vistos) == 100
     assert len(set(vistos)) == 100, "offset repetiu conta entre páginas"
+
+
+def test_status_aceita_mais_de_um_valor(client: TestClient, headers):
+    aberta = _cria(client, headers, description="Aberta")
+    cancelada = _cria(client, headers, description="Cancelada")
+    client.post(f"/payables/bills/{cancelada['id']}/cancel", headers=headers)
+
+    corpo = client.get("/payables/bills?status=open&status=scheduled", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert aberta["id"] in ids
+    assert cancelada["id"] not in ids
+    assert corpo["total"] == len(ids)
+
+
+def test_from_ausente_nao_engole_atrasado_antigo(client: TestClient, headers):
+    """A visão padrão da tela NÃO manda `from`. Se alguém "simplificar" pondo um piso de data, a
+    conta mais urgente que existe — a vencida — some justamente da tela que serve para pagá-la."""
+    antiga = _cria(client, headers, description="Vencida", due_date="2026-02-01")
+    futura = _cria(client, headers, description="Futura", due_date="2027-01-10")
+
+    corpo = client.get("/payables/bills?status=open&to=2027-06-30", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert antiga["id"] in ids, "atrasado antigo tem de aparecer sem `from`"
+    assert futura["id"] in ids
+
+
+def test_to_e_inclusivo_na_borda(client: TestClient, headers):
+    na_borda = _cria(client, headers, description="Borda", due_date="2027-03-31")
+    depois = _cria(client, headers, description="Depois", due_date="2027-04-01")
+
+    corpo = client.get("/payables/bills?to=2027-03-31", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert na_borda["id"] in ids
+    assert depois["id"] not in ids
+
+
+def test_q_busca_em_descricao_e_em_fornecedor(client: TestClient, headers):
+    por_descricao = _cria(client, headers, description="Assinatura Anthropic", supplier="X")
+    por_fornecedor = _cria(client, headers, description="Ferramenta", supplier="Anthropic")
+    outra = _cria(client, headers, description="Aluguel", supplier="Imobiliaria")
+
+    corpo = client.get("/payables/bills?q=anthropic", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert por_descricao["id"] in ids, "busca tem de ser case-insensitive"
+    assert por_fornecedor["id"] in ids
+    assert outra["id"] not in ids
+
+
+def test_q_escapa_curinga_do_like(client: TestClient, headers):
+    """`ilike` interpreta `%` e `_`. Sem escape, digitar `%` casa com TUDO e a busca parece estar
+    funcionando quando não está filtrando nada. A implementação ingênua passa em todos os outros
+    testes e falha só neste."""
+    com_percent = _cria(client, headers, description="100% Cacau", supplier="Doceria")
+    sem_percent = _cria(client, headers, description="Anthropic", supplier="X")
+
+    corpo = client.get("/payables/bills?q=%25", headers=headers).json()  # %25 = "%"
+    ids = [i["id"] for i in corpo["items"]]
+    assert com_percent["id"] in ids
+    assert sem_percent["id"] not in ids
+    assert corpo["total"] == 1
+
+
+def test_order_desc_inverte_a_lista(client: TestClient, headers):
+    _cria(client, headers, description="Primeira", due_date="2027-01-10")
+    _cria(client, headers, description="Ultima", due_date="2027-09-10")
+
+    asc = client.get("/payables/bills?order=asc", headers=headers).json()["items"]
+    desc = client.get("/payables/bills?order=desc", headers=headers).json()["items"]
+    assert asc[0]["description"] == "Primeira"
+    assert desc[0]["description"] == "Ultima"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "",
+        "?status=open",
+        "?status=open&status=scheduled",
+        "?to=2027-06-30",
+        "?from=2027-01-01&to=2027-12-31",
+        "?q=anthropic",
+        "?q=anthropic&status=open",
+    ],
+)
+def test_total_sempre_casa_com_a_lista(client: TestClient, headers, query: str):
+    """O alarme contra `list_payables` e `count_payables` divergirem de predicado."""
+    _cria(client, headers, description="Assinatura Anthropic", due_date="2027-01-10")
+    _cria(client, headers, description="Aluguel", due_date="2027-05-10")
+    _cria(client, headers, description="Curso", due_date="2028-01-10")
+
+    sep = "&" if query else "?"
+    corpo = client.get(f"/payables/bills{query}{sep}limit=500", headers=headers).json()
+    assert corpo["total"] == len(corpo["items"]), f"total divergiu da lista em {query!r}"

--- a/apps/api/tests/test_payables_listagem.py
+++ b/apps/api/tests/test_payables_listagem.py
@@ -1,0 +1,85 @@
+"""Listagem de Contas a Pagar: paginação honesta e filtros (spec 2026-08-18).
+
+O teste `test_teto_de_200_nao_engole_o_futuro` REPROVA o código anterior a esta spec, e é
+deliberado: `list_payables` tinha `limit=200` fixo e o router não expunha `limit`/`offset`, então
+a partir da 201ª conta as linhas seguintes eram inalcançáveis pela rota, sem aviso nenhum. Como a
+ordenação é por vencimento crescente, o que sumia era o FUTURO — contas ainda por pagar.
+"""
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+REGISTER = {
+    "legal_name": "Lista Co",
+    "document": "10101010000258",  # CNPJ com dígito verificador válido (validate_document)
+    "slug": "listaco",
+    "email": "lista@example.com",
+    "name": "Lista",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cria(client: TestClient, headers, **campos) -> dict:
+    """Cria uma conta a pagar e devolve o corpo criado."""
+    corpo = {
+        "description": "Conta",
+        "category": "Ferramentas",
+        "supplier": "Fornecedor",
+        "amount_cents": 10_000,
+        "due_date": date(2027, 1, 10).isoformat(),
+    }
+    corpo.update(campos)
+    resp = client.post("/payables/bills", json=corpo, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _cria_muitas(client: TestClient, headers, total: int) -> None:
+    """Cria `total` contas usando recorrência mensal.
+
+    `MAX_OCCURRENCES` (app/core/recurrence.py) e o schema limitam `recurrence_count` a 60, então
+    250 contas saem em 5 POSTs de 50 em vez de 250 chamadas HTTP.
+    """
+    assert total % 50 == 0, "use múltiplos de 50"
+    for lote in range(total // 50):
+        _cria(
+            client,
+            headers,
+            description=f"Serie {lote}",
+            due_date=date(2027 + lote, 1, 10).isoformat(),
+            recurrence="monthly",
+            recurrence_count=50,
+        )
+
+
+def test_teto_de_200_nao_engole_o_futuro(client: TestClient, headers):
+    _cria_muitas(client, headers, 250)
+
+    primeira = client.get("/payables/bills?limit=50&offset=0", headers=headers)
+    assert primeira.status_code == 200, primeira.text
+    corpo = primeira.json()
+    assert len(corpo["items"]) == 50
+    assert corpo["total"] == 250, "o total tem de ser o real, não o tamanho da página"
+
+    # A 201ª conta em diante era inalcançável pela rota antes desta spec.
+    depois_do_teto = client.get("/payables/bills?limit=50&offset=200", headers=headers)
+    assert depois_do_teto.status_code == 200, depois_do_teto.text
+    assert len(depois_do_teto.json()["items"]) == 50
+    assert depois_do_teto.json()["total"] == 250
+
+
+def test_pagina_nao_repete_nem_pula_conta(client: TestClient, headers):
+    _cria_muitas(client, headers, 100)
+    vistos: list[str] = []
+    for offset in (0, 50):
+        pagina = client.get(f"/payables/bills?limit=50&offset={offset}", headers=headers).json()
+        vistos.extend(item["id"] for item in pagina["items"])
+    assert len(vistos) == 100
+    assert len(set(vistos)) == 100, "offset repetiu conta entre páginas"

--- a/apps/api/tests/test_payables_reactivate.py
+++ b/apps/api/tests/test_payables_reactivate.py
@@ -1,0 +1,120 @@
+"""Reativar conta cancelada (spec 2026-08-18, §6).
+
+Reativar é rota PRÓPRIA, não `/reverse`: aquele apaga movimento bancário, e conta cancelada nunca
+teve um — `cancel_payable` só aceita conta em aberto.
+"""
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
+
+REGISTER = {
+    "legal_name": "Reativa Co",
+    "document": "10101010000339",  # CNPJ com dígito verificador válido (validate_document)
+    "slug": "reativaco",
+    "email": "reativa@example.com",
+    "name": "Reativa",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cria(client: TestClient, headers, **campos) -> dict:
+    corpo = {
+        "description": "Conta",
+        "category": "Ferramentas",
+        "supplier": "Fornecedor",
+        "amount_cents": 10_000,
+        "due_date": date(2027, 1, 10).isoformat(),
+    }
+    corpo.update(campos)
+    resp = client.post("/payables/bills", json=corpo, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_cancelada_volta_para_aberta_com_vencimento_intacto(client: TestClient, headers):
+    conta = _cria(client, headers, due_date="2027-01-10")
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "open"
+    assert resp.json()["due_date"] == "2027-01-10", "o vencimento contratado não se reescreve"
+
+
+def test_reativada_com_vencimento_passado_nasce_atrasada(client: TestClient, headers):
+    """Vencimento preservado + `is_overdue` derivado = ela volta Atrasada, que é o que ela é.
+
+    A data vem de `tenant_today`, nunca da hora em que a suíte roda.
+    """
+    ontem = tenant_today(DEFAULT_TENANT_TIMEZONE) - timedelta(days=1)
+    conta = _cria(client, headers, due_date=ontem.isoformat())
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "open"
+    assert resp.json()["is_overdue"] is True
+
+
+def test_conta_aberta_nao_pode_ser_reativada(client: TestClient, headers):
+    conta = _cria(client, headers)
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+    assert resp.status_code == 409
+    assert "cancelada" in resp.json()["detail"].lower()
+
+
+def test_conta_paga_nao_pode_ser_reativada(client: TestClient, headers):
+    """Conta paga tem movimento bancário atrás dela; o caminho de volta dela é `/reverse`."""
+    resp_conta = client.post(
+        "/bank/accounts",
+        json={
+            "name": "Itaú PJ",
+            "kind": "checking",
+            "opening_balance_cents": 500_000,
+            "opening_balance_is_known": True,
+            "opening_date": "2026-01-01",
+        },
+        headers=headers,
+    )
+    assert resp_conta.status_code == 201, resp_conta.text
+    banco = resp_conta.json()["id"]
+    hoje = tenant_today(DEFAULT_TENANT_TIMEZONE).isoformat()
+    conta = _cria(client, headers, due_date=hoje)
+    paga = client.post(
+        f"/payables/bills/{conta['id']}/pay",
+        json={"bank_account_id": banco, "paid_on": hoje},
+        headers=headers,
+    )
+    assert paga.status_code == 200, paga.text
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+    assert resp.status_code == 409
+
+
+def test_conta_inexistente_devolve_404(client: TestClient, headers):
+    resp = client.post("/payables/bills/nao-existe/reactivate", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_reativacao_entra_na_auditoria(client: TestClient, headers, db):
+    from sqlalchemy import select
+
+    from app.core.audit import AuditEntry
+
+    conta = _cria(client, headers)
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+    client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    acoes = list(db.scalars(select(AuditEntry.action).where(AuditEntry.target == conta["id"])))
+    assert "payable.reactivate" in acoes

--- a/apps/api/tests/test_payment_queue.py
+++ b/apps/api/tests/test_payment_queue.py
@@ -153,7 +153,7 @@ def test_queue_beyond_30_days_excluded(client: TestClient, headers):
     for bucket in ("atrasados", "hoje", "proximos_7_dias", "proximos_30_dias"):
         assert q[bucket] == []
     # segue existente na lista completa de Contas a Pagar (não é a fila que o some)
-    assert len(client.get("/payables/bills", headers=headers).json()) == 1
+    assert len(client.get("/payables/bills", headers=headers).json()["items"]) == 1
 
 
 def test_queue_summary_counts_and_sums(client: TestClient, headers):

--- a/apps/api/tests/test_receipts.py
+++ b/apps/api/tests/test_receipts.py
@@ -406,7 +406,7 @@ def test_new_bill_conta_e_obrigatoria_apenas_quando_da_baixa(
     if mark_paid:
         assert resp.status_code == 422, resp.text
         # A conta NÃO foi criada — a validação acontece antes de qualquer escrita.
-        assert client.get("/payables/bills", headers=headers).json() == []
+        assert client.get("/payables/bills", headers=headers).json()["items"] == []
         assert [i["id"] for i in client.get("/payables/receipts", headers=headers).json()] == [rid]
     else:
         assert resp.status_code == 201, resp.text
@@ -558,7 +558,7 @@ def test_new_bill_recusa_valor_zero(client: TestClient, headers, conta_primaria)
 def test_create_bill_continua_funcionando_apos_refactor(client: TestClient, headers):
     """Guarda de regressão do refactor build_payable/create_payable."""
     b = _bill(client, headers, due_date="2099-06-01", recurrence="monthly", recurrence_count=3)
-    todas = client.get("/payables/bills", headers=headers).json()
+    todas = client.get("/payables/bills", headers=headers).json()["items"]
     assert len([x for x in todas if x["recurrence_group"] == b["recurrence_group"]]) == 3
 
 

--- a/apps/web/e2e/pagar-360.spec.ts
+++ b/apps/web/e2e/pagar-360.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { alvosPequenos, medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * Gate de LAYOUT da tela de Contas a Pagar em 360px (spec 2026-08-18).
+ *
+ * A tela ganhou uma superfície nova — a barra de recorte, com cinco controles — e um rodapé de
+ * contagem. Cinco controles numa linha de 360px é exatamente a forma que se espreme até o polegar
+ * não acertar nenhum, e nenhuma asserção de classe CSS pega isso: `toContain("flex-wrap")` já
+ * passou verde neste projeto com a tela quebrada.
+ *
+ * Payload de pior caso plausível: fornecedor comprido, valor de 6 dígitos, e centros/categorias
+ * com nomes longos — porque dado curto sempre cabe, e medir com ele é medir uma tela que não
+ * existe.
+ */
+
+const CONTA = {
+  id: "b-1",
+  tenant_id: "00000000-0000-4000-8000-000000000002",
+  description: "Assinatura anual da plataforma de inteligência",
+  category: "Ferramentas",
+  supplier: "Fornecedor Internacional de Tecnologia Ltda",
+  amount_cents: 118_573_04,
+  due_date: "2026-09-20",
+  competence_date: null,
+  chart_account_id: null,
+  contract_id: null,
+  cost_center_id: null,
+  status: "open",
+  is_overdue: false,
+  paid_at: null,
+  recurrence: "monthly",
+  recurrence_count: 12,
+  recurrence_group: "g-1",
+  payment_code: "",
+  attachment_url: "",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/payables/summary": {
+      open_cents: 18_575_704,
+      overdue_cents: 0,
+      week_cents: 1_800_000,
+      month_cents: 18_575_704,
+      paid_month_cents: 562_541,
+      scheduled_cents: 0,
+    },
+    "/payables/bills": { items: [CONTA], total: 213 },
+    "/payables/receipts": [],
+    "/chart-of-accounts": [
+      { id: "ca-1", categoria: "Ferramentas e assinaturas de software", grupo: "DESPESA" },
+    ],
+    "/cost-centers": [{ id: "cc-1", name: "Técnica e Infraestrutura" }],
+  });
+});
+
+test("a barra de recorte reflui e a página não rola de lado", async ({ page }) => {
+  await page.goto("/pagar");
+  await expect(page.getByLabel("Buscar fornecedor ou descrição")).toBeVisible();
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+
+  // A tabela rola de lado por construção (`min-w-[48rem]` dentro de `overflow-x-auto`), então o
+  // recorte é a barra: ali NADA pode sobrar, porque ela não tem deslizador nenhum.
+  const cortes = await textoForaDaTela(page, "[data-testid='filtros-da-lista']");
+  expect(cortes, JSON.stringify(cortes, null, 2)).toEqual([]);
+});
+
+test("cada controle do recorte cabe na tela e é tocável", async ({ page }) => {
+  await page.goto("/pagar");
+  await expect(page.getByLabel("Status")).toBeVisible();
+
+  for (const rotulo of ["Buscar fornecedor ou descrição", "Status", "Vencimento até"]) {
+    const caixa = await page.getByLabel(rotulo).boundingBox();
+    expect(caixa, `${rotulo} sem caixa`).not.toBeNull();
+    expect(caixa!.x, `${rotulo} começa fora da tela`).toBeGreaterThanOrEqual(0);
+    expect(caixa!.x + caixa!.width, `${rotulo} estoura os 360px`).toBeLessThanOrEqual(360);
+    expect(caixa!.height, `${rotulo} baixo demais para o polegar`).toBeGreaterThanOrEqual(44);
+  }
+
+  const pequenos = await alvosPequenos(page, 44, "[data-testid='filtros-da-lista']");
+  expect(pequenos, JSON.stringify(pequenos, null, 2)).toEqual([]);
+});
+
+test("as dimensões extras existem, atrás de 'Mais filtros' no celular", async ({ page }) => {
+  await page.goto("/pagar");
+  await expect(page.getByLabel("Status")).toBeVisible();
+
+  // Recolhidas por padrão em 360px — é o que devolve a dobra para a lista.
+  await expect(page.getByLabel("Centro de custo")).toBeHidden();
+
+  await page.getByRole("button", { name: "Mais filtros" }).click();
+
+  await expect(page.getByLabel("Centro de custo")).toBeVisible();
+  await expect(page.getByLabel("Categoria")).toBeVisible();
+});
+
+test("a contagem aparece e a lista começa dentro da primeira dobra", async ({ page }) => {
+  await page.goto("/pagar");
+
+  await expect(page.getByText(/Mostrando 1 de 213/i)).toBeVisible();
+
+  const tabela = await page.locator("table").boundingBox();
+  expect(tabela, "tabela sem caixa").not.toBeNull();
+  // A lista é o motivo de a página existir. Com o GanchoDaVima acima do título ela nascia abaixo
+  // da dobra; ele desceu para depois da tabela justamente por isso.
+  expect(tabela!.y, "a tabela nasce abaixo da dobra de 740px").toBeLessThan(740);
+});

--- a/apps/web/e2e/pagar-contrato.spec.ts
+++ b/apps/web/e2e/pagar-contrato.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * Contrato de QUERY STRING entre a tela e o FastAPI — o único lugar onde axios de verdade roda.
+ *
+ * ⚠️ **Por que este arquivo existe.** O filtro de status é uma LISTA, e o padrão do axios serializa
+ * lista como `status[]=open&status[]=scheduled`. O FastAPI declara `status: list[str] | None =
+ * Query(default=None)` e só reconhece a forma REPETIDA (`status=open&status=scheduled`); com
+ * colchetes ele não vê parâmetro nenhum, devolve `None` e **ignora o filtro inteiro** — a tela
+ * pediria "o que eu devo" e receberia pago e cancelado junto, sem erro, sem sintoma.
+ *
+ * Nenhuma das outras camadas pega isto: o pytest monta a URL crua na forma certa, o vitest assere
+ * o objeto `params` ANTES de serializar, e o gate de layout recebe payload fixo seja qual for a
+ * query. Só uma medição da URL real fecha essa fresta.
+ */
+
+test("o filtro de status vai na forma que o FastAPI lê (repetida, sem colchetes)", async ({
+  page,
+}) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/payables/summary": {
+      open_cents: 0, overdue_cents: 0, week_cents: 0,
+      month_cents: 0, paid_month_cents: 0, scheduled_cents: 0,
+    },
+    "/payables/bills": { items: [], total: 0 },
+    "/payables/receipts": [],
+    "/chart-of-accounts": [],
+    "/cost-centers": [],
+  });
+
+  const urls: string[] = [];
+  page.on("request", (r) => {
+    if (r.url().includes("/payables/bills")) urls.push(r.url());
+  });
+
+  await page.goto("/pagar");
+  await expect(page.getByLabel("Status")).toBeVisible();
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  const query = decodeURIComponent(new URL(urls[0]).search);
+  expect(query, `query real: ${query}`).toContain("status=open");
+  expect(query, `query real: ${query}`).toContain("status=scheduled");
+  expect(query, "colchete = o FastAPI ignora o filtro em silêncio").not.toContain("status[]");
+  expect(query, "índice = o FastAPI ignora o filtro em silêncio").not.toContain("status[0]");
+});

--- a/apps/web/src/features/pagar/FiltrosDaLista.tsx
+++ b/apps/web/src/features/pagar/FiltrosDaLista.tsx
@@ -1,4 +1,5 @@
 import type { PayableStatus } from "@e1p/shared-types";
+import { useState } from "react";
 import type { CostCenter } from "../financeiro/costCenters";
 import type { ChartAccount } from "../financeiro/planoContas";
 import type { FiltroPagar } from "./filtros";
@@ -24,9 +25,13 @@ const campo =
 /**
  * A barra de recorte da lista.
  *
- * `flex-wrap` e não largura fixa: em 360px estes cinco controles refluem em duas linhas em vez de
- * se espremerem a ponto de o polegar não acertar nenhum. O gate de layout mede isso de verdade em
- * `e2e/pagar-360.spec.ts` — por `boundingBox`, não por classe CSS.
+ * ⚠️ **Dois dos cinco controles ficam atrás de "Mais filtros" no celular — e isso foi MEDIDO, não
+ * suposto.** A primeira versão punha os cinco na mesma linha com `flex-wrap`: em 360px eles
+ * refluíam em CINCO linhas e a barra sozinha ocupava ~300px. Somada aos cards de topo (192px), ela
+ * empurrava a tabela para `y=765` — fora de uma dobra de 740px. A lista é o motivo de a página
+ * existir; ela não pode nascer abaixo da dobra para que um filtro de centro de custo caiba acima.
+ *
+ * Acima de `sm` os cinco aparecem juntos: lá há largura para isso e o custo não existe.
  *
  * ⚠️ Os controles usam SÓ `aria-label`, sem um `<label>` irmão com o mesmo texto: os dois juntos
  * fazem `getByLabel` casar duas vezes e o gate falha por strict mode do Playwright, não por
@@ -43,18 +48,22 @@ export default function FiltrosDaLista({
   categorias: ChartAccount[];
   centros: CostCenter[];
 }) {
+  const [maisFiltros, setMaisFiltros] = useState(false);
   const padraoAtivo =
     valor.q === "" && valor.centroDeCusto === "" && valor.categoria === "" && valor.de === null;
+  // As duas dimensões extras ficam recolhidas SÓ no celular; de `sm` para cima elas são visíveis
+  // sempre, e o botão que as revela desaparece.
+  const extras = `${maisFiltros ? "flex" : "hidden"} sm:flex w-full gap-3 sm:w-auto`;
 
   return (
-    <div className="rounded-2xl bg-white p-4 shadow-sm">
+    <div data-testid="filtros-da-lista" className="rounded-2xl bg-white p-4 shadow-sm">
       <div className="flex flex-wrap items-center gap-3">
         <input
           value={valor.q}
           onChange={(e) => onChange({ ...valor, q: e.target.value })}
           placeholder="Buscar fornecedor ou descrição"
           aria-label="Buscar fornecedor ou descrição"
-          className={`${campo} min-w-0 flex-1 basis-56`}
+          className={`${campo} w-full min-w-0 sm:w-auto sm:flex-1 sm:basis-56`}
         />
 
         <select
@@ -67,7 +76,7 @@ export default function FiltrosDaLista({
             const olhandoParaTras = r.status.every((s) => s === "paid" || s === "canceled");
             onChange({ ...valor, status: r.status, ate: olhandoParaTras ? null : valor.ate });
           }}
-          className={campo}
+          className={`${campo} min-w-0 flex-1 sm:flex-none`}
         >
           {RECORTES.map((r) => (
             <option key={r.value} value={r.value}>
@@ -81,46 +90,60 @@ export default function FiltrosDaLista({
           aria-label="Vencimento até"
           value={valor.ate ?? ""}
           onChange={(e) => onChange({ ...valor, ate: e.target.value || null })}
-          className={campo}
+          className={`${campo} min-w-0 flex-1 sm:flex-none`}
         />
 
-        <select
-          aria-label="Centro de custo"
-          value={valor.centroDeCusto}
-          onChange={(e) => onChange({ ...valor, centroDeCusto: e.target.value })}
-          className={campo}
-        >
-          <option value="">Todos os centros</option>
-          {centros.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
+        <div className={extras}>
+          <select
+            aria-label="Centro de custo"
+            value={valor.centroDeCusto}
+            onChange={(e) => onChange({ ...valor, centroDeCusto: e.target.value })}
+            className={`${campo} min-w-0 flex-1 sm:flex-none`}
+          >
+            <option value="">Todos os centros</option>
+            {centros.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
 
-        <select
-          aria-label="Categoria"
-          value={valor.categoria}
-          onChange={(e) => onChange({ ...valor, categoria: e.target.value })}
-          className={campo}
-        >
-          <option value="">Todas as categorias</option>
-          {categorias.map((a) => (
-            <option key={a.id} value={a.id}>
-              {a.categoria}
-            </option>
-          ))}
-        </select>
+          <select
+            aria-label="Categoria"
+            value={valor.categoria}
+            onChange={(e) => onChange({ ...valor, categoria: e.target.value })}
+            className={`${campo} min-w-0 flex-1 sm:flex-none`}
+          >
+            <option value="">Todas as categorias</option>
+            {categorias.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.categoria}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      {!padraoAtivo && (
+      <div className="mt-3 flex flex-wrap items-center gap-4">
         <button
-          onClick={() => onChange({ ...valor, q: "", centroDeCusto: "", categoria: "", de: null })}
-          className="mt-3 min-h-[44px] text-xs font-medium text-neutral-500 hover:text-primary-600"
+          onClick={() => setMaisFiltros((v) => !v)}
+          aria-expanded={maisFiltros}
+          className="min-h-[44px] text-xs font-medium text-neutral-500 hover:text-primary-600 sm:hidden"
         >
-          Limpar filtros
+          {maisFiltros ? "Menos filtros" : "Mais filtros"}
         </button>
-      )}
+
+        {!padraoAtivo && (
+          <button
+            onClick={() =>
+              onChange({ ...valor, q: "", centroDeCusto: "", categoria: "", de: null })
+            }
+            className="min-h-[44px] text-xs font-medium text-neutral-500 hover:text-primary-600"
+          >
+            Limpar filtros
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/pagar/FiltrosDaLista.tsx
+++ b/apps/web/src/features/pagar/FiltrosDaLista.tsx
@@ -1,0 +1,126 @@
+import type { PayableStatus } from "@e1p/shared-types";
+import type { CostCenter } from "../financeiro/costCenters";
+import type { ChartAccount } from "../financeiro/planoContas";
+import type { FiltroPagar } from "./filtros";
+
+/** Os recortes de status que a tela oferece. "Em aberto" são DOIS status, não um. */
+const RECORTES: { value: string; label: string; status: PayableStatus[] }[] = [
+  { value: "abertas", label: "Em aberto", status: ["open", "scheduled"] },
+  { value: "paid", label: "Pago", status: ["paid"] },
+  { value: "scheduled", label: "Agendada", status: ["scheduled"] },
+  { value: "canceled", label: "Cancelado", status: ["canceled"] },
+];
+
+function valorDoRecorte(status: PayableStatus[]): string {
+  const achado = RECORTES.find(
+    (r) => r.status.length === status.length && r.status.every((s) => status.includes(s)),
+  );
+  return achado?.value ?? "abertas";
+}
+
+const campo =
+  "min-h-[44px] rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400";
+
+/**
+ * A barra de recorte da lista.
+ *
+ * `flex-wrap` e não largura fixa: em 360px estes cinco controles refluem em duas linhas em vez de
+ * se espremerem a ponto de o polegar não acertar nenhum. O gate de layout mede isso de verdade em
+ * `e2e/pagar-360.spec.ts` — por `boundingBox`, não por classe CSS.
+ *
+ * ⚠️ Os controles usam SÓ `aria-label`, sem um `<label>` irmão com o mesmo texto: os dois juntos
+ * fazem `getByLabel` casar duas vezes e o gate falha por strict mode do Playwright, não por
+ * defeito da tela.
+ */
+export default function FiltrosDaLista({
+  valor,
+  onChange,
+  categorias,
+  centros,
+}: {
+  valor: FiltroPagar;
+  onChange: (f: FiltroPagar) => void;
+  categorias: ChartAccount[];
+  centros: CostCenter[];
+}) {
+  const padraoAtivo =
+    valor.q === "" && valor.centroDeCusto === "" && valor.categoria === "" && valor.de === null;
+
+  return (
+    <div className="rounded-2xl bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          value={valor.q}
+          onChange={(e) => onChange({ ...valor, q: e.target.value })}
+          placeholder="Buscar fornecedor ou descrição"
+          aria-label="Buscar fornecedor ou descrição"
+          className={`${campo} min-w-0 flex-1 basis-56`}
+        />
+
+        <select
+          aria-label="Status"
+          value={valorDoRecorte(valor.status)}
+          onChange={(e) => {
+            const r = RECORTES.find((x) => x.value === e.target.value)!;
+            // Histórico não tem por que herdar o horizonte de "o que eu devo": quem procura o que
+            // já pagou quer olhar para trás, e um teto no fim do mês que vem não recorta nada ali.
+            const olhandoParaTras = r.status.every((s) => s === "paid" || s === "canceled");
+            onChange({ ...valor, status: r.status, ate: olhandoParaTras ? null : valor.ate });
+          }}
+          className={campo}
+        >
+          {RECORTES.map((r) => (
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+
+        <input
+          type="date"
+          aria-label="Vencimento até"
+          value={valor.ate ?? ""}
+          onChange={(e) => onChange({ ...valor, ate: e.target.value || null })}
+          className={campo}
+        />
+
+        <select
+          aria-label="Centro de custo"
+          value={valor.centroDeCusto}
+          onChange={(e) => onChange({ ...valor, centroDeCusto: e.target.value })}
+          className={campo}
+        >
+          <option value="">Todos os centros</option>
+          {centros.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label="Categoria"
+          value={valor.categoria}
+          onChange={(e) => onChange({ ...valor, categoria: e.target.value })}
+          className={campo}
+        >
+          <option value="">Todas as categorias</option>
+          {categorias.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.categoria}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {!padraoAtivo && (
+        <button
+          onClick={() => onChange({ ...valor, q: "", centroDeCusto: "", categoria: "", de: null })}
+          className="mt-3 min-h-[44px] text-xs font-medium text-neutral-500 hover:text-primary-600"
+        >
+          Limpar filtros
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -721,3 +721,57 @@ describe("recorte e paginacao da lista (spec 2026-08-18)", () => {
     });
   });
 });
+
+describe("reativar conta cancelada (spec 2026-08-18, §6)", () => {
+  const CONTA_CANCELADA = {
+    ...CONTA_ABERTA,
+    id: "b-9",
+    description: "Assinatura cancelada",
+    status: "canceled",
+  };
+
+  function renderPagar() {
+    render(
+      <MemoryRouter>
+        <PageActionsProvider>
+          <PagarPage />
+        </PageActionsProvider>
+      </MemoryRouter>,
+    );
+  }
+
+  function mockComCancelada() {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [CONTA_CANCELADA], total: 1 } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+  }
+
+  it("linha cancelada oferece Reativar", async () => {
+    mockComCancelada();
+    renderPagar();
+
+    expect(await screen.findByRole("button", { name: /reativar/i })).toBeInTheDocument();
+  });
+
+  it("linha aberta NAO oferece Reativar", async () => {
+    mockComConta([CONTA]);
+    renderPagar();
+    await screen.findByText("Aluguel");
+
+    expect(screen.queryByRole("button", { name: /reativar/i })).not.toBeInTheDocument();
+  });
+
+  it("Reativar chama a rota propria, nao /reverse", async () => {
+    mockComCancelada();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderPagar();
+
+    fireEvent.click(await screen.findByRole("button", { name: /reativar/i }));
+
+    await waitFor(() => expect(api.post).toHaveBeenCalledWith("/payables/bills/b-9/reactivate"));
+  });
+});

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -50,7 +50,8 @@ const CONTA_ABERTA = {
 function mockComConta(contasBancarias: unknown[]) {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
-    if (url === "/payables/bills") return Promise.resolve({ data: [CONTA_ABERTA] } as never);
+    if (url === "/payables/bills")
+      return Promise.resolve({ data: { items: [CONTA_ABERTA], total: 1 } } as never);
     if (url === "/bank/accounts") return Promise.resolve({ data: contasBancarias } as never);
     return Promise.resolve({ data: [] } as never);
   });
@@ -89,7 +90,8 @@ function renderPage() {
 beforeEach(() => {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
-    if (url === "/payables/bills") return Promise.resolve({ data: [] } as never);
+    if (url === "/payables/bills")
+      return Promise.resolve({ data: { items: [], total: 0 } } as never);
     if (url === "/contracts") return Promise.resolve({ data: [] } as never);
     return Promise.resolve({ data: [] } as never);
   });
@@ -144,7 +146,8 @@ describe("PagarPage — bandeja de comprovantes (Task 11)", () => {
   it("mostra o aviso quando há comprovantes aguardando", async () => {
     vi.mocked(api.get).mockImplementation((url: string) => {
       if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
-      if (url === "/payables/bills") return Promise.resolve({ data: [] } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [], total: 0 } } as never);
       if (url === "/payables/receipts")
         return Promise.resolve({
           data: [
@@ -180,14 +183,17 @@ describe("PagarPage — bandeja de comprovantes (Task 11)", () => {
       if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
       if (url === "/payables/bills")
         return Promise.resolve({
-          data: [{
-            id: "b-1", description: "Aluguel", category: "Estrutura", supplier: "Imobiliária",
-            amount_cents: 250000, due_date: "2099-08-05", status: "open", is_overdue: false,
-            paid_at: null, recurrence: "none", recurrence_count: 1, recurrence_group: null,
-            payment_code: "", attachment_url: "", created_at: "2026-01-01T00:00:00Z",
-            tenant_id: "t-1", competence_date: null, chart_account_id: null, contract_id: null,
-            cost_center_id: null,
-          }],
+          data: {
+            items: [{
+              id: "b-1", description: "Aluguel", category: "Estrutura", supplier: "Imobiliária",
+              amount_cents: 250000, due_date: "2099-08-05", status: "open", is_overdue: false,
+              paid_at: null, recurrence: "none", recurrence_count: 1, recurrence_group: null,
+              payment_code: "", attachment_url: "", created_at: "2026-01-01T00:00:00Z",
+              tenant_id: "t-1", competence_date: null, chart_account_id: null, contract_id: null,
+              cost_center_id: null,
+            }],
+            total: 1,
+          },
         } as never);
       return Promise.resolve({ data: [] } as never);
     });
@@ -428,7 +434,7 @@ describe("Story 8.14 — a conta agendada tem rótulo próprio e gesto próprio"
     vi.mocked(api.get).mockImplementation((url: string) => {
       if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
       if (url === "/payables/bills") {
-        return Promise.resolve({ data: [CONTA_AGENDADA] } as never);
+        return Promise.resolve({ data: { items: [CONTA_AGENDADA], total: 1 } } as never);
       }
       if (url === "/bank/accounts") return Promise.resolve({ data: [CONTA] } as never);
       return Promise.resolve({ data: [] } as never);
@@ -524,7 +530,8 @@ describe("PagarPage — duplicar conta a pagar", () => {
   function mockBills(bills: unknown[]) {
     vi.mocked(api.get).mockImplementation((url: string) => {
       if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
-      if (url === "/payables/bills") return Promise.resolve({ data: bills } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: bills, total: bills.length } } as never);
       return Promise.resolve({ data: [] } as never);
     });
   }
@@ -614,5 +621,71 @@ describe("PagarPage — duplicar conta a pagar", () => {
     expect(screen.getByLabelText("Fornecedor")).toHaveValue("");
     expect(screen.getByLabelText("Valor (R$)")).toHaveValue("");
     expect(screen.getByLabelText("Vencimento")).toHaveValue("");
+  });
+});
+
+describe("recorte e paginacao da lista (spec 2026-08-18)", () => {
+  function renderPagar() {
+    render(
+      <MemoryRouter>
+        <PageActionsProvider>
+          <PagarPage />
+        </PageActionsProvider>
+      </MemoryRouter>,
+    );
+  }
+
+  function paramsDaUltimaBusca(): Record<string, unknown> {
+    const chamada = vi
+      .mocked(api.get)
+      .mock.calls.filter(([u]) => u === "/payables/bills")
+      .at(-1)!;
+    return (chamada[1] as { params: Record<string, unknown> }).params;
+  }
+
+  it("pede a primeira pagina com o recorte padrao", async () => {
+    mockComConta([CONTA]);
+    renderPagar();
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/payables/bills", expect.anything()));
+    const params = paramsDaUltimaBusca();
+    expect(params.status).toEqual(["open", "scheduled"]);
+    // Atrasado vence no passado: um piso de data esconderia a conta mais urgente que existe.
+    expect(params).not.toHaveProperty("from");
+    expect(params.offset).toBe(0);
+  });
+
+  it("mostra quantas contas estao a vista e quantas existem", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [CONTA_ABERTA], total: 213 } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPagar();
+
+    expect(await screen.findByText(/Mostrando 1 de 213/i)).toBeInTheDocument();
+  });
+
+  it("carregar mais ANEXA a lista em vez de substituir", async () => {
+    const SEGUNDA = { ...CONTA_ABERTA, id: "b-2", description: "Energia" };
+    vi.mocked(api.get).mockImplementation((url: string, config?: unknown) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills") {
+        const offset = (config as { params: { offset: number } }).params.offset;
+        return Promise.resolve({
+          data: { items: offset === 0 ? [CONTA_ABERTA] : [SEGUNDA], total: 2 },
+        } as never);
+      }
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPagar();
+
+    expect(await screen.findByText("Aluguel")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /carregar mais/i }));
+
+    expect(await screen.findByText("Energia")).toBeInTheDocument();
+    // O erro classico de paginacao: a segunda pagina apagar a primeira.
+    expect(screen.getByText("Aluguel")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -688,4 +688,36 @@ describe("recorte e paginacao da lista (spec 2026-08-18)", () => {
     // O erro classico de paginacao: a segunda pagina apagar a primeira.
     expect(screen.getByText("Aluguel")).toBeInTheDocument();
   });
+
+  it("digitar no filtro de texto dispara UMA chamada, nao uma por tecla", async () => {
+    mockComConta([CONTA]);
+    renderPagar();
+    await screen.findByText("Aluguel");
+    const antes = vi.mocked(api.get).mock.calls.filter(([u]) => u === "/payables/bills").length;
+
+    fireEvent.change(screen.getByLabelText(/buscar fornecedor ou descri/i), {
+      target: { value: "anthropic" },
+    });
+
+    await waitFor(() => {
+      expect(paramsDaUltimaBusca().q).toBe("anthropic");
+    });
+    const depois = vi.mocked(api.get).mock.calls.filter(([u]) => u === "/payables/bills").length;
+    expect(depois - antes).toBe(1);
+  });
+
+  it("trocar o status para Cancelado refaz a busca com o recorte novo", async () => {
+    mockComConta([CONTA]);
+    renderPagar();
+    await screen.findByText("Aluguel");
+
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "canceled" } });
+
+    await waitFor(() => {
+      const params = paramsDaUltimaBusca();
+      expect(params.status).toEqual(["canceled"]);
+      expect(params.order).toBe("desc"); // historico se le do mais recente para tras
+      expect(params.offset).toBe(0); // trocar filtro volta para a primeira pagina
+    });
+  });
 });

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -194,6 +194,26 @@ export default function PagarPage() {
    * A consequência no sistema, essa sim, é idêntica: a conta volta para "A pagar", reaparece na
    * Fila e o movimento bancário é apagado.
    */
+  /**
+   * Reativar é rota PRÓPRIA, não `/reverse`.
+   *
+   * `reverse` apaga movimento bancário — trabalho que aqui não existe, porque cancelar só age
+   * sobre conta em aberto, que não tem movimento nenhum. A confirmação avisa do vencimento porque
+   * é a única consequência que surpreende: reativada depois do prazo, a conta volta Atrasada, com
+   * a data original preservada.
+   */
+  async function reactivate(id: string) {
+    if (
+      !confirm(
+        'Reativar esta conta? Ela volta para "A pagar" com o vencimento original — se ele já ' +
+          "passou, ela aparece como Atrasada e você pode editar a data.",
+      )
+    )
+      return;
+    await api.post(`/payables/bills/${id}/reactivate`);
+    load();
+  }
+
   async function reverse(id: string, agendada = false) {
     const pergunta = agendada
       ? "Cancelar o agendamento desta conta? O débito programado deixa de ser contado e ela volta " +
@@ -333,6 +353,14 @@ export default function PagarPage() {
                         {p.status === "scheduled" && (
                           <button onClick={() => reverse(p.id, true)} className="text-xs font-medium text-neutral-400 hover:text-danger">
                             Cancelar agendamento
+                          </button>
+                        )}
+                        {/* Invisível na visão padrão (que abre em "Em aberto"); chega-se a ela
+                            por Status → Cancelado. Reativar é gesto deliberado, não algo em que
+                            se tropeça enquanto se dá baixa em contas. */}
+                        {p.status === "canceled" && (
+                          <button onClick={() => reactivate(p.id)} className="text-xs font-medium text-neutral-500 hover:text-primary-600">
+                            Reativar
                           </button>
                         )}
                       </div>

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -12,6 +12,7 @@ import type { CostCenter } from "../financeiro/costCenters";
 import CostCenterSelect from "../financeiro/CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
 import { DialogDeBaixa } from "./EscolhaDaBaixa";
+import FiltrosDaLista from "./FiltrosDaLista";
 import { camposDaCopia, type CamposDaConta } from "./duplicar";
 import { formatDay, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
@@ -106,8 +107,7 @@ export default function PagarPage() {
   // Comprovantes que chegaram pelo celular e ainda não foram vinculados a nenhuma conta.
   const [inbox, setInbox] = useState<{ id: string }[]>([]);
   const fuso = useFuso();
-  // O `setFiltro` entra na Task 6, junto com a barra de recorte que o aciona.
-  const [filtro] = useState<FiltroPagar>(() => filtroPadrao(today(fuso)));
+  const [filtro, setFiltro] = useState<FiltroPagar>(() => filtroPadrao(today(fuso)));
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [carregando, setCarregando] = useState(false);
@@ -148,7 +148,17 @@ export default function PagarPage() {
   }, [filtro]);
 
   useEffect(() => {
-    load();
+    let vivo = true;
+    // Um filtro de texto sem debounce dispara uma chamada por tecla; `vivo` descarta a resposta de
+    // um recorte que o usuário já abandonou e evita a lista "piscar" com dado velho. Mesmo padrão
+    // de `AccountModal.tsx`.
+    const t = setTimeout(() => {
+      if (vivo) load(0);
+    }, 300);
+    return () => {
+      vivo = false;
+      clearTimeout(t);
+    };
   }, [load]);
 
   // Rótulo estruturado quando o lançamento tem vínculo; senão cai no texto legado (`category`).
@@ -201,8 +211,6 @@ export default function PagarPage() {
         <h1 className="text-2xl font-bold text-neutral-800">Despesas</h1>
       </div>
 
-      <GanchoDaVima gancho="payables.conta.criada" />
-
       {inbox.length > 0 && (
         <Link
           to={`/comprovante/${inbox[0].id}`}
@@ -221,6 +229,13 @@ export default function PagarPage() {
         <Stat label="Nesta semana" value={brl(summary.week_cents)} tone="text-neutral-700" />
         <Stat label="Pago no mês" value={brl(summary.paid_month_cents)} tone="text-accent-700" />
       </div>
+
+      <FiltrosDaLista
+        valor={filtro}
+        onChange={setFiltro}
+        categorias={chartAccounts}
+        centros={costCenters}
+      />
 
       {/* overflow-x-auto (não overflow-hidden): achado de campo — em tela estreita a tabela tem
           7 colunas e ficava CORTADA em vez de rolável, escondendo Status e as ações (Editar/
@@ -347,6 +362,11 @@ export default function PagarPage() {
           )}
         </div>
       </div>
+
+      {/* O gancho da Vima vive DEPOIS da tabela desde a spec 2026-08-18. Acima do título ele
+          ocupava ~200px da primeira dobra e empurrava a lista para fora da tela — disputando o
+          espaço mais nobre com o motivo pelo qual a página é aberta. Continua sendo respondido. */}
+      <GanchoDaVima gancho="payables.conta.criada" />
 
       {/* A baixa passa por aqui desde a Story 8.13: a conta bancária de onde o dinheiro saiu é
           obrigatória no backend (8.12) e o dia é escolhido junto, no MESMO container do botão que

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -1,4 +1,4 @@
-import type { Contract, Payable, PayablesSummary } from "@e1p/shared-types";
+import type { Contract, Payable, PayablesPage, PayablesSummary } from "@e1p/shared-types";
 import { Copy, Paperclip } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
@@ -13,10 +13,15 @@ import CostCenterSelect from "../financeiro/CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
 import { DialogDeBaixa } from "./EscolhaDaBaixa";
 import { camposDaCopia, type CamposDaConta } from "./duplicar";
-import { formatDay } from "../../lib/datetime";
+import { formatDay, today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+import { type FiltroPagar, filtroPadrao, paraQuery } from "./filtros";
 
 /** Grupos DRE cabíveis numa DESPESA (Contas a Pagar nunca lança em Receita). */
 const EXPENSE_GROUPS = GRUPOS_DRE.filter((g) => g !== "RECEITA");
+
+/** Tamanho da página. 50 cabe numa rolagem curta e mantém o "carregar mais" barato. */
+const PAGINA = 50;
 
 /** Seletor "Vincular a contrato" (Story 5.4) — opcional; vazio = bucket "Empresa" (overhead). */
 function ContractSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
@@ -100,14 +105,33 @@ export default function PagarPage() {
   const [pagando, setPagando] = useState<Payable | null>(null);
   // Comprovantes que chegaram pelo celular e ainda não foram vinculados a nenhuma conta.
   const [inbox, setInbox] = useState<{ id: string }[]>([]);
+  const fuso = useFuso();
+  // O `setFiltro` entra na Task 6, junto com a barra de recorte que o aciona.
+  const [filtro] = useState<FiltroPagar>(() => filtroPadrao(today(fuso)));
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [carregando, setCarregando] = useState(false);
 
-  const load = useCallback(async () => {
-    const [s, b] = await Promise.all([
-      api.get<PayablesSummary>("/payables/summary"),
-      api.get<Payable[]>("/payables/bills"),
-    ]);
-    setSummary(s.data);
-    setBills(b.data);
+  const load = useCallback(async (proximoOffset = 0) => {
+    setCarregando(true);
+    let b: { data: PayablesPage };
+    try {
+      const [s, pagina] = await Promise.all([
+        api.get<PayablesSummary>("/payables/summary"),
+        api.get<PayablesPage>("/payables/bills", {
+          params: paraQuery(filtro, PAGINA, proximoOffset),
+        }),
+      ]);
+      b = pagina;
+      setSummary(s.data);
+    } finally {
+      setCarregando(false);
+    }
+    // `proximoOffset > 0` é "carregar mais": ANEXA. Substituir aqui é o erro clássico de
+    // paginação, e ele passa despercebido porque a primeira página sempre parece certa.
+    setBills((antes) => (proximoOffset === 0 ? b.data.items : [...antes, ...b.data.items]));
+    setTotal(b.data.total);
+    setOffset(proximoOffset);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de contas a pagar continua funcionando normalmente.
     const [ca, cc] = await Promise.all([
@@ -121,7 +145,7 @@ export default function PagarPage() {
       .get<{ id: string }[]>("/payables/receipts")
       .catch(() => ({ data: [] as { id: string }[] }));
     setInbox(pend.data);
-  }, []);
+  }, [filtro]);
 
   useEffect(() => {
     load();
@@ -304,6 +328,24 @@ export default function PagarPage() {
             </tbody>
           </table>
         )}
+
+        {/* A contagem aparece SEMPRE, não só quando trunca: é ela que torna o corte visível
+            antes de o dono precisar dele. O defeito que esta tela tinha não era ter um teto —
+            era o teto não se anunciar. */}
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-neutral-100 px-4 py-3">
+          <p className="text-xs text-neutral-500">
+            Mostrando {bills.length} de {total}
+          </p>
+          {bills.length < total && (
+            <button
+              onClick={() => load(offset + PAGINA)}
+              disabled={carregando}
+              className="min-h-[44px] rounded-pill px-4 text-sm font-medium text-primary-600 hover:bg-primary-50 disabled:opacity-50"
+            >
+              {carregando ? "Carregando…" : "Carregar mais"}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* A baixa passa por aqui desde a Story 8.13: a conta bancária de onde o dinheiro saiu é

--- a/apps/web/src/features/pagar/filtros.test.ts
+++ b/apps/web/src/features/pagar/filtros.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { fimDoMesSeguinte, filtroPadrao, paraQuery } from "./filtros";
+
+describe("fimDoMesSeguinte", () => {
+  it("agosto devolve o fim de setembro", () => {
+    expect(fimDoMesSeguinte("2026-08-18")).toBe("2026-09-30");
+  });
+
+  it("vira o ano em dezembro", () => {
+    expect(fimDoMesSeguinte("2026-12-05")).toBe("2027-01-31");
+  });
+
+  it("acerta fevereiro bissexto", () => {
+    expect(fimDoMesSeguinte("2028-01-10")).toBe("2028-02-29");
+  });
+
+  it("acerta fevereiro comum", () => {
+    expect(fimDoMesSeguinte("2027-01-10")).toBe("2027-02-28");
+  });
+
+  it("acerta o ano secular nao bissexto", () => {
+    expect(fimDoMesSeguinte("2100-01-10")).toBe("2100-02-28");
+  });
+});
+
+describe("filtroPadrao", () => {
+  const padrao = filtroPadrao("2026-08-18");
+
+  it("abre em 'o que eu devo': aberta e agendada", () => {
+    expect(padrao.status).toEqual(["open", "scheduled"]);
+  });
+
+  it("NAO tem piso de data", () => {
+    // Atrasado vence no passado. Qualquer `de` esconde a conta mais urgente que existe.
+    expect(padrao.de).toBeNull();
+  });
+
+  it("tem teto no fim do mes seguinte", () => {
+    expect(padrao.ate).toBe("2026-09-30");
+  });
+});
+
+describe("paraQuery", () => {
+  it("omite o que esta vazio, em vez de mandar chave nula", () => {
+    const q = paraQuery(filtroPadrao("2026-08-18"), 50, 0);
+    expect(q).toEqual({
+      status: ["open", "scheduled"],
+      to: "2026-09-30",
+      order: "asc",
+      limit: 50,
+      offset: 0,
+    });
+    expect(q).not.toHaveProperty("from");
+    expect(q).not.toHaveProperty("q");
+  });
+
+  it("manda o texto quando ele existe", () => {
+    const f = { ...filtroPadrao("2026-08-18"), q: "anthropic" };
+    expect(paraQuery(f, 50, 0).q).toBe("anthropic");
+  });
+
+  it("historico vem decrescente", () => {
+    const f = { ...filtroPadrao("2026-08-18"), status: ["paid" as const], ate: null };
+    expect(paraQuery(f, 50, 0).order).toBe("desc");
+  });
+
+  it("repassa limit e offset da paginacao", () => {
+    const q = paraQuery(filtroPadrao("2026-08-18"), 50, 100);
+    expect(q.limit).toBe(50);
+    expect(q.offset).toBe(100);
+  });
+});

--- a/apps/web/src/features/pagar/filtros.ts
+++ b/apps/web/src/features/pagar/filtros.ts
@@ -1,0 +1,73 @@
+import type { PayableStatus } from "@e1p/shared-types";
+
+/** O recorte da lista de Contas a Pagar. `de`/`ate` são YYYY-MM-DD ou `null` (sem limite). */
+export type FiltroPagar = {
+  status: PayableStatus[];
+  de: string | null;
+  ate: string | null;
+  q: string;
+  centroDeCusto: string;
+  categoria: string;
+};
+
+const DIAS_NO_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function bissexto(ano: number): boolean {
+  return (ano % 4 === 0 && ano % 100 !== 0) || ano % 400 === 0;
+}
+
+/**
+ * Último dia do mês SEGUINTE ao de `hojeYmd`, também em YYYY-MM-DD.
+ *
+ * Aritmética de string, nunca `new Date`: o `hojeYmd` já chega no fuso do tenant (via
+ * `today(useFuso())`), e reconstruir um `Date` a partir dele devolveria o cálculo ao fuso do
+ * navegador — em UTC-3, das 21h à meia-noite o horizonte pularia um dia inteiro.
+ */
+export function fimDoMesSeguinte(hojeYmd: string): string {
+  const [ano0, mes0] = hojeYmd.split("-").map(Number);
+  // `mes0` é 1-based; usá-lo como índice 0-based já aponta para o mês seguinte.
+  const ano = ano0 + Math.floor(mes0 / 12);
+  const mes = (mes0 % 12) + 1;
+  const dias = mes === 2 && bissexto(ano) ? 29 : DIAS_NO_MES[mes - 1];
+  return `${ano}-${String(mes).padStart(2, "0")}-${String(dias).padStart(2, "0")}`;
+}
+
+/**
+ * A visão padrão: "o que eu devo".
+ *
+ * `de: null` é deliberado e não é esquecimento. Atrasado tem vencimento no passado; qualquer piso
+ * de data esconde exatamente a conta mais urgente que existe. O que o horizonte corta é só o
+ * futuro distante — e o lugar de olhar longe é a Projeção de caixa.
+ */
+export function filtroPadrao(hojeYmd: string): FiltroPagar {
+  return {
+    status: ["open", "scheduled"],
+    de: null,
+    ate: fimDoMesSeguinte(hojeYmd),
+    q: "",
+    centroDeCusto: "",
+    categoria: "",
+  };
+}
+
+/** Histórico se lê do mais recente para o mais antigo; o que se deve, do mais próximo em diante. */
+function ordem(status: PayableStatus[]): "asc" | "desc" {
+  const olhandoParaTras = status.every((s) => s === "paid" || s === "canceled");
+  return status.length > 0 && olhandoParaTras ? "desc" : "asc";
+}
+
+/** Serializa para os `params` do axios. Chave vazia é OMITIDA, nunca mandada como null. */
+export function paraQuery(
+  f: FiltroPagar,
+  limit: number,
+  offset: number,
+): Record<string, unknown> {
+  const q: Record<string, unknown> = { order: ordem(f.status), limit, offset };
+  if (f.status.length > 0) q.status = f.status;
+  if (f.de) q.from = f.de;
+  if (f.ate) q.to = f.ate;
+  if (f.q.trim()) q.q = f.q.trim();
+  if (f.centroDeCusto) q.cost_center_id = f.centroDeCusto;
+  if (f.categoria) q.chart_account_id = f.categoria;
+  return q;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,10 +1,26 @@
 import type { ApiError, AuthToken, GoogleCalendarStatus } from "@e1p/shared-types";
 import axios, { AxiosError } from "axios";
 
+/**
+ * Serialização de parâmetros de LISTA na forma que o FastAPI lê.
+ *
+ * ⚠️ **`indexes: null` não é preferência de estilo — sem ele o filtro é ignorado em silêncio.**
+ * O padrão do axios serializa `{status: ["open","scheduled"]}` como
+ * `status[]=open&status[]=scheduled`. O FastAPI declara `status: list[str] | None =
+ * Query(default=None)` e só reconhece a forma REPETIDA (`status=open&status=scheduled`); com
+ * colchetes ele não enxerga o parâmetro, recebe `None` e devolve a lista **sem filtro nenhum** —
+ * a tela pede "o que eu devo" e recebe pago e cancelado junto. Sem erro, sem sintoma.
+ *
+ * Medido em `e2e/pagar-contrato.spec.ts`, que é o único lugar onde axios de verdade roda: o pytest
+ * monta a URL crua já na forma certa e o vitest assere o objeto `params` antes de serializar.
+ */
+const PARAMS_REPETIDOS = { indexes: null } as const;
+
 /** Cliente HTTP único da aplicação. Em dev o Vite faz proxy de /api -> :8000. */
 export const api = axios.create({
   baseURL: "/api",
   headers: { "Content-Type": "application/json" },
+  paramsSerializer: PARAMS_REPETIDOS,
 });
 
 // Injeta o token salvo em toda requisição.
@@ -18,6 +34,7 @@ api.interceptors.request.use((config) => {
 export const publicApi = axios.create({
   baseURL: "/api",
   headers: { "Content-Type": "application/json" },
+  paramsSerializer: PARAMS_REPETIDOS,
 });
 
 /**

--- a/docs/superpowers/plans/2026-08-18-contas-a-pagar-recorte.md
+++ b/docs/superpowers/plans/2026-08-18-contas-a-pagar-recorte.md
@@ -1,0 +1,1838 @@
+# Contas a Pagar — recorte da lista e reativar cancelada — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Contas a Pagar passa a abrir em "o que eu devo", com filtros no servidor, paginação que anuncia o que corta, e conta cancelada volta a ser reativável.
+
+**Architecture:** `GET /payables/bills` ganha filtros por query string e passa a devolver `{items, total}` em vez de lista nua; buscar e contar compartilham um único construtor de predicado. Reativar é rota nova (`POST /bills/{id}/reactivate`), não reuso de `/reverse`. No front, o estado do filtro sai para um módulo puro (`filtros.ts`) e a barra para um componente próprio, porque `PagarPage.tsx` já tem 660 linhas e quatro modais.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.x + Pydantic v2 (`apps/api`); React 18 + TypeScript + Tailwind + Vite (`apps/web`); pytest + TestClient; vitest + Testing Library; Playwright a 360px.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-contas-a-pagar-recorte-design.md`
+
+## ⚠️ Antes da Task 1: isolamento
+
+Em 18/08/2026 este checkout tinha **outra sessão trabalhando em Agenda**, com `CLAUDE.md`,
+`AgendaPage.tsx`, `NewEventModal.tsx`, `BlocoDaAgenda.tsx` e `ClientDetailPage.tsx` modificados e
+não commitados, na branch `feat/agenda-escolher-horario`. O repositório tem **um único checkout
+git** — os diretórios irmãos não têm `.git`.
+
+Antes de qualquer commit: use `superpowers:using-git-worktrees` para criar worktree isolada em
+`.claude/worktrees/`, a partir de `main`. Não commite na branch de Agenda; não faça `checkout -b`
+com o trabalho alheio na árvore.
+
+Verifique `git status` e `git branch --show-current` **você mesmo** antes de cada commit — neste
+repositório o estado já mudou no meio de uma sessão.
+
+## Global Constraints
+
+- **Fuso:** datas de "hoje" vêm de `hoje_do_tenant(db)` no back e de `useFuso()` + `today(fuso)` no front. `datetime.now(UTC).date()` e `new Date()` cru são regressão.
+- **Import absoluto** no backend (`from app.modules...`), padrão do repositório.
+- **Rede sempre mockada** nos testes de front (`vi.mock("../../lib/api", ...)`).
+- **Medição de layout por `boundingBox`**, nunca `toContain` de classe CSS.
+- **Verde exige três comandos:** `pytest -q`, `TZ=UTC pytest -q`, `pytest -m rls_e2e` (este exige Docker e fica fora do `-q` por padrão).
+- **Commits convencionais:** `feat:`, `fix:`, `test:`, `docs:`.
+- Rodar comandos de teste em **primeiro plano**, nunca em background.
+- Backend roda de `apps/api` com o venv em `apps/api/.venv`. Front roda de `apps/web` com `pnpm`.
+
+---
+
+### Task 1: `GET /bills` devolve `{items, total}` e aceita `limit`/`offset`
+
+Esta task sozinha mata o defeito mais grave: hoje a rota devolve as 200 contas mais antigas e o
+resto desaparece sem aviso.
+
+**Files:**
+- Modify: `apps/api/app/modules/payables/schemas.py` (adicionar `PayablesPageOut` ao fim do arquivo)
+- Modify: `apps/api/app/modules/payables/service.py:325-332` (`list_payables`) e acrescentar `_filtros` + `count_payables`
+- Modify: `apps/api/app/modules/payables/router.py:72-84` (`list_bills`)
+- Test: `apps/api/tests/test_payables_listagem.py` (novo)
+
+**Interfaces:**
+- Produces:
+  - `schemas.PayablesPageOut(BaseModel)` com `items: list[PayableOut]` e `total: int`
+  - `service._filtros(stmt, *, status: list[str] | None = None)` — recebe e devolve um `Select`
+  - `service.count_payables(db: Session, *, status: list[str] | None = None) -> int`
+  - `service.list_payables(db, *, status: list[str] | None = None, limit: int = 200, offset: int = 0) -> list[Payable]`
+- Consumes: nada de tasks anteriores.
+
+⚠️ `status` passa de `str | None` para `list[str] | None`. Os chamadores existentes passam `None`;
+confira com `grep -rn "list_payables" apps/api` antes de terminar e ajuste quem passar string.
+
+- [ ] **Step 1: Escrever o teste que reprova o código de hoje**
+
+Criar `apps/api/tests/test_payables_listagem.py`:
+
+```python
+"""Listagem de Contas a Pagar: paginação honesta e filtros (spec 2026-08-18).
+
+O teste `test_teto_de_200_nao_engole_o_futuro` REPROVA o código anterior a esta spec, e é
+deliberado: `list_payables` tinha `limit=200` fixo e o router não expunha `limit`/`offset`, então
+a partir da 201ª conta as linhas seguintes eram inalcançáveis pela rota, sem aviso nenhum.
+"""
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+REGISTER = {
+    "legal_name": "Lista Co",
+    "document": "10101010000178",
+    "slug": "listaco",
+    "email": "lista@example.com",
+    "name": "Lista",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cria(client: TestClient, headers, **campos) -> dict:
+    """Cria uma conta a pagar e devolve o corpo criado."""
+    corpo = {
+        "description": "Conta",
+        "category": "Ferramentas",
+        "supplier": "Fornecedor",
+        "amount_cents": 10_000,
+        "due_date": date(2027, 1, 10).isoformat(),
+    }
+    corpo.update(campos)
+    resp = client.post("/payables/bills", json=corpo, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _cria_muitas(client: TestClient, headers, total: int) -> None:
+    """Cria `total` contas usando recorrência mensal.
+
+    `MAX_OCCURRENCES` (app/core/recurrence.py) e o schema limitam `recurrence_count` a 60, então
+    250 contas saem em 5 POSTs de 50 em vez de 250 chamadas HTTP.
+    """
+    assert total % 50 == 0, "use múltiplos de 50"
+    for lote in range(total // 50):
+        _cria(
+            client,
+            headers,
+            description=f"Serie {lote}",
+            due_date=date(2027 + lote, 1, 10).isoformat(),
+            recurrence="monthly",
+            recurrence_count=50,
+        )
+
+
+def test_teto_de_200_nao_engole_o_futuro(client: TestClient, headers):
+    _cria_muitas(client, headers, 250)
+
+    primeira = client.get("/payables/bills?limit=50&offset=0", headers=headers)
+    assert primeira.status_code == 200, primeira.text
+    corpo = primeira.json()
+    assert len(corpo["items"]) == 50
+    assert corpo["total"] == 250, "o total tem de ser o real, não o tamanho da página"
+
+    # A 201ª conta em diante era inalcançável pela rota antes desta spec.
+    depois_do_teto = client.get("/payables/bills?limit=50&offset=200", headers=headers)
+    assert depois_do_teto.status_code == 200, depois_do_teto.text
+    assert len(depois_do_teto.json()["items"]) == 50
+    assert depois_do_teto.json()["total"] == 250
+
+
+def test_pagina_nao_repete_nem_pula_conta(client: TestClient, headers):
+    _cria_muitas(client, headers, 100)
+    vistos: list[str] = []
+    for offset in (0, 50):
+        pagina = client.get(f"/payables/bills?limit=50&offset={offset}", headers=headers).json()
+        vistos.extend(item["id"] for item in pagina["items"])
+    assert len(vistos) == 100
+    assert len(set(vistos)) == 100, "offset repetiu conta entre páginas"
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_listagem.py -v
+```
+
+Esperado: FAIL. `corpo["items"]` levanta `TypeError: list indices must be integers` porque a rota
+ainda devolve lista nua.
+
+- [ ] **Step 3: Adicionar `PayablesPageOut` ao schema**
+
+Ao fim de `apps/api/app/modules/payables/schemas.py`:
+
+```python
+class PayablesPageOut(BaseModel):
+    """Uma página da listagem de contas a pagar — `items` + o `total` REAL do recorte.
+
+    O `total` não é enfeite: sem ele a tela não consegue dizer "mostrando 50 de 213", e o
+    truncamento volta a ser silencioso — que foi exatamente o defeito que esta spec corrigiu.
+    Ele conta o recorte inteiro, ignorando `limit`/`offset`.
+    """
+
+    items: list[PayableOut]
+    total: int
+```
+
+- [ ] **Step 4: `_filtros`, `count_payables` e `list_payables` no service**
+
+Substituir `list_payables` (hoje em `apps/api/app/modules/payables/service.py:325-332`) por:
+
+```python
+def _filtros(stmt, *, status: list[str] | None = None):
+    """Construtor ÚNICO do predicado da listagem — usado por `list_payables` E `count_payables`.
+
+    ⚠️ **Não duplique este `where` do outro lado.** Dois blocos copiados divergem na primeira
+    manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
+    quebra, o rodapé só passa a mentir. É um modo de falha discreto e caro de achar.
+    """
+    if status:
+        stmt = stmt.where(Payable.status.in_(status))
+    return stmt
+
+
+def list_payables(
+    db: Session,
+    *,
+    status: list[str] | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[Payable]:
+    limit = max(1, min(limit, 500))
+    stmt = _filtros(select(Payable), status=status).order_by(Payable.due_date)
+    return list(db.scalars(stmt.limit(limit).offset(max(0, offset))).all())
+
+
+def count_payables(db: Session, *, status: list[str] | None = None) -> int:
+    """Quantas contas o recorte tem, ignorando `limit`/`offset`."""
+    stmt = _filtros(select(func.count()).select_from(Payable), status=status)
+    return int(db.scalar(stmt) or 0)
+```
+
+`func` e `select` já estão importados no topo do arquivo (linha 6).
+
+- [ ] **Step 5: Ajustar a rota**
+
+Em `apps/api/app/modules/payables/router.py`, trocar `PayableOut` por `PayablesPageOut` no import
+vindo de `app.modules.payables.schemas` e substituir `list_bills` (linha 72):
+
+```python
+@router.get("/bills", response_model=PayablesPageOut)
+def list_bills(
+    status: list[str] | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    _user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> PayablesPageOut:
+    # Fuso resolvido UMA vez para a página inteira: `_out` por linha faria uma consulta de perfil
+    # por conta (N+1). Mesmo cuidado da listagem de `receivables`.
+    hoje = hoje_do_tenant(db)
+    itens = service.list_payables(db, status=status, limit=limit, offset=offset)
+    return PayablesPageOut(
+        items=[service.payable_out(p, hoje) for p in itens],
+        total=service.count_payables(db, status=status),
+    )
+```
+
+- [ ] **Step 6: Conferir os outros chamadores de `list_payables`**
+
+```
+cd apps/api && grep -rn "list_payables" app tests
+```
+
+Qualquer chamada passando `status="open"` (string) vira `status=["open"]`. Corrija todas antes de
+seguir.
+
+- [ ] **Step 7: Rodar a suíte de payables inteira**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_listagem.py tests/test_payables.py tests/test_payables_scheduled.py tests/test_payables_bank_origin.py tests/test_payables_paid_before.py -v
+```
+
+Esperado: PASS em tudo. Se algum teste antigo esperava lista nua de `GET /bills`, ele muda para
+`["items"]` — é a mudança de contrato prevista na §5.1 da spec, não um teste enfraquecido.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/app/modules/payables/schemas.py apps/api/app/modules/payables/service.py apps/api/app/modules/payables/router.py apps/api/tests/test_payables_listagem.py
+git commit -m "feat: contas a pagar paginam com total real, sem teto silencioso"
+```
+
+---
+
+### Task 2: filtros de status, período, texto, centro de custo e categoria
+
+**Files:**
+- Modify: `apps/api/app/modules/payables/service.py` (`_filtros`, `list_payables`, `count_payables`)
+- Modify: `apps/api/app/modules/payables/router.py` (`list_bills`)
+- Test: `apps/api/tests/test_payables_listagem.py` (acrescentar)
+
+**Interfaces:**
+- Consumes: `_filtros`, `list_payables`, `count_payables` da Task 1.
+- Produces: assinatura final compartilhada pelas três funções —
+  `*, status: list[str] | None, due_from: date | None, due_to: date | None, q: str | None, cost_center_id: str | None, chart_account_id: str | None` e, só em `list_payables`, `order: str = "asc"` além de `limit`/`offset`.
+- Produces: `service._escapa_curinga(termo: str) -> str`
+
+⚠️ `from` é palavra reservada em Python: o parâmetro se chama `due_from` e recebe `alias="from"` no
+`Query`. Mesmo para `due_to`/`to`, por simetria.
+
+- [ ] **Step 1: Escrever os testes dos filtros**
+
+Acrescentar a `apps/api/tests/test_payables_listagem.py`:
+
+```python
+def test_status_aceita_mais_de_um_valor(client: TestClient, headers):
+    aberta = _cria(client, headers, description="Aberta")
+    cancelada = _cria(client, headers, description="Cancelada")
+    client.post(f"/payables/bills/{cancelada['id']}/cancel", headers=headers)
+
+    corpo = client.get("/payables/bills?status=open&status=scheduled", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert aberta["id"] in ids
+    assert cancelada["id"] not in ids
+    assert corpo["total"] == len(ids)
+
+
+def test_from_ausente_nao_engole_atrasado_antigo(client: TestClient, headers):
+    """A visão padrão da tela NÃO manda `from`. Se alguém "simplificar" pondo um piso de data, a
+    conta mais urgente que existe — a vencida — some justamente da tela que serve para pagá-la."""
+    antiga = _cria(client, headers, description="Vencida", due_date="2026-02-01")
+    futura = _cria(client, headers, description="Futura", due_date="2027-01-10")
+
+    corpo = client.get("/payables/bills?status=open&to=2027-06-30", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert antiga["id"] in ids, "atrasado antigo tem de aparecer sem `from`"
+    assert futura["id"] in ids
+
+
+def test_to_e_inclusivo_na_borda(client: TestClient, headers):
+    na_borda = _cria(client, headers, description="Borda", due_date="2027-03-31")
+    depois = _cria(client, headers, description="Depois", due_date="2027-04-01")
+
+    corpo = client.get("/payables/bills?to=2027-03-31", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert na_borda["id"] in ids
+    assert depois["id"] not in ids
+
+
+def test_q_busca_em_descricao_e_em_fornecedor(client: TestClient, headers):
+    por_descricao = _cria(client, headers, description="Assinatura Anthropic", supplier="X")
+    por_fornecedor = _cria(client, headers, description="Ferramenta", supplier="Anthropic")
+    outra = _cria(client, headers, description="Aluguel", supplier="Imobiliária")
+
+    corpo = client.get("/payables/bills?q=anthropic", headers=headers).json()
+    ids = [i["id"] for i in corpo["items"]]
+    assert por_descricao["id"] in ids, "busca tem de ser case-insensitive"
+    assert por_fornecedor["id"] in ids
+    assert outra["id"] not in ids
+
+
+def test_q_escapa_curinga_do_like(client: TestClient, headers):
+    """`ilike` interpreta `%` e `_`. Sem escape, digitar `%` casa com TUDO e a busca parece estar
+    funcionando quando não está filtrando nada. A implementação ingênua passa em todos os outros
+    testes e falha só neste."""
+    com_percent = _cria(client, headers, description="100% Cacau", supplier="Doceria")
+    sem_percent = _cria(client, headers, description="Anthropic", supplier="X")
+
+    corpo = client.get("/payables/bills?q=%25", headers=headers).json()  # %25 = "%"
+    ids = [i["id"] for i in corpo["items"]]
+    assert com_percent["id"] in ids
+    assert sem_percent["id"] not in ids
+    assert corpo["total"] == 1
+
+
+def test_order_desc_inverte_a_lista(client: TestClient, headers):
+    _cria(client, headers, description="Primeira", due_date="2027-01-10")
+    _cria(client, headers, description="Ultima", due_date="2027-09-10")
+
+    asc = client.get("/payables/bills?order=asc", headers=headers).json()["items"]
+    desc = client.get("/payables/bills?order=desc", headers=headers).json()["items"]
+    assert asc[0]["description"] == "Primeira"
+    assert desc[0]["description"] == "Ultima"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "",
+        "?status=open",
+        "?status=open&status=scheduled",
+        "?to=2027-06-30",
+        "?from=2027-01-01&to=2027-12-31",
+        "?q=anthropic",
+        "?q=anthropic&status=open",
+    ],
+)
+def test_total_sempre_casa_com_a_lista(client: TestClient, headers, query: str):
+    """O alarme contra `list_payables` e `count_payables` divergirem de predicado."""
+    _cria(client, headers, description="Assinatura Anthropic", due_date="2027-01-10")
+    _cria(client, headers, description="Aluguel", due_date="2027-05-10")
+    _cria(client, headers, description="Curso", due_date="2028-01-10")
+
+    sep = "&" if query else "?"
+    corpo = client.get(f"/payables/bills{query}{sep}limit=500", headers=headers).json()
+    assert corpo["total"] == len(corpo["items"]), f"total divergiu da lista em {query!r}"
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_listagem.py -v
+```
+
+Esperado: os testes novos falham (parâmetros ignorados devolvem tudo). Os dois da Task 1 continuam
+passando.
+
+- [ ] **Step 3: Implementar os filtros no service**
+
+Em `apps/api/app/modules/payables/service.py`, substituir o `_filtros` da Task 1 e ajustar as duas
+funções que o usam:
+
+```python
+def _escapa_curinga(termo: str) -> str:
+    """Neutraliza `%` e `_` para que o texto do usuário seja tratado como TEXTO no `ilike`.
+
+    Sem isto, buscar `%` casa com todas as linhas e a busca parece funcionar enquanto não filtra
+    nada — o pior tipo de defeito de busca, porque não tem sintoma.
+    """
+    return termo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _filtros(
+    stmt,
+    *,
+    status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+):
+    """Construtor ÚNICO do predicado da listagem — usado por `list_payables` E `count_payables`.
+
+    ⚠️ **Não duplique este `where` do outro lado.** Dois blocos copiados divergem na primeira
+    manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
+    quebra, o rodapé só passa a mentir. É um modo de falha discreto e caro de achar.
+
+    `due_from` é opcional **e a tela não o manda na visão padrão, de propósito**: atrasado tem
+    vencimento no passado, então qualquer piso de data esconde a conta mais urgente que existe.
+    """
+    if status:
+        stmt = stmt.where(Payable.status.in_(status))
+    if due_from is not None:
+        stmt = stmt.where(Payable.due_date >= due_from)
+    if due_to is not None:
+        stmt = stmt.where(Payable.due_date <= due_to)
+    if q:
+        alvo = f"%{_escapa_curinga(q)}%"
+        stmt = stmt.where(
+            or_(
+                Payable.description.ilike(alvo, escape="\\"),
+                Payable.supplier.ilike(alvo, escape="\\"),
+            )
+        )
+    if cost_center_id:
+        stmt = stmt.where(Payable.cost_center_id == cost_center_id)
+    if chart_account_id:
+        stmt = stmt.where(Payable.chart_account_id == chart_account_id)
+    return stmt
+
+
+def list_payables(
+    db: Session,
+    *,
+    status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+    order: str = "asc",
+    limit: int = 200,
+    offset: int = 0,
+) -> list[Payable]:
+    limit = max(1, min(limit, 500))
+    stmt = _filtros(
+        select(Payable),
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
+    coluna = Payable.due_date.desc() if order == "desc" else Payable.due_date.asc()
+    stmt = stmt.order_by(coluna, Payable.id)
+    return list(db.scalars(stmt.limit(limit).offset(max(0, offset))).all())
+
+
+def count_payables(
+    db: Session,
+    *,
+    status: list[str] | None = None,
+    due_from: date | None = None,
+    due_to: date | None = None,
+    q: str | None = None,
+    cost_center_id: str | None = None,
+    chart_account_id: str | None = None,
+) -> int:
+    """Quantas contas o recorte tem, ignorando `limit`/`offset`."""
+    stmt = _filtros(
+        select(func.count()).select_from(Payable),
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
+    return int(db.scalar(stmt) or 0)
+```
+
+`or_`, `func`, `select` e `date` já estão importados no topo do arquivo (linhas 4 e 6).
+
+O desempate por `Payable.id` no `order_by` não é enfeite: sem ele, contas com o mesmo vencimento
+podem trocar de posição entre páginas e o `offset` repete ou pula linha — o `test_pagina_nao_repete_nem_pula_conta` da Task 1 é quem cobra isso.
+
+- [ ] **Step 4: Repassar os parâmetros na rota**
+
+Substituir `list_bills` em `apps/api/app/modules/payables/router.py`:
+
+```python
+@router.get("/bills", response_model=PayablesPageOut)
+def list_bills(
+    status: list[str] | None = Query(default=None),
+    # `from`/`to` são as palavras naturais na URL; `from` é reservada em Python, daí o alias.
+    due_from: date_type | None = Query(default=None, alias="from"),
+    due_to: date_type | None = Query(default=None, alias="to"),
+    q: str | None = Query(default=None, max_length=120),
+    cost_center_id: str | None = Query(default=None),
+    chart_account_id: str | None = Query(default=None),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    _user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> PayablesPageOut:
+    hoje = hoje_do_tenant(db)
+    recorte = dict(
+        status=status,
+        due_from=due_from,
+        due_to=due_to,
+        q=q,
+        cost_center_id=cost_center_id,
+        chart_account_id=chart_account_id,
+    )
+    itens = service.list_payables(db, order=order, limit=limit, offset=offset, **recorte)
+    return PayablesPageOut(
+        items=[service.payable_out(p, hoje) for p in itens],
+        total=service.count_payables(db, **recorte),
+    )
+```
+
+O `recorte` como dict único é o que garante que buscar e contar recebam **exatamente** os mesmos
+filtros — esquecer um argumento em uma das chamadas é o mesmo defeito da §5.2 pela porta da rota.
+
+- [ ] **Step 5: Rodar os testes**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_listagem.py -v
+```
+
+Esperado: PASS em todos, incluindo os sete casos parametrizados de `test_total_sempre_casa_com_a_lista`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/payables/service.py apps/api/app/modules/payables/router.py apps/api/tests/test_payables_listagem.py
+git commit -m "feat: listagem de contas a pagar aceita status, periodo, texto e dimensoes"
+```
+
+---
+
+### Task 3: `POST /bills/{id}/reactivate`
+
+**Files:**
+- Modify: `apps/api/app/modules/payables/service.py` (nova `reactivate_payable`, logo abaixo de `cancel_payable`, hoje na linha 713)
+- Modify: `apps/api/app/modules/payables/router.py` (nova rota, depois de `cancel_bill`)
+- Test: `apps/api/tests/test_payables_reactivate.py` (novo)
+
+**Interfaces:**
+- Produces: `service.reactivate_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str) -> Payable`
+- Produces: rota `POST /payables/bills/{payable_id}/reactivate` → `PayableOut`
+- Consumes: `STATUS_OPEN` e `STATUS_CANCELED` de `app.modules.payables.models` (já importados no service).
+
+- [ ] **Step 1: Escrever os testes**
+
+Criar `apps/api/tests/test_payables_reactivate.py`:
+
+```python
+"""Reativar conta cancelada (spec 2026-08-18, §6)."""
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today
+
+REGISTER = {
+    "legal_name": "Reativa Co",
+    "document": "10101010000179",
+    "slug": "reativaco",
+    "email": "reativa@example.com",
+    "name": "Reativa",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cria(client: TestClient, headers, **campos) -> dict:
+    corpo = {
+        "description": "Conta",
+        "category": "Ferramentas",
+        "supplier": "Fornecedor",
+        "amount_cents": 10_000,
+        "due_date": date(2027, 1, 10).isoformat(),
+    }
+    corpo.update(campos)
+    resp = client.post("/payables/bills", json=corpo, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_cancelada_volta_para_aberta_com_vencimento_intacto(client: TestClient, headers):
+    conta = _cria(client, headers, due_date="2027-01-10")
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "open"
+    assert resp.json()["due_date"] == "2027-01-10", "o vencimento contratado não se reescreve"
+
+
+def test_reativada_com_vencimento_passado_nasce_atrasada(client: TestClient, headers):
+    """Vencimento preservado + `is_overdue` derivado = ela volta Atrasada, que é o que ela é.
+
+    A data vem de `tenant_today`, nunca da hora em que a suíte roda.
+    """
+    ontem = tenant_today(DEFAULT_TENANT_TIMEZONE) - timedelta(days=1)
+    conta = _cria(client, headers, due_date=ontem.isoformat())
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "open"
+    assert resp.json()["is_overdue"] is True
+
+
+def test_conta_aberta_nao_pode_ser_reativada(client: TestClient, headers):
+    conta = _cria(client, headers)
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+    assert resp.status_code == 409
+    assert "cancelada" in resp.json()["detail"].lower()
+
+
+def test_conta_paga_nao_pode_ser_reativada(client: TestClient, headers):
+    """Conta paga tem movimento bancário atrás dela; o caminho de volta dela é `/reverse`."""
+    resp_conta = client.post(
+        "/bank/accounts",
+        json={
+            "name": "Itaú PJ",
+            "kind": "checking",
+            "opening_balance_cents": 500_000,
+            "opening_balance_is_known": True,
+            "opening_date": "2026-01-01",
+        },
+        headers=headers,
+    )
+    banco = resp_conta.json()["id"]
+    hoje = tenant_today(DEFAULT_TENANT_TIMEZONE).isoformat()
+    conta = _cria(client, headers, due_date=hoje)
+    paga = client.post(
+        f"/payables/bills/{conta['id']}/pay",
+        json={"bank_account_id": banco, "paid_on": hoje},
+        headers=headers,
+    )
+    assert paga.status_code == 200, paga.text
+
+    resp = client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+    assert resp.status_code == 409
+
+
+def test_conta_inexistente_devolve_404(client: TestClient, headers):
+    resp = client.post("/payables/bills/nao-existe/reactivate", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_reativacao_entra_na_auditoria(client: TestClient, headers, db):
+    from sqlalchemy import select
+
+    from app.core.audit import AuditEntry
+
+    conta = _cria(client, headers)
+    client.post(f"/payables/bills/{conta['id']}/cancel", headers=headers)
+    client.post(f"/payables/bills/{conta['id']}/reactivate", headers=headers)
+
+    acoes = list(db.scalars(select(AuditEntry.action).where(AuditEntry.target == conta["id"])))
+    assert "payable.reactivate" in acoes
+```
+
+⚠️ Antes de rodar, confirme o caminho real do modelo de auditoria:
+`grep -rn "class AuditEntry" apps/api/app`. Ajuste o import do último teste se o nome ou o módulo
+diferirem — o resto do teste não muda.
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_reactivate.py -v
+```
+
+Esperado: FAIL com 404/405 em todos — a rota não existe.
+
+- [ ] **Step 3: Implementar `reactivate_payable`**
+
+Em `apps/api/app/modules/payables/service.py`, logo depois de `cancel_payable`:
+
+```python
+def reactivate_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str) -> Payable:
+    """Devolve uma conta CANCELADA para 'open', com o vencimento original intacto.
+
+    ⚠️ **Não é `reverse`, e a separação é de significado, não de estilo.** `reverse` quer dizer
+    *"esta saída não vai acontecer"*, e o trabalho dele é APAGAR o movimento bancário. Reativar
+    quer dizer o oposto: *"esta saída volta a ser esperada"*. E como `cancel_payable` só aceita
+    conta em aberto, aqui **não existe movimento bancário nem evento de Agenda para desfazer** —
+    cancelar nunca criou nem removeu nenhum dos dois. Fundir os dois verbos obrigaria um
+    `if status == canceled: pula tudo` no meio da lógica mais delicada do arquivo, e é assim que
+    um dos dois caminhos deixa de receber a próxima correção.
+
+    **O vencimento não se reescreve.** Reativada depois do prazo, a conta volta Atrasada — porque é
+    o que ela é. Empurrar a data para hoje apagaria o vencimento que o dono de fato contratou, e a
+    Projeção e o DRE passariam a contar uma data que nunca existiu. Ela nasce editável (`open`),
+    então corrigir a data continua sendo um gesto disponível, só não imposto.
+    """
+    p = db.scalar(select(Payable).where(Payable.id == payable_id).with_for_update())
+    if p is None:
+        raise PayableError("Conta não encontrada", 404)
+    if p.status != STATUS_CANCELED:
+        raise PayableError("Só contas canceladas podem ser reativadas", 409)
+    p.status = STATUS_OPEN
+    audit.record(db, tenant_id=tenant_id, actor=actor, action="payable.reactivate", target=p.id)
+    db.commit()
+    db.refresh(p)
+    return p
+```
+
+- [ ] **Step 4: Expor a rota**
+
+Em `apps/api/app/modules/payables/router.py`, depois de `cancel_bill`:
+
+```python
+@router.post("/bills/{payable_id}/reactivate", response_model=PayableOut)
+def reactivate_bill(
+    payable_id: str,
+    user: CurrentUser = Depends(_guard),
+    db: Session = Depends(get_tenant_db),
+) -> PayableOut:
+    try:
+        p = service.reactivate_payable(
+            db, payable_id=payable_id, tenant_id=user.tenant_id, actor=user.user_id
+        )
+    except service.PayableError as e:
+        raise _err(e) from e
+    return _out(db, p)
+```
+
+`PayableOut` continua sendo importado no router (a Task 1 acrescentou `PayablesPageOut`, não
+substituiu) — confirme que os dois estão no bloco de import.
+
+- [ ] **Step 5: Rodar os testes**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest tests/test_payables_reactivate.py -v
+```
+
+Esperado: PASS nos seis.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/payables/service.py apps/api/app/modules/payables/router.py apps/api/tests/test_payables_reactivate.py
+git commit -m "feat: conta a pagar cancelada volta a ser reativavel"
+```
+
+---
+
+### Task 4: `filtros.ts` — o estado do filtro, puro e testável
+
+**Files:**
+- Create: `apps/web/src/features/pagar/filtros.ts`
+- Create: `apps/web/src/features/pagar/filtros.test.ts`
+- Modify: `packages/shared-types/src/index.ts` (acrescentar `PayablesPage` logo depois de `Payable`, hoje terminando na linha 481)
+
+**Interfaces:**
+- Produces (TS):
+  - `interface PayablesPage { items: Payable[]; total: number }` em `shared-types`
+  - `type FiltroPagar = { status: PayableStatus[]; de: string | null; ate: string | null; q: string; centroDeCusto: string; categoria: string }`
+  - `function fimDoMesSeguinte(hojeYmd: string): string`
+  - `function filtroPadrao(hojeYmd: string): FiltroPagar`
+  - `function paraQuery(f: FiltroPagar, limit: number, offset: number): Record<string, unknown>`
+- Consumes: nada de tasks anteriores (é o primeiro arquivo de front).
+
+- [ ] **Step 1: Escrever os testes**
+
+Criar `apps/web/src/features/pagar/filtros.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { fimDoMesSeguinte, filtroPadrao, paraQuery } from "./filtros";
+
+describe("fimDoMesSeguinte", () => {
+  it("agosto devolve o fim de setembro", () => {
+    expect(fimDoMesSeguinte("2026-08-18")).toBe("2026-09-30");
+  });
+
+  it("vira o ano em dezembro", () => {
+    expect(fimDoMesSeguinte("2026-12-05")).toBe("2027-01-31");
+  });
+
+  it("acerta fevereiro bissexto", () => {
+    expect(fimDoMesSeguinte("2028-01-10")).toBe("2028-02-29");
+  });
+
+  it("acerta fevereiro comum", () => {
+    expect(fimDoMesSeguinte("2027-01-10")).toBe("2027-02-28");
+  });
+
+  it("acerta o ano secular nao bissexto", () => {
+    expect(fimDoMesSeguinte("2100-01-10")).toBe("2100-02-28");
+  });
+});
+
+describe("filtroPadrao", () => {
+  const padrao = filtroPadrao("2026-08-18");
+
+  it("abre em 'o que eu devo': aberta e agendada", () => {
+    expect(padrao.status).toEqual(["open", "scheduled"]);
+  });
+
+  it("NAO tem piso de data", () => {
+    // Atrasado vence no passado. Qualquer `de` esconde a conta mais urgente que existe.
+    expect(padrao.de).toBeNull();
+  });
+
+  it("tem teto no fim do mes seguinte", () => {
+    expect(padrao.ate).toBe("2026-09-30");
+  });
+});
+
+describe("paraQuery", () => {
+  it("omite o que esta vazio, em vez de mandar chave nula", () => {
+    const q = paraQuery(filtroPadrao("2026-08-18"), 50, 0);
+    expect(q).toEqual({
+      status: ["open", "scheduled"],
+      to: "2026-09-30",
+      order: "asc",
+      limit: 50,
+      offset: 0,
+    });
+    expect(q).not.toHaveProperty("from");
+    expect(q).not.toHaveProperty("q");
+  });
+
+  it("manda o texto quando ele existe", () => {
+    const f = { ...filtroPadrao("2026-08-18"), q: "anthropic" };
+    expect(paraQuery(f, 50, 0).q).toBe("anthropic");
+  });
+
+  it("historico vem decrescente", () => {
+    const f = { ...filtroPadrao("2026-08-18"), status: ["paid" as const], ate: null };
+    expect(paraQuery(f, 50, 0).order).toBe("desc");
+  });
+
+  it("repassa limit e offset da paginacao", () => {
+    const q = paraQuery(filtroPadrao("2026-08-18"), 50, 100);
+    expect(q.limit).toBe(50);
+    expect(q.offset).toBe(100);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/filtros.test.ts
+```
+
+Esperado: FAIL — `Cannot find module "./filtros"`.
+
+- [ ] **Step 3: Acrescentar `PayablesPage` a `shared-types`**
+
+Em `packages/shared-types/src/index.ts`, logo depois da interface `Payable` (que termina na linha
+481) e antes de `PayablesSummary`:
+
+```ts
+/** Uma página de `GET /payables/bills` — `items` mais o total REAL do recorte.
+ *
+ * O `total` ignora `limit`/`offset` de propósito: é ele que permite à tela dizer
+ * "mostrando 50 de 213". Sem isso o truncamento volta a ser silencioso.
+ */
+export interface PayablesPage {
+  items: Payable[];
+  total: number;
+}
+```
+
+- [ ] **Step 4: Implementar `filtros.ts`**
+
+Criar `apps/web/src/features/pagar/filtros.ts`:
+
+```ts
+import type { PayableStatus } from "@e1p/shared-types";
+
+/** O recorte da lista de Contas a Pagar. `de`/`ate` são YYYY-MM-DD ou `null` (sem limite). */
+export type FiltroPagar = {
+  status: PayableStatus[];
+  de: string | null;
+  ate: string | null;
+  q: string;
+  centroDeCusto: string;
+  categoria: string;
+};
+
+const DIAS_NO_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function bissexto(ano: number): boolean {
+  return (ano % 4 === 0 && ano % 100 !== 0) || ano % 400 === 0;
+}
+
+/**
+ * Último dia do mês SEGUINTE ao de `hojeYmd`, também em YYYY-MM-DD.
+ *
+ * Aritmética de string, nunca `new Date`: o `hojeYmd` já chega no fuso do tenant (via
+ * `today(useFuso())`), e reconstruir um `Date` a partir dele devolveria o cálculo ao fuso do
+ * navegador — em UTC-3, das 21h à meia-noite o horizonte pularia um dia inteiro.
+ */
+export function fimDoMesSeguinte(hojeYmd: string): string {
+  const [ano0, mes0] = hojeYmd.split("-").map(Number);
+  // `mes0` é 1-based; usá-lo como índice 0-based já aponta para o mês seguinte.
+  const ano = ano0 + Math.floor(mes0 / 12);
+  const mes = (mes0 % 12) + 1;
+  const dias = mes === 2 && bissexto(ano) ? 29 : DIAS_NO_MES[mes - 1];
+  return `${ano}-${String(mes).padStart(2, "0")}-${String(dias).padStart(2, "0")}`;
+}
+
+/**
+ * A visão padrão: "o que eu devo".
+ *
+ * `de: null` é deliberado e não é esquecimento. Atrasado tem vencimento no passado; qualquer piso
+ * de data esconde exatamente a conta mais urgente que existe. O que o horizonte corta é só o
+ * futuro distante — e o lugar de olhar longe é a Projeção de caixa.
+ */
+export function filtroPadrao(hojeYmd: string): FiltroPagar {
+  return {
+    status: ["open", "scheduled"],
+    de: null,
+    ate: fimDoMesSeguinte(hojeYmd),
+    q: "",
+    centroDeCusto: "",
+    categoria: "",
+  };
+}
+
+/** Histórico se lê do mais recente para o mais antigo; o que se deve, do mais próximo em diante. */
+function ordem(status: PayableStatus[]): "asc" | "desc" {
+  const olhandoParaTras = status.every((s) => s === "paid" || s === "canceled");
+  return status.length > 0 && olhandoParaTras ? "desc" : "asc";
+}
+
+/** Serializa para os `params` do axios. Chave vazia é OMITIDA, nunca mandada como null. */
+export function paraQuery(
+  f: FiltroPagar,
+  limit: number,
+  offset: number,
+): Record<string, unknown> {
+  const q: Record<string, unknown> = { order: ordem(f.status), limit, offset };
+  if (f.status.length > 0) q.status = f.status;
+  if (f.de) q.from = f.de;
+  if (f.ate) q.to = f.ate;
+  if (f.q.trim()) q.q = f.q.trim();
+  if (f.centroDeCusto) q.cost_center_id = f.centroDeCusto;
+  if (f.categoria) q.chart_account_id = f.categoria;
+  return q;
+}
+```
+
+- [ ] **Step 5: Rodar os testes**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/filtros.test.ts
+```
+
+Esperado: PASS nos catorze.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/features/pagar/filtros.ts apps/web/src/features/pagar/filtros.test.ts packages/shared-types/src/index.ts
+git commit -m "feat: estado do filtro de contas a pagar, isolado e testavel"
+```
+
+---
+
+### Task 5: `PagarPage` consome `{items, total}` e ganha "carregar mais"
+
+Sem filtros ainda — só o contrato novo, a contagem honesta e a paginação. A tela continua
+mostrando o mesmo que hoje.
+
+**Files:**
+- Modify: `apps/web/src/features/pagar/PagarPage.tsx:88-124` (estado e `load`) e a região da tabela (linhas 200-295)
+- Modify: `apps/web/src/features/pagar/PagarPage.test.tsx:49-57` (`mockComConta`) e demais mocks de `/payables/bills`
+
+**Interfaces:**
+- Consumes: `PayablesPage` e `filtroPadrao`/`paraQuery` da Task 4; `useFuso()` de `../../store/auth`; `today()` de `../../lib/datetime`.
+- Produces: dentro de `PagarPage`, o estado `filtro`, `total`, `offset` e a função `load(reiniciando: boolean)` que a Task 6 vai reusar.
+
+⚠️ O mock de `api.get` em `PagarPage.test.tsx` casa por `url === "/payables/bills"`. Como os
+parâmetros vão no **config** do axios (`api.get(url, { params })`), a comparação continua valendo —
+mas o **corpo** devolvido tem de virar `{ items: [...], total: n }`, senão a página lê `.items` de
+um array e quebra. Ajuste todos os pontos que devolvem `/payables/bills`.
+
+- [ ] **Step 1: Escrever os testes**
+
+Acrescentar a `apps/web/src/features/pagar/PagarPage.test.tsx` (e primeiro ajustar `mockComConta` e
+os demais mocks para devolverem `{ items: [CONTA_ABERTA], total: 1 }`):
+
+```ts
+it("pede a primeira pagina com o recorte padrao", async () => {
+  mockComConta([CONTA]);
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(api.get).toHaveBeenCalledWith("/payables/bills", expect.anything()));
+  const [, config] = vi.mocked(api.get).mock.calls.find(([u]) => u === "/payables/bills")!;
+  const params = (config as { params: Record<string, unknown> }).params;
+  expect(params.status).toEqual(["open", "scheduled"]);
+  expect(params).not.toHaveProperty("from"); // atrasado antigo tem de caber na visao padrao
+  expect(params.offset).toBe(0);
+});
+
+it("mostra quantas contas estao a vista e quantas existem", async () => {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+    if (url === "/payables/bills")
+      return Promise.resolve({ data: { items: [CONTA_ABERTA], total: 213 } } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(/Mostrando 1 de 213/i)).toBeInTheDocument();
+});
+
+it("carregar mais ANEXA a lista em vez de substituir", async () => {
+  const SEGUNDA = { ...CONTA_ABERTA, id: "b-2", description: "Energia" };
+  vi.mocked(api.get).mockImplementation((url: string, config?: unknown) => {
+    if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+    if (url === "/payables/bills") {
+      const offset = (config as { params: { offset: number } }).params.offset;
+      return Promise.resolve({
+        data: { items: offset === 0 ? [CONTA_ABERTA] : [SEGUNDA], total: 2 },
+      } as never);
+    }
+    return Promise.resolve({ data: [] } as never);
+  });
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText("Aluguel")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /carregar mais/i }));
+
+  expect(await screen.findByText("Energia")).toBeInTheDocument();
+  // O erro classico de paginacao: a segunda pagina apagar a primeira.
+  expect(screen.getByText("Aluguel")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/PagarPage.test.tsx
+```
+
+Esperado: FAIL nos três testes novos.
+
+- [ ] **Step 3: Trocar o estado e o `load` em `PagarPage.tsx`**
+
+Acrescentar aos imports do topo:
+
+```tsx
+import type { Contract, Payable, PayablesPage, PayablesSummary } from "@e1p/shared-types";
+import { formatDay, today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
+import { filtroPadrao, paraQuery, type FiltroPagar } from "./filtros";
+```
+
+Dentro de `PagarPage`, acrescentar aos `useState` existentes:
+
+```tsx
+const fuso = useFuso();
+const [filtro, setFiltro] = useState<FiltroPagar>(() => filtroPadrao(today(fuso)));
+const [total, setTotal] = useState(0);
+const [offset, setOffset] = useState(0);
+const [carregando, setCarregando] = useState(false);
+```
+
+Declarar `PAGINA` no **nível do módulo**, junto de `RECUR` e `EXPENSE_GROUPS` (topo do arquivo,
+fora do componente) — o rodapé da tabela também a usa:
+
+```tsx
+/** Tamanho da página. 50 cabe numa rolagem curta e mantém o "carregar mais" barato. */
+const PAGINA = 50;
+```
+
+E substituir o `load` (linha 104) por:
+
+```tsx
+const load = useCallback(
+  async (proximoOffset = 0) => {
+    setCarregando(true);
+    try {
+      const [s, b] = await Promise.all([
+        api.get<PayablesSummary>("/payables/summary"),
+        api.get<PayablesPage>("/payables/bills", {
+          params: paraQuery(filtro, PAGINA, proximoOffset),
+        }),
+      ]);
+      setSummary(s.data);
+      // `proximoOffset > 0` é "carregar mais": ANEXA. Substituir aqui é o erro clássico de
+      // paginação, e ele passa despercebido porque a primeira página sempre parece certa.
+      setBills((antes) => (proximoOffset === 0 ? b.data.items : [...antes, ...b.data.items]));
+      setTotal(b.data.total);
+      setOffset(proximoOffset);
+    } finally {
+      setCarregando(false);
+    }
+    const [ca, cc] = await Promise.all([
+      api.get<ChartAccount[]>("/chart-of-accounts").catch(() => ({ data: [] as ChartAccount[] })),
+      api.get<CostCenter[]>("/cost-centers").catch(() => ({ data: [] as CostCenter[] })),
+    ]);
+    setChartAccounts(ca.data);
+    setCostCenters(cc.data);
+    const pend = await api
+      .get<{ id: string }[]>("/payables/receipts")
+      .catch(() => ({ data: [] as { id: string }[] }));
+    setInbox(pend.data);
+  },
+  [filtro],
+);
+
+useEffect(() => {
+  load(0);
+}, [load]);
+```
+
+⚠️ As chamadas existentes `load()` depois de cancelar/estornar/pagar continuam válidas — sem
+argumento elas recarregam a primeira página, que é o comportamento certo depois de uma ação que
+muda status.
+
+- [ ] **Step 4: Acrescentar o rodapé de contagem**
+
+Logo **depois** do `</table>` e ainda dentro da `div` com `overflow-x-auto`
+(hoje na linha ~293), acrescentar:
+
+```tsx
+<div className="flex items-center justify-between gap-3 border-t border-neutral-100 px-4 py-3">
+  <p className="text-xs text-neutral-500">
+    Mostrando {bills.length} de {total}
+  </p>
+  {bills.length < total && (
+    <button
+      onClick={() => load(offset + PAGINA)}
+      disabled={carregando}
+      className="min-h-[44px] rounded-pill px-4 text-sm font-medium text-primary-600 hover:bg-primary-50 disabled:opacity-50"
+    >
+      {carregando ? "Carregando…" : "Carregar mais"}
+    </button>
+  )}
+</div>
+```
+
+A contagem aparece **sempre**, não só quando trunca: é ela que torna o corte visível antes de o
+dono precisar dele.
+
+- [ ] **Step 5: Rodar os testes de front**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/
+```
+
+Esperado: PASS. Testes antigos que mockavam `/payables/bills` como array precisam do ajuste do
+aviso acima — é a mudança de contrato, não asserção enfraquecida.
+
+- [ ] **Step 6: Typecheck**
+
+```
+cd apps/web && pnpm tsc --noEmit
+```
+
+Esperado: sem erro. Se `@e1p/shared-types` não resolver `PayablesPage`, rode o build do pacote
+compartilhado antes (`cd packages/shared-types && pnpm build`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/pagar/PagarPage.tsx apps/web/src/features/pagar/PagarPage.test.tsx
+git commit -m "feat: contas a pagar pagina e diz quantas contas existem"
+```
+
+---
+
+### Task 6: a barra de filtros e o `GanchoDaVima` fora da primeira dobra
+
+**Files:**
+- Create: `apps/web/src/features/pagar/FiltrosDaLista.tsx`
+- Modify: `apps/web/src/features/pagar/PagarPage.tsx` (montar a barra; mover `GanchoDaVima` para depois da tabela)
+- Modify: `apps/web/src/features/pagar/PagarPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `FiltroPagar` da Task 4; `ChartAccount` de `../financeiro/planoContas`; `CostCenter` de `../financeiro/costCenters`; o estado `filtro`/`setFiltro` da Task 5.
+- Produces: `<FiltrosDaLista valor={FiltroPagar} onChange={(f: FiltroPagar) => void} categorias={ChartAccount[]} centros={CostCenter[]} />`
+
+- [ ] **Step 1: Escrever os testes**
+
+Acrescentar a `apps/web/src/features/pagar/PagarPage.test.tsx`:
+
+```ts
+it("digitar no filtro de texto dispara UMA chamada, nao uma por tecla", async () => {
+  vi.useFakeTimers();
+  mockComConta([CONTA]);
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+  await vi.runOnlyPendingTimersAsync();
+  const antes = vi.mocked(api.get).mock.calls.filter(([u]) => u === "/payables/bills").length;
+
+  fireEvent.change(screen.getByPlaceholderText(/fornecedor ou descri/i), {
+    target: { value: "anthropic" },
+  });
+  await vi.advanceTimersByTimeAsync(400);
+
+  const depois = vi.mocked(api.get).mock.calls.filter(([u]) => u === "/payables/bills").length;
+  expect(depois - antes).toBe(1);
+  vi.useRealTimers();
+});
+
+it("trocar o status para Cancelado refaz a busca com o recorte novo", async () => {
+  mockComConta([CONTA]);
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+  await screen.findByText("Aluguel");
+
+  fireEvent.change(screen.getByLabelText(/status/i), { target: { value: "canceled" } });
+
+  await waitFor(() => {
+    const ultima = vi
+      .mocked(api.get)
+      .mock.calls.filter(([u]) => u === "/payables/bills")
+      .at(-1)!;
+    const params = (ultima[1] as { params: Record<string, unknown> }).params;
+    expect(params.status).toEqual(["canceled"]);
+    expect(params.order).toBe("desc"); // historico se le do mais recente para tras
+    expect(params.offset).toBe(0); // trocar filtro volta para a primeira pagina
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/PagarPage.test.tsx
+```
+
+Esperado: FAIL — não existe campo de texto nem seletor de status.
+
+- [ ] **Step 3: Criar `FiltrosDaLista.tsx`**
+
+```tsx
+import type { PayableStatus } from "@e1p/shared-types";
+import type { CostCenter } from "../financeiro/costCenters";
+import type { ChartAccount } from "../financeiro/planoContas";
+import type { FiltroPagar } from "./filtros";
+
+/** Os recortes de status que a tela oferece. "Em aberto" são DOIS status, não um. */
+const RECORTES: { value: string; label: string; status: PayableStatus[] }[] = [
+  { value: "abertas", label: "Em aberto", status: ["open", "scheduled"] },
+  { value: "paid", label: "Pago", status: ["paid"] },
+  { value: "scheduled", label: "Agendada", status: ["scheduled"] },
+  { value: "canceled", label: "Cancelado", status: ["canceled"] },
+];
+
+function valorDoRecorte(status: PayableStatus[]): string {
+  const achado = RECORTES.find(
+    (r) => r.status.length === status.length && r.status.every((s) => status.includes(s)),
+  );
+  return achado?.value ?? "abertas";
+}
+
+const campo =
+  "min-h-[44px] rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400";
+
+/**
+ * A barra de recorte da lista.
+ *
+ * `flex-wrap` e não largura fixa: em 360px estes cinco controles reflui em duas linhas em vez de
+ * se espremerem a ponto de o polegar não acertar nenhum. O gate de layout mede isso de verdade em
+ * `e2e/pagar-360.spec.ts`.
+ */
+export default function FiltrosDaLista({
+  valor,
+  onChange,
+  categorias,
+  centros,
+}: {
+  valor: FiltroPagar;
+  onChange: (f: FiltroPagar) => void;
+  categorias: ChartAccount[];
+  centros: CostCenter[];
+}) {
+  const padraoAtivo =
+    valor.q === "" && valor.centroDeCusto === "" && valor.categoria === "" && valor.de === null;
+
+  return (
+    <div className="rounded-2xl bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          value={valor.q}
+          onChange={(e) => onChange({ ...valor, q: e.target.value })}
+          placeholder="Buscar fornecedor ou descrição"
+          aria-label="Buscar fornecedor ou descrição"
+          className={`${campo} min-w-0 flex-1 basis-56`}
+        />
+
+        {/* Só `aria-label`, sem <label> irmão: os dois juntos fazem `getByLabel` casar duas vezes
+            e o gate de 360px falha por strict mode do Playwright, não por defeito da tela. */}
+        <select
+          aria-label="Status"
+          value={valorDoRecorte(valor.status)}
+          onChange={(e) => {
+            const r = RECORTES.find((x) => x.value === e.target.value)!;
+            // Histórico não tem por que herdar o horizonte de "o que eu devo".
+            const olhandoParaTras = r.status.every((s) => s === "paid" || s === "canceled");
+            onChange({ ...valor, status: r.status, ate: olhandoParaTras ? null : valor.ate });
+          }}
+          className={campo}
+        >
+          {RECORTES.map((r) => (
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+
+        <input
+          type="date"
+          aria-label="Vencimento até"
+          value={valor.ate ?? ""}
+          onChange={(e) => onChange({ ...valor, ate: e.target.value || null })}
+          className={campo}
+        />
+
+        <select
+          aria-label="Centro de custo"
+          value={valor.centroDeCusto}
+          onChange={(e) => onChange({ ...valor, centroDeCusto: e.target.value })}
+          className={campo}
+        >
+          <option value="">Todos os centros</option>
+          {centros.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label="Categoria"
+          value={valor.categoria}
+          onChange={(e) => onChange({ ...valor, categoria: e.target.value })}
+          className={campo}
+        >
+          <option value="">Todas as categorias</option>
+          {categorias.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.categoria}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {!padraoAtivo && (
+        <button
+          onClick={() =>
+            onChange({ ...valor, q: "", centroDeCusto: "", categoria: "", de: null })
+          }
+          className="mt-3 min-h-[44px] text-xs font-medium text-neutral-500 hover:text-primary-600"
+        >
+          Limpar filtros
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Montar a barra e aplicar o debounce em `PagarPage.tsx`**
+
+Importar `import FiltrosDaLista from "./FiltrosDaLista";` e trocar o `useEffect` da Task 5 por uma
+versão com debounce, seguindo o padrão de `AccountModal.tsx:154-170`:
+
+```tsx
+useEffect(() => {
+  let vivo = true;
+  // Um filtro de texto sem debounce dispara uma chamada por tecla; `vivo` descarta a resposta de
+  // um recorte que o usuário já abandonou e evita a lista "piscar" com dado velho.
+  const t = setTimeout(() => {
+    if (vivo) load(0);
+  }, 300);
+  return () => {
+    vivo = false;
+    clearTimeout(t);
+  };
+}, [load]);
+```
+
+Renderizar a barra logo acima da `div` da tabela:
+
+```tsx
+<FiltrosDaLista
+  valor={filtro}
+  onChange={setFiltro}
+  categorias={chartAccounts}
+  centros={costCenters}
+/>
+```
+
+- [ ] **Step 5: Mover o `GanchoDaVima` para depois da tabela**
+
+Recortar `<GanchoDaVima gancho="payables.conta.criada" />` de onde está hoje (logo abaixo do
+título) e colar **depois** do bloco `</div>` que fecha a tabela. Ele continua sendo respondido; só
+para de ocupar cerca de 200px da primeira dobra, empurrando para fora da tela a lista que é o
+motivo de a página existir.
+
+- [ ] **Step 6: Rodar os testes e o typecheck**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/ && pnpm tsc --noEmit
+```
+
+Esperado: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/pagar/FiltrosDaLista.tsx apps/web/src/features/pagar/PagarPage.tsx apps/web/src/features/pagar/PagarPage.test.tsx
+git commit -m "feat: contas a pagar abre no que se deve, com barra de recorte"
+```
+
+---
+
+### Task 7: a ação "Reativar" na linha cancelada
+
+**Files:**
+- Modify: `apps/web/src/features/pagar/PagarPage.tsx` (funções de ação por volta da linha 150 e a célula de ações da tabela)
+- Modify: `apps/web/src/features/pagar/PagarPage.test.tsx`
+
+**Interfaces:**
+- Consumes: rota `POST /payables/bills/{id}/reactivate` da Task 3; `load` da Task 5.
+- Produces: nada consumido por tasks posteriores.
+
+- [ ] **Step 1: Escrever os testes**
+
+```ts
+const CONTA_CANCELADA = {
+  ...CONTA_ABERTA,
+  id: "b-9",
+  description: "Assinatura cancelada",
+  status: "canceled",
+};
+
+function mockComCancelada() {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+    if (url === "/payables/bills")
+      return Promise.resolve({ data: { items: [CONTA_CANCELADA], total: 1 } } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+  vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+}
+
+it("linha cancelada oferece Reativar", async () => {
+  mockComCancelada();
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole("button", { name: /reativar/i })).toBeInTheDocument();
+});
+
+it("linha aberta NAO oferece Reativar", async () => {
+  mockComConta([CONTA]);
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+  await screen.findByText("Aluguel");
+
+  expect(screen.queryByRole("button", { name: /reativar/i })).not.toBeInTheDocument();
+});
+
+it("Reativar chama a rota certa e recarrega", async () => {
+  mockComCancelada();
+  vi.spyOn(window, "confirm").mockReturnValue(true);
+  render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <PagarPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(await screen.findByRole("button", { name: /reativar/i }));
+
+  await waitFor(() =>
+    expect(api.post).toHaveBeenCalledWith("/payables/bills/b-9/reactivate"),
+  );
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/PagarPage.test.tsx
+```
+
+Esperado: FAIL — não existe botão "Reativar".
+
+- [ ] **Step 3: Implementar a ação**
+
+Ao lado de `cancel` e `reverse` em `PagarPage.tsx`:
+
+```tsx
+/**
+ * Reativar é rota PRÓPRIA, não `/reverse`.
+ *
+ * `reverse` apaga movimento bancário — trabalho que aqui não existe, porque cancelar só age sobre
+ * conta em aberto, que não tem movimento nenhum. A confirmação avisa do vencimento porque é a
+ * única consequência que surpreende: reativada depois do prazo, a conta volta Atrasada, com a data
+ * original preservada.
+ */
+async function reactivate(id: string) {
+  if (
+    !confirm(
+      'Reativar esta conta? Ela volta para "A pagar" com o vencimento original — se ele já ' +
+        "passou, ela aparece como Atrasada e você pode editar a data.",
+    )
+  )
+    return;
+  await api.post(`/payables/bills/${id}/reactivate`);
+  load();
+}
+```
+
+E na célula de ações da tabela, ao lado dos blocos `p.status === "paid"` e `p.status === "scheduled"`:
+
+```tsx
+{p.status === "canceled" && (
+  <button
+    onClick={() => reactivate(p.id)}
+    className="text-xs font-medium text-neutral-500 hover:text-primary-600"
+  >
+    Reativar
+  </button>
+)}
+```
+
+- [ ] **Step 4: Rodar os testes**
+
+```
+cd apps/web && pnpm vitest run src/features/pagar/ && pnpm tsc --noEmit
+```
+
+Esperado: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/pagar/PagarPage.tsx apps/web/src/features/pagar/PagarPage.test.tsx
+git commit -m "feat: reativar conta cancelada pela tela de contas a pagar"
+```
+
+---
+
+### Task 8: gate de layout a 360px
+
+**Files:**
+- Create: `apps/web/e2e/pagar-360.spec.ts`
+
+**Interfaces:**
+- Consumes: `mockarApi` de `apps/web/e2e/support/api.ts`; a barra da Task 6.
+- Produces: nada.
+
+⚠️ `mockarApi` casa por **prefixo mais longo**. Registre `/payables/bills` e, se algum teste
+precisar, `/payables/bills/paid-before` — senão o segundo recebe a página de contas.
+
+- [ ] **Step 1: Escrever a spec**
+
+Criar `apps/web/e2e/pagar-360.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+
+/**
+ * Gate de LAYOUT da tela de Contas a Pagar a 360px.
+ *
+ * Mede `boundingBox`, nunca classe CSS: `toContain("flex-wrap")` já passou verde neste projeto com
+ * a tela quebrada. Payload de pior caso plausível — fornecedor comprido e valor de 6 dígitos —
+ * porque dado curto sempre cabe, e medir com ele é medir uma tela que não existe.
+ */
+const CONTA = {
+  id: "b-1",
+  tenant_id: "t-1",
+  description: "Assinatura anual da plataforma de inteligência",
+  category: "Ferramentas",
+  supplier: "Fornecedor Internacional de Tecnologia Ltda",
+  amount_cents: 118_573_04,
+  due_date: "2026-09-20",
+  competence_date: null,
+  chart_account_id: null,
+  contract_id: null,
+  cost_center_id: null,
+  status: "open",
+  is_overdue: false,
+  paid_at: null,
+  recurrence: "monthly",
+  recurrence_count: 12,
+  recurrence_group: "g-1",
+  payment_code: "",
+  attachment_url: "",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+test.beforeEach(async ({ page }) => {
+  await mockarApi(page, {
+    "/payables/summary": {
+      open_cents: 18_575_704,
+      overdue_cents: 0,
+      week_cents: 1_800_000,
+      month_cents: 18_575_704,
+      paid_month_cents: 562_541,
+      scheduled_cents: 0,
+    },
+    "/payables/bills": { items: [CONTA], total: 213 },
+    "/payables/receipts": [],
+    "/chart-of-accounts": [],
+    "/cost-centers": [],
+  });
+});
+
+test("a barra de filtros reflui e nada estoura os 360px", async ({ page }) => {
+  await page.goto("/pagar");
+
+  const busca = page.getByLabel("Buscar fornecedor ou descrição");
+  await expect(busca).toBeVisible();
+
+  const largura = await page.evaluate(() => document.documentElement.scrollWidth);
+  expect(largura, "a pagina inteira nao pode rolar na horizontal").toBeLessThanOrEqual(360);
+
+  for (const rotulo of ["Buscar fornecedor ou descrição", "Status", "Vencimento até"]) {
+    const caixa = await page.getByLabel(rotulo).boundingBox();
+    expect(caixa, `${rotulo} sem caixa`).not.toBeNull();
+    expect(caixa!.x, `${rotulo} comeca fora da tela`).toBeGreaterThanOrEqual(0);
+    expect(caixa!.x + caixa!.width, `${rotulo} estoura os 360px`).toBeLessThanOrEqual(360);
+  }
+});
+
+test("os controles do filtro sao alvos de toque de 44px", async ({ page }) => {
+  await page.goto("/pagar");
+
+  for (const rotulo of ["Buscar fornecedor ou descrição", "Status", "Vencimento até"]) {
+    const caixa = await page.getByLabel(rotulo).boundingBox();
+    expect(caixa!.height, `${rotulo} baixo demais para o polegar`).toBeGreaterThanOrEqual(44);
+  }
+});
+
+test("a contagem aparece e o gancho da Vima nao ocupa a primeira dobra", async ({ page }) => {
+  await page.goto("/pagar");
+
+  await expect(page.getByText(/Mostrando 1 de 213/i)).toBeVisible();
+
+  const tabela = await page.locator("table").boundingBox();
+  expect(tabela, "tabela sem caixa").not.toBeNull();
+  // A lista é o motivo de a página existir: ela tem de começar dentro da primeira tela.
+  expect(tabela!.y, "a tabela nasce abaixo da dobra").toBeLessThan(740);
+});
+```
+
+⚠️ Confirme a rota real da tela antes de rodar: `grep -rn "PagarPage" apps/web/src/app`. Se o
+caminho não for `/pagar`, ajuste os três `page.goto`.
+
+- [ ] **Step 2: Rodar o gate**
+
+```
+cd apps/web && pnpm playwright test e2e/pagar-360.spec.ts
+```
+
+Esperado: PASS nos três. Se algo estourar a largura, o conserto é no `flex-wrap`/`basis` da barra —
+não afrouxe a asserção.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/pagar-360.spec.ts
+git commit -m "test: gate de layout de contas a pagar a 360px"
+```
+
+---
+
+### Task 9: verificação final e registro no CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (raiz do repositório)
+
+**Interfaces:**
+- Consumes: tudo das Tasks 1-8.
+- Produces: nada.
+
+- [ ] **Step 1: Rodar a suíte de backend completa**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest -q
+```
+
+Esperado: PASS. Rodar em primeiro plano e ler a saída inteira.
+
+- [ ] **Step 2: Rodar a suíte de backend em UTC**
+
+```
+cd apps/api && TZ=UTC .venv/Scripts/python -m pytest -q
+```
+
+Esperado: PASS. Esta classe de quebra noturna já reincidiu duas vezes neste repositório; um teste
+que passa no fuso local e falha em UTC é bug real, não flakiness.
+
+- [ ] **Step 3: Rodar o isolamento por tenant**
+
+```
+cd apps/api && .venv/Scripts/python -m pytest -m rls_e2e
+```
+
+Exige Docker (leva ~10s). Esta task **mexeu em construtor de query**: um filtro que vaze escopo de
+tenant é bug de segurança, não de usabilidade, e este marcador fica fora do `pytest -q` por padrão.
+
+- [ ] **Step 4: Rodar front e gate de layout**
+
+```
+cd apps/web && pnpm vitest run && pnpm tsc --noEmit && pnpm playwright test
+```
+
+Esperado: PASS em tudo.
+
+- [ ] **Step 5: Registrar no CLAUDE.md**
+
+Acrescentar à seção de Contas a Pagar:
+
+```markdown
+### Contas a Pagar — o recorte da lista (2026-08-18)
+
+A tela abre em **"o que eu devo"**: `status ∈ (open, scheduled)`, **sem piso de data** e com teto no
+fim do mês seguinte. O "sem piso" é deliberado — atrasado vence no passado, e um `from` na visão
+padrão esconderia a conta mais urgente que existe. Histórico (pago/cancelado) vem `order=desc`.
+
+`GET /payables/bills` devolve **`{items, total}`**, não lista nua, e aceita `status` (repetível),
+`from`, `to`, `q`, `cost_center_id`, `chart_account_id`, `order`, `limit`, `offset`. O `total` é o
+do recorte inteiro: é ele que sustenta o "Mostrando 50 de 213". Antes desta mudança a rota devolvia
+as **200 mais antigas** e o resto sumia sem aviso — inclusive contas futuras ainda por pagar.
+
+`list_payables` e `count_payables` compartilham `_filtros()`. **Não duplique o `where`**: divergindo,
+o rodapé passa a anunciar um número que a lista não confirma, sem nada quebrar.
+
+`POST /payables/bills/{id}/reactivate` devolve conta cancelada para `open` **com o vencimento
+original**. Não é `/reverse`: aquele apaga movimento bancário, e conta cancelada nunca teve um.
+
+A **busca da barra de cima continua desligada** (`AppShell.tsx`, input sem handler). Não é
+regressão e não é bug — é o Projeto B, ainda sem spec. O filtro de texto de Contas a Pagar é o
+primitivo que ele vai reusar.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: registra o recorte de contas a pagar e o reactivate"
+```
+
+---
+
+## Verificação de cobertura da spec
+
+| Seção da spec | Task |
+|---|---|
+| §3 visão padrão (dois status, sem piso, horizonte) | 4 (`filtroPadrao`), 6 (barra) |
+| §3 ordenação por intenção | 2 (`order`), 4 (`ordem()`) |
+| §4 contagem honesta + carregar mais | 5 |
+| §4 cards não seguem o filtro | 5 (não são tocados, de propósito) |
+| §4 `GanchoDaVima` desce | 6 |
+| §5.1 `{items,total}` + params | 1, 2 |
+| §5.2 predicado único | 1, 2 |
+| §5.3 escape de curinga | 2 |
+| §5.4 horizonte no fuso do tenant | 4 |
+| §5.5 paginação | 1, 5 |
+| §6 reativar (rota, serviço, vencimento preservado) | 3, 7 |
+| §7 peças | 1-7 |
+| §8 testes | todas |
+| §9 360px | 8 |
+| §11 assimetria de receivables | fora de escopo, registrada |
+| §12 CLAUDE.md | 9 |

--- a/docs/superpowers/specs/2026-08-18-contas-a-pagar-recorte-design.md
+++ b/docs/superpowers/specs/2026-08-18-contas-a-pagar-recorte-design.md
@@ -1,0 +1,285 @@
+# Contas a Pagar — o recorte da lista, e reativar conta cancelada
+
+**Data:** 2026-08-18
+**Origem:** pedido do fundador — *"esta tela esta um linguicao, cada vez que vai aumentando o
+volume de registro fica dificil o uso, em virtude da rolagem"*, *"conseguir reativar um contas a
+pagar cancelado"* e *"busca nao esta funcionando"*.
+
+## 1. O problema
+
+A tela abre numa lista única, sem filtro nenhum, ordenada por vencimento **crescente**. Três
+consequências, e a mais grave não é a que motivou o pedido.
+
+**A tela está ancorada no passado.** `order_by(Payable.due_date)` sem direção coloca a conta mais
+antiga já paga na primeira linha. Em produção hoje isso é maio de 2026: o registro menos acionável
+que existe ocupa o lugar para onde os olhos do dono vão primeiro, e o que ele veio ver — o que
+vence agora — está no meio da rolagem.
+
+**A lista cresce sozinha.** Recorrência neste sistema é **materializada**, não projetada:
+`service.create_payable` grava N linhas reais, uma por ocorrência, ligadas por `recurrence_group`.
+Um pró-labore mensal por doze meses são doze registros. O volume que incomoda o dono não vem de ele
+lançar mais despesa; vem de ele ter lançado uma.
+
+**E o corte acontece do lado errado, em silêncio.** `service.list_payables` tem `limit: int = 200`
+com teto rígido de 500, e o router **não expõe** `limit` nem `offset`. Combinado com a ordenação
+crescente, a rota devolve **as 200 mais antigas**. Passando de 200 contas no tenant, o que
+desaparece da tela não é o histórico velho: são as contas **futuras, ainda por pagar**. Sem aviso,
+sem contagem, sem sintoma visível. Este é o defeito mais sério dos três e ninguém o havia notado.
+
+Somados: a rolagem é o sintoma, a ancoragem é a causa e o truncamento silencioso é o risco.
+
+## 2. Escopo
+
+**Dentro:** o recorte da lista de Contas a Pagar (filtros, horizonte, paginação com contagem
+honesta), a correção do teto de 200 e a reativação de conta cancelada. Front e back, módulo
+`payables`.
+
+**Fora, e é uma separação deliberada:** a **busca global** da barra de cima. O campo *"Buscar
+cliente, projeto ou processo"* do `AppShell` nunca foi ligado — o próprio código diz *"A busca não
+tem handler nenhum — é decoração até alguém ligá-la"* (`AppShell.tsx:184`). Não é regressão; é um
+`<input>` sem `onChange`. Ligá-lo exige decidir quais entidades entram, como rankear resultado de
+tipos diferentes, como o RLS se aplica a uma consulta que cruza tabelas e se `pg_trgm`/`tsvector`
+são necessários — o projeto inteiro não tem infra de busca, o único `ilike` do backend está em
+`crm/service.py:394`. **É um segundo projeto, com spec própria**, e ele vai reusar o filtro de
+texto de `payables` que esta spec constrói.
+
+Fora também: reativar cobrança em Contas a Receber (§11), agrupamento visual por série de
+recorrência, e otimização de índice para o `ilike`.
+
+## 3. A visão padrão — a decisão central
+
+A tela abre em **"o que eu devo"**: `status ∈ (open, scheduled)`, **sem limite inferior de data** e
+com teto no fim do mês seguinte.
+
+O "sem limite inferior" é a parte que não pode ser simplificada. Atrasado tem vencimento no
+passado; qualquer piso de data esconde exatamente a conta mais urgente que existe. O horizonte
+corta **só o futuro distante** — e o lugar de olhar longe continua sendo a Projeção de caixa, que
+já existe para isso.
+
+**A ordenação segue a intenção do filtro:**
+
+| Recorte | Ordem | Por quê |
+|---|---|---|
+| Em aberto / agendada | `due_date` crescente | o vencimento mais próximo primeiro; atrasado no topo |
+| Pago (histórico) | `due_date` **decrescente** | o mais recente primeiro; manter crescente aqui é o defeito de hoje |
+| Cancelado | `due_date` decrescente | quem procura uma cancelada procura a última, não a de 2025 |
+
+Pago e cancelado saem da visão inicial e ficam a um clique, no filtro de status.
+
+## 4. A tela
+
+```
+Página / Contas a Pagar
+Despesas
+[A pagar 185.757,04] [Atrasado 0,00] [Nesta semana 18.000] [Pago no mês 5.625]
+--------------------------------------------------------------------------
+ buscar fornecedor ou descrição   [Em aberto v] [Até out/26 v]
+                                  [Centro de custo v] [Categoria v]
+ chips do filtro ativo                              limpar filtros
+--------------------------------------------------------------------------
+ CONTA        CATEGORIA   CENTRO   VENCIMENTO   VALOR   STATUS   (ações)
+ ...
+--------------------------------------------------------------------------
+ Mostrando 23 de 23                            [ver mais adiante]
+```
+
+**A linha de contagem nunca mente.** `Mostrando 50 de 213`, com `carregar mais`. Se algum dia
+truncar, o dono vê. O pecado do bug de hoje não é ter um teto — é o teto não se anunciar, e
+qualquer solução que mantenha o silêncio reconstrói o mesmo defeito com filtro novo por cima.
+
+**Os quatro cards de topo não seguem o filtro.** Eles são o retrato do tenant inteiro e continuam
+sendo. Ganham rótulo explícito para que a lista filtrada mostrando R$ 3 mil ao lado de um card de
+R$ 185 mil não pareça contradição.
+
+**O `GanchoDaVima` desce para baixo da tabela.** Hoje o bloco *"Você emite nota fiscal?"* ocupa
+cerca de 200px logo abaixo do título e empurra a tabela para fora da primeira dobra. Ele continua
+sendo respondido; só para de disputar a dobra com o motivo pelo qual a tela foi aberta. Decisão
+acatada pelo fundador, fora do pedido original.
+
+**Reativar** aparece como ação nas linhas de status `Cancelado` — invisíveis na visão padrão,
+alcançáveis por `Status → Cancelado`. Isso é coerente: reativar é gesto deliberado, não algo em que
+se tropeça enquanto se dá baixa em contas.
+
+## 5. A API
+
+### 5.1 `GET /payables/bills` — recorte e total
+
+```
+GET /payables/bills
+  ?status=open&status=scheduled     repetível; a visão padrão manda os dois
+  &from=YYYY-MM-DD                  due_date >=   (ausente no padrão, de propósito — §3)
+  &to=YYYY-MM-DD                    due_date <=   (fim do mês seguinte, no padrão)
+  &q=anthropic                      ilike em description OU supplier
+  &cost_center_id=... &chart_account_id=...
+  &order=asc|desc  &limit=50  &offset=0
+-> { "items": [PayableOut, ...], "total": 213 }
+```
+
+`status` passa de `str | None` para `list[str] | None`. A visão padrão são **dois** status, não um;
+na rede o valor único de hoje continua válido, então nada existente quebra.
+
+**`order` é decidido pelo front, não inferido pelo back.** A regra da §3 ("histórico vem
+decrescente") mora em `filtros.ts` e chega ao servidor como parâmetro explícito; o backend obedece
+e valida. A alternativa — o backend adivinhar a direção a partir do status pedido — esconde a regra
+num lugar onde ninguém a procura e quebra assim que alguém combinar "pago + em aberto" na mesma
+consulta. O padrão, se `order` vier ausente, é `asc`.
+
+**A resposta deixa de ser lista nua e vira `{ items, total }`.** É mudança de contrato, e é
+justificada: sem `total` não existe "mostrando 50 de 213", e sem isso o truncamento volta a ser
+silencioso. O custo é contido — a coleção tem **um único chamador**, `PagarPage.tsx:107` (as demais
+chamadas em `apps/web` são de item único ou de subrotas), e `Payable` é escrito à mão em
+`packages/shared-types/src/index.ts:459`, então o TypeScript aponta o lugar exato a corrigir em vez
+de deixar quebrar em runtime.
+
+### 5.2 Buscar e contar saem do mesmo predicado
+
+`list_payables` e `count_payables` **compartilham** um `_filtros(stmt, ...)`. Não é preferência de
+estilo: dois blocos de `where` copiados divergem na primeira manutenção, e a partir daí a tela
+anuncia um número que a própria lista não confirma. É um modo de falha discreto — nada quebra, o
+rodapé só passa a mentir — e por isso ele ganha construtor único e teste dedicado (§8.2).
+
+### 5.3 O `q` precisa escapar `%` e `_`
+
+`ilike` interpreta os dois como curinga. Digitar `%` sem escape casa com tudo, e a busca parece
+funcionar quando na verdade não está filtrando nada. O escape acontece antes de montar o padrão, e
+tem teste próprio (§8.3) porque a implementação ingênua passa em todos os outros.
+
+### 5.4 O horizonte é calculado no fuso do tenant
+
+O front deriva "fim do mês seguinte" com `useFuso()` (`store/auth.tsx:115`) e `today(fuso)`
+(`lib/datetime.ts:105`). `new Date()` cru reintroduziria a classe de bug do fuso pela porta do
+filtro: em UTC-3, das 21h à meia-noite o horizonte pularia um dia inteiro.
+
+### 5.5 Paginação
+
+O teto de 500 do serviço permanece como guarda contra pedido absurdo, mas agora acompanhado do
+`total` real — truncar deixa de ser invisível. O front pagina por `offset` com `carregar mais`, que
+**anexa** ao que já está na tela. Esta é a primeira lista paginada do projeto; o padrão que ela
+estabelece vale para as próximas.
+
+## 6. Reativar conta cancelada
+
+### 6.1 Rota nova, e por quê
+
+```
+POST /payables/bills/{id}/reactivate -> PayableOut
+```
+
+Reusar `POST /reverse` seria errado por **significado**, não por estilo. `reverse` quer dizer *"esta
+saída não vai acontecer"*, e o trabalho dele é **apagar o movimento bancário** — o trecho com o
+raciocínio mais cuidadoso do arquivo, com três alternativas rejeitadas documentadas. Reativar quer
+dizer o oposto: *"esta saída volta a ser esperada"*. E como `cancel_payable` só aceita conta em
+aberto, **não existe movimento bancário nem evento de Agenda para desfazer**. Fundir os dois
+obrigaria um `if status == canceled: pula tudo` no meio dessa lógica, e é assim que um dos dois
+caminhos deixa de receber a próxima correção.
+
+### 6.2 O serviço
+
+Simétrico a `cancel_payable`: trava a linha com `with_for_update()`, 404 se não existe, **409 se o
+status não for `canceled`** (*"Só contas canceladas podem ser reativadas"*), põe `open`, grava
+`payable.reactivate` na auditoria — seguindo o padrão `payable.<verbo>` dos outros seis — e
+commita. Nada de bancário, nada de Agenda.
+
+### 6.3 O vencimento é preservado
+
+Uma conta cancelada que vencia 20/08, reativada em 18/09, volta como **Atrasada**, com o vencimento
+original. `is_overdue` calcula isso sozinho.
+
+As duas alternativas foram consideradas e rejeitadas. **Pedir a nova data** num diálogo cobra dois
+passos toda vez, inclusive nos casos em que a data original ainda vale. **Empurrar para hoje**
+automaticamente apaga o vencimento que o dono de fato contratou — e a partir daí a Projeção e o DRE
+passam a contar uma data que nunca existiu. Preservar não inventa nada, e a conta reativada já é
+editável (status `open`), então corrigir a data é um gesto disponível, não um gesto imposto.
+
+## 7. As peças
+
+| Arquivo | Mudança |
+|---|---|
+| `apps/api/app/modules/payables/service.py` | `_filtros()` novo; `list_payables` ganha filtros/ordem; `count_payables` novo; `reactivate_payable` novo |
+| `apps/api/app/modules/payables/router.py` | query params em `GET /bills`; response model novo; rota `POST /bills/{id}/reactivate` |
+| `apps/api/app/modules/payables/schemas.py` | `PayablesPageOut { items, total }` |
+| `packages/shared-types/src/index.ts` | `PayablesPage` ao lado de `Payable` (escrito à mão) |
+| `apps/web/src/features/pagar/FiltrosDaLista.tsx` | **novo** — a barra de filtros, isolada da página |
+| `apps/web/src/features/pagar/filtros.ts` | **novo** — estado do filtro, padrões e serialização para query string; unitário, sem DOM |
+| `apps/web/src/features/pagar/PagarPage.tsx` | consome `{items,total}`, costura filtros, `carregar mais`, ação Reativar, `GanchoDaVima` para baixo |
+
+A barra e a lógica de filtro saem em arquivos próprios porque `PagarPage.tsx` já tem 660 linhas e
+carrega quatro modais; empilhar mais estado ali torna o arquivo difícil de manter e de editar com
+segurança. `filtros.ts` sem DOM é o que permite testar os padrões e a serialização sem montar a
+página inteira.
+
+## 8. Testes
+
+O teste que mais importa é o que **reprova a versão atual do código**. Sem ele, "o teto de 200 foi
+consertado" é opinião.
+
+**8.1 — O teto, provado com volume.** 250 contas criadas. `limit=50&offset=0` devolve 50 itens e
+`total=250`; `offset=200` devolve linhas que **hoje são inalcançáveis pela rota**. Falha no código
+de hoje. É a régua da entrega.
+
+**8.2 — Contagem casa com lista, sob cada filtro.** Para cada combinação, com `limit` folgado,
+`total == len(items)`. É o alarme contra o `_filtros` divergir (§5.2).
+
+**8.3 — `q` escapa curinga.** Com "100% Cacau" e "Anthropic" no banco, buscar `%` traz **uma**
+linha. A implementação ingênua passa em todos os outros testes e falha só neste.
+
+**8.4 — `from` ausente não engole atrasado antigo.** Conta vencida há seis meses aparece na visão
+padrão. É a §3 virando asserção.
+
+**8.5 — `status` repetível; `to` inclusivo na borda; `order` asc e desc.**
+
+**8.6 — Reativar, matriz completa.** `canceled -> open` com vencimento intacto; `paid`, `open` e
+`scheduled` -> 409; id inexistente -> 404; auditoria gravou `payable.reactivate`.
+
+**8.7 — Reativada com vencimento passado nasce `is_overdue`**, com `hoje_do_tenant` injetado —
+nunca a hora em que a suíte roda.
+
+**8.8 — `PagarPage.test.tsx`:** o estado inicial manda dois status, `to` no fim do mês seguinte e
+**`from` ausente**; digitar dispara **uma** chamada e não uma por tecla (o `debounce` de
+`AccountModal.tsx:154`); `carregar mais` **anexa** em vez de substituir; "Mostrando X de Y" reflete
+o `total`; linha cancelada tem "Reativar" e linha aberta não tem.
+
+**8.9 — `filtros.test.ts`** (unitário): padrões corretos, serialização para query string,
+`limpar filtros` volta ao padrão e não a vazio.
+
+**Antes de declarar verde, três comandos e não um:** `pytest -q`; depois `TZ=UTC pytest -q` (esta
+classe de quebra noturna já reincidiu duas vezes neste repositório); e `pytest -m rls_e2e` com
+Docker — este porque a mudança mexe em construtor de query, e um filtro que vaze escopo de tenant é
+bug de segurança, não de usabilidade. Ele fica fora do `pytest -q` por padrão, então precisa ser
+pedido explicitamente.
+
+**Não será testado:** desempenho do `ilike`. Sem volume de produção, qualquer número seria
+decorativo.
+
+## 9. 360px
+
+`apps/web/e2e/pagar-360.spec.ts`, seguindo a convenção existente: Vite sozinho, API interceptada
+por `page.route`, sem backend e sem Docker.
+
+Mede `boundingBox` de verdade — a barra de filtros reflui em duas linhas e nada estoura os 360px —
+e valida alvos de toque de 44px nos controles. **Não** `toContain("flex-wrap")`: asserção de classe
+CSS já passou verde com a tela quebrada neste projeto, e a régua aqui é medida, não string.
+
+## 10. Riscos
+
+| Risco | Mitigação |
+|---|---|
+| `total` e `items` divergirem por `where` duplicado | Construtor `_filtros` único (§5.2) + teste 8.2 |
+| Curinga não escapado fazer a busca parecer funcionar sem filtrar | Escape explícito + teste 8.3, que reprova a versão ingênua |
+| Horizonte calculado com `new Date()` cru reintroduzir bug de fuso | `useFuso()` + `today(fuso)`, com o motivo escrito no código |
+| `carregar mais` substituir em vez de anexar | Teste 8.8, escrito para este defeito específico |
+| Filtro novo vazar escopo de tenant | `pytest -m rls_e2e` obrigatório antes de verde |
+| Alguém "simplificar" o padrão pondo um `from` na visão inicial e sumir com o atrasado | Teste 8.4 + o motivo registrado na §3 |
+
+## 11. Assimetria registrada
+
+`receivables.cancel_charge` tem o mesmo beco sem saída: cobrança cancelada também não volta. Fora
+de escopo por ora — não foi pedido e dobraria a superfície de teste — mas fica anotado para quando
+incomodar. A rota lá seria `POST /receivables/charges/{id}/reactivate`, com a mesma forma da §6.2.
+
+## 12. Entrada no CLAUDE.md
+
+Último passo obrigatório: registrar que Contas a Pagar passou a abrir em "o que eu devo" (e por
+quê), que `GET /payables/bills` devolve `{items,total}` com filtros, que existe `reactivate` e que
+a busca da barra de cima **continua desligada** — este último para que a próxima sessão não gaste
+tempo procurando um bug que não existe.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -481,6 +481,16 @@ export interface Payable {
   created_at: string;
 }
 
+/** Uma página de `GET /payables/bills` — `items` mais o total REAL do recorte.
+ *
+ * O `total` ignora `limit`/`offset` de propósito: é ele que permite à tela dizer
+ * "mostrando 50 de 213". Sem isso o truncamento volta a ser silencioso.
+ */
+export interface PayablesPage {
+  items: Payable[];
+  total: number;
+}
+
 export interface PayablesSummary {
   open_cents: number;
   overdue_cents: number;


### PR DESCRIPTION
## Resumo

A tela de Contas a Pagar era uma lista única, sem filtro, ordenada por vencimento **crescente** — a conta mais antiga já paga ocupava a primeira linha, e o dono rolava até o meio para achar o que vence agora. Como recorrência aqui é **materializada** (`create_payable` grava N linhas reais), a lista crescia sozinha sem ele lançar nada.

O pedido era sobre rolagem. O defeito mais grave era outro.

## ⚠️ O bug que ninguém tinha notado

`list_payables` tinha `limit=200` fixo e o router **não expunha** `limit`/`offset`. Com a ordenação crescente, a rota devolvia as **200 mais antigas** — passando de 200 contas, o que sumia da tela era o **futuro, ainda por pagar**. Sem aviso, sem contagem, sem sintoma.

`test_teto_de_200_nao_engole_o_futuro` **reprova o código anterior a este PR** e é a régua da entrega.

## O que muda

- **A tela abre em "o que eu devo"**: `status ∈ (open, scheduled)`, **sem piso de data** e com teto no fim do mês seguinte. O "sem piso" é deliberado — atrasado vence no passado, e um `from` na visão padrão esconderia a conta mais urgente que existe.
- **`GET /payables/bills` devolve `{items, total}`** e aceita `status` (repetível), `from`, `to`, `q`, `cost_center_id`, `chart_account_id`, `order`, `limit`, `offset`. A tela mostra **"Mostrando X de Y" sempre**, não só quando trunca: o pecado antigo não era ter teto, era o teto não se anunciar.
- **Ordenação segue a intenção do filtro**: em aberto `asc`, histórico `desc`.
- **`POST /payables/bills/{id}/reactivate`** — conta cancelada volta para `open` **com o vencimento original**. Reativada depois do prazo nasce Atrasada, que é o que ela é.
- **`GanchoDaVima` desceu para depois da tabela** — ocupava ~200px da primeira dobra.

### Por que `reactivate` é rota nova, e não `/reverse`

`reverse` significa *"esta saída não vai acontecer"* e seu trabalho é **apagar o movimento bancário**. Reativar significa o oposto. E como `cancel_payable` só aceita conta em aberto, aqui não existe movimento nenhum para desfazer. Fundir os dois obrigaria um `if status == canceled: pula tudo` no meio da lógica mais delicada do arquivo.

## Dois achados durante a execução

**1. O gate de 360px cobrou um conserto.** Medido, não suposto: com os cinco controles na mesma linha, a barra refluía em cinco linhas, ocupava ~300px e jogava a tabela para `y=765` — fora da dobra de 740px. A lista nascia fora da tela. Centro de custo e Categoria foram para trás de "Mais filtros" **só no celular**; tabela voltou para `y=653`.

**2. `fix:` incluído — o filtro não funcionaria em produção.** O axios serializava `status[]=open&status[]=scheduled`. O FastAPI declara `status: list[str] | None = Query(default=None)` e só reconhece a forma **repetida**; com colchetes ele não vê o parâmetro, recebe `None` e devolve a lista **sem filtro nenhum** — a tela pediria "o que eu devo" e receberia pago e cancelado junto, sem erro e sem sintoma.

Nenhuma camada de teste pegava isso, e vale entender por quê: o pytest monta a URL crua já na forma certa, o vitest assere o objeto `params` **antes** de serializar, e o gate de layout recebe payload fixo seja qual for a query. Só medir a URL real fecha a fresta — `e2e/pagar-contrato.spec.ts` é o único lugar do projeto onde axios de verdade roda.

## Guardas contra regressão

| Risco | Teste |
|---|---|
| `total` divergir da lista por `where` duplicado | `test_total_sempre_casa_com_a_lista` (7 combinações) |
| `q` sem escape fazer a busca parecer funcionar sem filtrar | `test_q_escapa_curinga_do_like` — a versão ingênua passa em todos os outros e falha só nele |
| Alguém pôr um `from` na visão padrão e sumir com o atrasado | `test_from_ausente_nao_engole_atrasado_antigo` |
| `carregar mais` substituir em vez de anexar | teste dedicado em `PagarPage.test.tsx` |
| Colchete voltar na query string | `e2e/pagar-contrato.spec.ts` |
| Barra estourar 360px | `e2e/pagar-360.spec.ts`, por `boundingBox` — nunca `toContain` de classe CSS |

## Verificação

| Comando | Resultado |
|---|---|
| `pytest -q` | **2207 passed**, 1 skipped (baseline 2186 → +21) |
| `TZ=UTC pytest -q` | **2207 passed**, 1 skipped — idêntico |
| `pytest -m rls_e2e` | **65 passed** (mexeu em construtor de query; filtro que vaze escopo de tenant é bug de segurança) |
| `pnpm vitest run` | **713 passed** (70 arquivos) |
| `pnpm playwright test` | **37 passed** (gate de layout do projeto inteiro) |
| `pnpm tsc --noEmit` | limpo |

Rebaseado sobre `main` (`159b66b`) e reverificado depois do rebase.

## Fora de escopo, registrado

- **A busca da barra de cima continua desligada** (`AppShell.tsx`, `<input>` sem `onChange`). Não é regressão — nunca foi ligada. É projeto próprio, com spec própria; o filtro de texto daqui é o primitivo que ele vai reusar.
- **`receivables.cancel_charge` tem o mesmo beco sem saída** — cobrança cancelada também não volta.
- **Sem índice para o `ilike`**. `pg_trgm` é o gatilho quando incomodar; otimização especulativa agora.

## Documentação

- Spec: `docs/superpowers/specs/2026-08-18-contas-a-pagar-recorte-design.md`
- Plano: `docs/superpowers/plans/2026-08-18-contas-a-pagar-recorte.md`
- `CLAUDE.md` atualizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)
