### PR TITLE
test: os testes de fuso do tenant passam a poder falhar (#120)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,46 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   checks to pass" (mesmo modelo de `secret-scan`/`sast-semgrep`). Enquanto isso, a régua **mede e não
   barra** — e foi a ausência de barreira, não a de conhecimento, que deixou seis telas passarem.
 
+### 5.2 A régua do fuso nos testes (issue #120, fechada em 2026-08-18)
+
+**Um teste sobre fuso do tenant que roda com o fuso do tenant IGUAL ao da máquina não testa fuso
+nenhum.** `apps/web/vitest.config.ts` fixa `env: { TZ: "America/Sao_Paulo" }` para a suíte inteira.
+Enquanto o mock devolver `useFuso: () => "America/Sao_Paulo"` — ou o teste não mockar nada e cair no
+fallback `FUSO_PADRAO`, que é o mesmo valor —, ler o instante pelo fuso do **tenant** e lê-lo pelas
+partes locais do `Date` produzem o mesmo resultado **por construção**. É a família do
+`toContain("flex-wrap")` do §5.1: asserção estruturalmente incapaz de falhar.
+
+Medido na PR #119: **5 de 5 mutações no coração do `features/agenda/grade.ts` sobreviveram a 11
+testes verdes** — inclusive trocar `today(fuso, …)` por `localYmd(new Date(…))`. A mutação sobreviveu
+ao teste literalmente chamado *"agrupa pelo dia do TENANT, não pelo do navegador"*. **A produção
+estava certa; o que faltava era um teste capaz de dizer isso.**
+
+- **O padrão** é `let fusoDoTenant = "America/Sao_Paulo"` no topo, `vi.mock(".../store/auth", () => ({
+  useFuso: () => fusoDoTenant }))`, reset no `beforeEach` e `fusoDoTenant = FUSO_DISTANTE` só nos
+  testes que existem para provar fuso. `FUSO_DISTANTE = "Asia/Tokyo"` (UTC+9, sem horário de verão):
+  12h à frente do runner, então os dois caminhos discordam até sobre que **dia** é. Referências:
+  `features/agenda/grade.test.ts` e `features/agenda/NewEventModal.test.tsx`.
+- ⚠️ **Nem toda asserção com data deve trocar de fuso, e a exceção precisa estar ESCRITA.** As provas
+  de que uma **data de calendário NÃO converte** (`formatDay` em `all_day`/`due_date`) só funcionam
+  com um fuso **negativo**: é o UTC−3 que puxa a meia-noite UTC para o dia anterior e denuncia um
+  `formatDateShort` indevido. Em Tóquio, `00:00Z` vira 09:00 do mesmo dia e a mutação **sobrevive** —
+  "consertar" esses testes para um fuso distante os ENFRAQUECE. Os casos estão comentados no lugar
+  (`BlocoDaAgenda.test.tsx`, `CrmPage.test.tsx`).
+- ⚠️ **Marca gravada não se compara com a função que a gravou.** `EntradaDoDia.test.tsx` afirmava
+  `localStorage.setItem(CHAVE, today(FUSO))` e o componente lia `today(fuso)`: o teste comparava o
+  código consigo mesmo e passava com qualquer fuso. Agora a marca é uma **string literal**
+  (`"2026-08-17"`) com o relógio congelado num instante em que Tóquio, São Paulo e UTC discordam.
+- **A correção só vale verificada POR MUTAÇÃO.** Para cada asserção consertada, troque a leitura de
+  produção para o fuso do navegador (`today(fuso)` → `localYmd(new Date())`, ou
+  `formatX(iso, fuso)` → `formatX(iso, Intl.DateTimeFormat().resolvedOptions().timeZone)`) e confirme
+  que o teste **morre**. Sem isso a correção é cosmética. Restaure por **cópia do arquivo**, nunca
+  por `git checkout` num arquivo com trabalho não commitado.
+- **Dívida que fica:** a mesma classe existe fora da lista de quem mocka `useFuso`. Os testes de
+  `pagar/ComprovantePage`, `pagar/PagarPage` e `cobrancas/CobrancasPage` montam "hoje" com
+  `d.getFullYear()/getMonth()/getDate()` (o dia do **navegador**) e comparam com o `today(fuso)` da
+  tela; com tenant e runner no mesmo fuso, essas asserções também não conseguem falhar. Não foram
+  tocadas nesta passada.
+
 ## 6. Estado atual / roadmap
 - [x] Fundação do monorepo, docs, agentes de QA, CI local.
 - [x] Core do backend: tenancy (RLS) + anonimizador + camada de IA + auditoria.

--- a/apps/web/src/features/agenda/EscolherHorario.test.tsx
+++ b/apps/web/src/features/agenda/EscolherHorario.test.tsx
@@ -14,9 +14,18 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: () => "Erro inesperado",
 }));
 
-vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). O `vitest.config.ts`
+// fixa o fuso da MÁQUINA em America/Sao_Paulo: enquanto o tenant mockado for esse mesmo valor,
+// `eventosDoDia`/`faixasLivres`/`hojeDoTenant` lidos pelo fuso do tenant e lidos pelas partes
+// locais do `Date` dão o MESMO resultado — e nenhuma asserção deste arquivo consegue distinguir
+// os dois. É o defeito da issue #120, a família do `toContain("flex-wrap")` do CLAUDE.md §5.1.
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner: sob ele os dois caminhos
+// discordam até sobre que DIA é. Mesmo valor que `grade.test.ts` usa no nível unitário — aqui
+// ele prova que o COMPONENTE repassa o fuso do tenant àquela aritmética, e não outro qualquer.
+const FUSO_DISTANTE = "Asia/Tokyo";
 
-
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
 
 // O dia base deste arquivo é quinta 15/10/2026 às 09:00 do tenant (12:00Z), não o 10/10 da
 // fixture compartilhada.
