### PR TITLE
test(web): a regua de 360px passa a medir a CAIXA dos modais (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,28 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
 - **As fixtures são de PIOR CASO PLAUSÍVEL** (nome longo de banco, valor de 6 dígitos, título de
   grupo comprido), nas formas reais de `packages/shared-types`. Dado curto sempre cabe: medir com ele
   é medir uma tela que não existe.
+- **Modal medido = `testId` na CAIXA** (#123, desde 2026-08-18). O recorte da varredura entra pela
+  prop `testId` do `components/Modal.tsx`, e ela é aplicada na **caixa** — cabeçalho e barra de ação
+  inclusive. Recorte no `children` deixa os dois FORA da conta **por construção**: foi assim que
+  `textoForaDaTela` devolveu **lista vazia** com o "Fechar" em **x=698** numa tela de 360 (#119).
+  Medidos hoje: `EscolherHorario` (`ficha-marcar-360`), `AccountModal` (`modal-conta-360`), o
+  detalhe de evento da Agenda (`agenda-evento-360`) e "Declarar saldo"/"Lançar movimento"
+  (`contas-modais-360`).
+- ⚠️ **`scrollWidth` NÃO vê o defeito do título — a BORDA vê.** Sem `min-w-0`, o `<h2>` é item de flex
+  com `min-width: auto`: ele **cresce** em vez de transbordar. Com o conserto do #119 revertido e
+  medido, `scrollWidth === clientWidth` seguia **verde** enquanto a borda direita do título ia a
+  **894px** e o "Fechar" a **946px** numa viewport de 360. Mede-se `boundingBox` do título contra a
+  borda da CAIXA; `scrollWidth` fica como segunda metade, nunca como a única.
+- ⚠️ **A 5273 colide entre WORKTREES do próprio e1p, e isso já mediu o branch errado.** Com
+  `reuseExistingServer: !CI`, um Vite de OUTRO checkout na 5273 fazia o Playwright **reusar** aquele
+  servidor e medir o código do outro branch em silêncio: em 18/08/2026, **35 dos 41** testes
+  vermelhos com `getByTestId` "não encontrado" para um `data-testid` escrito no arquivo — e o modo
+  de falha oposto (**verde** contra código alheio) seria indistinguível de aprovação. Agora
+  `reuseExistingServer` é **`false` sempre**: porta ocupada vira erro alto em vez de medição falsa.
+  Para rodar duas worktrees ao mesmo tempo: `E2E_PORT=5373 pnpm --filter @e1p/web e2e`.
+- **Dívida:** a medição de modal cobre **4 dos 18** arquivos que usam `Modal` (5 dos 35 modais). Os
+  dois de maior exposição ainda sem medida são os de título digitado pelo dono: `EstoquePage`
+  (`Movimentar: {item.name}`) e `ProdutosPage` (`Vender: {product.name}`).
 - ⚠️ **O CI não tinha NENHUM job de frontend até esta data** — o `vitest` nunca rodou nele, e nenhuma
   medição de tela era exigida em PR. O job `frontend` (typecheck + vitest + playwright) fecha isso.
 - ⚠️ **O job roda Node 24, e a versão NÃO é detalhe de infraestrutura.** A raiz declara

--- a/apps/web/e2e/agenda-evento-360.spec.ts
+++ b/apps/web/e2e/agenda-evento-360.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { agendaEvent as evento } from "./support/fixtures";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O detalhe de compromisso da Agenda em 360×740 — o gêmeo exato do defeito do #119.
+ *
+ * `AgendaPage` monta este modal com `<Modal title={event.title}>`: o título é **digitado pelo
+ * dono** e `title` aceita **255 chars** (`agenda/schemas.py`). Sem espaço, hífen ou barra não há
+ * onde quebrar — o `<h2>` cresce, espreme o "Fechar" e o empurra para fora da tela. Foi assim, no
+ * seletor de horário, que o botão foi parar em **x=698** numa viewport de 360.
+ *
+ * ⚠️ A varredura é recortada pela CAIXA (`data-testid="modal-evento"`, aplicado pela prop `testId`
+ * do `Modal`), nunca pelo conteúdo. Recorte no `children` deixa cabeçalho e rodapé fora da conta
+ * por construção, e foi ele que devolveu **lista vazia** com o botão 338px fora da tela. Os dois
+ * disfarces continuam de pé e por isso não bastam sozinhos: o `scrollWidth` da PÁGINA segue 360
+ * (a caixa tem `overflow-y-auto`) e um `<h2>` sem `min-w-0 break-words` cresce em vez de quebrar.
+ */
+
+// Pior caso PLAUSÍVEL (§5.1), não `lorem ipsum`: um lorem tem espaço sobrando e mediria uma tela
+// que não existe. O que o dono digita de verdade num título comprido é isto — sem espaço, sem
+// hífen e sem barra, o único formato em que o navegador não tem candidato a quebra.
+const TITULO_SEM_ESPACO =
+  "AlinhamentoFinalDoCasamentoDaJulianaComTodosOsFornecedoresBuffetFotografiaEDecoracao2026";
+
+test.beforeEach(async ({ page }) => {
+  // Relógio congelado em 18/08/2026 (fuso do tenant): a grade abre no mês CORRENTE, e sem isto o
+  // compromisso simplesmente não estaria na tela em setembro.
+  await page.clock.setFixedTime(new Date("2026-08-18T12:00:00Z"));
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/agenda/events": [
+      evento({
+        id: "ev-longo",
+        title: TITULO_SEM_ESPACO,
+        starts_at: "2026-08-18T13:00:00Z",
+        ends_at: "2026-08-18T14:00:00Z",
+        location: "Espaço de eventos",
+        guests: ["juliana@exemplo.com.br"],
+      }),
+    ],
+  });
+  await page.goto("/agenda");
+  // O chip do mês tem `truncate` — o que se mede aqui é o MODAL que ele abre.
+  await page.getByText(TITULO_SEM_ESPACO.slice(0, 24), { exact: false }).first().click();
+  await expect(page.getByTestId("modal-evento")).toBeVisible();
+});
+
+test("o título digitado pelo dono não empurra o 'Fechar' para fora da tela", async ({ page }) => {
+  const fechar = page.getByTestId("modal-evento").getByRole("button", { name: /fechar/i });
+  const caixa = await fechar.boundingBox();
+  expect(caixa).not.toBeNull();
+  expect(caixa!.x).toBeGreaterThanOrEqual(0);
+  expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
+});
+
+test("o título QUEBRA dentro da caixa em vez de esticá-la", async ({ page }) => {
+  const titulo = page.getByRole("heading", { name: TITULO_SEM_ESPACO });
+  await expect(titulo).toBeVisible();
+  const caixa = await page.getByTestId("modal-evento").boundingBox();
+  const doTitulo = await titulo.boundingBox();
+
+  // As DUAS metades, e nesta ordem — porque a segunda sozinha é falsa confiança medida.
+  //
+  // 1) O `<h2>` não pode passar da borda direita da CAIXA. É esta que acusa o defeito do #119:
+  //    sem `min-w-0`, o `<h2>` é item de flex com `min-width: auto`, e o mínimo de um item de
+  //    flex é o seu conteúdo mínimo — a palavra inteira. Ele não transborda: ele CRESCE, e leva
+  //    a linha do cabeçalho junto.
+  expect(doTitulo!.x + doTitulo!.width).toBeLessThanOrEqual(caixa!.x + caixa!.width + 0.5);
+
+  // 2) E não pode vazar TINTA mantendo a caixa no lugar (`overflow-wrap: normal` + palavra sem
+  //    espaço) — o que `getBoundingClientRect` não vê e `scrollWidth` vê.
+  //
+  // ⚠️ Medido com `min-w-0 break-words` removido do `Modal.tsx`: a metade (2) continua VERDE
+  //    (`scrollWidth === clientWidth`) enquanto a metade (1) devolve 946px de borda direita numa
+  //    tela de 360. Uma asserção de `scrollWidth` sozinha aqui seria o teste que passa com a tela
+  //    quebrada — a forma exata que o CLAUDE.md §5.1 proíbe.
+  const [scrollWidth, clientWidth] = await titulo.evaluate((el) => [el.scrollWidth, el.clientWidth]);
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 0.5);
+});
+
+test("nada da CAIXA do detalhe existe só depois de rolar de lado", async ({ page }) => {
+  expect(await textoForaDaTela(page, '[data-testid="modal-evento"]')).toEqual([]);
+
+  // E a página não passa a rolar de lado só porque o detalhe abriu.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+});
+
+test("a régua enxerga um vazamento plantado no CABEÇALHO da caixa", async ({ page }) => {
+  // Controle positivo, e ele é o ponto do #123: uma varredura que devolve `[]` não distingue
+  // "nada vaza" de "nada foi medido". Aqui o vazamento é plantado DENTRO do cabeçalho — a região
+  // que o recorte antigo (no `children`) deixava de fora — e a régua tem de acusá-lo.
+  await page.getByTestId("modal-evento").evaluate((caixa) => {
+    const isca = document.createElement("p");
+    isca.textContent = "x".repeat(120);
+    isca.setAttribute("data-isca", "1");
+    caixa.querySelector("h2")?.after(isca);
+  });
+  const cortes = await textoForaDaTela(page, '[data-testid="modal-evento"]');
+  expect(cortes.length).toBeGreaterThan(0);
+  expect(cortes[0].forcaFora).toBeGreaterThan(0.5);
+});

--- a/apps/web/e2e/contas-modais-360.spec.ts
+++ b/apps/web/e2e/contas-modais-360.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * "Declarar saldo" e "Lançar movimento" em 360×740 — os outros dois modais de título DIGITADO.
+ *
+ * `ContasSaldosPage` monta os dois com `title={`Declarar saldo — ${account.name}`}` (e o gêmeo do
+ * lançamento): o nome da conta é do dono e aceita **120 chars** (`bank/schemas.py`). É a mesma
+ * exposição do #119 — o `<h2>` sem `min-w-0` é item de flex com `min-width: auto`, então diante de
+ * uma palavra sem espaço ele CRESCE, leva a linha do cabeçalho junto e empurra o "Fechar" para
+ * fora dos 360.
+ *
+ * ⚠️ A varredura é recortada pela CAIXA (`testId` do `Modal`), nunca pelo conteúdo: com o recorte
+ * no `children`, cabeçalho e barra de ação ficam fora da conta e a medição devolve lista vazia com
+ * o botão a centenas de pixels da tela — foi exatamente o que aconteceu no #119.
+ *
+ * A página em si já é medida por `toque-360.spec.ts` (alvo tocável) e `modal-conta-360.spec.ts`
+ * (o cadastro de conta). O que faltava aqui, e é do #123, era medir o que esses dois ABREM.
+ */
+
+// Pior caso PLAUSÍVEL (§5.1): 76 chars sem espaço, hífen ou barra, dentro dos 120 que o backend
+// aceita. Não é `lorem ipsum` — um lorem tem espaço sobrando e mediria uma tela que não existe.
+const NOME_SEM_ESPACO =
+  "ContaCorrentePrincipalBancoCooperativoSicrediAgencia1234ContaDaEmpresaME";
+
+const CONTA = {
+  id: "00000000-0000-4000-8000-000000000001",
+  name: NOME_SEM_ESPACO,
+  kind: "checking",
+  institution: "Banco Cooperativo Sicredi S.A.",
+  institution_code: "748",
+  branch: "1234-5",
+  number: "12345-6",
+  holder_document: "123.456.789-00",
+  pix_key: "",
+  opening_balance_cents: 125000,
+  opening_balance_is_known: true,
+  opening_date: "2026-01-01",
+  is_primary: true,
+  archived_at: null,
+  saldo_derivado_cents: 12845079,
+  saldo_derivado_origem: "banco",
+  agendado_saida_cents: 1238000,
+  agendado_entrada_cents: 0,
+  agendado_origem: "banco",
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/bank/accounts": [CONTA],
+    // Sem esta chave o prefixo `/bank/accounts` casaria e o cartão leria uma LISTA DE CONTAS como
+    // se fosse um checkpoint — ver a nota em `support/api.ts`.
+    [`/bank/accounts/${CONTA.id}/checkpoints`]: [],
+    "/bank/transfers": [],
+  });
+  await page.goto("/financeiro/contas");
+  await expect(page.getByRole("button", { name: "Declarar saldo" })).toBeVisible();
+});
+
+test("o nome digitado pelo dono não empurra o 'Fechar' do 'Declarar saldo' para fora", async ({
+  page,
+}) => {
+  await page.getByRole("button", { name: "Declarar saldo" }).click();
+  const caixa = page.getByTestId("modal-declarar-saldo");
+  await expect(caixa).toBeVisible();
+
+  const fechar = await caixa.getByRole("button", { name: /fechar/i }).boundingBox();
+  expect(fechar).not.toBeNull();
+  expect(fechar!.x).toBeGreaterThanOrEqual(0);
+  expect(fechar!.x + fechar!.width).toBeLessThanOrEqual(360);
+
+  // O título quebra dentro da caixa em vez de esticá-la. Medido pela BORDA, não por `scrollWidth`:
+  // o `<h2>` sem `min-w-0` cresce em vez de transbordar, e ali `scrollWidth === clientWidth`
+  // continua verdadeiro com a tela quebrada (medido no `agenda-evento-360.spec.ts`).
+  const daCaixa = await caixa.boundingBox();
+  const titulo = await caixa.getByRole("heading").boundingBox();
+  expect(titulo!.x + titulo!.width).toBeLessThanOrEqual(daCaixa!.x + daCaixa!.width + 0.5);
+
+  // E nada da CAIXA — cabeçalho e barra de ação inclusive — existe só depois de rolar de lado.
+  expect(await textoForaDaTela(page, '[data-testid="modal-declarar-saldo"]')).toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+test("o mesmo nome não empurra o 'Fechar' do 'Lançar movimento' para fora", async ({ page }) => {
+  await page.getByRole("button", { name: "Lançar movimento" }).click();
+  const caixa = page.getByTestId("modal-lancar-movimento");
+  await expect(caixa).toBeVisible();
+
+  const fechar = await caixa.getByRole("button", { name: /fechar/i }).boundingBox();
+  expect(fechar).not.toBeNull();
+  expect(fechar!.x + fechar!.width).toBeLessThanOrEqual(360);
+
+  const daCaixa = await caixa.boundingBox();
+  const titulo = await caixa.getByRole("heading").boundingBox();
+  expect(titulo!.x + titulo!.width).toBeLessThanOrEqual(daCaixa!.x + daCaixa!.width + 0.5);
+
+  expect(await textoForaDaTela(page, '[data-testid="modal-lancar-movimento"]')).toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+test("a régua enxerga um vazamento plantado no CABEÇALHO da caixa", async ({ page }) => {
+  // Controle positivo, e é o ponto do #123: `[]` não distingue "nada vaza" de "nada foi medido".
+  // A isca vai para o cabeçalho — a região que o recorte no `children` deixava de fora.
+  await page.getByRole("button", { name: "Declarar saldo" }).click();
+  const caixa = page.getByTestId("modal-declarar-saldo");
+  await expect(caixa).toBeVisible();
+
+  await caixa.evaluate((box) => {
+    const isca = document.createElement("p");
+    isca.textContent = "x".repeat(120);
+    box.querySelector("h2")?.after(isca);
+  });
+  const cortes = await textoForaDaTela(page, '[data-testid="modal-declarar-saldo"]');
+  expect(cortes.length).toBeGreaterThan(0);
+  expect(cortes[0].forcaFora).toBeGreaterThan(0.5);
+});

--- a/apps/web/e2e/modal-conta-360.spec.ts
+++ b/apps/web/e2e/modal-conta-360.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { mockarApi } from "./support/api";
-import { alvosPequenos } from "./support/medidas";
+import { alvosPequenos, medirPagina, textoForaDaTela } from "./support/medidas";
 import { semearSessao } from "./support/sessao";
 
 /**
@@ -65,4 +65,45 @@ test("nenhum BOTÃO do modal fica abaixo do mínimo tocável", async ({ page }) 
     a.descricao.startsWith("button"),
   );
   expect(pequenos).toEqual([]);
+});
+
+test("nada da CAIXA do cadastro existe só depois de rolar de lado", async ({ page }) => {
+  // Faltava ATÉ O #123: este spec recortava o overlay e só chamava `alvosPequenos` — nunca mediu
+  // vazamento de texto. A varredura agora é recortada pela CAIXA (`testId` do `Modal`), que é o
+  // recorte que inclui o cabeçalho e a barra de ação; recorte no `children` foi o defeito de
+  // origem do #119.
+  expect(await textoForaDaTela(page, '[data-testid="modal-conta"]')).toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+
+  // E também no estado que faz a caixa crescer: "Não sei o saldo agora" troca o campo de saldo por
+  // um parágrafo de três linhas e é o caminho que a Story 8.21 introduziu.
+  await page.getByText("Não sei o saldo agora").click();
+  expect(await textoForaDaTela(page, '[data-testid="modal-conta"]')).toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+test("a régua enxerga vazamento no CABEÇALHO e na BARRA DE AÇÃO", async ({ page }) => {
+  // O controle positivo deste modal, e ele é diferente do `agenda-evento-360.spec.ts` de
+  // propósito.
+  //
+  // ⚠️ Aqui o título é CONSTANTE ("Nova conta" / "Editar conta"), então remover `min-w-0
+  // break-words` do `Modal.tsx` — o defeito do #119 — **não** deixa este spec vermelho: não há
+  // palavra do dono para não caber. Medido, não suposto. O que este modal precisa provar é a
+  // outra metade do #119: que as duas regiões que o recorte antigo excluía por construção — o
+  // cabeçalho e a barra de ação `sticky` — estão DENTRO da conta. Por isso a isca é plantada nas
+  // duas, e as duas têm de aparecer.
+  const caixa = page.getByTestId("modal-conta");
+  await caixa.evaluate((box) => {
+    const isca = (marca: string) => {
+      const p = document.createElement("p");
+      p.textContent = marca.repeat(120);
+      return p;
+    };
+    box.querySelector("h2")?.after(isca("x"));
+    box.querySelector(".sticky")?.append(isca("y"));
+  });
+
+  const cortes = await textoForaDaTela(page, '[data-testid="modal-conta"]');
+  expect(cortes.filter((c) => c.texto.startsWith("x")).length).toBe(1);
+  expect(cortes.filter((c) => c.texto.startsWith("y")).length).toBe(1);
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,7 +9,18 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * Porta 5273, não 5173: a 5173 colide com outro projeto nas máquinas de desenvolvimento. Sempre
  * `127.0.0.1` — `localhost` resolve para ::1 em algumas delas e o Vite não atende ali.
+ *
+ * ⚠️ **E a 5273 colide entre WORKTREES do próprio e1p** (#123). Duas sessões no mesmo repo, uma por
+ * worktree, disputam esta porta — e com `reuseExistingServer` o Playwright REUSA o Vite do outro
+ * checkout e mede **o código do outro branch**, sem dizer nada. Medido em 18/08/2026: 35 dos 41
+ * testes vermelhos contra um servidor que não era deste checkout, com `getByTestId` "não
+ * encontrado" para um `data-testid` escrito no arquivo. O modo de falha OPOSTO — verde contra o
+ * código alheio — é indistinguível de aprovação, e por isso `reuseExistingServer` é `false`
+ * sempre: porta ocupada passa a ser erro alto ("port is already used") em vez de medição falsa.
+ * Para rodar duas worktrees ao mesmo tempo: `E2E_PORT=5373 pnpm e2e`.
  */
+const PORTA = Number(process.env.E2E_PORT ?? 5273);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -17,7 +28,7 @@ export default defineConfig({
   retries: 0,
   reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
   use: {
-    baseURL: "http://127.0.0.1:5273",
+    baseURL: `http://127.0.0.1:${PORTA}`,
     locale: "pt-BR",
     timezoneId: "America/Sao_Paulo",
     screenshot: "only-on-failure",
@@ -37,9 +48,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm vite --port 5273 --host 127.0.0.1",
-    url: "http://127.0.0.1:5273",
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm vite --port ${PORTA} --host 127.0.0.1`,
+    url: `http://127.0.0.1:${PORTA}`,
+    // `false` inclusive fora do CI — ver o ⚠️ do cabeçalho: reusar o servidor de outra worktree é
+    // medir o branch errado em silêncio.
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -390,7 +390,8 @@ function EventDetailModal({ event, onClose }: { event: AgendaEvent; onClose: () 
     : `${formatDateTime(event.starts_at, fuso)} – ${hhmm(event.ends_at, fuso)}`;
 
   return (
-    <Modal title={event.title} open onClose={onClose}>
+    // `testId` na CAIXA (#123): o título aqui é DIGITADO pelo dono, a mesma exposição do #119.
+    <Modal title={event.title} open onClose={onClose} testId="modal-evento">
       <div className="space-y-3 text-sm">
         <div className="flex flex-wrap items-center gap-2 text-neutral-600">
           <span className="tabular-nums">{when}</span>

--- a/apps/web/src/features/financeiro/AccountModal.tsx
+++ b/apps/web/src/features/financeiro/AccountModal.tsx
@@ -228,6 +228,10 @@ export default function AccountModal({
       title={editing ? "Editar conta" : "Nova conta"}
       open={open}
       onClose={onClose}
+      // Na CAIXA, via a prop do `Modal` — nunca num `<div>` do conteúdo. Recorte no miolo deixa
+      // o título e a barra de ação fora de `textoForaDaTela`, que foi como um "Fechar" a 698px
+      // numa tela de 360 passou por uma medição que devolveu lista vazia (#119).
+      testId="modal-conta"
       // A ação vai para a barra fixa do `Modal`: em 360×740 este formulário tem 1010px numa caixa
       // de 629px, e no corpo o botão nascia 303px abaixo da borda da tela — 467px abaixo da
       // escolha "não sei o saldo" que ele efetiva (a forma do PR #56).

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -930,6 +930,9 @@ function DeclararSaldoModal({
       title={account ? `Declarar saldo — ${account.name}` : "Declarar saldo"}
       open={account !== null}
       onClose={onClose}
+      // Na CAIXA (#123). O nome da conta é digitado pelo dono e entra no título: é a exposição
+      // do #119, e recorte no conteúdo deixaria justamente o título fora da medição.
+      testId="modal-declarar-saldo"
     >
       <div className="space-y-3">
         <p className="text-sm text-neutral-600">
@@ -1039,6 +1042,8 @@ function LancarMovimentoModal({
       title={account ? `Lançar movimento — ${account.name}` : "Lançar movimento"}
       open={account !== null}
       onClose={onClose}
+      // Na CAIXA (#123) — mesmo motivo do `DeclararSaldoModal` acima.
+      testId="modal-lancar-movimento"
     >
       <div className="space-y-3">
         <Field label="Data" value={postedAt} onChange={setPostedAt} type="date" />


### PR DESCRIPTION
## O que muda

Na #119, a varredura `textoForaDaTela` devolveu **lista vazia** enquanto um nome de contato sem espaço empurrava o botão "Fechar" para **x=698 numa viewport de 360px**. A causa era o **recorte**: media-se `[data-testid="seletor-horario"]`, que estava no `children` do `Modal` — cabeçalho e rodapé ficavam fora da medição **por construção**, e a barra de ação é justamente onde mora a saída de escape.

O conserto do componente saiu na #119 (prop `testId` na caixa, `min-w-0 break-words` no `<h2>`, `shrink-0` no botão). **Este PR é a medição** — sem ela, 17 modais dependiam de o conserto compartilhado estar certo, com nada medindo.

| Modal | `testId` |
|---|---|
| `AccountModal` | `modal-conta` |
| Detalhe de evento da Agenda (`AgendaPage`) | `modal-evento` |
| `DeclararSaldoModal` (`ContasSaldosPage`) | `modal-declarar-saldo` |
| `LancarMovimentoModal` (`ContasSaldosPage`) | `modal-lancar-movimento` |

Os dois de `ContasSaldosPage` entraram porque a página já tinha spec de 360px **e** o título deles carrega `account.name` digitado pelo dono — mesma exposição da #119. Specs: `modal-conta-360.spec.ts` (ganhou `textoForaDaTela`, que nunca teve), `agenda-evento-360.spec.ts` e `contas-modais-360.spec.ts` (novos).

Fixtures de pior caso plausível: **87 e 71 chars sem espaço, hífen ou barra**, dentro dos limites reais (`title` 255 em `agenda/schemas.py`, `name` 120 em `bank/schemas.py`). Um `lorem ipsum` teria espaço sobrando e mediria uma tela que não existe.

## Controle positivo

Removendo `min-w-0 break-words` do `Modal.tsx` — **5 failed / 9 passed**:

```
agenda-evento-360 › não empurra o 'Fechar' para fora da tela
  Expected: <= 360      Received: 946.296875
agenda-evento-360 › o título QUEBRA dentro da caixa em vez de esticá-la
  Expected: <= 344.5    Received: 894.296875
contas-modais-360 › 'Fechar' do 'Declarar saldo'      Received: 782.359375
contas-modais-360 › 'Fechar' do 'Lançar movimento'    Received: 819.328125
```

Restaurado por cópia: **41 passed**.

## Dois achados

**1. `scrollWidth` não vê este defeito.** Sem `min-w-0`, o `<h2>` é item de flex com `min-width: auto`: ele **cresce** em vez de transbordar, e `scrollWidth === clientWidth` seguia verde com o título a **894px numa tela de 360**. A primeira versão do teste tinha exatamente essa asserção fraca — trocada por medição de borda contra a borda da caixa. Mesma família do `toContain("flex-wrap")` do §5.1.

**2. O `pnpm e2e` estava medindo o Vite de OUTRA worktree, em silêncio.** A porta 5273 é disputada entre worktrees do próprio e1p, e `reuseExistingServer: !CI` fazia o Playwright reusar o servidor do checkout vizinho: **35 failed / 6 passed** contra código que não era deste branch, com `getByTestId` "não encontrado" para um `data-testid` escrito no arquivo. O modo de falha **oposto** — verde contra código alheio — seria indistinguível de aprovação. Corrigido em `playwright.config.ts` (commit próprio): `reuseExistingServer: false` sempre (porta ocupada vira erro alto) e porta via `E2E_PORT`.

`modal-conta-360` **não** fica vermelho com a mutação do `<h2>` — o título do `AccountModal` é constante. Está escrito no spec, e o controle dele é outro: planta isca no cabeçalho e na barra `sticky`, as duas regiões que o recorte antigo excluía.

## Cobertura honesta

**4 dos 18 arquivos** que importam `components/Modal`; **5 dos 35 modais** instanciados (`ContasSaldosPage` tem 5, e 2 foram medidos).

Faltam 14 arquivos. Os de maior exposição são `EstoquePage` (`Movimentar: {item.name}`) e `ProdutosPage` (`Vender: {product.name}`) — título digitado pelo dono, forma exata da #119. Issue-irmã.

## Verificação

```
E2E_PORT=5473 pnpm e2e   41 passed (29.2s)
pnpm lint                exit 0
pnpm typecheck           exit 0
pnpm test                69 arquivos · 693 passed
```

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)