### PR TITLE
chore: config do issue-wt para este repo

### DIFF
--- a/.claude/issue-wt.json
+++ b/.claude/issue-wt.json
@@ -1,0 +1,38 @@
+{
+  "_leiame": [
+    "Config do issue-wt — 'uma issue, uma worktree'. O SCRIPT NAO MORA NESTE REPO:",
+    "ele e global, em ~/.claude/scripts/issue-wt.sh, e a disciplina que o acompanha esta",
+    "na skill ~/.claude/skills/issue-worktrees/. Este arquivo e so o que e especifico do e1p.",
+    "Rode 'issue-wt config' para ver o exemplo completo com todos os campos."
+  ],
+
+  "worktreeDir": ".claude/worktrees",
+  "baseRef": "origin/main",
+  "install": "pnpm install --frozen-lockfile",
+
+  "_portas": [
+    "A porta de cada issue e portBase + (numero % 90) — deterministica, e por isso duas",
+    "worktrees vivas nunca disputam a mesma. Isto NAO e conveniencia: com porta",
+    "compartilhada o Playwright reusa o Vite de outra worktree e mede o branch ERRADO em",
+    "silencio (achado da issue #123; ver o cabecalho de apps/web/playwright.config.ts).",
+    "5300 e nao 5100/5200 para nao esbarrar na 5173 do Vite nem na 5273 do gate."
+  ],
+  "portEnv": "E2E_PORT",
+  "portBase": 5300,
+
+  "branchPrefixes": {
+    "bug": "fix",
+    "enhancement": "feat",
+    "test": "test",
+    "qa-e2e": "test",
+    "docs": "docs",
+    "default": "chore"
+  },
+
+  "gates": [
+    { "name": "lint", "cmd": "pnpm lint", "dir": "apps/web" },
+    { "name": "typecheck", "cmd": "pnpm typecheck", "dir": "apps/web" },
+    { "name": "test", "cmd": "pnpm test", "dir": "apps/web" },
+    { "name": "e2e", "cmd": "pnpm e2e", "dir": "apps/web" }
+  ]
+}


### PR DESCRIPTION
## O que é

Um arquivo, `.claude/issue-wt.json`. Nenhum código, nenhum teste, nenhum gate alterado.

É a configuração do **`issue-wt`** — a ferramenta de *"uma issue, uma worktree"* que saiu da leva de PRs #124/#126/#127/#128/#132/#133/#134/#137. O script é **global** (`~/.claude/scripts/issue-wt.sh`) e a disciplina que o acompanha é uma skill (`~/.claude/skills/issue-worktrees/`); **nenhum dos dois vive neste repositório**, de propósito — eles servem qualquer projeto. Este arquivo é só o que é específico do e1p.

Como isso é confuso para quem topar com um config órfão, o próprio arquivo carrega um `_leiame` apontando onde a ferramenta mora.

## O que ele responde

| Campo | Por que este valor |
|---|---|
| `worktreeDir` | `.claude/worktrees/`, que já está no `.gitignore` (linha 57) |
| `install` | pnpm com `--frozen-lockfile`, como o job `frontend` do CI |
| `gates` | lint → typecheck → test → e2e, **a mesma ordem do CI** |
| `branchPrefixes` | mapeia o label da issue (`bug` → `fix/`, `qa-e2e` → `test/`…) |
| `portBase: 5300` | longe da 5173 do Vite e da 5273 do gate |

## O campo que não é conveniência

`portBase` existe por causa de um defeito real, achado na issue #123: a porta de cada issue é `portBase + (número % 90)`, **determinística**, para que duas worktrees vivas nunca disputem a mesma.

Com porta compartilhada, o Playwright reusa o Vite de **outra worktree** e mede o branch errado **em silêncio**. Naquela ocorrência deu 35 testes vermelhos contra código que não era daquele checkout — mas o modo de falha **oposto** é o perigoso: verde contra código alheio é indistinguível de aprovação. O `playwright.config.ts` já carrega essa história no cabeçalho; aqui é a outra ponta da mesma corda.

## Verificação

```
JSON valido
  .portBase            5300
  .gates | length      4
  .gates[3].cmd        pnpm e2e
  .branchPrefixes.bug  fix

os quatro gates existem em apps/web/package.json:
  pnpm lint       -> eslint . --max-warnings 0
  pnpm typecheck  -> tsc --noEmit
  pnpm test       -> vitest run
  pnpm e2e        -> playwright test
```

Config que aponta para comando inexistente só falha na hora do uso — por isso a conferência contra o `package.json` real, e não só o parse.

O ciclo completo foi exercitado numa issue de verdade antes deste PR (a #135): worktree criada, branch derivada do label, `pnpm install` rodado e `E2E_PORT=5345` atribuída. A worktree de teste foi desfeita.

## Nota

O leitor do config **para e berra** se o arquivo existir e não houver `node`/`python` para lê-lo, em vez de cair em defaults. Nesta máquina não há `jq`, e a primeira versão ignorava o config em silêncio — a mesma classe de falha que as issues #120 e #123 trataram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)