@@ -39,6 +48,7 @@ const abrir = (onEscolher = vi.fn()) => {
 
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
   // "Agora" fixo: 10/10/2026 09:00 no fuso do tenant. Sem isto, os testes de faixa livre
   // mudariam de resultado conforme o dia em que a suíte roda.
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -51,6 +61,10 @@ afterEach(() => {
 
 describe("EscolherHorario", () => {
   it("mostra a disponibilidade do dia escolhido antes de qualquer formulário", async () => {
+    // ⚠️ Fuso do runner de propósito: este teste é sobre a ORDEM (a agenda antes do formulário) e
+    // sobre a faixa tomada sumir da oferta — não sobre fuso. Ele não distingue tenant de
+    // navegador, e não é para distinguir: quem faz essa prova é o `describe` "fuso do tenant,
+    // não do navegador" no fim do arquivo. Não troque o fuso aqui.
     mockar([evento()]);
     abrir();
 
@@ -91,6 +105,9 @@ describe("EscolherHorario", () => {
   });
 
   it("no dia de hoje, não oferece horário que já passou", async () => {
+    // ⚠️ Fuso do runner de propósito: o que se prova aqui é a REGRA DO CORTE (`<=`, a faixa das
+    // 09h em ponto já não vale), não de que relógio ele sai. O teste irmão em "fuso do tenant,
+    // não do navegador" faz a outra prova, com o corte lido em Tóquio.
     mockar([]);
     abrir();
 
@@ -176,5 +193,54 @@ describe("EscolherHorario", () => {
     await userEvent.click(screen.getByRole("button", { name: /16 de novembro/ }));
     expect(screen.getByText("Compromisso de novembro")).toBeInTheDocument();
     expect(screen.queryByText("Alinhamento do casamento")).not.toBeInTheDocument();
+  });
+
+  /**
+   * `grade.test.ts` já prova, no nível unitário, que `eventosDoDia`/`faixasLivres`/`hojeDoTenant`
+   * respeitam o fuso que RECEBEM. O que falta — e é o que estes dois testes fecham — é que o
+   * COMPONENTE entregue a elas o fuso do TENANT (`useFuso()`), e não o relógio da máquina. Sem um
+   * fuso distante do runner, essa passagem de parâmetro é invisível: os dois valores coincidem.
+   */
+  describe("fuso do tenant, não do navegador", () => {
+    it("abre no dia de HOJE do tenant e corta o passado pelo relógio dele", async () => {
+      // 10/10/2026 22:00Z é 11/10 07:00 em Tóquio e 10/10 19:00 em São Paulo (o fuso do runner).
+      // Lendo pelo tenant: o seletor abre no dia 11 e, às 07h, a janela inteira de 08–18h ainda
+      // está por vir. Lendo pelo navegador: abriria no dia 10 às 19h, com TUDO já no passado —
+      // "Sem horário livre". Os dois desfechos são opostos, e é isso que a asserção mede.
+      fusoDoTenant = FUSO_DISTANTE;
+      vi.setSystemTime(new Date("2026-10-10T22:00:00Z"));
+      mockar([]);
+      abrir();
+
+      await waitFor(() => expect(vi.mocked(api.get)).toHaveBeenCalled());
+
+      expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(/11 de outubro/i);
+      expect(screen.getByRole("button", { name: "08:00–09:00" })).toBeInTheDocument();
+      expect(screen.queryByText(/sem horário livre/i)).not.toBeInTheDocument();
+    });
+
+    it("põe o compromisso no dia do tenant — e é lá que a faixa dele some da oferta", async () => {
+      // 15/10 23:00Z–16/10 00:00Z é 16/10 08:00–09:00 em Tóquio e 15/10 20:00–21:00 em São Paulo.
+      // O compromisso troca de DIA conforme o fuso, e a faixa que ele ocupa vai junto: só quem lê
+      // pelo tenant o coloca no dia 16 tomando as 08h. Quem lê pelo navegador deixa o dia 16
+      // inteiramente livre — e o seletor ofereceria 08:00 em cima de um compromisso existente,
+      // que é o defeito exato que a feature existe para impedir.
+      fusoDoTenant = FUSO_DISTANTE;
+      mockar([evento({ starts_at: "2026-10-15T23:00:00Z", ends_at: "2026-10-16T00:00:00Z" })]);
+      abrir();
+
+      await userEvent.click(await screen.findByRole("button", { name: /16 de outubro/ }));
+
+      expect(screen.getByText("Alinhamento do casamento")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "08:00–09:00" })).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "09:00–10:00" })).toBeInTheDocument();
+
+      // E o espelho: no dia 15 — onde o relógio do NAVEGADOR o colocaria — ele não está, e as
+      // 20h nem sequer são oferecidas (a janela para às 18h), então a prova é a ausência do
+      // título e a oferta intacta das 08h.
+      await userEvent.click(screen.getByRole("button", { name: /15 de outubro/ }));
+      expect(screen.queryByText("Alinhamento do casamento")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "08:00–09:00" })).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/cockpit/CockpitPage.test.tsx
+++ b/apps/web/src/features/cockpit/CockpitPage.test.tsx
@@ -20,11 +20,20 @@ vi.mock("../../lib/api", () => ({
 
 // CockpitPage usa useAuth() (lança sem AuthProvider). Mockamos o store para não montar o provider
 // (que registra um interceptor no `api` real — desnecessário e ruidoso no teste). `user` pode ser null.
+// O fuso do TENANT é trocável por teste (mesmo modelo de `NewEventModal.test.tsx`). O
+// `vitest.config.ts` fixa o fuso da MÁQUINA em America/Sao_Paulo; enquanto o tenant mockado for
+// esse mesmo valor, `today(fuso)` e `localYmd(new Date())` devolvem o MESMO dia por construção, e
+// um teste chamado "no fuso do tenant" passa mesmo com a tela lendo o fuso do NAVEGADOR.
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner: sob ele os dois caminhos
+// discordam, inclusive sobre que DIA é. É o único jeito de a asserção poder falhar.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
 vi.mock("../../store/auth", () => ({
   useAuth: () => ({ user: null }),
   // O Cockpit pede `/cockpit/summary?day=` com o dia NO FUSO DO TENANT — sem isto o mock
   // derruba a tela antes de qualquer asserção.
-  useFuso: () => "America/Sao_Paulo",
+  useFuso: () => fusoDoTenant,
 }));
 
 const EMPTY = {
@@ -52,6 +61,7 @@ function renderPage() {
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
   vi.mocked(api.post).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("CockpitPage — Cobrar com IA e resiliência (Story 7.15, Task 3)", () => {
@@ -107,10 +117,22 @@ describe("CockpitPage — Cobrar com IA e resiliência (Story 7.15, Task 3)", ()
     expect(screen.getByText("Taxa de Conversão")).toBeInTheDocument();
   });
 
+  /** O `?day=` efetivamente pedido ao servidor. */
+  function diaPedido() {
+    return vi
+      .mocked(api.get)
+      .mock.calls.find(([u]) => String(u).startsWith("/cockpit/summary"))?.[0];
+  }
+
   it("pede o resumo do dia NO FUSO DO TENANT, não do dia UTC", async () => {
     // Às 23:30 em São Paulo já é o dia seguinte em UTC. O código antigo montava o parâmetro com
     // `new Date().toISOString().slice(0, 10)` e pedia ao servidor o resumo do dia SEGUINTE —
     // toda noite, das 21h à meia-noite, o Cockpit mostrava o dia errado.
+    //
+    // ⚠️ Este teste prova TENANT ≠ UTC, e SÓ isso: o tenant aqui é o mesmo fuso do runner, então
+    // ele não distingue "dia do tenant" de "dia do navegador" — o teste irmão logo abaixo é quem
+    // faz essa outra prova. Não "conserte" este trocando o fuso: a asserção UTC precisa de um
+    // tenant a OESTE de Greenwich para existir.
     //
     // A data é deliberadamente distante de hoje: se os fake timers não pegassem, a asserção
     // cairia na data real e o teste falharia em vez de passar por engano.
@@ -121,10 +143,26 @@ describe("CockpitPage — Cobrar com IA e resiliência (Story 7.15, Task 3)", ()
     renderPage();
 
     await waitFor(() => expect(api.get).toHaveBeenCalled());
-    const url = vi
-      .mocked(api.get)
-      .mock.calls.find(([u]) => String(u).startsWith("/cockpit/summary"))?.[0];
-    expect(url).toBe("/cockpit/summary?day=2027-03-14"); // e NÃO ?day=2027-03-15 (o dia UTC)
+    expect(diaPedido()).toBe("/cockpit/summary?day=2027-03-14"); // e NÃO ?day=2027-03-15 (o dia UTC)
+
+    vi.useRealTimers();
+  });
+
+  it("pede o dia do TENANT, não o do NAVEGADOR", async () => {
+    // Tenant em Tóquio (UTC+9), máquina em São Paulo (UTC−3, fixado pelo `vitest.config.ts`).
+    // 14/03/2027 22:30Z é 15/03 07:30 em Tóquio, 14/03 19:30 em São Paulo e 14/03 em UTC — os
+    // três discordam, e só quem lê pelo fuso do TENANT pede o dia 15.
+    fusoDoTenant = FUSO_DISTANTE;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2027-03-14T22:30:00Z"));
+    vi.mocked(api.get).mockResolvedValue({ data: EMPTY } as never);
+
+    renderPage();
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    // `localYmd(new Date())` (fuso do navegador) e `toISOString().slice(0,10)` (UTC) dariam
+    // ambos 2027-03-14 aqui: as duas mutações morrem nesta linha.
+    expect(diaPedido()).toBe("/cockpit/summary?day=2027-03-15");
 
     vi.useRealTimers();
   });

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -10,6 +10,20 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: (e: unknown) => String(e),
 }));
 
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). Antes da issue #120
+// este arquivo não mockava `useFuso` e caía no fallback `FUSO_PADRAO = "America/Sao_Paulo"` — o
+// MESMO fuso que o `vitest.config.ts` fixa para a máquina. Com os dois iguais, o separador de dia
+// e o horário de cada bolha saem idênticos lendo pelo tenant ou pelo relógio do navegador, e a
+// asserção sobre eles fica estruturalmente incapaz de falhar. O default abaixo preserva
+// exatamente o comportamento anterior de todos os outros testes deste arquivo.
+// `ClientTimeline` (renderizado por esta tela) também consome `useFuso` — o mock parcial cobre
+// os dois, e nenhum dos dois usa mais nada de `store/auth`.
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+
 // Nenhum teste deste arquivo depende de chamadas de um teste anterior — cada um remonta seu
 // próprio `mockImplementation`. Sem isto, o HISTÓRICO de chamadas (não só o resultado) vaza de
 // um teste para o próximo, o que já quebrou uma asserção `not.toHaveBeenCalledWith` real (ver
@@ -17,6 +31,7 @@ vi.mock("../../lib/api", () => ({
 // a implementação que cada teste instala antes do reset ter chance de rodar de novo.
 beforeEach(() => {
   vi.clearAllMocks();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 function renderNaRota(rota: string) {
@@ -69,7 +84,59 @@ describe("ConversasPage", () => {
     expect(screen.getByPlaceholderText(/mensagem/i)).toBeInTheDocument();
   });
 
+  it("o separador de dia e o horário saem no fuso do TENANT, não no do navegador", async () => {
+    // O fio agrupa por DIA (`dayKey`) e carimba cada bolha (`hhmm`), os dois no fuso do tenant.
+    // O teste irmão abaixo mede as duas coisas com o tenant no MESMO fuso da máquina, e por isso
+    // não consegue distinguir os dois caminhos — é o defeito da issue #120. Aqui o tenant vai
+    // para Tóquio (UTC+9) e a máquina fica em São Paulo (UTC−3): 19/07 23:30Z é 20/07 08:30 em
+    // Tóquio e 19/07 20:30 em São Paulo. Muda o horário E o dia do separador.
+    fusoDoTenant = FUSO_DISTANTE;
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [{
+            chat_id: "c1", kind: "direct" as const, title: "Murilo Moreschi", phone: "5511977776666",
+            client_id: "c1", last_message_at: "2026-07-19T23:30:00Z",
+            last_message_preview: "sempre na curva", unread: false,
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/timeline") {
+        return Promise.resolve({
+          data: [{
+            source: "conversation", direction: "in", kind: "text",
+            text_body: "sempre na curva", media_attachment_id: null, purpose_label: null,
+            sender_name: null, created_at: "2026-07-19T23:30:00Z",
+          }],
+        });
+      }
+      if (url === "/whatsapp-conversations/c1/window") {
+        return Promise.resolve({ data: { within_session_window: true } });
+      }
+      if (url === "/whatsapp-templates") return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: [] });
+    });
+
+    renderNaRota("/conversas");
+    await waitFor(() => screen.getByText("Murilo Moreschi"));
+    await userEvent.click(screen.getByText("Murilo Moreschi"));
+    await waitFor(() => expect(screen.getAllByText("sempre na curva").length).toBeGreaterThan(0));
+
+    expect(screen.getByText("08:30")).toBeInTheDocument();
+    expect(screen.queryByText("20:30")).not.toBeInTheDocument();
+    // O separador do dia acompanha: segunda 20/07 em Tóquio, domingo 19/07 em São Paulo. O regex
+    // exige o dia-da-semana antes da data, o que distingue o SEPARADOR do carimbo da lista de
+    // conversas (que é só a data) — mesma distinção do teste irmão.
+    expect(screen.getByText(/^\S+,? 20\/07\/2026$/)).toBeInTheDocument();
+    // 19/07 não aparece em lugar NENHUM da tela: nem no separador, nem no carimbo da lista, que
+    // também converte pelo fuso do tenant.
+    expect(screen.queryAllByText(/19\/07\/2026/)).toHaveLength(0);
+  });
+
   it("distingue autor e mostra dia e horário de cada mensagem", async () => {
+    // ⚠️ Fuso do runner de propósito: o que este teste mede é a AUTORIA ("Você ·") e a contagem
+    // de separadores (um por dia, não um por mensagem) — não a conversão de fuso, que o teste
+    // logo acima prova com o tenant em Tóquio. Não troque o fuso aqui.
     // Instantes fixos em UTC-3 (fuso do produto) para o horário renderizado ser previsível.
     // Os dois primeiros são do mesmo dia; o terceiro é de outro dia — exige 2 separadores.
     vi.mocked(api.get).mockImplementation((url: string) => {

--- a/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
@@ -14,7 +14,16 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: () => "Erro inesperado",
 }));
 
-vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). O `vitest.config.ts`
+// fixa o fuso da MÁQUINA em America/Sao_Paulo: com os dois iguais, converter um instante pelo fuso
+// do tenant e lê-lo pelas partes locais do `Date` dá o MESMO resultado, e a asserção de fuso fica
+// estruturalmente incapaz de falhar (§5.1 do CLAUDE.md, a família do `toContain("flex-wrap")`).
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner — sob ele os dois caminhos
+// discordam até sobre que DIA é.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
 
 const evento = (over: Record<string, unknown> = {}) => ({
   id: "ev-1", tenant_id: "t1", title: "Atendimento", description: "", kind: "atendimento",
@@ -38,6 +47,7 @@ const renderBloco = () => render(<BlocoDaAgenda clientId="cli-1" nome="Loana" />
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
   vi.mocked(api.post).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 // Em `afterEach`, não no corpo do teste: se uma asserção falhar antes do `useRealTimers()`, os
@@ -93,6 +103,11 @@ describe("BlocoDaAgenda", () => {
     expect(await screen.findByText("Compromisso de hoje")).toBeInTheDocument();
     // Dia inteiro formata pela STRING (`formatDay`), sem `Date` — nunca `formatDateTime`, que
     // trataria a meia-noite UTC como um instante e converteria para o fuso do tenant.
+    //
+    // ⚠️ Aqui o fuso do tenant é o do runner DE PROPÓSITO, e trocá-lo por Tóquio ENFRAQUECERIA a
+    // asserção: este teste prova que a data de calendário NÃO converte, e quem denuncia a
+    // conversão indevida é um fuso NEGATIVO (UTC−3 puxa a meia-noite UTC para 15/08 21:00). Em
+    // Tóquio, 00:00Z vira 09:00 do MESMO dia 16 e a mutação sobreviveria. Não "conserte".
     expect(screen.getByText("16/08/2026")).toBeInTheDocument();
   });
 
@@ -136,6 +151,12 @@ describe("BlocoDaAgenda", () => {
 
     // O seletor sai de cena e o formulário entra com a escolha já feita — o dono não redigita
     // a data que acabou de apontar no calendário.
+    //
+    // ⚠️ Fuso do runner de propósito: este teste é sobre a COSTURA (a escolha atravessa do
+    // seletor para o formulário), não sobre fuso. A prova de que a hora escolhida é a hora de
+    // PAREDE DO TENANT — `instanteNoFuso` + `paraInputLocal`, com tenant em Tóquio — já vive em
+    // `features/agenda/NewEventModal.test.tsx`, no dono da conversão. Trocar o fuso aqui só
+    // trocaria a string esperada por outra igualmente arbitrária e duplicaria aquela prova.
     expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Marcar com Loana" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Início")).toHaveValue("2026-08-20T10:00");
@@ -158,17 +179,17 @@ describe("BlocoDaAgenda", () => {
     expect(screen.queryByRole("heading", { name: "Novo evento" })).not.toBeInTheDocument();
   });
 
-  it("formata o horário no fuso do tenant", async () => {
-    // 13:00 UTC em America/Sao_Paulo (UTC−3, sem horário de verão) é 10:00.
-    // ⚠️ Este teste NÃO distingue fuso do tenant de fuso do navegador, e o comentário anterior
-    // dizia que sim ("headless roda em UTC"): `vitest.config.ts` fixa `TZ: "America/Sao_Paulo"`
-    // para a suíte inteira, e o mock de `useFuso` devolve o mesmo valor — com os dois iguais, os
-    // dois caminhos dão o mesmo resultado. Quem quiser essa prova use um fuso de tenant DIFERENTE
-    // do runner, como `grade.test.ts` faz com `FUSO_DISTANTE`.
-    mockar([evento({ starts_at: "2026-08-20T13:00:00Z" })]);
+  it("formata o horário no fuso do TENANT, não no do navegador", async () => {
+    // Tenant em Tóquio (UTC+9), máquina em São Paulo (UTC−3, fixado pelo `vitest.config.ts`).
+    // 20/08 23:00Z é 21/08 08:00 em Tóquio e 20/08 20:00 em São Paulo: os dois caminhos discordam
+    // na HORA e no DIA, então a asserção abaixo só passa lendo pelo fuso do tenant.
+    fusoDoTenant = FUSO_DISTANTE;
+    mockar([evento({ starts_at: "2026-08-20T23:00:00Z" })]);
     renderBloco();
 
-    expect(await screen.findByText("20/08/2026 10:00")).toBeInTheDocument();
+    expect(await screen.findByText("21/08/2026 08:00")).toBeInTheDocument();
+    // O que `localYmd`/`toLocaleString` sem `timeZone` mostrariam — o relógio de quem abriu a tela.
+    expect(screen.queryByText("20/08/2026 20:00")).not.toBeInTheDocument();
   });
 
   it("falha de rede vira aviso, não derruba a ficha", async () => {

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -10,7 +10,15 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: () => "Erro inesperado",
 }));
 
-vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). O `vitest.config.ts`
+// fixa o fuso da MÁQUINA em America/Sao_Paulo: com os dois iguais, `formatTime(m.created_at, fuso)`
+// e ler o relógio do navegador dão a MESMA hora por construção, e nenhuma asserção consegue
+// distinguir um do outro (issue #120).
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
 
 const conversa = (chat_id: string, title: string) => ({
   chat_id, kind: "direct", title, phone: "5511999998888",
@@ -55,6 +63,7 @@ const renderBloco = () =>
 // `url.startsWith(...)` no `mockar`. Mesmo padrão de `ConversasPage.test.tsx`/`ClientTimeline.test.tsx`.
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("BlocoDaConversa", () => {
@@ -63,6 +72,23 @@ describe("BlocoDaConversa", () => {
     renderBloco();
     expect(await screen.findByText("Boa noite")).toBeInTheDocument();
     expect(screen.getByText("Oi Ju, tudo bem?")).toBeInTheDocument();
+  });
+
+  it("carimba a hora da mensagem no fuso do TENANT, não no do navegador", async () => {
+    // O bloco mostra a hora de cada bolha (`formatTime(m.created_at, fuso)`) e, até a issue #120,
+    // NENHUM teste daqui afirmava nada sobre ela — o mock de `useFuso` existia só para a tela não
+    // quebrar. Com tenant e runner no mesmo fuso, acrescentar a asserção também não provaria
+    // nada: 23:10Z daria 20:10 pelos dois caminhos.
+    //
+    // Tenant em Tóquio (UTC+9), máquina em São Paulo (UTC−3): 15/08 23:10Z é 08:10 do dia
+    // SEGUINTE em Tóquio e 20:10 do mesmo dia em São Paulo.
+    fusoDoTenant = FUSO_DISTANTE;
+    mockar([conversa("chat-1", "Ju")]);
+    renderBloco();
+
+    await screen.findByText("Boa noite");
+    expect(screen.getByText("08:10")).toBeInTheDocument();
+    expect(screen.queryByText("20:10")).not.toBeInTheDocument();
   });
 
   it("pede a timeline já cortada no servidor (limit=5), não a inteira", async () => {

--- a/apps/web/src/features/crm/ClientTimeline.test.tsx
+++ b/apps/web/src/features/crm/ClientTimeline.test.tsx
@@ -9,6 +9,10 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: (e: unknown) => String(e),
 }));
 
+// Fuso do tenant igual ao do runner (o `vitest.config.ts` fixa `TZ: "America/Sao_Paulo"`), e aqui
+// isso NÃO é o defeito da issue #120: quem varia é a MÁQUINA — o teste "formata no fuso do tenant"
+// lá embaixo troca `process.env.TZ` para Tóquio, que é a outra metade da mesma prova. Nenhum outro
+// teste deste arquivo afirma coisa alguma sobre data ou hora, então nada mais aqui depende de fuso.
 vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
 
 const ENTRADA = {
@@ -118,6 +122,10 @@ describe("ClientTimeline", () => {
       // O `quando()` antigo, no relógio da MÁQUINA (Tóquio, UTC+9), teria mostrado
       // 17/08/2026 08:30 — um dia adiante e 12h de diferença. Isso NÃO pode aparecer.
       expect(screen.queryByText("17/08/2026 08:30")).not.toBeInTheDocument();
+      // ✅ VERIFICADO POR MUTAÇÃO (issue #120): trocar `formatDateTime(e.at, fuso)` por
+      // `formatDateTime(e.at, Intl.DateTimeFormat().resolvedOptions().timeZone)` — ler pelo fuso
+      // do navegador — MATA este teste. É a prova de que o `process.env.TZ` acima chega mesmo ao
+      // `Intl` em tempo de execução, e de que a asserção não é decorativa.
     });
   });
 

--- a/apps/web/src/features/crm/CrmPage.test.tsx
+++ b/apps/web/src/features/crm/CrmPage.test.tsx
@@ -18,6 +18,19 @@ vi.mock("../../lib/api", () => ({
     "Erro inesperado",
 }));
 
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). Antes da issue #120
+// este arquivo não mockava `useFuso` e caía no fallback `FUSO_PADRAO = "America/Sao_Paulo"` — o
+// MESMO fuso que o `vitest.config.ts` fixa para a máquina. Com os dois iguais, converter um
+// instante pelo fuso do tenant e lê-lo pelo relógio do navegador dá o mesmo resultado por
+// construção, e a asserção de fuso não consegue falhar. `CrmPage` e sua subárvore (`Modal`,
+// `GanchoDaVima`, `pageActions`) só usam `useFuso` deste módulo — o mock parcial é seguro.
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner: sob ele os dois caminhos
+// discordam até sobre que DIA é.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+
 // Estratégia (a) da Task 0: o botão "Novo cliente" vive na topbar (AppShell). Topbar de teste local.
 function Topbar() {
   const { action } = usePageActions();
@@ -43,6 +56,7 @@ beforeEach(() => {
     return Promise.resolve({ data: [] } as never);
   });
   vi.mocked(api.post).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("CrmPage — Novo cliente (Story 7.15, Task 1)", () => {
@@ -244,6 +258,9 @@ describe("CrmPage — a linha do próximo passo", () => {
   });
 
   it("mostra o próximo compromisso quando existe", async () => {
+    // ⚠️ Fuso do runner de propósito: este teste é sobre a LINHA existir com o título certo, não
+    // sobre conversão de fuso — 14:00Z cai no dia 20 em qualquer fuso plausível. A prova de fuso
+    // é o teste "converte o instante para o fuso do TENANT" mais abaixo. Não troque o fuso aqui.
     vi.mocked(api.get).mockResolvedValue({
       data: boardCom("2026-08-20T14:00:00Z", "Reunião de alinhamento"),
     } as never);
@@ -271,12 +288,11 @@ describe("CrmPage — a linha do próximo passo", () => {
 
 describe("CrmPage — próximo passo de dia inteiro não 'volta' um dia (achado da revisão final)", () => {
   // `receivables/service.py::build_charge` ancora o evento de cobrança à MEIA-NOITE UTC (não na
-  // meia-noite do fuso do tenant, ao contrário de `agenda/service.py::create_event`). O teste
-  // roda sem `AuthContext` ao redor (`renderPage` só empacota Router + PageActions), e
-  // `useFuso()` cai no fallback `FUSO_PADRAO = "America/Sao_Paulo"` (UTC−3) quando o contexto
-  // é `null` — o cenário exato do achado: "2026-08-22T00:00:00Z" em UTC−3 é 21/08 21h. Formatar
-  // como INSTANTE (`formatDateShort`, que converte fuso) imprimiria "21/08"; o card tem que
-  // usar `formatDay` (lê a string, sem conversão) e mostrar "22/08" — a data real do vencimento.
+  // meia-noite do fuso do tenant, ao contrário de `agenda/service.py::create_event`). Com o
+  // tenant em UTC−3 — o padrão deste arquivo — "2026-08-22T00:00:00Z" é 21/08 21h: o cenário
+  // exato do achado. Formatar como INSTANTE (`formatDateShort`, que converte fuso) imprimiria
+  // "21/08"; o card tem que usar `formatDay` (lê a string, sem conversão) e mostrar "22/08" — a
+  // data real do vencimento.
   const boardComProximo = (
     nextEventAt: string, nextEventTitle: string, allDay: boolean,
   ): Board => ({
@@ -294,6 +310,11 @@ describe("CrmPage — próximo passo de dia inteiro não 'volta' um dia (achado 
   });
 
   it("cobrança vencendo dia 22 mostra 22/08 no card, não 21/08", async () => {
+    // ⚠️ Fuso do runner (UTC−3) DE PROPÓSITO, e trocá-lo por Tóquio ENFRAQUECERIA a asserção:
+    // o que este teste prova é que a data de calendário NÃO converte, e quem denuncia a conversão
+    // indevida é um fuso NEGATIVO — em UTC−3 a meia-noite UTC "volta" para 21/08 21h. Em Tóquio,
+    // 00:00Z vira 09:00 do MESMO dia 22 e a troca por `formatDateShort` sobreviveria. Não
+    // "conserte" este para um fuso distante.
     vi.mocked(api.get).mockResolvedValue({
       data: boardComProximo("2026-08-22T00:00:00Z", "A receber: Fulana", true),
     } as never);
@@ -304,15 +325,21 @@ describe("CrmPage — próximo passo de dia inteiro não 'volta' um dia (achado 
     expect(screen.queryByText(/em 21\/08/i)).not.toBeInTheDocument();
   });
 
-  it("compromisso COM horário continua convertendo para o fuso do tenant (formatDateShort)", async () => {
+  it("compromisso COM horário converte o instante para o fuso do TENANT, não do navegador", async () => {
     // Contraste: `all_day: false` não pode passar a usar `formatDay` por engano — um evento com
     // horário É um instante de verdade, e tem que continuar convertendo fuso.
+    //
+    // Tenant em Tóquio (UTC+9), máquina em São Paulo (UTC−3): 20/08 23:00Z é 21/08 08:00 em
+    // Tóquio e 20/08 20:00 em São Paulo. Só quem lê pelo fuso do TENANT escreve 21/08 no card;
+    // ler pelo relógio do navegador — ou pela string, como o ramo `all_day` faz — daria 20/08.
+    fusoDoTenant = FUSO_DISTANTE;
     vi.mocked(api.get).mockResolvedValue({
-      data: boardComProximo("2026-08-20T14:00:00Z", "Reunião de alinhamento", false),
+      data: boardComProximo("2026-08-20T23:00:00Z", "Reunião de alinhamento", false),
     } as never);
     renderPage();
     expect(
-      await screen.findByText(/próximo: Reunião de alinhamento em 20\/08/i),
+      await screen.findByText(/próximo: Reunião de alinhamento em 21\/08/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/em 20\/08/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/vima/BriefingPage.test.tsx
+++ b/apps/web/src/features/vima/BriefingPage.test.tsx
@@ -13,9 +13,16 @@ vi.mock("../../lib/api", () => ({
     "Erro inesperado",
 }));
 
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). O `vitest.config.ts`
+// fixa o fuso da MÁQUINA em America/Sao_Paulo: com os dois iguais, a hora do briefing formatada
+// pelo fuso do tenant e lida pelo relógio do navegador coincidem por construção (issue #120).
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner.
+const FUSO_DISTANTE = "Asia/Tokyo";
+
 vi.mock("../../store/auth", () => ({
   useAuth: () => ({ user: { name: "Flávio Kato" } }),
-  useFuso: () => "America/Sao_Paulo",
+  useFuso: () => fusoDoTenant,
 }));
 
 const BRIEFING = {
@@ -66,6 +73,7 @@ beforeEach(() => {
   vi.mocked(api.get).mockReset();
   vi.mocked(api.post).mockReset();
   vi.mocked(api.patch).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("BriefingPage", () => {
@@ -118,6 +126,23 @@ describe("BriefingPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText(/Entrou um pagamento/)).toBeInTheDocument());
     expect(screen.queryByText(/Escrito pela IA/i)).not.toBeInTheDocument();
+  });
+
+  it("carimba a hora do briefing no fuso do TENANT, não no do navegador", async () => {
+    // A tela mostra a hora em que o briefing foi escrito (`formatTime(briefing.created_at, fuso)`)
+    // e, até a issue #120, nenhum teste daqui afirmava nada sobre ela — o mock de `useFuso`
+    // existia só para a tela não quebrar. Com tenant e runner no mesmo fuso, acrescentar a
+    // asserção também não provaria nada.
+    //
+    // Tenant em Tóquio (UTC+9), máquina em São Paulo (UTC−3): 06/08 10:05Z é 19:05 em Tóquio e
+    // 07:05 em São Paulo — e o briefing é da MANHÃ do dono, então trocar os dois é visível.
+    fusoDoTenant = FUSO_DISTANTE;
+    mockGet(BRIEFING);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Entrou um pagamento/)).toBeInTheDocument());
+    expect(screen.getByText("19:05")).toBeInTheDocument();
+    expect(screen.queryByText("07:05")).not.toBeInTheDocument();
   });
 
   it("falha de rede não deixa a tela em branco — o caminho para o painel continua", async () => {

--- a/apps/web/src/features/vima/EntradaDoDia.test.tsx
+++ b/apps/web/src/features/vima/EntradaDoDia.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
-import { today } from "../../lib/datetime";
 import EntradaDoDia, { CHAVE_ENTRADA } from "./EntradaDoDia";
 
-const FUSO = "America/Sao_Paulo";
+// O fuso do TENANT é trocável por teste (modelo de `NewEventModal.test.tsx`). O `vitest.config.ts`
+// fixa o fuso da MÁQUINA em America/Sao_Paulo: enquanto o tenant mockado for esse mesmo valor,
+// `today(fuso)` e `localYmd(new Date())` devolvem o MESMO dia por construção, e a marca de
+// "já entrei hoje" não consegue provar que é o dia do TENANT.
+let fusoDoTenant = "America/Sao_Paulo";
+// Tóquio (UTC+9) está 12h à frente do runner — sob ele os dois caminhos discordam sobre o DIA.
+const FUSO_DISTANTE = "Asia/Tokyo";
 
 vi.mock("../../lib/api", () => ({
   api: { get: vi.fn(), post: vi.fn() },
@@ -13,7 +18,7 @@ vi.mock("../../lib/api", () => ({
 }));
 
 vi.mock("../../store/auth", () => ({
-  useFuso: () => FUSO,
+  useFuso: () => fusoDoTenant,
 }));
 
 function renderEntrada() {
@@ -37,7 +42,25 @@ function renderEntrada() {
 beforeEach(() => {
   localStorage.clear();
   vi.mocked(api.get).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
+
+// Em `afterEach`, não no corpo do teste: uma asserção que falha antes do `useRealTimers()` faria
+// os fake timers vazarem para os testes seguintes, e uma falha viraria cascata sem relação.
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * Congela o relógio num instante em que TÓQUIO, SÃO PAULO e UTC discordam sobre que dia é:
+ * 16/08/2026 22:00Z é 17/08 07:00 em Tóquio, 16/08 19:00 em São Paulo (o fuso do runner) e
+ * 16/08 em UTC. Só quem lê pelo fuso do TENANT chega ao dia 17.
+ */
+const HOJE_EM_TOQUIO = "2026-08-17";
+function relogioEmQueOsFusosDiscordam() {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date("2026-08-16T22:00:00Z"));
+}
 
 describe("EntradaDoDia — o briefing é porta de entrada UMA VEZ POR DIA", () => {
   it("briefing de hoje ainda não lido: a entrada é a Vima", async () => {
@@ -53,27 +76,42 @@ describe("EntradaDoDia — o briefing é porta de entrada UMA VEZ POR DIA", () =
   });
 
   it("já entrou hoje neste aparelho: vai direto ao Cockpit, SEM perguntar de novo", async () => {
-    // A marca é o dia do TENANT, não `toISOString().slice(0,10)` (que é o dia UTC). A primeira
-    // versão deste teste usou UTC e falhou só depois das 21h no Brasil — a mesma classe de bug
-    // que a correção de fuso de 2026-08-05 eliminou de ~25 telas.
-    localStorage.setItem(CHAVE_ENTRADA, today(FUSO));
+    // A marca é o dia do TENANT, não `toISOString().slice(0,10)` (que é o dia UTC) nem o dia do
+    // NAVEGADOR. A primeira versão deste teste usou UTC e falhou só depois das 21h no Brasil — a
+    // mesma classe de bug que a correção de fuso de 2026-08-05 eliminou de ~25 telas.
+    //
+    // ⚠️ A marca é uma STRING LITERAL de propósito. Escrevê-la com `today(fuso)` — como esta
+    // versão fazia — usa a MESMA função que a tela usa: o teste compara o código consigo mesmo e
+    // passa qualquer que seja o fuso, inclusive com a tela lendo o do navegador.
+    fusoDoTenant = FUSO_DISTANTE;
+    relogioEmQueOsFusosDiscordam();
+    localStorage.setItem(CHAVE_ENTRADA, HOJE_EM_TOQUIO);
+    // A rede responde, mesmo não devendo ser chamada: assim, uma marca que não bate falha na
+    // asserção ("o cockpit" não aparece) em vez de estourar num `undefined.then` sem sentido.
+    vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
     renderEntrada();
     await waitFor(() => expect(screen.getByText("o cockpit")).toBeInTheDocument());
     expect(api.get).not.toHaveBeenCalled();
   });
 
   it("marca de ONTEM não vale: o briefing é diário", async () => {
+    // Fuso do runner de propósito: "2020-01-01" está a seis anos de qualquer leitura possível, e
+    // nenhum fuso do mundo muda essa resposta. Este teste é sobre a marca VELHA, não sobre fuso.
     localStorage.setItem(CHAVE_ENTRADA, "2020-01-01");
     vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
     renderEntrada();
     await waitFor(() => expect(screen.getByText("a tela do briefing")).toBeInTheDocument());
   });
 
-  it("marca o dia ao decidir — quem volta ao painel não é reenviado à Vima em loop", async () => {
+  it("marca o dia ao decidir — e o dia gravado é o do TENANT, não o do navegador", async () => {
+    // O outro lado da marca: além de LER pelo fuso do tenant, a entrada tem que GRAVAR nele.
+    // Gravar o dia do navegador faria a marca vencer cedo (ou tarde) demais para quem viaja.
+    fusoDoTenant = FUSO_DISTANTE;
+    relogioEmQueOsFusosDiscordam();
     vi.mocked(api.get).mockResolvedValue({ data: { id: "b1", read_at: null } });
     renderEntrada();
     await waitFor(() => expect(screen.getByText("a tela do briefing")).toBeInTheDocument());
-    expect(localStorage.getItem(CHAVE_ENTRADA)).toBeTruthy();
+    expect(localStorage.getItem(CHAVE_ENTRADA)).toBe(HOJE_EM_TOQUIO); // e NÃO "2026-08-16"
   });
 
   it("briefing indisponível não tranca a entrada: cai no Cockpit e tenta de novo depois", async () => {


### PR DESCRIPTION
## O que muda

**Zero código de produção.** Só testes e CLAUDE.md.

`apps/web/vitest.config.ts` fixa `env: { TZ: "America/Sao_Paulo" }` para a suíte inteira. Quando o mock devolve o **mesmo** fuso, ler pelo fuso do tenant e ler pelas partes locais do `Date` produzem o mesmo resultado **por construção** — a asserção é estruturalmente incapaz de falhar. É como, na #119, 5 de 5 mutações no coração do `grade.ts` sobreviveram a 11 testes verdes, incluindo o teste literalmente chamado *"agrupa pelo dia do TENANT, não pelo do navegador"*.

Agora as asserções que existem para provar fuso do tenant rodam sob **Asia/Tokyo** (+12h do runner, vira o dia), e o dia do tenant, o de UTC e o do navegador **discordam entre si** nos instantes escolhidos.

## Prova por mutação: 15 aplicadas, 15 mortas

Correção de teste que não é verificada por mutação é cosmética. Cada asserção consertada teve a leitura correspondente na produção trocada para o fuso do navegador, e o teste morreu:

| Mutação | Teste que morreu |
|---|---|
| `CockpitPage` `today(fuso)` → `localYmd(new Date())` | "pede o dia do TENANT, não o do NAVEGADOR" — `expected '…day=2027-03-14' to be '…day=2027-03-15'` |
| `CockpitPage` `today(fuso)` → `toISOString().slice(0,10)` | os **dois** testes de dia (UTC e navegador) |
| `EntradaDoDia` `today(fuso)` → `localYmd(new Date())` | 2 testes (`expected '2026-08-16' to be '2026-08-17'`) |
| `BlocoDaAgenda` `formatDateTime(…, fuso)` → navegador | "formata o horário no fuso do TENANT" |
| `EscolherHorario` `eventosDoDia(…, fuso)` → `eventsOfDay(…)` | "põe o compromisso no dia do tenant" — **a mutação exata que a issue nomeia** |
| `EscolherHorario` `hojeDoTenant(fuso)` → `startOfDay(new Date())` | "abre no dia de HOJE do tenant e corta o passado pelo relógio dele" |
| `CrmPage`, `BlocoDaConversa`, `BriefingPage`, `ConversasPage`, `ClientTimeline`, `ledger`… | (+9 linhas, todas mortas) |

Restauração sempre por cópia de arquivo, nunca `git checkout` — o arquivo tinha trabalho não commitado.

## Duas asserções que NÃO migram, e a issue estava errada nesse ponto

As provas de que uma **data de calendário não converte** (`formatDay` em `all_day` e `due_date`) só denunciam a conversão indevida sob fuso **negativo**: em UTC−3 a meia-noite UTC "volta" um dia; em Tóquio `00:00Z` vira 09:00 do **mesmo** dia e a mutação **sobrevive**. Migrá-las enfraqueceria o teste. Ficaram em São Paulo, com a razão e um *"não conserte"* escritos no próprio arquivo.

## O alcance real era outro

A issue falava em 12 arquivos; o grep devolve **9**. Em compensação, apareceu **um fora do grep**: `ConversasPage.test.tsx` não mocka `useFuso` e cai no fallback `FUSO_PADRAO = "America/Sao_Paulo"` — mesma doença por outro caminho. `CrmPage.test.tsx` estava no mesmo caso.

Também foi desfeita uma tautologia: `EntradaDoDia` escrevia a marca do localStorage com `today(FUSO)` e comparava com `today(FUSO)` — o código conferido consigo mesmo. Agora é string literal com relógio congelado.

Um arquivo mudou **só comentário**: `ClientTimeline.test.tsx` já era capaz de falhar (varia o `TZ` da máquina, não o do tenant). Verificado por mutação e anotado, para ninguém "consertar" o que está certo.

## Dívida registrada, fora do escopo

`ComprovantePage`, `PagarPage` e `CobrancasPage` montam "hoje" na mão com `getFullYear()/getMonth()/getDate()` — o dia do **navegador** — e comparam com o `today(fuso)` da tela. Mesma incapacidade estrutural, fora do recorte do `grep useFuso`. Está no §5.2 e vira issue-irmã.

## Verificação

```
pnpm lint       exit 0
pnpm typecheck  exit 0
pnpm test       69 arquivos · 699 testes · 699 passed
```

693 na base, +6 aqui. (A #121 acrescenta outros 22 por conta própria, em ramo separado.)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

