### PR TITLE
feat: a busca da barra de cima passa a buscar, em sete tipos e duas camadas

### DIFF
--- a/apps/api/app/core/textsearch.py
+++ b/apps/api/app/core/textsearch.py
@@ -1,0 +1,29 @@
+"""Primitivo de busca textual — um lugar só para escapar curinga e montar o padrão do `ilike`.
+
+Extraído de `payables/service.py` (#125) quando a busca global passou a precisar dele em sete
+tabelas. Mora aqui, e não copiado por módulo, porque o modo de falha da divergência é MUDO: a cópia
+que ficar para trás não quebra nada, só passa a não filtrar, e a tela continua respondendo.
+"""
+from __future__ import annotations
+
+#: Passe sempre junto com o padrão: `coluna.ilike(padrao_ilike(termo), escape=ESCAPE)`.
+#: Sem o `escape`, a barra invertida que este módulo insere é lida como texto e o escape não
+#: acontece — o `ilike` volta a tratar `%` como curinga e o defeito reaparece silenciosamente.
+ESCAPE = "\\"
+
+
+def escapa_curinga(termo: str) -> str:
+    """Neutraliza `%` e `_` para que o texto do usuário seja tratado como TEXTO no `ilike`.
+
+    Sem isto, buscar `%` casa com todas as linhas e a busca parece funcionar enquanto não filtra
+    nada — o pior tipo de defeito de busca, porque não tem sintoma.
+
+    A barra invertida é escapada PRIMEIRO: fazê-lo por último re-escaparia as barras que os dois
+    `replace` seguintes acabaram de inserir, e `%` viraria `\\\\%` (barra literal + curinga vivo).
+    """
+    return termo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def padrao_ilike(termo: str) -> str:
+    """`%termo%` com o miolo escapado. Os `%` das pontas são os curingas que a busca QUER."""
+    return f"%{escapa_curinga(termo)}%"

--- a/apps/api/app/modules/__init__.py
+++ b/apps/api/app/modules/__init__.py
@@ -36,6 +36,7 @@ from app.modules.products.router import router as products_router
 from app.modules.quotes.router import public_router as quotes_public_router
 from app.modules.quotes.router import router as quotes_router
 from app.modules.receivables.router import router as receivables_router
+from app.modules.search.router import router as search_router
 from app.modules.settings.router import router as settings_router
 from app.modules.stock.router import router as stock_router
 from app.modules.vima.router import router as vima_router
@@ -74,6 +75,7 @@ ALL_ROUTERS: list[APIRouter] = [
     funnels_router,
     stock_router,
     settings_router,
+    search_router,
     whatsapp_templates_router,
     whatsapp_inbox_router,
     whatsapp_inbox_public_router,

--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -24,6 +24,7 @@ from app.core.facts import (
     Fact,
 )
 from app.core.phone import normalize_br
+from app.core.textsearch import ESCAPE, padrao_ilike
 from app.modules.crm.models import (
     DEFAULT_STAGES,
     Client,
@@ -390,8 +391,9 @@ def list_clients(
     if gender is not None:
         stmt = stmt.where(Client.gender == gender)
     if search:
-        like = f"%{search}%"
-        stmt = stmt.where(Client.name.ilike(like))
+        # `padrao_ilike` + `escape`: sem os dois, buscar `%` casa com TODAS as linhas e a busca
+        # parece funcionar enquanto não filtra nada. Mesmo defeito que o #125 achou em payables.
+        stmt = stmt.where(Client.name.ilike(padrao_ilike(search), escape=ESCAPE))
     if tag is not None:
         # Filtro por tag em Python (portável entre SQLite/Postgres). stmt já vem ORDENADO,
         # então a paginação sobre o resultado é determinística. TODO: usar operador JSON

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -13,6 +13,7 @@ from app.core.recurrence import advance, occurrences
 # O estado é DERIVADO da data, nunca escolhido (Story 8.14 AC2). O helper é **público e neutro**
 # (`app/core/`) porque a Story 8.15 o consome para `Charge` — **importar, nunca copiar**.
 from app.core.scheduling import janela_de_caixa, status_por_data
+from app.core.textsearch import ESCAPE, padrao_ilike
 from app.db.base import _uuid
 
 # ⚠️ **Duas palavras `scheduled` neste arquivo, e elas NÃO são a mesma coisa.** O `scheduled` da
@@ -322,15 +323,6 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     return p
 
 
-def _escapa_curinga(termo: str) -> str:
-    """Neutraliza `%` e `_` para que o texto do usuário seja tratado como TEXTO no `ilike`.
-
-    Sem isto, buscar `%` casa com todas as linhas e a busca parece funcionar enquanto não filtra
-    nada — o pior tipo de defeito de busca, porque não tem sintoma.
-    """
-    return termo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
 def _filtros(
     stmt,
     *,
@@ -357,11 +349,11 @@ def _filtros(
     if due_to is not None:
         stmt = stmt.where(Payable.due_date <= due_to)
     if q:
-        alvo = f"%{_escapa_curinga(q)}%"
+        alvo = padrao_ilike(q)
         stmt = stmt.where(
             or_(
-                Payable.description.ilike(alvo, escape="\\"),
-                Payable.supplier.ilike(alvo, escape="\\"),
+                Payable.description.ilike(alvo, escape=ESCAPE),
+                Payable.supplier.ilike(alvo, escape=ESCAPE),
             )
         )
     if cost_center_id:

--- a/apps/api/app/modules/search/registro.py
+++ b/apps/api/app/modules/search/registro.py
@@ -1,0 +1,172 @@
+"""As entidades que a busca global enxerga — declarativas, num lugar só.
+
+Acrescentar um tipo é acrescentar uma entrada. O que NÃO entra aqui: lista sem endereço que saiba
+receber uma busca. Contas a pagar, cobranças e produtos ficaram de fora por isso — o `q` do #125 é
+estado React e `/pagar?q=x` é inerte hoje (spec §2, issue #138).
+
+A ORDEM das entradas é a ordem dos grupos na tela: gente primeiro, depois o diálogo, depois
+compromisso e dinheiro, depois o que se constrói. Ela mora aqui, e só aqui.
+
+`modulo` não é decoração. A RLS garante que o tenant é o certo; ela NÃO garante que este usuário
+pode ver este módulo — isso é `require_module`. Sem este campo, a busca seria a porta dos fundos do
+RBAC: um sub-usuário sem acesso a Jurídico digitaria três letras e leria títulos de petição
+(spec §6.4).
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import or_, select
+
+from app.core.textsearch import ESCAPE
+from app.modules.contracts.models import Contract
+from app.modules.crm.models import Client
+from app.modules.funnels.models import Funnel
+from app.modules.juridico.models import LegalDocument
+from app.modules.pages.models import Page
+from app.modules.quotes.models import Quote
+from app.modules.whatsapp_inbox.models import WhatsappChat, WhatsappMessage
+
+
+@dataclass(frozen=True)
+class Entidade:
+    """Uma linha do registro. Tudo que a busca precisa saber sobre um tipo."""
+
+    tipo: str
+    modelo: Any
+    #: O mesmo nome que `require_module` usa nas rotas do módulo — copiar outro nome aqui
+    #: criaria uma segunda definição de "pode ver", e as duas divergiriam.
+    modulo: str
+    campos_rasos: tuple
+    campos_fundos: tuple
+    #: A coluna que decide "prefixo vem antes de casamento no meio" na ordenação.
+    principal: Any
+    recencia: Any
+    titulo: Callable[[Any], str]
+    subtitulo: Callable[[Any], str]
+    rota: Callable[[Any], str]
+    #: Predicado alternativo, para quem casa por JOIN e não por coluna própria. Só `conversation`
+    #: usa. Assinatura: `(padrao, escape, fundo, corte) -> ClauseElement`.
+    predicado: Callable[[str, str, bool, datetime | None], Any] | None = field(default=None)
+
+
+def _predicado_da_conversa(padrao: str, escape: str, fundo: bool, corte: datetime | None):
+    """Conversa casa pelo título OU pelo cliente vinculado OU (na camada funda) pelas mensagens.
+
+    `WhatsappChat.title` é nullable e curto: grupo sem assunto conhecido, `@lid` sem telefone. E
+    `client_id` também é nullable — grupo não vira contato do CRM. Nenhum dos dois sozinho acha a
+    conversa que o dono procura, então os dois entram.
+
+    A subquery das mensagens devolve **chat_id**, não mensagens: é isso que faz quarenta mensagens
+    casando virarem UMA linha em vez de afogarem os outros seis tipos com o mesmo diálogo repetido.
+    """
+    clientes = select(Client.id).where(Client.name.ilike(padrao, escape=escape))
+    condicoes = [
+        WhatsappChat.title.ilike(padrao, escape=escape),
+        WhatsappChat.client_id.in_(clientes),
+    ]
+    if fundo:
+        mensagens = select(WhatsappMessage.chat_id).where(
+            WhatsappMessage.text_body.ilike(padrao, escape=escape)
+        )
+        # O recorte de meses vale SÓ aqui: mensagem é a única tabela cujo volume o justifica.
+        if corte is not None:
+            mensagens = mensagens.where(WhatsappMessage.created_at >= corte)
+        condicoes.append(WhatsappChat.id.in_(mensagens))
+    return or_(*condicoes)
+
+
+REGISTRO: tuple[Entidade, ...] = (
+    Entidade(
+        tipo="client",
+        modelo=Client,
+        modulo="crm",
+        campos_rasos=(Client.name, Client.email, Client.phone, Client.document),
+        campos_fundos=(Client.notes,),
+        principal=Client.name,
+        recencia=Client.updated_at,
+        titulo=lambda c: c.name,
+        subtitulo=lambda c: c.email or c.phone or "",
+        rota=lambda c: f"/crm/clients/{c.id}",
+    ),
+    Entidade(
+        tipo="conversation",
+        modelo=WhatsappChat,
+        # A caixa de entrada do WhatsApp é guardada como CRM, não como módulo próprio
+        # (`whatsapp_inbox/router.py:26`). Seguir o guard que já existe, não inventar outro.
+        modulo="crm",
+        campos_rasos=(WhatsappChat.title,),
+        campos_fundos=(),
+        principal=WhatsappChat.title,
+        recencia=WhatsappChat.updated_at,
+        titulo=lambda ch: ch.title or "Conversa sem nome",
+        subtitulo=lambda ch: ch.chat_jid,
+        rota=lambda ch: f"/conversas/{ch.id}",
+        predicado=_predicado_da_conversa,
+    ),
+    Entidade(
+        tipo="contract",
+        modelo=Contract,
+        modulo="contracts",
+        campos_rasos=(Contract.title, Contract.signer_name),
+        campos_fundos=(),
+        principal=Contract.title,
+        recencia=Contract.updated_at,
+        titulo=lambda c: c.title,
+        subtitulo=lambda c: c.signer_name or c.status,
+        rota=lambda c: f"/contratos/{c.id}",
+    ),
+    Entidade(
+        tipo="quote",
+        modelo=Quote,
+        modulo="quotes",
+        campos_rasos=(Quote.title, Quote.client_name),
+        campos_fundos=(Quote.notes,),
+        principal=Quote.title,
+        recencia=Quote.updated_at,
+        titulo=lambda q: q.title,
+        subtitulo=lambda q: q.client_name or q.status,
+        rota=lambda q: f"/orcamentos/{q.id}",
+    ),
+    Entidade(
+        tipo="legal_document",
+        modelo=LegalDocument,
+        modulo="juridico",
+        campos_rasos=(LegalDocument.title, LegalDocument.skill),
+        campos_fundos=(LegalDocument.content,),
+        principal=LegalDocument.title,
+        recencia=LegalDocument.updated_at,
+        titulo=lambda d: d.title,
+        subtitulo=lambda d: d.skill,
+        rota=lambda d: f"/juridico/{d.id}",
+    ),
+    Entidade(
+        tipo="page",
+        modelo=Page,
+        modulo="pages",
+        campos_rasos=(Page.title, Page.public_slug),
+        campos_fundos=(),
+        principal=Page.title,
+        recencia=Page.updated_at,
+        titulo=lambda p: p.title,
+        subtitulo=lambda p: p.public_slug or p.status,
+        rota=lambda p: f"/sites/{p.id}",
+    ),
+    Entidade(
+        tipo="funnel",
+        modelo=Funnel,
+        modulo="funnels",
+        campos_rasos=(Funnel.name,),
+        campos_fundos=(),
+        principal=Funnel.name,
+        recencia=Funnel.updated_at,
+        titulo=lambda f: f.name,
+        subtitulo=lambda f: "",
+        rota=lambda f: f"/funis/{f.id}",
+    ),
+)
+
+__all__ = ["ESCAPE", "REGISTRO", "Entidade"]

--- a/apps/api/app/modules/search/router.py
+++ b/apps/api/app/modules/search/router.py
@@ -27,11 +27,21 @@ def _modulos(user: CurrentUser) -> list[str]:
 @router.get("", response_model=SearchOut)
 def search(
     q: str = Query(default=""),
+    depth: str = Query(default="shallow", pattern="^(shallow|deep)$"),
+    # `0` = sem recorte. O teto de 120 é guarda contra pedido absurdo, não regra de negócio.
+    months: int = Query(default=12, ge=0, le=120),
     limit: int = Query(default=3, ge=1, le=50),
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_tenant_db),
 ) -> SearchOut:
-    grupos = service.buscar(db, q=q, modulos_liberados=_modulos(user), limite=limit)
+    grupos = service.buscar(
+        db,
+        q=q,
+        modulos_liberados=_modulos(user),
+        profundidade=depth,
+        meses=months,
+        limite=limit,
+    )
     return SearchOut(
         groups=[
             SearchGroupOut(

--- a/apps/api/app/modules/search/router.py
+++ b/apps/api/app/modules/search/router.py
@@ -1,0 +1,54 @@
+"""Busca global — a rota.
+
+**Sem `require_module` como guarda da rota, e isso é deliberado.** A busca cruza sete módulos; um
+guard só teria de escolher um deles e estaria errado nos outros seis. O RBAC entra como FILTRO por
+entidade, dentro do serviço, com o MESMO critério de `require_module` — dono, ou `allowed_modules`
+vazio, vê tudo (spec §6.4).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_current_user, get_tenant_db
+from app.modules.search import service
+from app.modules.search.schemas import SearchGroupOut, SearchItemOut, SearchOut
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+def _modulos(user: CurrentUser) -> list[str]:
+    """Mesma regra de `require_module`: dono, ou lista vazia, não tem restrição."""
+    if user.role == "owner":
+        return []
+    return user.allowed_modules
+
+
+@router.get("", response_model=SearchOut)
+def search(
+    q: str = Query(default=""),
+    limit: int = Query(default=3, ge=1, le=50),
+    user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_tenant_db),
+) -> SearchOut:
+    grupos = service.buscar(db, q=q, modulos_liberados=_modulos(user), limite=limit)
+    return SearchOut(
+        groups=[
+            SearchGroupOut(
+                type=g.tipo,
+                has_more=g.tem_mais,
+                total=g.total,
+                items=[
+                    SearchItemOut(
+                        id=i.id,
+                        title=i.titulo,
+                        subtitle=i.subtitulo,
+                        route=i.rota,
+                        snippet=i.trecho,
+                    )
+                    for i in g.itens
+                ],
+            )
+            for g in grupos
+        ]
+    )

--- a/apps/api/app/modules/search/schemas.py
+++ b/apps/api/app/modules/search/schemas.py
@@ -1,0 +1,28 @@
+"""Contrato da busca global."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SearchItemOut(BaseModel):
+    id: str
+    title: str
+    subtitle: str
+    #: Caminho pronto para o router do front. Quem decide para onde o resultado leva é o backend,
+    #: no registro — a tela não remonta rota a partir do tipo.
+    route: str
+    #: Só em `depth=deep`: na camada rasa não há corpo de onde extrair trecho.
+    snippet: str | None = None
+
+
+class SearchGroupOut(BaseModel):
+    type: str
+    has_more: bool
+    #: Só em `depth=deep`. Contar na camada rasa custaria sete `count()` por tecla — e `has_more`
+    #: não tem como mentir sobre um número que não anuncia (spec §6.1).
+    total: int | None = None
+    items: list[SearchItemOut]
+
+
+class SearchOut(BaseModel):
+    groups: list[SearchGroupOut]

--- a/apps/api/app/modules/search/service.py
+++ b/apps/api/app/modules/search/service.py
@@ -13,17 +13,23 @@ tem que ser avaliada antes do operador e o `ILIKE` vira filtro pós-segurança. 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, time, timedelta
 
-from sqlalchemy import case, or_, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.core.textsearch import ESCAPE, escapa_curinga, padrao_ilike
 from app.modules.search.registro import REGISTRO, Entidade
+from app.modules.settings.service import hoje_do_tenant
 
 #: Abaixo disto a busca não consulta o banco. Uma letra casa com quase tudo e custaria sete
 #: varreduras por tecla — e o resultado seria ruído, não resposta.
 MIN_CARACTERES = 2
+
+#: O trecho mostrado na camada funda. Assimétrico de propósito: o que vem DEPOIS do termo costuma
+#: ser o que explica a frase; o que vem antes serve só para o olho reconhecer onde está.
+TRECHO_ANTES = 40
+TRECHO_DEPOIS = 80
 
 
 @dataclass
@@ -74,27 +80,68 @@ def _ordem(entidade: Entidade, termo: str):
     )
 
 
+def _trecho(texto: str, termo: str) -> str:
+    """Um pedaço do corpo em volta do casamento, para o leitor reconhecer o contexto."""
+    if not texto:
+        return ""
+    pos = texto.lower().find(termo.lower())
+    if pos < 0:
+        return texto[:TRECHO_DEPOIS]
+    inicio = max(0, pos - TRECHO_ANTES)
+    fim = min(len(texto), pos + len(termo) + TRECHO_DEPOIS)
+    return ("..." if inicio > 0 else "") + texto[inicio:fim] + ("..." if fim < len(texto) else "")
+
+
+def _trecho_da_linha(entidade: Entidade, linha, termo: str) -> str | None:
+    """O primeiro campo fundo que contém o termo vira o trecho mostrado na tela."""
+    for coluna in entidade.campos_fundos:
+        texto = getattr(linha, coluna.key, "") or ""
+        if termo.lower() in texto.lower():
+            return _trecho(texto, termo)
+    return None
+
+
+def _corte_de_mensagens(db: Session, meses: int) -> datetime | None:
+    """A data-piso do recorte, no FUSO DO TENANT. `meses <= 0` significa "tudo".
+
+    `datetime.now(UTC)` aqui reintroduziria a classe de bug do fuso pela porta do filtro de data:
+    em UTC-3, das 21h à meia-noite o piso pularia um dia inteiro.
+    """
+    if meses <= 0:
+        return None
+    piso = hoje_do_tenant(db) - timedelta(days=30 * meses)
+    return datetime.combine(piso, time.min, tzinfo=UTC)
+
+
 def buscar(
     db: Session,
     *,
     q: str,
     modulos_liberados: list[str],
+    profundidade: str = "shallow",
+    meses: int = 12,
     limite: int = 3,
 ) -> list[GrupoBruto]:
-    """Camada rasa: rótulo + campos de identidade, agrupado por tipo, na ordem do registro."""
+    """Rasa: rótulo + identidade. Funda: acrescenta corpo, notas e mensagens.
+
+    Agrupado por tipo, na ordem do registro. Grupo sem item não entra no resultado.
+    """
     termo = " ".join(q.split())
     if len(termo) < MIN_CARACTERES:
         return []
 
+    fundo = profundidade == "deep"
     padrao = padrao_ilike(termo)
+    corte = _corte_de_mensagens(db, meses) if fundo else None
     grupos: list[GrupoBruto] = []
 
     for entidade in REGISTRO:
         if not _liberado(entidade, modulos_liberados):
             continue
+        onde = _predicado(entidade, padrao, fundo, corte)
         stmt = (
             select(entidade.modelo)
-            .where(_predicado(entidade, padrao, False, None))
+            .where(onde)
             .order_by(*_ordem(entidade, termo))
             # +1 descobre `tem_mais` sem um `count()` por tipo. Um booleano não tem como mentir
             # sobre um número que ele não anuncia — a contagem exata é da camada funda.
@@ -103,6 +150,13 @@ def buscar(
         linhas = list(db.scalars(stmt).all())
         if not linhas:
             continue
+        # MESMO `onde` da lista. Contar com um predicado paralelo faria o rodapé anunciar um
+        # número que a lista não confirma — nada quebra, o rodapé só passa a mentir (#125).
+        total = (
+            db.scalar(select(func.count()).select_from(entidade.modelo).where(onde))
+            if fundo
+            else None
+        )
         grupos.append(
             GrupoBruto(
                 tipo=entidade.tipo,
@@ -112,10 +166,12 @@ def buscar(
                         titulo=entidade.titulo(linha),
                         subtitulo=entidade.subtitulo(linha),
                         rota=entidade.rota(linha),
+                        trecho=_trecho_da_linha(entidade, linha, termo) if fundo else None,
                     )
                     for linha in linhas[:limite]
                 ],
                 tem_mais=len(linhas) > limite,
+                total=total,
             )
         )
     return grupos

--- a/apps/api/app/modules/search/service.py
+++ b/apps/api/app/modules/search/service.py
@@ -1,0 +1,121 @@
+"""A busca global. Uma consulta curta por tipo, agrupada em Python.
+
+**Sem `UNION`, e isso é decisão.** Como o resultado é agrupado por tipo (spec §9), não existe
+ranking global a calcular — não há nada para o banco juntar. Cada consulta fica trivial, sem cast
+entre sete modelos de formatos diferentes, e idêntica em SQLite e Postgres. É o que mantém isto
+coberto pelo `pytest -q` inteiro, que roda SQLite.
+
+**Sem índice de texto, e isso também é decisão medida.** Sob RLS, o Postgres não usa índice
+trigrama nem tsvector para `ILIKE`: `texticlike` não é `leakproof`, então a política de segurança
+tem que ser avaliada antes do operador e o `ILIKE` vira filtro pós-segurança. Medido em 2026-08-18:
+0,7 ms com a RLS fora do caminho contra 154 ms com ela. Ver spec §5 antes de propor `pg_trgm`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import case, or_, select
+from sqlalchemy.orm import Session
+
+from app.core.textsearch import ESCAPE, escapa_curinga, padrao_ilike
+from app.modules.search.registro import REGISTRO, Entidade
+
+#: Abaixo disto a busca não consulta o banco. Uma letra casa com quase tudo e custaria sete
+#: varreduras por tecla — e o resultado seria ruído, não resposta.
+MIN_CARACTERES = 2
+
+
+@dataclass
+class ItemBruto:
+    id: str
+    titulo: str
+    subtitulo: str
+    rota: str
+    trecho: str | None = None
+
+
+@dataclass
+class GrupoBruto:
+    tipo: str
+    itens: list[ItemBruto]
+    tem_mais: bool
+    total: int | None = None
+
+
+def _liberado(entidade: Entidade, modulos_liberados: list[str]) -> bool:
+    """Espelha `require_module`: lista vazia = sem restrição. Ver spec §6.4."""
+    return not modulos_liberados or entidade.modulo in modulos_liberados
+
+
+def _predicado(entidade: Entidade, padrao: str, fundo: bool, corte: datetime | None):
+    """Construtor ÚNICO do predicado — usado pela LISTA e (na camada funda) pela CONTAGEM.
+
+    ⚠️ **Não duplique este `where` do outro lado.** Dois blocos copiados divergem na primeira
+    manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
+    quebra, o rodapé só passa a mentir. É a lição do #125, e ela custou caro para ser aprendida.
+    """
+    if entidade.predicado is not None:
+        return entidade.predicado(padrao, ESCAPE, fundo, corte)
+    campos = entidade.campos_rasos + (entidade.campos_fundos if fundo else ())
+    return or_(*[coluna.ilike(padrao, escape=ESCAPE) for coluna in campos])
+
+
+def _ordem(entidade: Entidade, termo: str):
+    """Dois degraus: prefixo antes de casamento no meio; depois, o mais recente.
+
+    Dois e não três porque cabe num `case()` portátil e num teste que se lê. Não há score entre
+    tipos — o agrupamento por tipo substitui o ranking.
+    """
+    prefixo = f"{escapa_curinga(termo)}%"
+    return (
+        case((entidade.principal.ilike(prefixo, escape=ESCAPE), 0), else_=1),
+        entidade.recencia.desc(),
+    )
+
+
+def buscar(
+    db: Session,
+    *,
+    q: str,
+    modulos_liberados: list[str],
+    limite: int = 3,
+) -> list[GrupoBruto]:
+    """Camada rasa: rótulo + campos de identidade, agrupado por tipo, na ordem do registro."""
+    termo = " ".join(q.split())
+    if len(termo) < MIN_CARACTERES:
+        return []
+
+    padrao = padrao_ilike(termo)
+    grupos: list[GrupoBruto] = []
+
+    for entidade in REGISTRO:
+        if not _liberado(entidade, modulos_liberados):
+            continue
+        stmt = (
+            select(entidade.modelo)
+            .where(_predicado(entidade, padrao, False, None))
+            .order_by(*_ordem(entidade, termo))
+            # +1 descobre `tem_mais` sem um `count()` por tipo. Um booleano não tem como mentir
+            # sobre um número que ele não anuncia — a contagem exata é da camada funda.
+            .limit(limite + 1)
+        )
+        linhas = list(db.scalars(stmt).all())
+        if not linhas:
+            continue
+        grupos.append(
+            GrupoBruto(
+                tipo=entidade.tipo,
+                itens=[
+                    ItemBruto(
+                        id=linha.id,
+                        titulo=entidade.titulo(linha),
+                        subtitulo=entidade.subtitulo(linha),
+                        rota=entidade.rota(linha),
+                    )
+                    for linha in linhas[:limite]
+                ],
+                tem_mais=len(linhas) > limite,
+            )
+        )
+    return grupos

--- a/apps/api/tests/test_crm.py
+++ b/apps/api/tests/test_crm.py
@@ -317,3 +317,21 @@ def test_update_client(client: TestClient, headers):
     assert resp.status_code == 200
     assert resp.json()["name"] == "Depois"
     assert resp.json()["phone"] == "+5511999999999"
+
+
+def test_busca_do_crm_trata_porcento_como_texto(client: TestClient, headers):
+    """`%` sem escape casa com TODAS as linhas: a busca parece funcionar e não filtra nada.
+
+    Mesmo defeito que o #125 consertou em `payables` — e o pior tipo de defeito de busca, porque
+    não tem sintoma: a tela responde, a lista vem cheia, e ninguém desconfia.
+    """
+    client.post("/crm/clients", json={"name": "Ana Souza"}, headers=headers)
+    client.post("/crm/clients", json={"name": "Bruno Lima"}, headers=headers)
+
+    achou_tudo = client.get("/crm/clients", params={"search": "%"}, headers=headers)
+    achou_ana = client.get("/crm/clients", params={"search": "ana"}, headers=headers)
+
+    assert achou_tudo.status_code == 200
+    assert achou_tudo.json() == [], "buscar '%' deve casar com NADA — é texto, não curinga"
+    # A contraprova: a busca continua funcionando para texto de verdade.
+    assert [c["name"] for c in achou_ana.json()] == ["Ana Souza"]

--- a/apps/api/tests/test_rls_isolation.py
+++ b/apps/api/tests/test_rls_isolation.py
@@ -180,3 +180,82 @@ def test_cross_tenant_isolation_joao_nao_ve_maria() -> None:
         assert _actors_as_superuser(super_url) == ["joao", "maria"], (
             "superuser deveria enxergar as duas linhas (bypass de RLS)"
         )
+
+
+def _insert_cliente(app_url: str, tenant_id: str, nome: str) -> None:
+    """Insere um cliente do CRM com a GUC do tenant setada — espelha `_insert_audit`."""
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                {"tid": tenant_id},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO clients (id, tenant_id, name, gender, notes, tags, source, "
+                    "stage_entered_at, created_at, updated_at) "
+                    "VALUES (:id, :tid, :nome, 'unspecified', '', '[]', 'manual', "
+                    "now(), now(), now())"
+                ),
+                {"id": str(uuid4()), "tid": tenant_id, "nome": nome},
+            )
+            conn.commit()
+    finally:
+        engine.dispose()
+
+
+def _busca_pela_otica_de(app_url: str, tenant_id: str, termo: str) -> set[str]:
+    """Roda a busca global como `e1p_app` com a GUC do tenant — RLS real, não SQLite.
+
+    A busca cruza sete tabelas; o `pytest -q` roda SQLite, onde a RLS nem existe. Sem este teste,
+    "a busca não vaza entre tenants" seria opinião.
+    """
+    from sqlalchemy.orm import Session
+
+    from app.modules.search.service import buscar
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                {"tid": tenant_id},
+            )
+            conn.commit()
+            with Session(bind=conn) as db:
+                grupos = buscar(db, q=termo, modulos_liberados=[])
+                return {item.titulo for grupo in grupos for item in grupo.itens}
+    finally:
+        engine.dispose()
+
+
+def test_busca_global_nao_atravessa_tenant() -> None:
+    """A busca global não devolve dado de outro tenant — no Postgres real, como `e1p_app`."""
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        joao_tenant = str(uuid4())
+        maria_tenant = str(uuid4())
+        # Nomes que casam com o MESMO termo: se a RLS falhasse, os dois viriam juntos.
+        _insert_cliente(app_url, joao_tenant, "Ana do Joao")
+        _insert_cliente(app_url, maria_tenant, "Ana da Maria")
+
+        assert _busca_pela_otica_de(app_url, joao_tenant, "ana") == {"Ana do Joao"}, (
+            "a busca do João trouxe a cliente da Maria"
+        )
+        assert _busca_pela_otica_de(app_url, maria_tenant, "ana") == {"Ana da Maria"}, (
+            "a busca da Maria trouxe a cliente do João"
+        )

--- a/apps/api/tests/test_search_deep.py
+++ b/apps/api/tests/test_search_deep.py
@@ -1,0 +1,192 @@
+"""A busca global — camada funda: corpo de documento, notas e mensagens.
+
+O que esta camada custa foi medido (spec §5): 140-270 ms sobre 240k mensagens, e isso NÃO melhora
+com índice — sob RLS o Postgres não usa trigrama nem tsvector para `ILIKE`. A única alavanca é
+quantas linhas se varre, e é por isso que o recorte de meses existe.
+"""
+from datetime import UTC, datetime, timedelta
+
+from app.modules.crm.models import Client
+from app.modules.juridico.models import LegalDocument
+from app.modules.search.service import buscar
+from app.modules.whatsapp_inbox.models import WhatsappChat, WhatsappMessage
+
+TENANT = "t-aaaaaaaa"
+TODOS: list[str] = []
+
+
+def _por_tipo(grupos):
+    return {g.tipo: g for g in grupos}
+
+
+def test_corpo_do_documento_so_e_lido_na_camada_funda(db):
+    db.add(
+        LegalDocument(
+            tenant_id=TENANT, skill="peticao", title="Peticao 1",
+            content="... com pedido de rescisao antecipada do contrato ...",
+        )
+    )
+    db.commit()
+
+    rasa = buscar(db, q="rescisao", modulos_liberados=TODOS)
+    funda = buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep")
+
+    assert rasa == [], "corpo não é lido na camada rasa — é o que a mantém em milissegundos"
+    assert {g.tipo for g in funda} == {"legal_document"}
+    assert "rescisao" in funda[0].itens[0].trecho.lower()
+
+
+def test_notas_do_cliente_entram_na_camada_funda(db):
+    db.add(Client(tenant_id=TENANT, name="Zulmira", notes="prefere ser chamada de Zu"))
+    db.commit()
+
+    rasa = buscar(db, q="chamada", modulos_liberados=TODOS)
+    funda = buscar(db, q="chamada", modulos_liberados=TODOS, profundidade="deep")
+
+    assert rasa == []
+    assert _por_tipo(funda)["client"].itens[0].titulo == "Zulmira"
+
+
+def test_funda_conta_o_total_exato(db):
+    """Na página funda a contagem É a informação — ali ela é exata, não estimada."""
+    for i in range(7):
+        db.add(
+            LegalDocument(tenant_id=TENANT, skill="peticao", title=f"Doc {i}",
+                          content="rescisao")
+        )
+    db.commit()
+
+    grupo = buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep", limite=3)[0]
+
+    assert len(grupo.itens) == 3
+    assert grupo.tem_mais is True
+    assert grupo.total == 7
+
+
+def test_uma_conversa_e_um_resultado_mesmo_com_quarenta_mensagens(db):
+    """Spec §3: quarenta mensagens do mesmo chat saem como UMA linha.
+
+    O contrário afogaria os outros seis tipos com repetição do mesmo diálogo — que é exatamente o
+    risco levantado ao decidir incluir mensagens na busca.
+    """
+    chat = WhatsappChat(tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net", title="Ana")
+    db.add(chat)
+    db.commit()
+    for i in range(40):
+        db.add(
+            WhatsappMessage(tenant_id=TENANT, chat_id=chat.id, direction="in",
+                            text_body=f"falamos de rescisao na mensagem {i}")
+        )
+    db.commit()
+
+    grupo = _por_tipo(
+        buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep")
+    )["conversation"]
+
+    assert len(grupo.itens) == 1
+    assert grupo.total == 1
+
+
+def test_recorte_de_meses_vale_so_para_mensagens(db):
+    """Spec §6.2: cortar documento por data esconderia a petição de dois anos atrás — que é
+    justamente o tipo de coisa que se procura por texto."""
+    antigo = datetime.now(UTC) - timedelta(days=800)
+
+    doc = LegalDocument(tenant_id=TENANT, skill="peticao", title="Antiga", content="rescisao")
+    doc.created_at = antigo
+    db.add(doc)
+    chat = WhatsappChat(tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net", title="Ana")
+    db.add(chat)
+    db.commit()
+    msg = WhatsappMessage(tenant_id=TENANT, chat_id=chat.id, direction="in", text_body="rescisao")
+    msg.created_at = antigo
+    db.add(msg)
+    db.commit()
+
+    tipos = {
+        g.tipo
+        for g in buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep", meses=12)
+    }
+
+    assert "legal_document" in tipos, "documento antigo NÃO pode ser cortado pelo recorte"
+    assert "conversation" not in tipos, "mensagem de 800 dias atrás está fora dos 12 meses"
+
+
+def test_meses_zero_significa_tudo(db):
+    """O seletor oferece 'tudo'; quem precisa do histórico inteiro paga conscientemente."""
+    antigo = datetime.now(UTC) - timedelta(days=800)
+    chat = WhatsappChat(tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net", title="Ana")
+    db.add(chat)
+    db.commit()
+    msg = WhatsappMessage(tenant_id=TENANT, chat_id=chat.id, direction="in", text_body="rescisao")
+    msg.created_at = antigo
+    db.add(msg)
+    db.commit()
+
+    tipos = {
+        g.tipo
+        for g in buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep", meses=0)
+    }
+
+    assert "conversation" in tipos
+
+
+def test_trecho_mostra_o_contexto_e_nao_o_documento_inteiro(db):
+    corpo = "a" * 500 + " rescisao antecipada " + "b" * 500
+    db.add(LegalDocument(tenant_id=TENANT, skill="peticao", title="Doc", content=corpo))
+    db.commit()
+
+    trecho = buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep")[0].itens[0].trecho
+
+    assert "rescisao" in trecho
+    assert len(trecho) < len(corpo), "o trecho é um recorte, não o documento inteiro"
+
+
+def test_o_recorte_nasce_do_fuso_do_tenant_e_nao_do_relogio_do_servidor(db):
+    """A âncora de "hoje" é `hoje_do_tenant`, não `datetime.now(UTC)`.
+
+    Dois tenants em fusos separados por 25 horas (UTC+14 e UTC-11) enxergam dias diferentes ao
+    mesmo instante. Se o corte viesse do relógio do servidor, os dois piso seriam idênticos — e
+    esta é a classe de bug que o PR #78 fechou no resto do sistema.
+
+    Testar isto pela variável `TZ` não funcionaria: no Windows ela não muda o fuso local do
+    Python (verificado), e o fuso que importa aqui nunca foi o da máquina.
+    """
+    from app.modules.auth.models import Tenant
+    from app.modules.search.service import _corte_de_mensagens
+    from app.modules.settings.models import TenantProfile
+
+    tenant = Tenant(
+        id=TENANT, slug="estudio", legal_name="Estudio", document="1",
+        timezone="Pacific/Kiritimati",  # UTC+14
+    )
+    db.add(tenant)
+    # O perfil não é decoração do teste: `tenant_timezone` chega ao fuso por JOIN com
+    # `tenant_profiles` (é o join que recorta o tenant, porque `tenants` é global e sem RLS).
+    # Sem ele, a função cai no fuso padrão e o teste mediria o padrão duas vezes.
+    db.add(TenantProfile(tenant_id=TENANT, display_name="Estudio"))
+    db.commit()
+    adiantado = _corte_de_mensagens(db, 12)
+
+    tenant.timezone = "Pacific/Niue"  # UTC-11
+    db.commit()
+    atrasado = _corte_de_mensagens(db, 12)
+
+    assert adiantado is not None and atrasado is not None
+    # Estrito, e com a diferença exata: 25 horas de separação garantem que as duas datas locais
+    # NUNCA coincidem. Um `>=` aqui passaria com os dois piso idênticos — que é exatamente o
+    # sintoma de o corte ter vindo do relógio do servidor.
+    assert adiantado - atrasado == timedelta(days=1)
+
+
+def test_camada_funda_respeita_o_rbac(db):
+    """O RBAC não afrouxa quando a busca fica mais funda."""
+    db.add(LegalDocument(tenant_id=TENANT, skill="peticao", title="Doc", content="rescisao"))
+    db.commit()
+
+    tipos = {
+        g.tipo
+        for g in buscar(db, q="rescisao", modulos_liberados=["crm"], profundidade="deep")
+    }
+
+    assert tipos == set()

--- a/apps/api/tests/test_search_deep.py
+++ b/apps/api/tests/test_search_deep.py
@@ -136,7 +136,8 @@ def test_trecho_mostra_o_contexto_e_nao_o_documento_inteiro(db):
     db.add(LegalDocument(tenant_id=TENANT, skill="peticao", title="Doc", content=corpo))
     db.commit()
 
-    trecho = buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep")[0].itens[0].trecho
+    grupos = buscar(db, q="rescisao", modulos_liberados=TODOS, profundidade="deep")
+    trecho = grupos[0].itens[0].trecho
 
     assert "rescisao" in trecho
     assert len(trecho) < len(corpo), "o trecho é um recorte, não o documento inteiro"

--- a/apps/api/tests/test_search_router.py
+++ b/apps/api/tests/test_search_router.py
@@ -59,3 +59,28 @@ def test_porcento_nao_devolve_tudo(client: TestClient, headers):
 
 def test_sem_token_e_401(client: TestClient):
     assert client.get("/search", params={"q": "ana"}).status_code == 401
+
+
+def test_depth_deep_conta_e_traz_trecho(client: TestClient, headers):
+    client.post(
+        "/crm/clients",
+        json={"name": "Zulmira", "notes": "prefere ser chamada de Zu"},
+        headers=headers,
+    )
+
+    raso = client.get("/search", params={"q": "chamada"}, headers=headers).json()
+    fundo = client.get(
+        "/search", params={"q": "chamada", "depth": "deep"}, headers=headers
+    ).json()
+
+    assert raso == {"groups": []}, "notas não são lidas na camada rasa"
+    grupo = fundo["groups"][0]
+    assert grupo["total"] == 1
+    assert "chamada" in grupo["items"][0]["snippet"]
+
+
+def test_depth_invalido_e_422(client: TestClient, headers):
+    """O contrato é fechado: `depth` só aceita os dois valores que o serviço entende."""
+    r = client.get("/search", params={"q": "ana", "depth": "profundissimo"}, headers=headers)
+
+    assert r.status_code == 422

--- a/apps/api/tests/test_search_router.py
+++ b/apps/api/tests/test_search_router.py
@@ -1,0 +1,61 @@
+"""A rota da busca global."""
+import pytest
+from fastapi.testclient import TestClient
+
+REGISTER = {
+    "legal_name": "Estúdio Ana",
+    "document": "11222333000181",
+    "slug": "estudioana",
+    "email": "ana@example.com",
+    "name": "Ana",
+    "password": "senha-bem-comprida",
+}
+
+
+@pytest.fixture()
+def headers(client: TestClient) -> dict[str, str]:
+    token = client.post("/auth/register", json=REGISTER).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_agrupa_por_tipo(client: TestClient, headers):
+    client.post("/crm/clients", json={"name": "Ana Souza"}, headers=headers)
+
+    r = client.get("/search", params={"q": "ana"}, headers=headers)
+
+    assert r.status_code == 200
+    grupos = r.json()["groups"]
+    assert grupos[0]["type"] == "client"
+    assert grupos[0]["items"][0]["title"] == "Ana Souza"
+    assert grupos[0]["items"][0]["route"].startswith("/crm/clients/")
+
+
+def test_camada_rasa_nao_conta(client: TestClient, headers):
+    """`has_more` em vez de `total`: sete `count()` por tecla, para um número que ninguém pediu."""
+    client.post("/crm/clients", json={"name": "Ana Souza"}, headers=headers)
+
+    grupo = client.get("/search", params={"q": "ana"}, headers=headers).json()["groups"][0]
+
+    assert grupo["has_more"] is False
+    assert grupo["total"] is None
+
+
+def test_termo_curto_devolve_vazio(client: TestClient, headers):
+    client.post("/crm/clients", json={"name": "Ana Souza"}, headers=headers)
+
+    r = client.get("/search", params={"q": "a"}, headers=headers)
+
+    assert r.status_code == 200
+    assert r.json() == {"groups": []}
+
+
+def test_porcento_nao_devolve_tudo(client: TestClient, headers):
+    client.post("/crm/clients", json={"name": "Ana Souza"}, headers=headers)
+
+    r = client.get("/search", params={"q": "%%"}, headers=headers)
+
+    assert r.json() == {"groups": []}
+
+
+def test_sem_token_e_401(client: TestClient):
+    assert client.get("/search", params={"q": "ana"}).status_code == 401

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1,0 +1,137 @@
+"""A busca global — camada rasa.
+
+SQLite, como todo o `pytest -q`. Isolamento cross-tenant é validado em Postgres real, no
+`test_rls_isolation.py` (marcador `rls_e2e`) — aqui a RLS nem existe.
+"""
+from app.modules.contracts.models import Contract
+from app.modules.crm.models import Client
+from app.modules.juridico.models import LegalDocument
+from app.modules.search.service import buscar
+from app.modules.whatsapp_inbox.models import WhatsappChat
+
+TENANT = "t-aaaaaaaa"
+#: Lista vazia = sem restrição de módulo, exatamente como em `require_module`.
+TODOS: list[str] = []
+
+
+def _cliente(db, name="Ana Souza", **kw):
+    c = Client(tenant_id=TENANT, name=name, **kw)
+    db.add(c)
+    db.commit()
+    return c
+
+
+def _por_tipo(grupos):
+    return {g.tipo: g for g in grupos}
+
+
+def test_casa_pelo_nome_do_cliente(db):
+    _cliente(db, name="Ana Souza")
+    _cliente(db, name="Bruno Lima")
+
+    grupos = _por_tipo(buscar(db, q="ana", modulos_liberados=TODOS))
+
+    assert [i.titulo for i in grupos["client"].itens] == ["Ana Souza"]
+    assert grupos["client"].itens[0].rota.startswith("/crm/clients/")
+
+
+def test_casa_pelo_email_e_pelo_telefone(db):
+    """Quem digita um telefone está procurando a pessoa, não um número."""
+    _cliente(db, name="Zulmira", email="contato@padaria.com.br", phone="11999998888")
+
+    por_email = buscar(db, q="padaria", modulos_liberados=TODOS)
+    por_telefone = buscar(db, q="99999", modulos_liberados=TODOS)
+
+    assert {g.tipo for g in por_email} == {"client"}
+    assert {g.tipo for g in por_telefone} == {"client"}
+
+
+def test_porcento_nao_casa_com_tudo(db):
+    _cliente(db, name="Ana Souza")
+
+    assert buscar(db, q="%", modulos_liberados=TODOS) == []
+
+
+def test_termo_curto_nao_devolve_nada(db):
+    """Uma letra casa com quase tudo e custaria sete varreduras por tecla."""
+    _cliente(db, name="Ana Souza")
+
+    assert buscar(db, q="a", modulos_liberados=TODOS) == []
+    assert buscar(db, q="  ", modulos_liberados=TODOS) == []
+
+
+def test_prefixo_vem_antes_de_casamento_no_meio(db):
+    _cliente(db, name="Mariana Costa")  # 'ana' no meio
+    _cliente(db, name="Ana Beatriz")  # 'ana' no começo
+
+    itens = _por_tipo(buscar(db, q="ana", modulos_liberados=TODOS))["client"].itens
+
+    assert [i.titulo for i in itens] == ["Ana Beatriz", "Mariana Costa"]
+
+
+def test_grupo_vazio_nao_entra_no_resultado(db):
+    _cliente(db, name="Ana Souza")
+
+    assert {g.tipo for g in buscar(db, q="ana", modulos_liberados=TODOS)} == {"client"}
+
+
+def test_tem_mais_quando_passa_do_limite(db):
+    for i in range(5):
+        _cliente(db, name=f"Ana {i}")
+
+    grupo = _por_tipo(buscar(db, q="ana", modulos_liberados=TODOS, limite=3))["client"]
+
+    assert len(grupo.itens) == 3
+    assert grupo.tem_mais is True
+    assert grupo.total is None, "camada rasa não conta — contar é da funda"
+
+
+def test_conversa_casa_pelo_nome_do_cliente_vinculado(db):
+    """`WhatsappChat.title` é nullable; quem procura conversa procura pelo nome da pessoa."""
+    ana = _cliente(db, name="Ana Souza")
+    db.add(
+        WhatsappChat(
+            tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net",
+            title=None, client_id=ana.id,
+        )
+    )
+    db.commit()
+
+    grupos = _por_tipo(buscar(db, q="ana", modulos_liberados=TODOS))
+
+    assert "conversation" in grupos
+    assert len(grupos["conversation"].itens) == 1
+
+
+def test_conversa_casa_pelo_proprio_titulo(db):
+    """Grupo de WhatsApp não vira contato do CRM — só o título dele identifica a conversa."""
+    db.add(WhatsappChat(tenant_id=TENANT, chat_jid="123@g.us", kind="group", title="Obra Anapolis"))
+    db.commit()
+
+    grupos = _por_tipo(buscar(db, q="anapolis", modulos_liberados=TODOS))
+
+    assert grupos["conversation"].itens[0].titulo == "Obra Anapolis"
+
+
+def test_os_grupos_saem_na_ordem_do_registro(db):
+    """Gente primeiro, depois o diálogo, depois compromisso. A ordem é do backend, um lugar só."""
+    ana = _cliente(db, name="Ana Souza")
+    db.add(WhatsappChat(tenant_id=TENANT, chat_jid="55@s.whatsapp.net", client_id=ana.id))
+    db.add(Contract(tenant_id=TENANT, title="Contrato da Ana"))
+    db.commit()
+
+    tipos = [g.tipo for g in buscar(db, q="ana", modulos_liberados=TODOS)]
+
+    assert tipos == ["client", "conversation", "contract"]
+
+
+def test_modulo_bloqueado_nao_produz_grupo(db):
+    """RBAC (spec §6.4): a RLS garante o tenant certo, não que ESTE usuário vê ESTE módulo."""
+    _cliente(db, name="Ana Souza")
+    db.add(LegalDocument(tenant_id=TENANT, skill="peticao", title="Peticao da Ana"))
+    db.commit()
+
+    tipos = {g.tipo for g in buscar(db, q="ana", modulos_liberados=["crm"])}
+
+    assert "client" in tipos
+    assert "legal_document" not in tipos, "sub-usuário sem juridico leria título de petição"

--- a/apps/api/tests/test_textsearch.py
+++ b/apps/api/tests/test_textsearch.py
@@ -1,0 +1,32 @@
+"""O primitivo de busca textual — escape de curinga.
+
+Este é o teste que o #125 provou ser necessário: a implementação ingênua (`f"%{termo}%"`) passa em
+todos os OUTROS testes de busca, porque casar texto comum funciona. Só um caso com `%` denuncia.
+"""
+from app.core.textsearch import ESCAPE, escapa_curinga, padrao_ilike
+
+
+def test_escapa_porcento_e_underline():
+    assert escapa_curinga("100%") == "100\\%"
+    assert escapa_curinga("a_b") == "a\\_b"
+
+
+def test_texto_comum_passa_intacto():
+    assert escapa_curinga("Ana Souza") == "Ana Souza"
+
+
+def test_barra_invertida_e_escapada_primeiro():
+    """Se a barra fosse escapada por último, ela duplicaria as barras recém-inseridas e o `%`
+    voltaria a ser curinga vivo precedido de barra literal."""
+    assert escapa_curinga("\\%") == "\\\\\\%"
+
+
+def test_padrao_envolve_em_curingas_de_verdade():
+    """As pontas SÃO curinga — é isso que faz a busca casar no meio da palavra."""
+    assert padrao_ilike("ana") == "%ana%"
+    assert padrao_ilike("50%") == "%50\\%%"
+
+
+def test_escape_e_a_barra_invertida():
+    """O valor tem que casar com o que os `replace` inserem, senão o escape não acontece."""
+    assert ESCAPE == "\\"

--- a/apps/web/e2e/busca-360.spec.ts
+++ b/apps/web/e2e/busca-360.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * A busca a 360px — MEDIDA, não aferida por classe.
+ *
+ * `toContain("flex-wrap")` já passou verde neste projeto durante duas sessões com a
+ * `FilaPagamentosPage` quebrada em produção: o `overflow-x` estava certo, o `flex-wrap` estava
+ * certo, e a tela estava errada. Aqui tudo que decide é número vindo do navegador.
+ *
+ * Os payloads são de PIOR CASO plausível: título longo, vinte itens, trecho comprido. Dado curto
+ * sempre cabe — medir com ele é medir uma tela que não existe.
+ */
+
+const RESULTADOS = {
+  groups: [
+    {
+      type: "legal_document",
+      has_more: true,
+      total: 42,
+      items: Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        title: "Peticao inicial de rescisao contratual antecipada com pedido de tutela liminar",
+        subtitle: "peticao",
+        route: `/juridico/d${i}`,
+        snippet:
+          "...ficou combinada a rescisao antecipada do contrato conforme a clausula decima " +
+          "segunda, com aviso previo de trinta dias corridos contados da notificacao...",
+      })),
+    },
+  ],
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+});
+
+// A barra é medida a partir de `/financeiro/investimentos`, e não da raiz: `/` passa pelo
+// `EntradaDoDia`, que decide a porta do dia e não renderiza a shell com payload genérico. É a
+// mesma rota que o `shell-360.spec.ts` usa para medir esta barra, pelo mesmo motivo.
+const TELA_COM_SHELL = "/financeiro/investimentos";
+const MOCKS_DA_SHELL = { "/search": { groups: [] }, "/investments": [], "/bank/accounts": [] };
+
+test("a 360px o campo da barra some e a lupa leva para /busca", async ({ page }) => {
+  await mockarApi(page, MOCKS_DA_SHELL);
+
+  await page.goto(TELA_COM_SHELL);
+  // O campo continua escondido abaixo de `md` — é a medição do #58, não um esquecimento.
+  await expect(page.getByPlaceholder("Buscar cliente, contrato ou documento")).toBeHidden();
+
+  await page.getByRole("button", { name: "Buscar" }).click();
+
+  await expect(page).toHaveURL(/\/busca/);
+});
+
+test("o alvo da lupa é tocável (44px) e não disputa com o botão de menu", async ({ page }) => {
+  await mockarApi(page, MOCKS_DA_SHELL);
+  await page.goto(TELA_COM_SHELL);
+
+  const lupa = await page.getByRole("button", { name: "Buscar" }).boundingBox();
+  const menu = await page.getByRole("button", { name: "Abrir menu" }).boundingBox();
+
+  expect(lupa).not.toBeNull();
+  expect(menu).not.toBeNull();
+  expect(lupa!.width, "alvo menor que o polegar acerta").toBeGreaterThanOrEqual(44);
+  expect(lupa!.height).toBeGreaterThanOrEqual(44);
+  // Sobreposição faria um dos dois receber o toque destinado ao outro.
+  expect(lupa!.x >= menu!.x + menu!.width || menu!.x >= lupa!.x + lupa!.width).toBe(true);
+});
+
+test("a página de resultados não rola de lado a 360px", async ({ page }) => {
+  await mockarApi(page, { "/search": RESULTADOS });
+
+  await page.goto("/busca?q=rescisao");
+  await expect(page.getByText("Jurídico (42)")).toBeVisible();
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina, "a página estourou a viewport de 360px").toBe(360);
+});
+
+test("o seletor de recorte cabe e continua legível a 360px", async ({ page }) => {
+  await mockarApi(page, { "/search": RESULTADOS });
+  await page.goto("/busca?q=rescisao");
+
+  const caixa = await page.getByLabel(/mensagens dos últimos/i).boundingBox();
+
+  expect(caixa).not.toBeNull();
+  expect(caixa!.width).toBeGreaterThan(0);
+  expect(caixa!.x + caixa!.width, "o seletor saiu da viewport").toBeLessThanOrEqual(360);
+});

--- a/apps/web/e2e/busca-url.spec.ts
+++ b/apps/web/e2e/busca-url.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O contrato de QUERY STRING da busca — o único lugar onde o axios de verdade roda.
+ *
+ * ⚠️ **Por que este arquivo existe.** As outras três camadas são cegas à URL: o pytest monta a
+ * query crua já na forma certa, o vitest assere o objeto `params` ANTES de serializar, e o mock
+ * do gate de layout devolve payload fixo seja qual for a query. Foi exatamente essa fresta que
+ * escondeu o `status[]` até o #125 — o filtro ia com colchetes, o FastAPI ignorava em silêncio e
+ * a tela mostrava dado sem filtro nenhum, sem erro e sem sintoma.
+ */
+
+async function urlsDaBusca(page: Parameters<typeof semearSessao>[0]) {
+  const urls: string[] = [];
+  page.on("request", (r) => {
+    if (r.url().includes("/search")) urls.push(r.url());
+  });
+  return urls;
+}
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/search": { groups: [] } });
+});
+
+test("a busca funda manda q, depth e months na forma que o FastAPI lê", async ({ page }) => {
+  const urls = await urlsDaBusca(page);
+
+  await page.goto("/busca?q=rescisao");
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  const query = decodeURIComponent(new URL(urls[0]).search);
+  expect(query, `query real: ${query}`).toContain("q=rescisao");
+  expect(query, `query real: ${query}`).toContain("depth=deep");
+  expect(query, `query real: ${query}`).toContain("months=12");
+  expect(query, "colchete = o FastAPI ignora o parâmetro em silêncio").not.toContain("[]");
+});
+
+test("o termo do usuário chega ao servidor como TEXTO, não interpretado", async ({ page }) => {
+  const urls = await urlsDaBusca(page);
+
+  // `%` é curinga do `ilike`. Se ele chegasse cru e sem escape no backend, a busca casaria com
+  // tudo — o defeito que o #125 documentou e que esta entrega fecha no CRM.
+  await page.goto("/busca?q=100%25");
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  expect(new URL(urls[0]).searchParams.get("q")).toBe("100%");
+});
+
+test("trocar o recorte para 'tudo' manda months=0, e não omite o parâmetro", async ({ page }) => {
+  const urls = await urlsDaBusca(page);
+  await page.goto("/busca?q=rescisao");
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  await page.getByLabel(/mensagens dos últimos/i).selectOption("0");
+
+  // Omitir o parâmetro faria o backend aplicar o padrão de 12 meses — o oposto do pedido.
+  await expect
+    .poll(() => urls.some((u) => new URL(u).searchParams.get("months") === "0"))
+    .toBe(true);
+});
+
+test("com menos de dois caracteres o servidor não é consultado", async ({ page }) => {
+  const urls = await urlsDaBusca(page);
+
+  await page.goto("/busca?q=a");
+  await page.waitForTimeout(600); // acima do debounce de 250ms
+
+  expect(urls, "uma letra casaria com quase tudo — sete varreduras por tecla").toHaveLength(0);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
 import AdminDashboard from "../features/admin/AdminDashboard";
 import AgendaPage from "../features/agenda/AgendaPage";
 import FirstAccessPage from "../features/auth/FirstAccessPage";
+import BuscaPage from "../features/busca/BuscaPage";
 import LoginPage from "../features/auth/LoginPage";
 import CockpitPage from "../features/cockpit/CockpitPage";
 import ConfiguracoesPage from "../features/config/ConfiguracoesPage";
@@ -75,6 +76,7 @@ export default function App() {
             }
           />
           <Route path="/agenda" element={<AgendaPage />} />
+          <Route path="/busca" element={<BuscaPage />} />
           <Route path="/crm" element={<CrmPage />} />
           <Route path="/crm/clients/:id" element={<ClientDetailPage />} />
           <Route path="/conversas" element={<ConversasPage />} />

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,8 +1,9 @@
 import type { TenantProfile } from "@e1p/shared-types";
 import clsx from "clsx";
-import { Bell, ChevronDown, LogOut, Plus, Search, ShieldCheck, X } from "lucide-react";
+import { Bell, ChevronDown, LogOut, Menu, Plus, Search, ShieldCheck, X } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router-dom";
+import BuscaGlobal from "../features/busca/BuscaGlobal";
 import { api } from "../lib/api";
 import { applyBrandTheme } from "../lib/theme";
 import { useAuth } from "../store/auth";
@@ -163,6 +164,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
 function Topbar({ onOpen, sidebarOpen }: { onOpen: () => void; sidebarOpen: boolean }) {
   const { user, tenant, logout } = useAuth();
   const { action } = usePageActions();
+  const navigate = useNavigate();
 
   return (
     // `flex-wrap` + `order-last` abaixo de `sm`: a ação primária desce para uma linha própria, de
@@ -178,20 +180,25 @@ function Topbar({ onOpen, sidebarOpen }: { onOpen: () => void; sidebarOpen: bool
           // que o polegar não acerta.
           className="flex h-11 w-11 shrink-0 items-center justify-center rounded-pill bg-primary-50 text-primary-600"
         >
-          <Search size={16} />
+          {/* `Menu`, e não `Search`: este botão sempre abriu o menu (`aria-label` acima), mas
+              usava uma lupa. Com a lupa DE VERDADE agora ao lado dele, seriam dois ícones iguais
+              com significados diferentes — e o de baixo é o que o polegar procura no celular. */}
+          <Menu size={16} />
         </button>
       )}
 
-      {/* A busca não tem handler nenhum — é decoração até alguém ligá-la. Abaixo de `md` ela sai da
-          frente e devolve 152px à linha, em vez de virar um bolo cinza de 52px sem placeholder
-          legível, que foi o que a medição encontrou. */}
-      <div className="relative hidden min-w-0 max-w-md flex-1 md:block">
-        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
-        <input
-          placeholder="Buscar cliente, projeto ou processo"
-          className="w-full rounded-pill bg-neutral-50 py-2 pl-9 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary-300"
-        />
-      </div>
+      {/* Abaixo de `md` o campo sai da frente e devolve 152px à linha: a medição do PR #58 achou
+          que ali ele vira um bolo cinza de 52px sem placeholder legível. O acesso no celular é a
+          lupa abaixo, que leva à página `/busca` — já desenhada para caber num telefone. */}
+      <BuscaGlobal />
+
+      <button
+        onClick={() => navigate("/busca")}
+        aria-label="Buscar"
+        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-pill text-neutral-500 hover:text-neutral-800 md:hidden"
+      >
+        <Search size={20} />
+      </button>
 
       {/* `min-h-[44px]`: com `py-2` puro a altura dava 40px e o teste desta task pegaria. */}
       {action && (

--- a/apps/web/src/features/busca/BuscaGlobal.test.tsx
+++ b/apps/web/src/features/busca/BuscaGlobal.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const get = vi.fn();
+vi.mock("../../lib/api", () => ({ api: { get: (...a: unknown[]) => get(...a) } }));
+
+import BuscaGlobal from "./BuscaGlobal";
+
+/** Sonda: mostra a URL atual, para asserir navegação sem espiar o router por dentro. */
+function Sonda() {
+  const loc = useLocation();
+  return <p data-testid="url">{loc.pathname + loc.search}</p>;
+}
+
+const RESPOSTA = {
+  data: {
+    groups: [
+      {
+        type: "client",
+        has_more: false,
+        total: null,
+        items: [
+          { id: "1", title: "Ana Souza", subtitle: "ana@x.com", route: "/crm/clients/1", snippet: null },
+        ],
+      },
+      {
+        type: "contract",
+        has_more: false,
+        total: null,
+        items: [
+          { id: "9", title: "Contrato da Ana", subtitle: "assinado", route: "/contratos/9", snippet: null },
+        ],
+      },
+    ],
+  },
+};
+
+function montar() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <BuscaGlobal />
+      <Routes>
+        <Route path="*" element={<Sonda />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("BuscaGlobal", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue(RESPOSTA);
+  });
+
+  it("a seta para baixo ATRAVESSA grupos", async () => {
+    montar();
+    await userEvent.type(screen.getByRole("combobox"), "ana");
+    await screen.findByText("Clientes");
+
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+
+    // O segundo item está em OUTRO grupo: para o teclado a lista é uma só.
+    expect(screen.getByRole("option", { selected: true })).toHaveTextContent("Contrato da Ana");
+  });
+
+  it("Enter sem item focado leva para a página de resultados", async () => {
+    montar();
+    await userEvent.type(screen.getByRole("combobox"), "ana");
+    await screen.findByText("Clientes");
+
+    await userEvent.keyboard("{Enter}");
+
+    expect(screen.getByTestId("url")).toHaveTextContent("/busca?q=ana");
+  });
+
+  it("Enter com item focado abre o registro daquele item", async () => {
+    montar();
+    await userEvent.type(screen.getByRole("combobox"), "ana");
+    await screen.findByText("Clientes");
+
+    await userEvent.keyboard("{ArrowDown}{Enter}");
+
+    expect(screen.getByTestId("url")).toHaveTextContent("/crm/clients/1");
+  });
+
+  it("Esc fecha e devolve o foco ao campo", async () => {
+    montar();
+    const campo = screen.getByRole("combobox");
+    await userEvent.type(campo, "ana");
+    await screen.findByRole("listbox");
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(campo).toHaveFocus();
+  });
+
+  it("com menos de dois caracteres não consulta o servidor", async () => {
+    montar();
+    await userEvent.type(screen.getByRole("combobox"), "a");
+
+    // Uma letra casa com quase tudo: sete varreduras por tecla, para devolver ruído.
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("o vazio da camada rasa aponta para a funda", async () => {
+    get.mockResolvedValue({ data: { groups: [] } });
+    montar();
+    await userEvent.type(screen.getByRole("combobox"), "rescisao");
+
+    // É exatamente o caso em que a resposta pode estar na outra camada.
+    expect(await screen.findByText(/procurar em documentos e mensagens/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/busca/BuscaGlobal.tsx
+++ b/apps/web/src/features/busca/BuscaGlobal.tsx
@@ -1,0 +1,159 @@
+import { Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ROTULOS, itensEmSequencia } from "./resultado";
+import { useBusca } from "./useBusca";
+
+/** Espelha `MIN_CARACTERES` do backend — abaixo disto não há dropdown para mostrar. */
+const MIN_CARACTERES = 2;
+
+/**
+ * A busca da barra de cima — camada rasa.
+ *
+ * Sete tipos, até 3 por grupo, agrupados na ordem que o backend manda. O objetivo aqui é "me leva
+ * até a Ana" em uma tecla, sem ler nada. Procurar DENTRO de documento e mensagem é a página
+ * `/busca`, e o rodapé (e o estado vazio) levam até ela.
+ */
+export default function BuscaGlobal() {
+  const [termo, setTermo] = useState("");
+  const [aberto, setAberto] = useState(false);
+  const [foco, setFoco] = useState(-1); // -1 = nenhum item focado
+  const campo = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+  const { grupos, vazio } = useBusca(termo);
+  const sequencia = itensEmSequencia(grupos); // o teclado ATRAVESSA grupos
+
+  useEffect(() => {
+    const atalho = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        campo.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", atalho);
+    return () => document.removeEventListener("keydown", atalho);
+  }, []);
+
+  // O foco volta ao início a cada resultado novo. Manter o índice antigo apontaria para um item
+  // que não está mais na lista, e o `Enter` abriria o registro errado — silenciosamente.
+  useEffect(() => setFoco(-1), [grupos]);
+
+  function irParaAPagina() {
+    setAberto(false);
+    navigate(`/busca?q=${encodeURIComponent(termo.trim())}`);
+  }
+
+  function abrir(rota: string) {
+    setAberto(false);
+    navigate(rota);
+  }
+
+  function noTeclado(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFoco((i) => Math.min(i + 1, sequencia.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFoco((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (foco >= 0 && sequencia[foco]) abrir(sequencia[foco].route);
+      else irParaAPagina();
+    } else if (e.key === "Escape") {
+      setAberto(false);
+      campo.current?.focus();
+    }
+  }
+
+  const mostrando = aberto && termo.trim().length >= MIN_CARACTERES;
+  let indice = -1; // numeração contínua entre grupos, para casar com `sequencia`
+
+  return (
+    <div
+      className="relative hidden min-w-0 max-w-md flex-1 md:block"
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) setAberto(false);
+      }}
+    >
+      <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+      <input
+        ref={campo}
+        role="combobox"
+        aria-expanded={mostrando}
+        aria-controls="busca-resultados"
+        aria-autocomplete="list"
+        placeholder="Buscar cliente, contrato ou documento"
+        value={termo}
+        onChange={(e) => {
+          setTermo(e.target.value);
+          setAberto(true);
+        }}
+        onFocus={() => setAberto(true)}
+        onKeyDown={noTeclado}
+        className="w-full rounded-pill bg-neutral-50 py-2 pl-9 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary-300"
+      />
+
+      {mostrando && (
+        <div
+          id="busca-resultados"
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-96 w-full overflow-y-auto rounded-2xl border border-neutral-100 bg-white py-1 shadow-lg"
+        >
+          {grupos.map((g) => (
+            <div key={g.type}>
+              <p className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                {ROTULOS[g.type]}
+              </p>
+              {g.items.map((item) => {
+                indice += 1;
+                const meu = indice;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="option"
+                    aria-selected={foco === meu}
+                    // `onMouseDown` e não `onClick`: o `onBlur` do contêiner fecha o dropdown
+                    // antes que um `click` chegue a disparar, e o item simplesmente não abriria.
+                    onMouseDown={() => abrir(item.route)}
+                    className={`flex w-full flex-col px-3 py-2 text-left text-sm ${
+                      foco === meu ? "bg-primary-50" : "hover:bg-neutral-50"
+                    }`}
+                  >
+                    <span className="truncate">{item.title}</span>
+                    {item.subtitle && (
+                      <span className="truncate text-xs text-neutral-400">{item.subtitle}</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+
+          {vazio ? (
+            <div className="px-3 py-3 text-sm text-neutral-500">
+              Nada encontrado para «{termo.trim()}».{" "}
+              <button
+                type="button"
+                onMouseDown={irParaAPagina}
+                className="text-primary-600 underline"
+              >
+                procurar em documentos e mensagens
+              </button>
+            </div>
+          ) : (
+            grupos.length > 0 && (
+              <button
+                type="button"
+                onMouseDown={irParaAPagina}
+                className="mt-1 w-full border-t border-neutral-100 px-3 py-2 text-left text-xs text-primary-600"
+              >
+                ver todos os resultados
+              </button>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/busca/BuscaPage.test.tsx
+++ b/apps/web/src/features/busca/BuscaPage.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const get = vi.fn();
+vi.mock("../../lib/api", () => ({ api: { get: (...a: unknown[]) => get(...a) } }));
+
+import BuscaPage from "./BuscaPage";
+
+function montar(url = "/busca?q=rescisao") {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/busca" element={<BuscaPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const UM_GRUPO = {
+  data: {
+    groups: [
+      {
+        type: "legal_document",
+        has_more: true,
+        total: 12,
+        items: [
+          {
+            id: "d1",
+            title: "Peticao inicial",
+            subtitle: "peticao",
+            route: "/juridico/d1",
+            snippet: "...combinada a rescisao antecipada...",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("BuscaPage", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue(UM_GRUPO);
+  });
+
+  it("lê o termo da URL e busca FUNDO", async () => {
+    montar();
+
+    await waitFor(() =>
+      expect(get).toHaveBeenCalledWith(
+        "/search",
+        expect.objectContaining({
+          params: expect.objectContaining({ q: "rescisao", depth: "deep", months: 12 }),
+        }),
+      ),
+    );
+  });
+
+  it("mostra a contagem EXATA por grupo", async () => {
+    montar();
+
+    // Aqui a contagem É a informação — é o que impede o recorte de ser silencioso.
+    expect(await screen.findByText("Jurídico (12)")).toBeInTheDocument();
+  });
+
+  it("mostra o trecho do corpo, que é o motivo de existir a camada funda", async () => {
+    montar();
+
+    expect(await screen.findByText(/rescisao antecipada/)).toBeInTheDocument();
+  });
+
+  it("o seletor diz que o recorte é SÓ das mensagens", async () => {
+    montar();
+
+    // Rótulo genérico faria o dono achar que o documento antigo também foi cortado.
+    expect(await screen.findByLabelText(/mensagens dos últimos/i)).toBeInTheDocument();
+  });
+
+  it("trocar o recorte refaz a busca com o novo valor", async () => {
+    montar();
+    await screen.findByText("Jurídico (12)");
+
+    await userEvent.selectOptions(screen.getByLabelText(/mensagens dos últimos/i), "0");
+
+    await waitFor(() =>
+      expect(get).toHaveBeenCalledWith(
+        "/search",
+        expect.objectContaining({ params: expect.objectContaining({ months: 0 }) }),
+      ),
+    );
+  });
+
+  it("sem termo, não consulta o servidor", async () => {
+    montar("/busca");
+
+    expect(get).not.toHaveBeenCalled();
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+  });
+});

--- a/apps/web/src/features/busca/BuscaPage.tsx
+++ b/apps/web/src/features/busca/BuscaPage.tsx
@@ -1,0 +1,7 @@
+import { useSearchParams } from "react-router-dom";
+
+/** Esqueleto — a camada funda entra na Task 8. */
+export default function BuscaPage() {
+  const [params] = useSearchParams();
+  return <p>{params.get("q") ?? ""}</p>;
+}

--- a/apps/web/src/features/busca/BuscaPage.tsx
+++ b/apps/web/src/features/busca/BuscaPage.tsx
@@ -1,7 +1,128 @@
-import { useSearchParams } from "react-router-dom";
+import { Search } from "lucide-react";
+import { Link, useSearchParams } from "react-router-dom";
+import { ROTULOS } from "./resultado";
+import { useBusca } from "./useBusca";
 
-/** Esqueleto — a camada funda entra na Task 8. */
+/** `0` = sem recorte. Só afeta mensagens — ver a spec §6.2. */
+const RECORTES = [
+  { valor: 3, rotulo: "3 meses" },
+  { valor: 12, rotulo: "12 meses" },
+  { valor: 0, rotulo: "tudo" },
+];
+
+/**
+ * A página de resultados — camada funda.
+ *
+ * Aqui a busca lê o CORPO: documento jurídico, notas de cliente e orçamento, e o texto das
+ * mensagens do WhatsApp. Custa 150-270 ms sobre volume real, e isso não melhora com índice: sob
+ * RLS o Postgres não usa trigrama nem tsvector para `ILIKE` (spec §5). A única alavanca é quantas
+ * linhas se varre — daí o recorte, que é anunciado em vez de escondido.
+ */
 export default function BuscaPage() {
-  const [params] = useSearchParams();
-  return <p>{params.get("q") ?? ""}</p>;
+  const [params, setParams] = useSearchParams();
+  const termo = params.get("q") ?? "";
+  const meses = Number(params.get("months") ?? 12);
+  const { grupos, carregando, vazio } = useBusca(termo, {
+    profundidade: "deep",
+    meses,
+    limite: 20,
+  });
+
+  function trocar(chave: string, valor: string) {
+    const novo = new URLSearchParams(params);
+    if (valor) novo.set(chave, valor);
+    else novo.delete(chave);
+    // `replace`: uma entrada de histórico por tecla digitada encheria o botão "voltar" de
+    // estados intermediários que ninguém quer revisitar.
+    setParams(novo, { replace: true });
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-6">
+      <h1 className="mb-4 text-xl font-semibold">Busca</h1>
+
+      <div className="relative mb-3">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+        <input
+          type="search"
+          value={termo}
+          onChange={(e) => trocar("q", e.target.value)}
+          placeholder="Buscar em tudo, inclusive documentos e mensagens"
+          className="w-full rounded-pill bg-neutral-50 py-3 pl-9 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary-300"
+        />
+      </div>
+
+      <label className="mb-5 flex flex-wrap items-center gap-2 text-sm text-neutral-500">
+        {/* O rótulo NOMEIA o que é cortado. Dizer só "últimos 12 meses" faria o dono achar que a
+            petição de dois anos atrás também ficou de fora — e ela não fica. */}
+        <span>mensagens dos últimos</span>
+        <select
+          value={meses}
+          onChange={(e) => trocar("months", e.target.value)}
+          className="rounded-pill border border-neutral-200 bg-white px-3 py-1 text-sm"
+        >
+          {RECORTES.map((r) => (
+            <option key={r.valor} value={r.valor}>
+              {r.rotulo}
+            </option>
+          ))}
+        </select>
+        <span className="text-neutral-400">— documentos e cadastros não têm recorte de data</span>
+      </label>
+
+      {carregando && <p className="text-sm text-neutral-400">procurando…</p>}
+
+      {vazio && (
+        <p className="text-sm text-neutral-500">
+          Nada encontrado para «{termo.trim()}»
+          {meses > 0 && " nas mensagens do período escolhido"}.{" "}
+          {meses > 0 && (
+            <button
+              type="button"
+              onClick={() => trocar("months", "0")}
+              className="text-primary-600 underline"
+            >
+              procurar em todo o histórico
+            </button>
+          )}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-6">
+        {grupos.map((g) => (
+          <section key={g.type}>
+            <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-400">
+              {/* A contagem é EXATA aqui: é ela que impede o recorte de ser silencioso. */}
+              {ROTULOS[g.type]} ({g.total ?? g.items.length})
+            </h2>
+            <ul className="flex flex-col gap-1">
+              {g.items.map((item) => (
+                <li key={item.id}>
+                  <Link
+                    to={item.route}
+                    className="flex flex-col rounded-2xl px-3 py-2 hover:bg-neutral-50"
+                  >
+                    <span className="text-sm font-medium">{item.title}</span>
+                    {item.subtitle && (
+                      <span className="text-xs text-neutral-400">{item.subtitle}</span>
+                    )}
+                    {item.snippet && (
+                      <span className="mt-1 break-words text-xs text-neutral-500">
+                        {item.snippet}
+                      </span>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            {g.has_more && (
+              <p className="px-3 pt-1 text-xs text-neutral-400">
+                mostrando {g.items.length} de {g.total ?? g.items.length}
+              </p>
+            )}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/features/busca/resultado.test.ts
+++ b/apps/web/src/features/busca/resultado.test.ts
@@ -1,0 +1,55 @@
+import type { SearchGroup } from "@e1p/shared-types";
+import { describe, expect, it } from "vitest";
+import { ROTULOS, itensEmSequencia, semVazios } from "./resultado";
+
+function grupo(over: Partial<SearchGroup> = {}): SearchGroup {
+  return {
+    type: "client",
+    has_more: false,
+    total: null,
+    items: [{ id: "1", title: "Ana", subtitle: "", route: "/crm/clients/1", snippet: null }],
+    ...over,
+  };
+}
+
+describe("resultado da busca", () => {
+  it("descarta grupo sem item e preserva a ordem do backend", () => {
+    const grupos = semVazios([
+      grupo({ type: "contract", items: [] }),
+      grupo({ type: "client" }),
+      grupo({ type: "funnel" }),
+    ]);
+
+    expect(grupos.map((g) => g.type)).toEqual(["client", "funnel"]);
+  });
+
+  it("tem rótulo em português para os sete tipos", () => {
+    expect(Object.keys(ROTULOS)).toHaveLength(7);
+    expect(ROTULOS.legal_document).toBe("Jurídico");
+    expect(ROTULOS.conversation).toBe("Conversas");
+  });
+
+  it("a sequência do teclado atravessa grupos", () => {
+    const sequencia = itensEmSequencia([
+      grupo({
+        type: "client",
+        items: [
+          { id: "1", title: "Ana", subtitle: "", route: "/crm/clients/1", snippet: null },
+          { id: "2", title: "Ana P", subtitle: "", route: "/crm/clients/2", snippet: null },
+        ],
+      }),
+      grupo({
+        type: "contract",
+        items: [{ id: "9", title: "Contrato", subtitle: "", route: "/contratos/9", snippet: null }],
+      }),
+    ]);
+
+    // Três itens numa fila só: é o que faz a seta para baixo sair de Clientes e cair em
+    // Contratos sem o usuário precisar saber que mudou de grupo.
+    expect(sequencia.map((i) => i.route)).toEqual([
+      "/crm/clients/1",
+      "/crm/clients/2",
+      "/contratos/9",
+    ]);
+  });
+});

--- a/apps/web/src/features/busca/resultado.ts
+++ b/apps/web/src/features/busca/resultado.ts
@@ -1,0 +1,33 @@
+import type { SearchGroup, SearchItem, SearchType } from "@e1p/shared-types";
+
+/**
+ * Rótulos em português. O backend manda `type`; a UI mora aqui.
+ *
+ * A ORDEM dos grupos NÃO mora neste arquivo — ela vem do registro do backend
+ * (`app/modules/search/registro.py`), num lugar só. Reordenar aqui criaria uma segunda
+ * definição de "o que vem primeiro", e as duas divergiriam.
+ */
+export const ROTULOS: Record<SearchType, string> = {
+  client: "Clientes",
+  conversation: "Conversas",
+  contract: "Contratos",
+  quote: "Orçamentos",
+  legal_document: "Jurídico",
+  page: "Sites",
+  funnel: "Funis",
+};
+
+/** Grupo sem item não ocupa linha na tela. */
+export function semVazios(grupos: SearchGroup[]): SearchGroup[] {
+  return grupos.filter((g) => g.items.length > 0);
+}
+
+/**
+ * Todos os itens numa fila só, na ordem em que aparecem na tela.
+ *
+ * É o que a seta para baixo percorre: o usuário não deveria precisar saber que passou de
+ * Clientes para Contratos — para o polegar e para o teclado, a lista é uma só.
+ */
+export function itensEmSequencia(grupos: SearchGroup[]): SearchItem[] {
+  return grupos.flatMap((g) => g.items);
+}

--- a/apps/web/src/features/busca/useBusca.ts
+++ b/apps/web/src/features/busca/useBusca.ts
@@ -1,0 +1,68 @@
+import type { SearchGroup, SearchResponse } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import { semVazios } from "./resultado";
+
+const DEBOUNCE_MS = 250;
+
+/** Espelha `MIN_CARACTERES` do serviço: abaixo disto o backend não consulta o banco. */
+const MIN_CARACTERES = 2;
+
+export interface OpcoesDaBusca {
+  profundidade?: "shallow" | "deep";
+  /** `0` = sem recorte. Só afeta mensagens — ver a spec §6.2. */
+  meses?: number;
+  limite?: number;
+}
+
+export function useBusca(q: string, opcoes: OpcoesDaBusca = {}) {
+  const { profundidade = "shallow", meses = 12, limite = 3 } = opcoes;
+  const [grupos, setGrupos] = useState<SearchGroup[]>([]);
+  const [carregando, setCarregando] = useState(false);
+
+  useEffect(() => {
+    const termo = q.trim();
+    if (termo.length < MIN_CARACTERES) {
+      setGrupos([]);
+      setCarregando(false);
+      return;
+    }
+
+    // O `AbortController` não é enfeite: sem ele, a resposta de uma consulta ANTERIOR chega
+    // depois e sobrescreve a atual. O sintoma é "o resultado pisca errado" — nunca um erro,
+    // que é o que torna esse defeito difícil de achar depois que ele já está em produção.
+    const controle = new AbortController();
+    const timer = setTimeout(() => {
+      setCarregando(true);
+      api
+        .get<SearchResponse>("/search", {
+          params: { q: termo, depth: profundidade, months: meses, limit: limite },
+          signal: controle.signal,
+        })
+        .then((r) => {
+          setGrupos(semVazios(r.data.groups));
+          setCarregando(false);
+        })
+        .catch(() => {
+          // Requisição cancelada é o caso NORMAL aqui (o usuário continuou digitando), não erro
+          // de produto. Deixar `carregando` ligado seria mostrar um esqueleto que nunca sai.
+          if (!controle.signal.aborted) {
+            setGrupos([]);
+            setCarregando(false);
+          }
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controle.abort();
+    };
+  }, [q, profundidade, meses, limite]);
+
+  return {
+    grupos,
+    carregando,
+    /** Só é "vazio" depois que a resposta chegou — antes disso é "ainda não sei". */
+    vazio: !carregando && q.trim().length >= MIN_CARACTERES && grupos.length === 0,
+  };
+}

--- a/docs/superpowers/plans/2026-08-18-busca-global.md
+++ b/docs/superpowers/plans/2026-08-18-busca-global.md
@@ -1,0 +1,1699 @@
+# Busca global — plano de implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ligar o campo "Buscar cliente, projeto ou processo" da barra de cima, com uma camada rasa
+(dropdown) e uma camada funda (página `/busca`) sobre sete entidades.
+
+**Architecture:** um módulo `search` com um registro declarativo de entidades; o serviço roda uma
+consulta curta por tipo e agrupa em Python — sem `UNION`, sem migration, sem índice novo (a medição
+provou que a RLS impede qualquer índice de texto; ver spec §5). No front, um hook com debounce e
+`AbortController` alimenta o dropdown do `AppShell` e a página `/busca`.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2 (Python 3.13), React + React Router + axios, pytest
+(SQLite in-memory), vitest, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-busca-global-design.md`
+
+## Global Constraints
+
+- **Datas sempre no fuso do tenant.** Backend: `hoje_do_tenant(db)` de
+  `app.modules.settings.service`. Front: `useFuso()` de `store/auth.tsx` + `today(fuso)` de
+  `lib/datetime.ts`. `datetime.now(UTC).date()` e `new Date()` cru são regressão.
+- **Nenhuma query filtra tenant à mão.** O isolamento é da RLS; rotas usam
+  `Depends(get_tenant_db)`. Ver `apps/api/app/db/session.py`.
+- **`pytest -q` roda SQLite** (`tests/conftest.py:22`) — nada de SQL específico de Postgres no
+  caminho da busca.
+- **`paramsSerializer: {indexes: null}`** em `apps/web/src/lib/api.ts` não se mexe: sem ele o
+  FastAPI ignora parâmetro repetido em silêncio.
+- **Layout se prova medindo** com Playwright a 360px (`e2e/support/medidas.ts`). `toContain` de
+  classe CSS não é prova.
+- **Commits em português, conventional commits.** `main` é protegida: tudo por PR.
+- **Antes de dizer "verde":** `pytest -q`, `TZ=UTC pytest -q` e `pytest -m rls_e2e` (este exige
+  Docker). Rodar em primeiro plano.
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade | Task |
+|---|---|---|
+| `apps/api/app/core/textsearch.py` | escapar curinga e montar padrão de `ilike` — o primitivo, um lugar só | 1 |
+| `apps/api/app/modules/search/registro.py` | as sete entidades, declarativas: campos, módulo RBAC, rótulo, rota | 2 |
+| `apps/api/app/modules/search/service.py` | `buscar()` — uma consulta por tipo, agrupa, ordena | 2, 4 |
+| `apps/api/app/modules/search/schemas.py` | `SearchItemOut`, `SearchGroupOut`, `SearchOut` | 3 |
+| `apps/api/app/modules/search/router.py` | `GET /search`, filtro de RBAC | 3 |
+| `apps/web/src/features/busca/resultado.ts` | rótulos, ordem, tipos do front — sem DOM | 6 |
+| `apps/web/src/features/busca/useBusca.ts` | debounce + `AbortController` + estado | 6 |
+| `apps/web/src/features/busca/BuscaGlobal.tsx` | campo + dropdown + teclado | 7 |
+| `apps/web/src/features/busca/BuscaPage.tsx` | `/busca?q=` — camada funda, seletor de meses | 8 |
+
+Backend e front ficam em módulos próprios porque `AppShell.tsx` já carrega a barra inteira e
+`PagarPage.tsx` (660 linhas) é o exemplo de onde não se quer chegar. `resultado.ts` sem DOM é o que
+permite testar ordem e rótulos sem montar a página.
+
+---
+
+## Task 1: O primitivo de texto, e a dívida do CRM
+
+**Files:**
+- Create: `apps/api/app/core/textsearch.py`
+- Modify: `apps/api/app/modules/payables/service.py` (remove `_escapa_curinga`, importa o novo)
+- Modify: `apps/api/app/modules/crm/service.py:392-393`
+- Test: `apps/api/tests/test_textsearch.py` (criar), `apps/api/tests/test_crm.py` (acrescentar)
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `escapa_curinga(termo: str) -> str` e `padrao_ilike(termo: str) -> str` em
+  `app.core.textsearch`. As tasks 2 e 4 usam `padrao_ilike`.
+
+- [ ] **Step 1: Escrever o teste que REPROVA o código de hoje**
+
+Em `apps/api/tests/test_crm.py`, acrescentar (o arquivo já tem fixtures de cliente; seguir o padrão
+local para criar clientes):
+
+```python
+def test_busca_do_crm_trata_porcento_como_texto(client, db):
+    """`%` sem escape casa com TODAS as linhas: a busca parece funcionar e não filtra nada.
+
+    Mesmo defeito que o #125 consertou em payables. Este teste FALHA no código de hoje.
+    """
+    _cria_cliente(db, name="Ana Souza")
+    _cria_cliente(db, name="Bruno Lima")
+
+    r = client.get("/crm/clients", params={"search": "%"}, headers=_auth())
+
+    assert r.status_code == 200
+    assert r.json() == [], "buscar '%' deve casar com NADA — hoje devolve todos os clientes"
+```
+
+Se `_cria_cliente`/`_auth` não existirem com esses nomes no arquivo, usar os helpers que já estão
+lá; não criar helpers novos.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_crm.py::test_busca_do_crm_trata_porcento_como_texto -v`
+Expected: FAIL — a resposta traz os dois clientes.
+
+- [ ] **Step 3: Criar o primitivo**
+
+`apps/api/app/core/textsearch.py`:
+
+```python
+"""Primitivo de busca textual — um lugar só para escapar curinga e montar o padrão do `ilike`.
+
+Extraído de `payables/service.py` (#125) quando a busca global passou a precisar dele em sete
+tabelas. Manter aqui, e não copiado por módulo: duas cópias divergem, e o modo de falha é mudo.
+"""
+from __future__ import annotations
+
+
+def escapa_curinga(termo: str) -> str:
+    """Neutraliza `%` e `_` para que o texto do usuário seja tratado como TEXTO no `ilike`.
+
+    Sem isto, buscar `%` casa com todas as linhas e a busca parece funcionar enquanto não filtra
+    nada — o pior tipo de defeito de busca, porque não tem sintoma.
+
+    A barra invertida é escapada PRIMEIRO: fazê-lo por último re-escaparia as barras que os dois
+    `replace` seguintes acabaram de inserir.
+    """
+    return termo.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def padrao_ilike(termo: str) -> str:
+    """`%termo%` com o termo já escapado. Use sempre com `.ilike(padrao, escape="\\\\")`."""
+    return f"%{escapa_curinga(termo)}%"
+```
+
+- [ ] **Step 4: Teste do primitivo**
+
+`apps/api/tests/test_textsearch.py`:
+
+```python
+from app.core.textsearch import escapa_curinga, padrao_ilike
+
+
+def test_escapa_porcento_e_underline():
+    assert escapa_curinga("100%") == "100\\%"
+    assert escapa_curinga("a_b") == "a\\_b"
+
+
+def test_barra_invertida_e_escapada_primeiro():
+    """Se a barra fosse escapada por último, ela duplicaria as barras recém-inseridas."""
+    assert escapa_curinga("\\%") == "\\\\\\%"
+
+
+def test_padrao_envolve_em_porcento_nao_escapados():
+    assert padrao_ilike("ana") == "%ana%"
+    assert padrao_ilike("50%") == "%50\\%%"
+```
+
+- [ ] **Step 5: Trocar as duas cópias**
+
+Em `apps/api/app/modules/payables/service.py`: apagar a função `_escapa_curinga` e importar
+`from app.core.textsearch import padrao_ilike`. Em `_filtros`, trocar
+`alvo = f"%{_escapa_curinga(q)}%"` por `alvo = padrao_ilike(q)`. Não mudar mais nada — o
+`escape="\\"` das duas chamadas `.ilike` permanece.
+
+Em `apps/api/app/modules/crm/service.py:392-393`, trocar:
+
+```python
+    if search:
+        like = f"%{search}%"
+        stmt = stmt.where(Client.name.ilike(like))
+```
+
+por:
+
+```python
+    if search:
+        # `escape` + `padrao_ilike`: sem os dois, buscar `%` casa com todas as linhas e a busca
+        # parece funcionar enquanto não filtra nada (mesmo defeito do #125 em payables).
+        stmt = stmt.where(Client.name.ilike(padrao_ilike(search), escape="\\"))
+```
+
+com `from app.core.textsearch import padrao_ilike` no topo.
+
+- [ ] **Step 6: Rodar tudo e ver passar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_textsearch.py tests/test_crm.py tests/test_payables.py -v`
+Expected: PASS, incluindo o `test_q_escapa_curinga_do_like` que já existia em payables — ele é a
+rede que prova que a extração não mudou comportamento.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/app/core/textsearch.py apps/api/tests/test_textsearch.py apps/api/app/modules/payables/service.py apps/api/app/modules/crm/service.py apps/api/tests/test_crm.py
+git commit -m "fix: buscar % no CRM devolvia todos os clientes
+
+O primitivo de escape do #125 sai de payables e vira core/textsearch.py, com
+tres chamadores. O CRM montava f\"%{search}%\" sem escapar nada: digitar % casava
+com tudo e a busca parecia funcionar enquanto nao filtrava nada."
+```
+
+---
+
+## Task 2: O registro das sete entidades e a busca rasa
+
+**Files:**
+- Create: `apps/api/app/modules/search/__init__.py` (vazio)
+- Create: `apps/api/app/modules/search/registro.py`
+- Create: `apps/api/app/modules/search/service.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+**Interfaces:**
+- Consumes: `padrao_ilike` da Task 1.
+- Produces:
+  - `Entidade` (dataclass) e `REGISTRO: tuple[Entidade, ...]` em `search.registro`
+  - `buscar(db, *, q: str, modulos_liberados: list[str], limite: int = 3) -> list[GrupoBruto]`
+    (a Task 4 **acrescenta** `profundidade` e `meses` a esta mesma função; nada é renomeado)
+  - `GrupoBruto` = `dataclass(tipo: str, itens: list[ItemBruto], tem_mais: bool,
+    total: int | None = None)`
+  - `ItemBruto` = `dataclass(id: str, titulo: str, subtitulo: str, rota: str,
+    trecho: str | None = None)`
+
+  A Task 3 monta os schemas a partir desses três nomes.
+
+- [ ] **Step 1: Escrever os testes da busca rasa**
+
+`apps/api/tests/test_search_service.py`:
+
+```python
+"""A busca global — camada rasa. SQLite, como todo o `pytest -q`."""
+from app.modules.crm.models import Client
+from app.modules.juridico.models import LegalDocument
+from app.modules.search.service import buscar
+from app.modules.whatsapp_inbox.models import WhatsappChat
+
+TODOS = []  # lista vazia = sem restrição de módulo (mesma regra de require_module)
+
+
+def _cliente(db, tenant="t-aaaaaaaa", **kw):
+    c = Client(tenant_id=tenant, name=kw.pop("name", "Ana Souza"), **kw)
+    db.add(c)
+    db.commit()
+    return c
+
+
+def test_casa_pelo_nome_do_cliente(db):
+    _cliente(db, name="Ana Souza")
+    _cliente(db, name="Bruno Lima")
+
+    grupos = {g.tipo: g for g in buscar(db, q="ana", modulos_liberados=TODOS)}
+
+    assert [i.titulo for i in grupos["client"].itens] == ["Ana Souza"]
+    assert grupos["client"].itens[0].rota.startswith("/crm/clients/")
+
+
+def test_casa_pelo_email_e_pelo_telefone(db):
+    _cliente(db, name="Zulmira", email="contato@padaria.com.br", phone="11999998888")
+
+    por_email = buscar(db, q="padaria", modulos_liberados=TODOS)
+    por_telefone = buscar(db, q="99999", modulos_liberados=TODOS)
+
+    assert {g.tipo for g in por_email if g.itens} == {"client"}
+    assert {g.tipo for g in por_telefone if g.itens} == {"client"}
+
+
+def test_porcento_nao_casa_com_tudo(db):
+    _cliente(db, name="Ana Souza")
+
+    grupos = buscar(db, q="%", modulos_liberados=TODOS)
+
+    assert all(g.itens == [] for g in grupos)
+
+
+def test_termo_curto_nao_devolve_nada(db):
+    _cliente(db, name="Ana Souza")
+
+    assert buscar(db, q="a", modulos_liberados=TODOS) == []
+    assert buscar(db, q=" ", modulos_liberados=TODOS) == []
+
+
+def test_prefixo_vem_antes_de_casamento_no_meio(db):
+    _cliente(db, name="Mariana Costa")   # 'ana' no meio
+    _cliente(db, name="Ana Beatriz")     # 'ana' no começo
+
+    itens = {g.tipo: g for g in buscar(db, q="ana", modulos_liberados=TODOS)}["client"].itens
+
+    assert [i.titulo for i in itens] == ["Ana Beatriz", "Mariana Costa"]
+
+
+def test_grupo_vazio_nao_entra_no_resultado(db):
+    _cliente(db, name="Ana Souza")
+
+    tipos = {g.tipo for g in buscar(db, q="ana", modulos_liberados=TODOS)}
+
+    assert tipos == {"client"}
+
+
+def test_tem_mais_quando_passa_do_limite(db):
+    for i in range(5):
+        _cliente(db, name=f"Ana {i}")
+
+    grupo = {g.tipo: g for g in buscar(db, q="ana", modulos_liberados=TODOS, limite=3)}["client"]
+
+    assert len(grupo.itens) == 3
+    assert grupo.tem_mais is True
+    assert grupo.total is None, "camada rasa não conta — conta é da funda"
+
+
+def test_conversa_casa_pelo_nome_do_cliente_vinculado(db):
+    """`WhatsappChat.title` é nullable; quem procura conversa procura pelo nome da pessoa."""
+    ana = _cliente(db, name="Ana Souza")
+    db.add(WhatsappChat(tenant_id="t-aaaaaaaa", chat_jid="5511@s.whatsapp.net",
+                        title=None, client_id=ana.id))
+    db.commit()
+
+    grupos = {g.tipo: g for g in buscar(db, q="ana", modulos_liberados=TODOS)}
+
+    assert grupos["conversation"].itens[0].titulo == "Ana Souza"
+
+
+def test_modulo_bloqueado_nao_produz_grupo(db):
+    """RBAC (spec §6.4): sub-usuário sem `juridico` não recebe grupo de jurídico."""
+    _cliente(db, name="Ana Souza")
+    db.add(LegalDocument(tenant_id="t-aaaaaaaa", skill="peticao", title="Peticao da Ana"))
+    db.commit()
+
+    tipos = {g.tipo for g in buscar(db, q="ana", modulos_liberados=["crm"])}
+
+    assert "client" in tipos
+    assert "legal_document" not in tipos
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_service.py -v`
+Expected: FAIL com `ModuleNotFoundError: app.modules.search`.
+
+- [ ] **Step 3: Escrever o registro**
+
+`apps/api/app/modules/search/registro.py`:
+
+```python
+"""As entidades que a busca global enxerga — declarativas, num lugar só.
+
+Acrescentar um tipo é acrescentar uma entrada. O que NÃO entra aqui: lista sem endereço que saiba
+receber busca (contas a pagar, cobranças, produtos — ver spec §2 e issue #138).
+
+`modulo` não é decoração: a RLS garante o tenant certo, não que ESTE usuário pode ver ESTE módulo.
+Sem ele, esta rota seria a porta dos fundos do `require_module` (spec §6.4).
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.modules.contracts.models import Contract
+from app.modules.crm.models import Client
+from app.modules.funnels.models import Funnel
+from app.modules.juridico.models import LegalDocument
+from app.modules.pages.models import Page
+from app.modules.quotes.models import Quote
+from app.modules.whatsapp_inbox.models import WhatsappChat
+
+
+@dataclass(frozen=True)
+class Entidade:
+    tipo: str
+    modelo: Any
+    modulo: str
+    campos_rasos: tuple
+    campos_fundos: tuple
+    principal: Any               # coluna que decide "prefixo vem antes" na ordenação
+    recencia: Any
+    titulo: Callable[[Any], str]
+    subtitulo: Callable[[Any], str]
+    rota: Callable[[Any], str]
+    # Predicado alternativo: usado só por `conversation`, que casa por join e não por coluna.
+    # NOTA: a Task 4 acrescenta dois parâmetros a este callable (`fundo`, `corte`). Se você já
+    # está implementando as duas, escreva direto na forma de quatro argumentos.
+    predicado: Callable[[str, str], Any] | None = field(default=None)
+
+
+def _predicado_da_conversa(padrao: str, escape: str):
+    """Conversa casa pelo título OU pelo nome do cliente vinculado.
+
+    `WhatsappChat.title` é nullable e curto (grupo sem assunto conhecido, `@lid` sem telefone).
+    Ninguém procura conversa pelo título dela — procura pelo nome da pessoa, que mora em `clients`.
+    """
+    from sqlalchemy import or_, select
+
+    subquery = select(Client.id).where(Client.name.ilike(padrao, escape=escape))
+    return or_(
+        WhatsappChat.title.ilike(padrao, escape=escape),
+        WhatsappChat.client_id.in_(subquery),
+    )
+
+
+REGISTRO: tuple[Entidade, ...] = (
+    Entidade(
+        tipo="client", modelo=Client, modulo="crm",
+        campos_rasos=(Client.name, Client.email, Client.phone, Client.document),
+        campos_fundos=(Client.notes,),
+        principal=Client.name, recencia=Client.updated_at,
+        titulo=lambda c: c.name,
+        subtitulo=lambda c: c.email or c.phone or "",
+        rota=lambda c: f"/crm/clients/{c.id}",
+    ),
+    Entidade(
+        tipo="conversation", modelo=WhatsappChat, modulo="crm",
+        campos_rasos=(WhatsappChat.title,), campos_fundos=(),
+        principal=WhatsappChat.title, recencia=WhatsappChat.updated_at,
+        titulo=lambda ch: ch.title or "Conversa",
+        subtitulo=lambda ch: ch.chat_jid,
+        rota=lambda ch: f"/conversas/{ch.id}",
+        predicado=_predicado_da_conversa,
+    ),
+    Entidade(
+        tipo="contract", modelo=Contract, modulo="contracts",
+        campos_rasos=(Contract.title, Contract.signer_name), campos_fundos=(),
+        principal=Contract.title, recencia=Contract.updated_at,
+        titulo=lambda c: c.title,
+        subtitulo=lambda c: c.signer_name or c.status,
+        rota=lambda c: f"/contratos/{c.id}",
+    ),
+    Entidade(
+        tipo="quote", modelo=Quote, modulo="quotes",
+        campos_rasos=(Quote.title, Quote.client_name), campos_fundos=(Quote.notes,),
+        principal=Quote.title, recencia=Quote.updated_at,
+        titulo=lambda q: q.title,
+        subtitulo=lambda q: q.client_name or q.status,
+        rota=lambda q: f"/orcamentos/{q.id}",
+    ),
+    Entidade(
+        tipo="legal_document", modelo=LegalDocument, modulo="juridico",
+        campos_rasos=(LegalDocument.title, LegalDocument.skill),
+        campos_fundos=(LegalDocument.content,),
+        principal=LegalDocument.title, recencia=LegalDocument.updated_at,
+        titulo=lambda d: d.title,
+        subtitulo=lambda d: d.skill,
+        rota=lambda d: f"/juridico/{d.id}",
+    ),
+    Entidade(
+        tipo="page", modelo=Page, modulo="pages",
+        campos_rasos=(Page.title, Page.public_slug), campos_fundos=(),
+        principal=Page.title, recencia=Page.updated_at,
+        titulo=lambda p: p.title,
+        subtitulo=lambda p: p.public_slug or p.status,
+        rota=lambda p: f"/sites/{p.id}",
+    ),
+    Entidade(
+        tipo="funnel", modelo=Funnel, modulo="funnels",
+        campos_rasos=(Funnel.name,), campos_fundos=(),
+        principal=Funnel.name, recencia=Funnel.updated_at,
+        titulo=lambda f: f.name,
+        subtitulo=lambda f: "",
+        rota=lambda f: f"/funis/{f.id}",
+    ),
+)
+```
+
+Se algum campo não existir com esse nome (ex.: `Contract.signer_name`, `Page.status`), **conferir o
+modelo e corrigir a entrada** — não inventar campo. A ordem das entradas é a ordem dos grupos na
+tela e não deve ser alterada.
+
+- [ ] **Step 4: Escrever o serviço (camada rasa)**
+
+`apps/api/app/modules/search/service.py`:
+
+```python
+"""A busca global. Uma consulta curta por tipo, agrupada em Python.
+
+Sem `UNION`: como o resultado é agrupado por tipo (spec §9), não existe ranking global a calcular e
+não há nada para o banco juntar. Cada consulta fica trivial e idêntica em SQLite e Postgres — que é
+o que mantém isto coberto pelo `pytest -q`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import case, or_, select
+from sqlalchemy.orm import Session
+
+from app.core.textsearch import escapa_curinga, padrao_ilike
+from app.modules.search.registro import REGISTRO, Entidade
+
+MIN_CARACTERES = 2
+_ESCAPE = "\\"
+
+
+@dataclass
+class ItemBruto:
+    id: str
+    titulo: str
+    subtitulo: str
+    rota: str
+    trecho: str | None = None
+
+
+@dataclass
+class GrupoBruto:
+    tipo: str
+    itens: list[ItemBruto]
+    tem_mais: bool
+    total: int | None = None
+
+
+def _liberado(entidade: Entidade, modulos_liberados: list[str]) -> bool:
+    """Espelha `require_module`: lista vazia = sem restrição. Ver spec §6.4."""
+    return not modulos_liberados or entidade.modulo in modulos_liberados
+
+
+def _predicado(entidade: Entidade, padrao: str):
+    if entidade.predicado is not None:
+        return entidade.predicado(padrao, _ESCAPE)
+    return or_(*[c.ilike(padrao, escape=_ESCAPE) for c in entidade.campos_rasos])
+
+
+def _ordem(entidade: Entidade, termo: str):
+    """Dois degraus: prefixo antes de casamento no meio; depois, o mais recente.
+
+    Dois e não três porque cabe num `case()` portátil e num teste que se lê.
+    """
+    prefixo = f"{escapa_curinga(termo)}%"
+    return (
+        case((entidade.principal.ilike(prefixo, escape=_ESCAPE), 0), else_=1),
+        entidade.recencia.desc(),
+    )
+
+
+def buscar(
+    db: Session,
+    *,
+    q: str,
+    modulos_liberados: list[str],
+    limite: int = 3,
+) -> list[GrupoBruto]:
+    termo = " ".join(q.split())
+    if len(termo) < MIN_CARACTERES:
+        # Uma letra casa com quase tudo e custaria sete varreduras por tecla.
+        return []
+
+    padrao = padrao_ilike(termo)
+    grupos: list[GrupoBruto] = []
+
+    for entidade in REGISTRO:
+        if not _liberado(entidade, modulos_liberados):
+            continue
+        stmt = (
+            select(entidade.modelo)
+            .where(_predicado(entidade, padrao))
+            .order_by(*_ordem(entidade, termo))
+            .limit(limite + 1)  # +1 = descobre `tem_mais` sem um `count()` por tipo
+        )
+        linhas = list(db.scalars(stmt).all())
+        if not linhas:
+            continue
+        grupos.append(
+            GrupoBruto(
+                tipo=entidade.tipo,
+                itens=[
+                    ItemBruto(
+                        id=linha.id,
+                        titulo=entidade.titulo(linha),
+                        subtitulo=entidade.subtitulo(linha),
+                        rota=entidade.rota(linha),
+                    )
+                    for linha in linhas[:limite]
+                ],
+                tem_mais=len(linhas) > limite,
+            )
+        )
+    return grupos
+```
+
+- [ ] **Step 5: Rodar e ver passar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_service.py -v`
+Expected: PASS nos 9 testes.
+
+Se `test_conversa_casa_pelo_nome_do_cliente_vinculado` falhar por causa do `in_(subquery)` em
+SQLite, **não trocar por filtro em Python** — conferir o `select` da subquery. Filtrar em Python
+quebraria o `limit` e o `tem_mais`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/search/ apps/api/tests/test_search_service.py
+git commit -m "feat: o registro das sete entidades e a busca rasa
+
+Uma consulta por tipo, sem UNION: como o resultado e agrupado por tipo, nao ha
+ranking global a calcular e nada para o banco juntar. Conversa casa pelo nome do
+cliente vinculado, porque WhatsappChat.title e nullable e ninguem procura conversa
+pelo titulo dela."
+```
+
+---
+
+## Task 3: A rota `GET /search`
+
+**Files:**
+- Create: `apps/api/app/modules/search/schemas.py`
+- Create: `apps/api/app/modules/search/router.py`
+- Modify: `apps/api/app/modules/__init__.py` (import + entrada em `ALL_ROUTERS`)
+- Test: `apps/api/tests/test_search_router.py`
+
+**Interfaces:**
+- Consumes: `buscar`, `GrupoBruto`, `ItemBruto` da Task 2.
+- Produces: `GET /search?q=&depth=&months=&limit=` devolvendo
+  `{"groups": [{"type","has_more","total","items":[{"id","title","subtitle","route","snippet"}]}]}`.
+  A Task 6 escreve os tipos do front a partir disso.
+
+- [ ] **Step 1: Escrever o teste da rota**
+
+`apps/api/tests/test_search_router.py`:
+
+```python
+def test_rota_agrupa_por_tipo(client, db):
+    _cria_cliente(db, name="Ana Souza")
+
+    r = client.get("/search", params={"q": "ana"}, headers=_auth())
+
+    assert r.status_code == 200
+    grupos = r.json()["groups"]
+    assert grupos[0]["type"] == "client"
+    assert grupos[0]["items"][0]["title"] == "Ana Souza"
+    assert grupos[0]["items"][0]["route"].startswith("/crm/clients/")
+    assert grupos[0]["has_more"] is False
+    assert grupos[0]["total"] is None
+
+
+def test_termo_curto_devolve_lista_vazia(client, db):
+    _cria_cliente(db, name="Ana Souza")
+
+    r = client.get("/search", params={"q": "a"}, headers=_auth())
+
+    assert r.status_code == 200
+    assert r.json() == {"groups": []}
+
+
+def test_sem_token_e_401(client):
+    assert client.get("/search", params={"q": "ana"}).status_code == 401
+```
+
+Reusar os helpers de autenticação já existentes nos testes do repositório (ver
+`tests/test_crm.py`); não criar um esquema de auth novo.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_router.py -v`
+Expected: FAIL com 404 — a rota não existe.
+
+- [ ] **Step 3: Schemas**
+
+`apps/api/app/modules/search/schemas.py`:
+
+```python
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SearchItemOut(BaseModel):
+    id: str
+    title: str
+    subtitle: str
+    route: str
+    snippet: str | None = None
+
+
+class SearchGroupOut(BaseModel):
+    type: str
+    has_more: bool
+    # `total` só existe em `depth=deep`. Na camada rasa, contar custaria sete `count()` por tecla
+    # — e `has_more` não tem como mentir sobre um número que não anuncia.
+    total: int | None = None
+    items: list[SearchItemOut]
+
+
+class SearchOut(BaseModel):
+    groups: list[SearchGroupOut]
+```
+
+- [ ] **Step 4: Router**
+
+`apps/api/app/modules/search/router.py`:
+
+```python
+"""Busca global — a rota.
+
+Sem `require_module`: a busca cruza sete módulos e um guard só não serviria. O RBAC entra como
+FILTRO por entidade (spec §6.4), usando o mesmo critério de `require_module` — dono ou
+`allowed_modules` vazio vê tudo.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.tenancy import CurrentUser, get_current_user, get_tenant_db
+from app.modules.search import service
+from app.modules.search.schemas import SearchGroupOut, SearchItemOut, SearchOut
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+def _modulos(user: CurrentUser) -> list[str]:
+    """Mesma regra de `require_module`: owner ou lista vazia = sem restrição."""
+    if user.role == "owner":
+        return []
+    return user.allowed_modules
+
+
+@router.get("", response_model=SearchOut)
+def search(
+    q: str = Query(default=""),
+    limit: int = Query(default=3, ge=1, le=50),
+    user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_tenant_db),
+) -> SearchOut:
+    grupos = service.buscar(db, q=q, modulos_liberados=_modulos(user), limite=limit)
+    return SearchOut(
+        groups=[
+            SearchGroupOut(
+                type=g.tipo,
+                has_more=g.tem_mais,
+                total=g.total,
+                items=[
+                    SearchItemOut(
+                        id=i.id, title=i.titulo, subtitle=i.subtitulo,
+                        route=i.rota, snippet=i.trecho,
+                    )
+                    for i in g.itens
+                ],
+            )
+            for g in grupos
+        ]
+    )
+```
+
+- [ ] **Step 5: Registrar o router**
+
+Em `apps/api/app/modules/__init__.py`: acrescentar
+`from app.modules.search.router import router as search_router` junto dos outros imports (ordem
+alfabética) e `search_router` na lista `ALL_ROUTERS`.
+
+- [ ] **Step 6: Rodar e ver passar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_router.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/app/modules/search/ apps/api/app/modules/__init__.py apps/api/tests/test_search_router.py
+git commit -m "feat: GET /search devolve os resultados agrupados por tipo
+
+Sem require_module na rota: a busca cruza sete modulos e um guard so nao serviria.
+O RBAC entra como filtro por entidade, com o mesmo criterio (dono ou
+allowed_modules vazio ve tudo)."
+```
+
+---
+
+## Task 4: A camada funda
+
+**Files:**
+- Modify: `apps/api/app/modules/search/service.py`
+- Modify: `apps/api/app/modules/search/router.py`
+- Test: `apps/api/tests/test_search_deep.py`
+
+**Interfaces:**
+- Consumes: tudo da Task 2 e 3.
+- Produces: `buscar(..., profundidade="deep", meses=12)` preenchendo `trecho` e `total`;
+  a rota aceita `depth=shallow|deep` e `months=3|12|0` (`0` = tudo).
+
+- [ ] **Step 1: Escrever os testes**
+
+`apps/api/tests/test_search_deep.py`:
+
+```python
+"""Camada funda: corpo de documento, notas e mensagens, com recorte de meses."""
+from datetime import UTC, datetime, timedelta
+
+
+def test_acha_no_corpo_do_documento_juridico(db):
+    from app.modules.juridico.models import LegalDocument
+    from app.modules.search.service import buscar
+
+    db.add(LegalDocument(tenant_id="t-aaaaaaaa", skill="peticao", title="Peticao 1",
+                         content="... pedido de rescisao antecipada ..."))
+    db.commit()
+
+    rasa = buscar(db, q="rescisao", modulos_liberados=[])
+    funda = buscar(db, q="rescisao", modulos_liberados=[], profundidade="deep")
+
+    assert rasa == [], "corpo não é lido na camada rasa"
+    assert {g.tipo for g in funda} == {"legal_document"}
+    assert "rescisao" in funda[0].itens[0].trecho.lower()
+
+
+def test_funda_conta_o_total_exato(db):
+    from app.modules.juridico.models import LegalDocument
+    from app.modules.search.service import buscar
+
+    for i in range(7):
+        db.add(LegalDocument(tenant_id="t-aaaaaaaa", skill="peticao", title=f"Doc {i}",
+                             content="rescisao"))
+    db.commit()
+
+    grupo = buscar(db, q="rescisao", modulos_liberados=[], profundidade="deep", limite=3)[0]
+
+    assert len(grupo.itens) == 3
+    assert grupo.total == 7, "na página funda a contagem É a informação; ela é exata"
+
+
+def test_uma_conversa_e_UM_resultado_mesmo_com_muitas_mensagens(db):
+    """Spec §3: quarenta mensagens do mesmo chat saem como uma linha, não quarenta."""
+    from app.modules.search.service import buscar
+    from app.modules.whatsapp_inbox.models import WhatsappChat, WhatsappMessage
+
+    chat = WhatsappChat(tenant_id="t-aaaaaaaa", chat_jid="5511@s.whatsapp.net", title="Ana")
+    db.add(chat)
+    db.commit()
+    for i in range(40):
+        db.add(WhatsappMessage(tenant_id="t-aaaaaaaa", chat_id=chat.id, direction="in",
+                               text_body=f"falamos de rescisao {i}"))
+    db.commit()
+
+    grupo = {g.tipo: g for g in
+             buscar(db, q="rescisao", modulos_liberados=[], profundidade="deep")}["conversation"]
+
+    assert len(grupo.itens) == 1
+    assert grupo.total == 1
+
+
+def test_recorte_de_meses_vale_SO_para_mensagens(db):
+    """Spec §6.2: cortar documentos por data esconderia a petição de dois anos atrás."""
+    from app.modules.juridico.models import LegalDocument
+    from app.modules.search.service import buscar
+    from app.modules.whatsapp_inbox.models import WhatsappChat, WhatsappMessage
+
+    antigo = datetime.now(UTC) - timedelta(days=800)
+    doc = LegalDocument(tenant_id="t-aaaaaaaa", skill="peticao", title="Antiga",
+                        content="rescisao")
+    doc.created_at = antigo
+    db.add(doc)
+    chat = WhatsappChat(tenant_id="t-aaaaaaaa", chat_jid="5511@s.whatsapp.net", title="Ana")
+    db.add(chat)
+    db.commit()
+    msg = WhatsappMessage(tenant_id="t-aaaaaaaa", chat_id=chat.id, direction="in",
+                          text_body="rescisao")
+    msg.created_at = antigo
+    db.add(msg)
+    db.commit()
+
+    tipos = {g.tipo for g in
+             buscar(db, q="rescisao", modulos_liberados=[], profundidade="deep", meses=12)}
+
+    assert "legal_document" in tipos, "documento antigo NÃO pode ser cortado pelo recorte"
+    assert "conversation" not in tipos, "mensagem antiga fica fora dos últimos 12 meses"
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_deep.py -v`
+Expected: FAIL — `buscar()` não aceita `profundidade`.
+
+- [ ] **Step 3: Implementar**
+
+Em `service.py`, acrescentar:
+
+```python
+from datetime import datetime, time, timedelta
+
+from sqlalchemy import func
+
+from app.modules.settings.service import hoje_do_tenant
+
+TRECHO_ANTES = 40
+TRECHO_DEPOIS = 80
+
+
+def _trecho(texto: str, termo: str) -> str:
+    """Um pedaço do corpo em volta do casamento, para o leitor reconhecer o contexto."""
+    if not texto:
+        return ""
+    pos = texto.lower().find(termo.lower())
+    if pos < 0:
+        return texto[:TRECHO_DEPOIS]
+    inicio = max(0, pos - TRECHO_ANTES)
+    fim = min(len(texto), pos + len(termo) + TRECHO_DEPOIS)
+    return ("..." if inicio > 0 else "") + texto[inicio:fim] + ("..." if fim < len(texto) else "")
+
+
+def _corte_de_mensagens(db: Session, meses: int) -> datetime | None:
+    """A data-piso do recorte, no FUSO DO TENANT.
+
+    `datetime.now(UTC)` aqui reintroduziria a classe de bug do fuso pela porta do filtro: em UTC-3,
+    das 21h à meia-noite o piso pularia um dia inteiro. `meses=0` significa "tudo".
+    """
+    if meses <= 0:
+        return None
+    hoje = hoje_do_tenant(db)
+    return datetime.combine(hoje - timedelta(days=30 * meses), time.min, tzinfo=UTC)
+```
+
+Substituir `_predicado` e `buscar` por:
+
+```python
+def _predicado(entidade: Entidade, padrao: str, fundo: bool, corte):
+    """Construtor ÚNICO do predicado — usado pela LISTA e pela CONTAGEM.
+
+    ⚠️ Não duplique este `where` do outro lado. Dois blocos copiados divergem na primeira
+    manutenção, e a partir daí a tela anuncia um `total` que a própria lista não confirma: nada
+    quebra, o rodapé só passa a mentir. É a lição do #125.
+    """
+    if entidade.predicado is not None:
+        return entidade.predicado(padrao, _ESCAPE, fundo, corte)
+    campos = entidade.campos_rasos + (entidade.campos_fundos if fundo else ())
+    return or_(*[c.ilike(padrao, escape=_ESCAPE) for c in campos])
+
+
+def buscar(
+    db: Session,
+    *,
+    q: str,
+    modulos_liberados: list[str],
+    profundidade: str = "shallow",
+    meses: int = 12,
+    limite: int = 3,
+) -> list[GrupoBruto]:
+    termo = " ".join(q.split())
+    if len(termo) < MIN_CARACTERES:
+        return []
+
+    fundo = profundidade == "deep"
+    padrao = padrao_ilike(termo)
+    corte = _corte_de_mensagens(db, meses) if fundo else None
+    grupos: list[GrupoBruto] = []
+
+    for entidade in REGISTRO:
+        if not _liberado(entidade, modulos_liberados):
+            continue
+        onde = _predicado(entidade, padrao, fundo, corte)
+        stmt = (
+            select(entidade.modelo)
+            .where(onde)
+            .order_by(*_ordem(entidade, termo))
+            .limit(limite + 1)
+        )
+        linhas = list(db.scalars(stmt).all())
+        if not linhas:
+            continue
+        # `total` só na camada funda: contar na rasa custaria sete `count()` por tecla, e
+        # `tem_mais` não tem como mentir sobre um número que não anuncia.
+        total = (
+            db.scalar(select(func.count()).select_from(entidade.modelo).where(onde))
+            if fundo
+            else None
+        )
+        grupos.append(
+            GrupoBruto(
+                tipo=entidade.tipo,
+                itens=[
+                    ItemBruto(
+                        id=linha.id,
+                        titulo=entidade.titulo(linha),
+                        subtitulo=entidade.subtitulo(linha),
+                        rota=entidade.rota(linha),
+                        trecho=_trecho_da_linha(entidade, linha, termo) if fundo else None,
+                    )
+                    for linha in linhas[:limite]
+                ],
+                tem_mais=len(linhas) > limite,
+                total=total,
+            )
+        )
+    return grupos
+
+
+def _trecho_da_linha(entidade: Entidade, linha, termo: str) -> str | None:
+    """O primeiro campo fundo que contém o termo vira o trecho mostrado na tela."""
+    for coluna in entidade.campos_fundos:
+        texto = getattr(linha, coluna.key, "") or ""
+        if termo.lower() in texto.lower():
+            return _trecho(texto, termo)
+    return None
+```
+
+E em `registro.py`, `_predicado_da_conversa` ganha a forma funda — **é ela que faz uma conversa ser
+UM resultado e o recorte de meses valer só para mensagens**:
+
+```python
+def _predicado_da_conversa(padrao: str, escape: str, fundo: bool, corte):
+    from sqlalchemy import or_, select
+
+    from app.modules.whatsapp_inbox.models import WhatsappMessage
+
+    clientes = select(Client.id).where(Client.name.ilike(padrao, escape=escape))
+    condicoes = [
+        WhatsappChat.title.ilike(padrao, escape=escape),
+        WhatsappChat.client_id.in_(clientes),
+    ]
+    if fundo:
+        # A subquery devolve CHATS, não mensagens: quarenta mensagens casando viram uma linha.
+        mensagens = select(WhatsappMessage.chat_id).where(
+            WhatsappMessage.text_body.ilike(padrao, escape=escape)
+        )
+        if corte is not None:
+            mensagens = mensagens.where(WhatsappMessage.created_at >= corte)
+        condicoes.append(WhatsappChat.id.in_(mensagens))
+    return or_(*condicoes)
+```
+
+O tipo do campo no dataclass passa a `Callable[[str, str, bool, Any], Any]`, e a chamada rasa da
+Task 2 vira `entidade.predicado(padrao, _ESCAPE, False, None)`.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_search_deep.py tests/test_search_service.py -v`
+Expected: PASS. Rodar também `TZ=UTC` e um fuso diferente:
+`cd apps/api && TZ=America/Sao_Paulo .venv/Scripts/python -m pytest tests/test_search_deep.py -v`
+
+- [ ] **Step 5: Expor na rota**
+
+Em `router.py`, acrescentar os parâmetros e repassá-los:
+
+```python
+    depth: str = Query(default="shallow", pattern="^(shallow|deep)$"),
+    months: int = Query(default=12, ge=0, le=120),
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/search/ apps/api/tests/test_search_deep.py
+git commit -m "feat: a camada funda le corpo de documento, notas e mensagens
+
+Uma conversa e UM resultado mesmo com quarenta mensagens casando — senao o proprio
+grupo se afogaria em repeticao do mesmo dialogo. O recorte de meses vale SO para
+mensagens: cortar documento por data esconderia a peticao de dois anos atras, que
+e justamente o que se procura por texto."
+```
+
+---
+
+## Task 5: Isolamento cross-tenant no Postgres real
+
+**Files:**
+- Modify: `apps/api/tests/test_rls_isolation.py` (acrescentar função, NÃO criar arquivo novo)
+
+**Interfaces:**
+- Consumes: `buscar` da Task 2/4.
+- Produces: nada consumido por outras tasks.
+
+**Por que neste arquivo:** cada `PostgresContainer` custa minutos de CI, e `test_rls_isolation.py`
+já faz o bootstrap do papel `e1p_app` e roda as migrations. O repositório instrui explicitamente a
+estender em vez de criar mais um arquivo de testcontainer (ver o cabeçalho de
+`tests/test_bank_rls.py`).
+
+- [ ] **Step 1: Escrever o teste**
+
+Acrescentar em `apps/api/tests/test_rls_isolation.py`:
+
+```python
+def _busca_pela_otica_de(app_url: str, tenant_id: str, termo: str) -> set[str]:
+    """Roda a busca global como `e1p_app` com a GUC do tenant — RLS real, não SQLite."""
+    from sqlalchemy.orm import Session
+
+    from app.modules.search.service import buscar
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                {"tid": tenant_id},
+            )
+            conn.commit()
+            with Session(bind=conn) as db:
+                grupos = buscar(db, q=termo, modulos_liberados=[])
+                return {i.titulo for g in grupos for i in g.itens}
+    finally:
+        engine.dispose()
+
+
+def test_busca_global_nao_atravessa_tenant() -> None:
+    """A busca cruza sete tabelas; o isolamento tem que valer em TODAS elas."""
+    with PostgresContainer(
+        "postgres:16-alpine", username=_ROOT_USER, password=_ROOT_PASS,
+        dbname=_DB_NAME, driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        joao = str(uuid4())
+        maria = str(uuid4())
+        _insert_cliente(app_url, joao, "Ana do Joao")
+        _insert_cliente(app_url, maria, "Ana da Maria")
+
+        assert _busca_pela_otica_de(app_url, joao, "ana") == {"Ana do Joao"}
+        assert _busca_pela_otica_de(app_url, maria, "ana") == {"Ana da Maria"}
+```
+
+Escrever `_insert_cliente` no mesmo arquivo, espelhando `_insert_audit` que já existe lá (INSERT
+cru com a GUC do tenant setada).
+
+- [ ] **Step 2: Rodar (exige Docker)**
+
+Run: `cd apps/api && .venv/Scripts/python -m pytest tests/test_rls_isolation.py -m rls_e2e -v`
+Expected: PASS. Se o Docker não estiver de pé, o teste é pulado — **isso não conta como verde.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/test_rls_isolation.py
+git commit -m "test: a busca global nao atravessa tenant, no Postgres real
+
+A busca cruza sete tabelas e o isolamento tem que valer em todas. Roda como
+e1p_app (nao-superusuario), no arquivo que ja tem o bootstrap — cada container
+novo custa minutos de CI."
+```
+
+---
+
+## Task 6: Os tipos e o hook do front
+
+**Files:**
+- Modify: `packages/shared-types/src/index.ts`
+- Create: `apps/web/src/features/busca/resultado.ts`
+- Create: `apps/web/src/features/busca/useBusca.ts`
+- Test: `apps/web/src/features/busca/resultado.test.ts`
+
+**Interfaces:**
+- Consumes: o contrato JSON da Task 3/4.
+- Produces: `SearchGroup`, `SearchItem` em `@e1p/shared-types`; `ROTULOS`, `ordenarGrupos()` em
+  `resultado.ts`; `useBusca(q, {profundidade, meses})` devolvendo
+  `{grupos, carregando, vazio}`. As Tasks 7 e 8 consomem os três.
+
+- [ ] **Step 1: Tipos compartilhados**
+
+Em `packages/shared-types/src/index.ts`, ao lado dos outros (escritos à mão, como `Payable`):
+
+```ts
+export type SearchType =
+  | "client" | "conversation" | "contract" | "quote"
+  | "legal_document" | "page" | "funnel";
+
+export interface SearchItem {
+  id: UUID;
+  title: string;
+  subtitle: string;
+  /** Caminho pronto para o router — o backend decide para onde o resultado leva. */
+  route: string;
+  /** Só em depth=deep; null na camada rasa, onde não há corpo de onde extrair trecho. */
+  snippet: string | null;
+}
+
+export interface SearchGroup {
+  type: SearchType;
+  has_more: boolean;
+  /** Só em depth=deep. Na camada rasa a contagem custaria sete count() por tecla. */
+  total: number | null;
+  items: SearchItem[];
+}
+```
+
+- [ ] **Step 2: Teste de `resultado.ts`**
+
+`apps/web/src/features/busca/resultado.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { ROTULOS, ordenarGrupos } from "./resultado";
+
+describe("resultado da busca", () => {
+  it("mantém a ordem do backend e descarta grupo vazio", () => {
+    const grupos = ordenarGrupos([
+      { type: "contract", has_more: false, total: null, items: [] },
+      { type: "client", has_more: false, total: null,
+        items: [{ id: "1", title: "Ana", subtitle: "", route: "/crm/clients/1", snippet: null }] },
+    ]);
+    expect(grupos.map((g) => g.type)).toEqual(["client"]);
+  });
+
+  it("tem rótulo em português para os sete tipos", () => {
+    expect(Object.keys(ROTULOS)).toHaveLength(7);
+    expect(ROTULOS.legal_document).toBe("Jurídico");
+  });
+});
+```
+
+- [ ] **Step 3: Rodar e ver falhar**
+
+Run: `cd apps/web && npx vitest run src/features/busca/resultado.test.ts`
+Expected: FAIL — módulo não existe.
+
+- [ ] **Step 4: Implementar `resultado.ts`**
+
+```ts
+import type { SearchGroup, SearchType } from "@e1p/shared-types";
+
+/** Rótulos em português. O backend manda `type`; a UI mora aqui. */
+export const ROTULOS: Record<SearchType, string> = {
+  client: "Clientes",
+  conversation: "Conversas",
+  contract: "Contratos",
+  quote: "Orçamentos",
+  legal_document: "Jurídico",
+  page: "Sites",
+  funnel: "Funis",
+};
+
+/** A ordem é a do backend (um lugar só). Aqui só se descarta grupo sem item. */
+export function ordenarGrupos(grupos: SearchGroup[]): SearchGroup[] {
+  return grupos.filter((g) => g.items.length > 0);
+}
+
+/** Todos os itens numa lista só — é o que o teclado percorre, atravessando grupos. */
+export function itensEmSequencia(grupos: SearchGroup[]) {
+  return grupos.flatMap((g) => g.items);
+}
+```
+
+- [ ] **Step 5: Implementar `useBusca.ts`**
+
+```ts
+import type { SearchGroup } from "@e1p/shared-types";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { ordenarGrupos } from "./resultado";
+
+const DEBOUNCE_MS = 250;
+const MIN_CARACTERES = 2;
+
+export function useBusca(
+  q: string,
+  opcoes: { profundidade?: "shallow" | "deep"; meses?: number; limite?: number } = {},
+) {
+  const { profundidade = "shallow", meses = 12, limite = 3 } = opcoes;
+  const [grupos, setGrupos] = useState<SearchGroup[]>([]);
+  const [carregando, setCarregando] = useState(false);
+
+  useEffect(() => {
+    const termo = q.trim();
+    if (termo.length < MIN_CARACTERES) {
+      setGrupos([]);
+      return;
+    }
+    // `AbortController` não é enfeite: sem ele a resposta de uma consulta ANTERIOR chega depois e
+    // sobrescreve a atual. O sintoma é "o resultado pisca errado", não um erro.
+    const controle = new AbortController();
+    const timer = setTimeout(async () => {
+      setCarregando(true);
+      try {
+        const r = await api.get<{ groups: SearchGroup[] }>("/search", {
+          params: { q: termo, depth: profundidade, months: meses, limit: limite },
+          signal: controle.signal,
+        });
+        setGrupos(ordenarGrupos(r.data.groups));
+      } catch {
+        // Requisição cancelada é o caso normal aqui, não erro de produto.
+      } finally {
+        setCarregando(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controle.abort();
+    };
+  }, [q, profundidade, meses, limite]);
+
+  return { grupos, carregando, vazio: !carregando && grupos.length === 0 };
+}
+```
+
+- [ ] **Step 6: Rodar e ver passar**
+
+Run: `cd apps/web && npx vitest run src/features/busca/ && npx tsc --noEmit`
+Expected: PASS + typecheck limpo.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/shared-types/src/index.ts apps/web/src/features/busca/
+git commit -m "feat(web): os tipos e o hook da busca global
+
+O AbortController evita o defeito classico da busca incremental: a resposta antiga
+chegando depois e sobrescrevendo a nova. Aparece como resultado piscando errado, e
+nao como erro."
+```
+
+---
+
+## Task 7: O dropdown na barra de cima
+
+**Files:**
+- Create: `apps/web/src/features/busca/BuscaGlobal.tsx`
+- Modify: `apps/web/src/app/AppShell.tsx:174-195`
+- Modify: `apps/web/src/app/App.tsx` (rota `/busca`)
+- Test: `apps/web/src/features/busca/BuscaGlobal.test.tsx`
+
+**Interfaces:**
+- Consumes: `useBusca`, `ROTULOS`, `ordenarGrupos`, `itensEmSequencia` da Task 6.
+- Produces: componente `<BuscaGlobal />`, montado pelo `AppShell`.
+
+- [ ] **Step 1: Teste de teclado**
+
+`apps/web/src/features/busca/BuscaGlobal.test.tsx`: montar com `MemoryRouter`, mockar `api.get`
+(vitest `vi.mock("@/lib/api")`) devolvendo dois grupos com um item cada, e asserir:
+
+```tsx
+it("a seta para baixo atravessa grupos e o Enter navega para o item focado", async () => {
+  render(<MemoryRouter><BuscaGlobal /></MemoryRouter>);
+  const campo = screen.getByPlaceholderText("Buscar cliente, contrato ou documento");
+  await userEvent.type(campo, "ana");
+  await screen.findByText("Clientes");
+
+  await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+  expect(screen.getByRole("option", { selected: true })).toHaveTextContent("Contrato da Ana");
+});
+
+it("Esc fecha e devolve o foco ao campo", async () => {
+  // ...
+  await userEvent.keyboard("{Escape}");
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  expect(campo).toHaveFocus();
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/web && npx vitest run src/features/busca/BuscaGlobal.test.tsx`
+Expected: FAIL — componente não existe.
+
+- [ ] **Step 3: Implementar o componente**
+
+O miolo é o teclado — o resto é marcação:
+
+```tsx
+import { Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ROTULOS, itensEmSequencia } from "./resultado";
+import { useBusca } from "./useBusca";
+
+export function BuscaGlobal() {
+  const [termo, setTermo] = useState("");
+  const [aberto, setAberto] = useState(false);
+  const [foco, setFoco] = useState(-1);          // -1 = nenhum item focado
+  const campo = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+  const { grupos, vazio } = useBusca(termo);
+  const sequencia = itensEmSequencia(grupos);    // o teclado ATRAVESSA grupos
+
+  // Ctrl/Cmd+K foca o campo. Listener no document, removido no cleanup.
+  useEffect(() => {
+    const atalho = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        campo.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", atalho);
+    return () => document.removeEventListener("keydown", atalho);
+  }, []);
+
+  // O foco é reposicionado a cada resultado novo: manter o índice antigo apontaria para um item
+  // que não está mais na lista, e o Enter abriria o registro errado.
+  useEffect(() => setFoco(-1), [grupos]);
+
+  function paraAPagina() {
+    navigate(`/busca?q=${encodeURIComponent(termo)}`);
+    setAberto(false);
+  }
+
+  function noTeclado(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFoco((i) => Math.min(i + 1, sequencia.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFoco((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (foco >= 0 && sequencia[foco]) {
+        navigate(sequencia[foco].route);
+        setAberto(false);
+      } else {
+        paraAPagina();
+      }
+    } else if (e.key === "Escape") {
+      setAberto(false);
+      campo.current?.focus();
+    }
+  }
+
+  let indice = -1;   // numeração contínua entre grupos, para casar com `sequencia`
+
+  return (
+    <div className="relative hidden min-w-0 max-w-md flex-1 md:block" onBlur={(e) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) setAberto(false);
+    }}>
+      <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+      <input
+        ref={campo}
+        role="combobox"
+        aria-expanded={aberto}
+        aria-controls="busca-resultados"
+        placeholder="Buscar cliente, contrato ou documento"
+        value={termo}
+        onChange={(e) => { setTermo(e.target.value); setAberto(true); }}
+        onFocus={() => setAberto(true)}
+        onKeyDown={noTeclado}
+        className="w-full rounded-pill bg-neutral-50 py-2 pl-9 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary-300"
+      />
+      {aberto && termo.trim().length >= 2 && (
+        <div id="busca-resultados" role="listbox"
+             className="absolute z-20 mt-1 w-full rounded-2xl border border-neutral-100 bg-white shadow-lg">
+          {grupos.map((g) => (
+            <div key={g.type}>
+              <p className="px-3 pt-2 text-xs font-semibold text-neutral-400">{ROTULOS[g.type]}</p>
+              {g.items.map((item) => {
+                indice += 1;
+                const meu = indice;
+                return (
+                  <button key={item.id} role="option" aria-selected={foco === meu}
+                          onMouseDown={() => navigate(item.route)}
+                          className={`flex w-full flex-col px-3 py-2 text-left text-sm ${foco === meu ? "bg-primary-50" : ""}`}>
+                    <span className="truncate">{item.title}</span>
+                    <span className="truncate text-xs text-neutral-400">{item.subtitle}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+          {vazio && (
+            <div className="px-3 py-3 text-sm text-neutral-500">
+              Nada encontrado para «{termo}».{" "}
+              <button onMouseDown={paraAPagina} className="text-primary-600 underline">
+                procurar em documentos e mensagens
+              </button>
+            </div>
+          )}
+          {!vazio && (
+            <button onMouseDown={paraAPagina}
+                    className="w-full border-t border-neutral-100 px-3 py-2 text-left text-xs text-primary-600">
+              ver todos os resultados
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+`onMouseDown` e não `onClick` nos itens: o `onBlur` do contêiner fecha o dropdown antes que um
+`click` chegue a disparar, e o resultado é um item que não abre quando clicado com o mouse.
+
+- [ ] **Step 4: Ligar no AppShell**
+
+Em `AppShell.tsx`, no bloco `hidden ... md:block` (linhas ~185-195), trocar o `<input>` decorativo
+por `<BuscaGlobal />`, apagando o comentário *"A busca não tem handler nenhum"*, que deixa de ser
+verdade.
+
+No botão de menu (linhas ~174-183): trocar `<Search size={16} />` por `<Menu size={16} />`
+(importar `Menu` de `lucide-react`). Ele tem `aria-label="Abrir menu"` e usar uma lupa ali, com uma
+lupa de verdade ao lado, seriam dois ícones iguais com significados diferentes.
+
+Acrescentar, visível só abaixo de `md`, um botão com `aria-label="Buscar"` e ícone `Search` que faz
+`navigate("/busca")`.
+
+- [ ] **Step 5: Registrar a rota**
+
+Em `App.tsx`, junto das rotas protegidas: `<Route path="/busca" element={<BuscaPage />} />`.
+Se a Task 8 ainda não rodou, criar `BuscaPage.tsx` como um componente mínimo que renderiza o termo
+— e completá-lo na Task 8. Não deixar a rota apontando para componente inexistente.
+
+- [ ] **Step 6: Rodar e ver passar**
+
+Run: `cd apps/web && npx vitest run && npx tsc --noEmit && npx eslint . --max-warnings 0`
+Expected: PASS nos três. `AppShell.test.tsx` já existe — se ele afere o `<input>` antigo,
+atualizá-lo, não removê-lo.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/features/busca/ apps/web/src/app/AppShell.tsx apps/web/src/app/App.tsx
+git commit -m "feat(web): a busca da barra de cima passa a buscar
+
+O botao de menu troca a lupa por Menu: com uma lupa de verdade ao lado, seriam dois
+icones iguais com significados diferentes. Abaixo de md o campo continua escondido
+(medicao do #58) e uma lupa leva para /busca."
+```
+
+---
+
+## Task 8: A página `/busca`
+
+**Files:**
+- Modify: `apps/web/src/features/busca/BuscaPage.tsx`
+- Test: `apps/web/src/features/busca/BuscaPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `useBusca` com `profundidade: "deep"`, `ROTULOS`.
+- Produces: a tela de `/busca?q=`.
+
+- [ ] **Step 1: Teste**
+
+```tsx
+it("lê o termo da URL e busca fundo", async () => {
+  render(<MemoryRouter initialEntries={["/busca?q=rescisao"]}>
+    <Routes><Route path="/busca" element={<BuscaPage />} /></Routes>
+  </MemoryRouter>);
+  await waitFor(() => expect(api.get).toHaveBeenCalledWith("/search",
+    expect.objectContaining({ params: expect.objectContaining({ q: "rescisao", depth: "deep" }) })));
+});
+
+it("mostra a contagem exata por grupo", async () => {
+  // grupo com total: 12 e 3 itens
+  expect(await screen.findByText("Jurídico (12)")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+Run: `cd apps/web && npx vitest run src/features/busca/BuscaPage.test.tsx`
+
+- [ ] **Step 3: Implementar**
+
+- Lê `q` de `useSearchParams`; digitar no campo da página atualiza a URL com `replace: true` (uma
+  entrada de histórico por tecla encheria o botão "voltar").
+- `useBusca(q, { profundidade: "deep", meses, limite: 20 })`.
+- Seletor de meses com três opções e o rótulo **"mensagens dos últimos 12 meses"** — o recorte vale
+  só para mensagens (spec §6.2), e o rótulo tem que dizer isso, senão vira recorte silencioso.
+- Cada grupo: `{ROTULOS[g.type]} ({g.total})`, itens com `snippet` quando houver.
+- Estado vazio honesto: *"Nada encontrado para «termo» nas mensagens dos últimos 12 meses"*, com
+  atalho para ampliar o recorte.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+Run: `cd apps/web && npx vitest run && npx tsc --noEmit`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/busca/
+git commit -m "feat(web): a pagina /busca procura no corpo dos documentos e nas mensagens
+
+O seletor diz 'mensagens dos ultimos 12 meses' porque o recorte vale so para elas.
+Rotulo generico faria o usuario achar que documento antigo tambem foi cortado — e
+recorte que nao se anuncia e o defeito que o #125 acabou de consertar."
+```
+
+---
+
+## Task 9: As duas medições de Playwright
+
+**Files:**
+- Create: `apps/web/e2e/busca-url.spec.ts`
+- Create: `apps/web/e2e/busca-360.spec.ts`
+
+**Interfaces:**
+- Consumes: `mockarApi` (`e2e/support/api.ts`), `semearSessao` (`e2e/support/sessao.ts`),
+  `medirPagina` e `alvosPequenos` (`e2e/support/medidas.ts`).
+- Produces: nada.
+
+- [ ] **Step 1: `busca-url.spec.ts` — medir a query string real**
+
+```ts
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O contrato de QUERY STRING da busca — o único lugar onde axios de verdade roda.
+ *
+ * As outras três camadas são cegas a isto: o pytest monta a URL crua, o vitest assere o objeto
+ * `params` ANTES de serializar, e o mock e2e devolve payload fixo seja qual for a query. Foi essa
+ * fresta que escondeu o `status[]` no #125.
+ */
+test("a busca funda manda q, depth e months na forma que o FastAPI lê", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/search": { groups: [] } });
+
+  const urls: string[] = [];
+  page.on("request", (r) => {
+    if (r.url().includes("/search")) urls.push(r.url());
+  });
+
+  await page.goto("/busca?q=rescisao");
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  const query = decodeURIComponent(new URL(urls[0]).search);
+  expect(query, `query real: ${query}`).toContain("q=rescisao");
+  expect(query, `query real: ${query}`).toContain("depth=deep");
+  expect(query, `query real: ${query}`).toContain("months=12");
+});
+
+test("o termo do usuário vai escapado, não interpretado", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/search": { groups: [] } });
+  const urls: string[] = [];
+  page.on("request", (r) => {
+    if (r.url().includes("/search")) urls.push(r.url());
+  });
+
+  await page.goto("/busca?q=100%25");
+  await expect.poll(() => urls.length).toBeGreaterThan(0);
+
+  expect(new URL(urls[0]).searchParams.get("q")).toBe("100%");
+});
+```
+
+- [ ] **Step 2: `busca-360.spec.ts` — medir, não aferir classe**
+
+```ts
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+test.use({ viewport: { width: 360, height: 740 } });
+
+test("a 360px o campo some, a lupa aparece e leva para /busca", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/search": { groups: [] } });
+
+  await page.goto("/");
+  await expect(page.getByPlaceholder("Buscar cliente, contrato ou documento")).toBeHidden();
+
+  await page.getByLabel("Buscar").click();
+  await expect(page).toHaveURL(/\/busca/);
+});
+
+test("a página de resultados não rola de lado a 360px", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/search": {
+      groups: [{
+        type: "legal_document", has_more: true, total: 42,
+        items: Array.from({ length: 20 }, (_, i) => ({
+          id: `d${i}`,
+          title: "Peticao inicial de rescisao contratual antecipada com pedido liminar",
+          subtitle: "peticao",
+          route: `/juridico/d${i}`,
+          snippet: "...combinada a rescisao antecipada conforme clausula decima segunda...",
+        })),
+      }],
+    },
+  });
+
+  await page.goto("/busca?q=rescisao");
+  await expect(page.getByText("Jurídico (42)")).toBeVisible();
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina, "a página rola de lado a 360px").toBeLessThanOrEqual(360);
+});
+```
+
+Os payloads são de **pior caso plausível** — título longo, 20 itens, trecho comprido. Dado curto
+sempre cabe: medir com ele é medir uma tela que não existe.
+
+- [ ] **Step 3: Rodar**
+
+Run: `cd apps/web && npx playwright test e2e/busca-url.spec.ts e2e/busca-360.spec.ts`
+Expected: PASS nos quatro.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/busca-url.spec.ts apps/web/e2e/busca-360.spec.ts
+git commit -m "test(web): a query string e a regua de 360px da busca, medidas
+
+A URL e medida de verdade porque as outras tres camadas sao cegas a ela — foi essa
+fresta que escondeu o status[] no #125. E o layout e medido com boundingBox:
+toContain de classe CSS ja passou verde com a tela quebrada neste projeto."
+```
+
+---
+
+## Fechamento
+
+- [ ] **Suíte inteira, em primeiro plano, nos três modos**
+
+```bash
+cd apps/api && .venv/Scripts/python -m pytest -q
+cd apps/api && TZ=UTC .venv/Scripts/python -m pytest -q
+cd apps/api && .venv/Scripts/python -m pytest -m rls_e2e     # exige Docker
+cd apps/web && npx vitest run && npx tsc --noEmit && npx eslint . --max-warnings 0
+cd apps/web && npx playwright test
+```
+
+Teste **pulado por falta de Docker não é teste verde.** Se `rls_e2e` não rodou, dizer isso.
+
+- [ ] **Abrir o PR** (`main` é protegida; 5 checks). Corpo do PR: o que muda para o dono, a decisão
+  do §5 (por que não há migration) e a nota de que a dívida do CRM foi paga junto.

--- a/docs/superpowers/specs/2026-08-18-busca-global-design.md
+++ b/docs/superpowers/specs/2026-08-18-busca-global-design.md
@@ -42,7 +42,8 @@ estaria na tela para onde o clique levou.
 
 Quando essas telas passarem a hidratar o filtro a partir da URL — o que também conserta o botão
 "voltar" e o link compartilhável, independentemente de busca —, incluí-las é acrescentar uma entrada
-por tela.
+por tela. Essa dívida virou a **issue #138**, separada de propósito: ela existe desde o #125 e
+incomoda quem só usa a tela, sem passar por busca nenhuma.
 
 Também fora: busca por tags, correção ortográfica, fuzzy, histórico de buscas recentes, e qualquer
 migration de índice — esta última porque a medição provou que não ajudaria (§5).
@@ -215,6 +216,30 @@ O corte é calculado com **`hoje_do_tenant(db)`** (`settings/service.py:112`).
 Uma letra casa com quase tudo e custaria sete varreduras por tecla. A rota devolve grupos vazios sem
 tocar no banco.
 
+### 6.4 RBAC: a busca não pode contornar `require_module`
+
+A RLS garante que o tenant é o certo. Ela **não** garante que este usuário pode ver este módulo —
+isso é `require_module`, que lê `allowed_modules` do token e existe em toda rota de negócio. Uma
+rota que cruza sete módulos com um guard só passaria por cima dele: um sub-usuário sem acesso a
+Jurídico digitaria três letras e leria títulos de petição.
+
+Cada entrada do registro declara o módulo a que pertence, e o serviço **pula** as entidades cujo
+módulo o usuário não pode ver. O mapa segue os guards que já existem:
+
+| Tipo | Módulo | Onde isso já está escrito |
+|---|---|---|
+| Cliente | `crm` | `crm/router.py:34` |
+| Conversa | `crm` | `whatsapp_inbox/router.py:26` — a caixa de entrada é guardada como CRM |
+| Contrato | `contracts` | `contracts/router.py:26` |
+| Orçamento | `quotes` | `quotes/router.py:25` |
+| Jurídico | `juridico` | `juridico/router.py:22` |
+| Site | `pages` | `pages/router.py:24` |
+| Funil | `funnels` | `funnels/router.py:29` |
+
+A regra de liberação é a mesma de `require_module` e não pode divergir dela: `role == "owner"`, ou
+`allowed_modules` vazio, veem tudo. Copiar o critério em vez de reusá-lo criaria duas definições de
+"pode ver", e elas divergiriam na primeira mudança.
+
 ## 7. O registro de entidades
 
 `apps/api/app/modules/search/registro.py` — uma lista declarativa de sete entradas:
@@ -295,7 +320,8 @@ exige zero. Falha em `main`, e é a régua da entrega.
 
 **`pytest -q` (SQLite):** os sete tipos casando pelo campo prometido; conversa casando pelo nome do
 cliente vinculado; `q` curto não consulta nada; a ordenação de dois degraus dentro do grupo; o corte
-de meses avaliado em fuso NÃO-UTC.
+de meses avaliado em fuso NÃO-UTC; e **um sub-usuário com `allowed_modules=["crm"]` recebendo o
+grupo de clientes e NENHUM grupo de jurídico** (§6.4) — RBAC não pode ser contornado por rota nova.
 
 **`pytest -m rls_e2e` (Docker/Postgres):** dois tenants, o B busca o termo que só existe no A e
 recebe zero, nos sete tipos. Isolamento é segurança — não pode viver só em SQLite, onde a RLS nem

--- a/docs/superpowers/specs/2026-08-18-busca-global-design.md
+++ b/docs/superpowers/specs/2026-08-18-busca-global-design.md
@@ -29,10 +29,23 @@ que escopo menor.
 na barra de cima, a página `/busca`, o acesso no celular, e a promoção do `_escapa_curinga` do #125
 a utilitário compartilhado — com a dívida equivalente do CRM paga de passagem (§8).
 
-**Fora:** contas a pagar, cobranças e produtos. São listas sem tela de detalhe; entram depois como
-entradas no registro (§7), não como reescrita. Também fora: busca por tags, correção ortográfica,
-fuzzy, histórico de buscas recentes, e qualquer migration de índice — esta última porque a medição
-provou que não ajudaria (§5).
+**Fora:** contas a pagar, cobranças e produtos. Entram depois como entradas no registro (§7), não
+como reescrita.
+
+O motivo não é "não têm tela de detalhe" — é mais específico, e foi verificado: **nenhuma das três
+tem endereço que saiba receber uma busca.** O #125 deu um `q` a Contas a Pagar, mas ele é estado
+React: `filtros.ts` serializa para os `params` do axios, e `PagarPage.tsx` não usa
+`useSearchParams` — o único do módulo está em `CompartilharPage.tsx`. Hoje `/pagar?q=anthropic` é
+inerte. E mandar o resultado para `/pagar` sem filtro seria pior que não tê-lo: a visão padrão é
+`status ∈ (open, scheduled)` dentro do horizonte, então uma conta **paga** encontrada pela busca não
+estaria na tela para onde o clique levou.
+
+Quando essas telas passarem a hidratar o filtro a partir da URL — o que também conserta o botão
+"voltar" e o link compartilhável, independentemente de busca —, incluí-las é acrescentar uma entrada
+por tela.
+
+Também fora: busca por tags, correção ortográfica, fuzzy, histórico de buscas recentes, e qualquer
+migration de índice — esta última porque a medição provou que não ajudaria (§5).
 
 ## 3. As duas camadas — a decisão central
 

--- a/docs/superpowers/specs/2026-08-18-busca-global-design.md
+++ b/docs/superpowers/specs/2026-08-18-busca-global-design.md
@@ -1,0 +1,335 @@
+# Busca global — ligar o campo da barra de cima
+
+**Data:** 2026-08-18
+**Origem:** pedido do fundador — *"quero ligar a busca global do e1p, o campo da barra de cima que
+hoje é decorativo"*.
+**Base:** `f7f0b4e` (`origin/main`, contém o #125).
+**Relacionada:** `2026-08-18-contas-a-pagar-recorte-design.md` §2, que separou este trabalho de
+propósito e construiu o primitivo de texto que esta spec promove a utilitário compartilhado.
+
+## 1. O problema
+
+O campo *"Buscar cliente, projeto ou processo"* existe em `AppShell.tsx:191` e nunca funcionou. O
+próprio código admite: *"A busca não tem handler nenhum — é decoração até alguém ligá-la"*
+(`AppShell.tsx:185`). É um `<input>` sem `onChange`, sem estado, sem rota. Não é regressão.
+
+O projeto não tem infraestrutura de busca: nenhum `tsvector`, nenhum `pg_trgm`, nenhuma rota de
+busca unificada. Antes desta spec, os únicos `ilike` do backend inteiro estavam em
+`crm/service.py:393` e `payables/service.py` — este último construído pelo #125.
+
+**O placeholder promete o que não existe.** Não há entidade "projeto" no sistema: nenhum módulo,
+nenhuma tabela, nenhuma rota. E "processo" é aproximação — o mais perto é `legal_documents`
+(Assistente Jurídico), que tem `title`, `skill` e `content`, mas nenhum número de processo. O texto
+do campo muda nesta entrega, independentemente do escopo escolhido: prometer e não entregar é pior
+que escopo menor.
+
+## 2. Escopo
+
+**Dentro:** duas camadas de busca (§3) sobre sete entidades (§4), a rota `GET /search`, o dropdown
+na barra de cima, a página `/busca`, o acesso no celular, e a promoção do `_escapa_curinga` do #125
+a utilitário compartilhado — com a dívida equivalente do CRM paga de passagem (§8).
+
+**Fora:** contas a pagar, cobranças e produtos. São listas sem tela de detalhe; entram depois como
+entradas no registro (§7), não como reescrita. Também fora: busca por tags, correção ortográfica,
+fuzzy, histórico de buscas recentes, e qualquer migration de índice — esta última porque a medição
+provou que não ajudaria (§5).
+
+## 3. As duas camadas — a decisão central
+
+São duas perguntas diferentes, e juntá-las numa superfície só é o que faz busca global ficar lenta
+e ruidosa:
+
+| | *"me leva até a Ana"* | *"onde foi que eu falei de rescisão"* |
+|---|---|---|
+| Onde | dropdown da barra de cima | página `/busca` |
+| O que lê | rótulo + campos de identidade | tudo, inclusive corpo de documento e mensagens |
+| Custo medido | 15-25 ms | 150-270 ms |
+| Resultado | uma linha, sem ler nada | trecho destacado, leitura |
+
+A camada rasa casa em nome/título e nos campos que **identificam**: email, telefone e documento do
+cliente; `client_name` e `signer_name` em orçamento e contrato; slug do site. A camada funda
+acrescenta o corpo: `legal_documents.content`, `clients.notes`, `quotes.notes` e
+`whatsapp_messages.text_body`.
+
+`Enter` na barra — ou o rodapé *"ver todos os resultados"* — navega para `/busca?q=termo`. Um motor
+só, com a profundidade como parâmetro da rota (§6).
+
+**O placeholder passa a ser `Buscar cliente, contrato ou documento`.** Três exemplos, não a lista
+dos sete: um placeholder que enumera tudo não cabe na largura e ainda assim mentiria por omissão no
+oitavo tipo que entrar depois. O que ele não pode continuar fazendo é citar "projeto", que não
+existe.
+
+**Uma conversa é UM resultado, mesmo na camada funda.** Se o termo aparece em quarenta mensagens do
+mesmo chat, sai uma linha — a conversa — com o trecho da mensagem mais recente que casou. O
+contrário afogaria os outros seis tipos com repetição do mesmo diálogo, que é exatamente o risco
+levantado ao escolher incluir mensagens.
+
+## 4. As sete entidades
+
+Critério: **só entra o que tem tela de destino**. Um resultado que não leva a lugar nenhum não é
+resultado.
+
+| Tipo | Destino | Campos rasos | Campos fundos |
+|---|---|---|---|
+| Cliente | `/crm/clients/:id` | `name`, `email`, `phone`, `document` | `notes` |
+| Conversa | `/conversas/:chatId` | `title` **+ nome do cliente vinculado** | `whatsapp_messages.text_body` |
+| Contrato | `/contratos/:id` | `title`, `signer_name` | — |
+| Orçamento | `/orcamentos/:id` | `title`, `client_name` | `notes` |
+| Jurídico | `/juridico/:id` | `title`, `skill` | `content` |
+| Site | `/sites/:id` | `title`, `public_slug` | — |
+| Funil | `/funis/:id` | `name` | — |
+
+Os grupos aparecem nessa ordem, sempre: gente primeiro, depois o diálogo, depois compromisso e
+dinheiro, depois o que se constrói.
+
+**Conversa é a exceção, e o registro admite isso em vez de disfarçar.** `WhatsappChat.title` é
+NULLABLE e curto — ninguém procura uma conversa pelo título dela; procura pelo nome da pessoa, que
+mora em `clients` via `client_id` (também nullable: `@lid` sem telefone não resolve cliente, e grupo
+não vira contato do CRM). A entrada de conversa carrega um predicado próprio com join, em vez de
+fingir que cabe numa lista de colunas.
+
+**E `whatsapp_messages` NÃO entra na camada rasa.** A medição mostrou 66-92 ms só em
+`sender_name ILIKE` sobre essa tabela — sozinha, mais cara que os outros seis tipos somados.
+
+## 5. A medição — e por que não há migration
+
+Método: banco descartável no Postgres 16.14 de dev, semeado com 5.000 clientes, 2.000 documentos
+jurídicos de ~8KB e 300.000 mensagens (93 MB), em três tenants — o principal com 4.000 clientes e
+240.000 mensagens. RLS ativa com `FORCE`, consultas rodadas por papel **não-superusuário**:
+superusuário ignora RLS e mediria outra coisa. Sanidade confirmada: sem tenant setado, zero linhas.
+
+| Consulta | Tempo |
+|---|---|
+| Cliente, 4 `ILIKE` em `OR` (nome, email, telefone, documento) | 3,8-7,2 ms |
+| Título de documento jurídico | 1,6-6,4 ms |
+| `sender_name` sobre 240k mensagens (**descartado da camada rasa**) | 66-92 ms |
+| Corpo de 240k mensagens | 140-270 ms |
+| Corpo de 2.000 documentos de 8KB | ~196 ms |
+| Corpo de mensagens, recorte de 12 meses | ~210 ms |
+| Corpo de mensagens, recorte de 3 meses | ~55 ms |
+
+O recorte de 12 meses quase não ajudou porque, nessa seletividade, o planejador continua varrendo a
+tabela inteira; o de 3 meses ajuda porque é seletivo o bastante para ele trocar de plano.
+
+### 5.1 O achado: a RLS impede qualquer índice de texto
+
+Criado o `pg_trgm` com índice GIN sobre `text_body` (47 MB, metade do tamanho da tabela, 9,5 s para
+construir), a mesma consulta **não usou o índice**. Nem com `enable_seqscan=off` — aí o planejador
+preferiu o índice de tenant e deixou o `ILIKE` como filtro.
+
+A mesma consulta como superusuário, com a RLS fora do caminho: **0,7 ms**. Índice GIN usado, 220x
+mais rápido.
+
+A causa está no catálogo:
+
+```
+proname     | proleakproof
+texteq      | t     <- o operador =
+texticlike  | f     <- ILIKE
+textlike    | f     <- LIKE
+ts_match_vq | f     <- o @@ do tsvector
+```
+
+Uma política RLS precisa ser avaliada ANTES de qualquer operador não-leakproof — senão o operador
+poderia observar linhas que a política esconde. Como `texticlike` não é leakproof, o `ILIKE` é
+rebaixado a filtro pós-segurança, e nenhum índice sobre a coluna de texto pode ser usado.
+
+Experimento de controle, na mesma tabela e na mesma sessão: trocando `ILIKE` por `=` (`texteq`, que
+É leakproof), o planejador usa o índice trigrama normalmente.
+
+Três consequências:
+
+1. **Não existe migration nesta entrega.** O `pg_trgm` custaria 47 MB e não aceleraria nada
+   enquanto a RLS existir — seria dívida pura.
+2. **`tsvector` esbarra na mesma parede**, por fato e não por preferência: `ts_match_vq` também é
+   `proleakproof = false`.
+3. **O piso é varrer as linhas do tenant.** A única alavanca é *quantas linhas* (§6.2).
+
+### 5.2 Duas saídas rejeitadas
+
+**`ALTER FUNCTION texticlike(text,text) LEAKPROOF`** destravaria o índice. Enfraquece a RLS do banco
+INTEIRO — todas as tabelas, todos os tenants — em troca de uma tela de busca.
+
+**Embrulhar a busca num `SECURITY DEFINER`** que filtre tenant à mão move o isolamento da política
+para o código de aplicação. É exatamente o que `db/session.py` proíbe: *"Nenhuma query de aplicação
+deve filtrar tenant manualmente"*.
+
+As duas trocam uma garantia estrutural por milissegundos numa tela. Nenhuma entra.
+
+## 6. A API
+
+### 6.1 A rota
+
+```
+GET /search?q=ana&depth=shallow&limit=3
+GET /search?q=rescisao&depth=deep&months=12&limit=20
+
+-> { "groups": [ { "type": "client",
+                   "has_more": true,
+                   "total": 12,            // somente em depth=deep
+                   "items": [ {"id","title","subtitle","route","snippet"} ] } ] }
+```
+
+`limit` é **por grupo**, não do total: `limit=3` significa até três clientes E até três contratos,
+não três resultados no mundo. `snippet` só vem em `depth=deep` — na camada rasa não há corpo de onde
+extrair trecho.
+
+`depth=shallow` **não** devolve `total`. Devolve `has_more`, obtido pedindo `limit+1` linhas. Não é
+preguiça: contagem exata custaria sete `count()` extras por tecla, e um booleano não tem como mentir
+sobre um número. Na página funda, onde a contagem É a informação, ela é exata — a mesma disciplina
+do #125, aplicada onde ela cabe.
+
+Os grupos saem na ordem do registro (backend, um lugar só). Os rótulos em português moram no front,
+onde a UI mora.
+
+### 6.2 O recorte de 12 meses
+
+`depth=deep` procura nas mensagens dos últimos 12 meses por padrão, com seletor visível de 3 meses /
+12 meses / tudo. O custo fica anunciado em vez de escondido, e quem precisa do histórico inteiro
+paga conscientemente. Recorte silencioso é a classe de defeito que o #125 acabou de consertar.
+
+**O recorte se aplica SOMENTE às mensagens**, e o rótulo do seletor diz isso — *"mensagens dos
+últimos 12 meses"*. Mensagem é a única tabela cujo volume justifica o corte; aplicar a mesma janela
+a documentos jurídicos esconderia a petição de dois anos atrás, que é justamente o tipo de coisa que
+se procura por texto. Cortar os seis tipos restantes para economizar milissegundos que eles não
+custam seria reconstruir o defeito do #125 com filtro novo por cima.
+
+O corte é calculado com **`hoje_do_tenant(db)`** (`settings/service.py:112`).
+`datetime.now(UTC).date()` reintroduziria a classe de bug do fuso pela porta do filtro de data.
+
+### 6.3 `q` com menos de 2 caracteres não consulta o banco
+
+Uma letra casa com quase tudo e custaria sete varreduras por tecla. A rota devolve grupos vazios sem
+tocar no banco.
+
+## 7. O registro de entidades
+
+`apps/api/app/modules/search/registro.py` — uma lista declarativa de sete entradas:
+
+```python
+Entidade(tipo="client", modelo=Client,
+         campos_rasos=(Client.name, Client.email, Client.phone, Client.document),
+         campos_fundos=(Client.notes,),
+         titulo=..., subtitulo=..., rota=lambda c: f"/crm/clients/{c.id}",
+         recencia=Client.updated_at)
+```
+
+Os sete modelos herdam `TimestampMixin`, então `updated_at` existe em todos e serve de desempate.
+
+**Sete consultas independentes, uma por tipo — sem `UNION`.** Como agrupar por tipo já é a decisão
+(§9), não existe ranking global a calcular e não há nada para o banco juntar. O SQL de cada entidade
+fica trivial, sem cast entre modelos, idêntico em SQLite e Postgres — logo, coberto pelo `pytest -q`
+inteiro, que roda SQLite (`tests/conftest.py:22`).
+
+Acrescentar contas a pagar depois é uma entrada nessa lista.
+
+### 7.1 Ordenação dentro do grupo
+
+Dois degraus: casamento no INÍCIO do campo principal vem antes de casamento no meio; desempate por
+`updated_at` decrescente. Dois, e não três, porque cabe num `case()` portátil e num teste que se lê.
+Não há score entre tipos — o agrupamento substitui o ranking.
+
+## 8. O primitivo compartilhado
+
+`apps/api/app/core/textsearch.py` — novo, com `escapa_curinga()` e `padrao_ilike()`. Três chamadores:
+
+| Chamador | Mudança |
+|---|---|
+| `search` | novo |
+| `payables` | troca a cópia privada; `test_q_escapa_curinga_do_like` vira a rede de regressão |
+| `crm` | **hoje monta `f"%{search}%"` sem escapar nada** (`crm/service.py:392-393`) |
+
+A dívida do CRM é o mesmo defeito que o #125 documentou: `%` sem escape casa com tudo, e a busca
+parece funcionar enquanto não filtra nada — o pior tipo de defeito de busca, porque não tem sintoma.
+Ela é paga aqui porque construir uma busca nova ao lado dela seria escolher não olhar.
+
+## 9. A tela
+
+```
+[lupa] Buscar cliente, contrato ou documento
++---------------------------------------------+
+| CLIENTES                                    |
+|  Ana Souza            ana@... 11 99999-...  |
+|  Ana Paula Lima       CPF 123...            |
+| CONVERSAS                                   |
+|  Ana Souza            ontem                 |
+| CONTRATOS                                   |
+|  Assessoria mensal    Ana Souza . assinado  |
++---------------------------------------------+
+|  ver todos os resultados para "ana"         |
++---------------------------------------------+
+```
+
+Seções fixas na ordem da §4, até 3 itens por seção, seção vazia some.
+
+**Teclado:** setas para cima e para baixo atravessam grupos, `Enter` abre o item focado ou — sem
+foco — vai para `/busca?q=`, `Esc` fecha e devolve o foco ao campo, clique fora fecha.
+`role="listbox"` + `aria-activedescendant`. `Ctrl/Cmd+K` foca o campo.
+
+**O estado vazio da camada rasa aponta para a funda:** *"Nada encontrado para rescisão"* com o link
+*"procurar em documentos e mensagens"*. É exatamente o caso em que a resposta está na outra camada.
+
+**No celular (abaixo de 768px)** o campo continua escondido — o PR #58 mediu que a 360px ele consome
+152px da linha e vira um bolo cinza sem placeholder legível. No lugar dele, uma lupa navega para
+`/busca`, que já é desenhada para caber num celular. **O botão de menu troca o ícone de lupa por
+`Menu`**: hoje ele é uma lupa com `aria-label="Abrir menu"` (`AppShell.tsx:174-183`), e com uma lupa
+de verdade ao lado seriam duas lupas com significados diferentes.
+
+## 10. Testes
+
+**O teste que reprova o código de hoje:** buscar `%` no CRM. Hoje devolve TODOS os clientes; o teste
+exige zero. Falha em `main`, e é a régua da entrega.
+
+**`pytest -q` (SQLite):** os sete tipos casando pelo campo prometido; conversa casando pelo nome do
+cliente vinculado; `q` curto não consulta nada; a ordenação de dois degraus dentro do grupo; o corte
+de meses avaliado em fuso NÃO-UTC.
+
+**`pytest -m rls_e2e` (Docker/Postgres):** dois tenants, o B busca o termo que só existe no A e
+recebe zero, nos sete tipos. Isolamento é segurança — não pode viver só em SQLite, onde a RLS nem
+existe.
+
+**Vitest:** `resultado.ts` (ordem dos grupos, grupo vazio some, `has_more`); teclado atravessando
+grupos.
+
+**Playwright:**
+
+- `e2e/busca-url.spec.ts` — **mede a query string real** (`q` escapado, `depth`, `months`). É a
+  fresta que o #125 descobriu: pytest monta URL crua, vitest assere params antes de serializar e o
+  mock e2e devolve payload fixo — nenhum dos três vê a query string de verdade. Modelo:
+  `e2e/pagar-contrato.spec.ts`.
+- `e2e/busca-360.spec.ts` — a 360px, **medindo** com `boundingBox`: o campo não aparece, a lupa
+  aparece e leva a `/busca`, e a página de resultados não estoura horizontalmente. Nada de
+  `toContain`.
+
+## 11. As peças
+
+| Arquivo | Mudança |
+|---|---|
+| `apps/api/app/core/textsearch.py` | **novo** — `escapa_curinga()`, `padrao_ilike()` |
+| `apps/api/app/modules/search/registro.py` | **novo** — as sete entidades, declarativas |
+| `apps/api/app/modules/search/service.py` | **novo** — `buscar()`, uma consulta por tipo |
+| `apps/api/app/modules/search/router.py` | **novo** — `GET /search` |
+| `apps/api/app/modules/search/schemas.py` | **novo** — `SearchGroupOut`, `SearchItemOut` |
+| `apps/api/app/modules/payables/service.py` | passa a usar o utilitário compartilhado |
+| `apps/api/app/modules/crm/service.py` | passa a usar o utilitário compartilhado (dívida paga) |
+| `packages/shared-types/src/index.ts` | `SearchGroup`, `SearchItem` (escritos à mão) |
+| `apps/web/src/features/busca/useBusca.ts` | **novo** — debounce 250ms + `AbortController` |
+| `apps/web/src/features/busca/resultado.ts` | **novo** — ordem e rótulos, sem DOM |
+| `apps/web/src/features/busca/BuscaGlobal.tsx` | **novo** — campo + dropdown |
+| `apps/web/src/features/busca/BuscaPage.tsx` | **novo** — `/busca?q=` |
+| `apps/web/src/app/AppShell.tsx` | liga o campo; ícone do menu; lupa no celular |
+| `apps/web/src/app/App.tsx` | rota `/busca` |
+
+O `AbortController` não é enfeite: sem ele a resposta de uma consulta anterior chega depois e
+sobrescreve a atual — o defeito clássico de busca incremental, que aparece como "o resultado pisca
+errado" e não como erro.
+
+## 12. Riscos conhecidos
+
+**A camada funda cresce linear.** 150-270 ms em 300k mensagens; em 1M, perto de 1s. O recorte de 12
+meses e o seletor (§6.2) são a mitigação, e ela é honesta: o usuário vê o recorte e pode desfazê-lo.
+Se um dia doer de verdade, a saída NÃO é `pg_trgm` (§5) — é reduzir linhas varridas, ou reabrir a
+discussão de RLS, que é decisão de arquitetura e não de tela.
+
+**Sete round-trips por consulta rasa.** Medidos em 15-25 ms somados. Se um dia isso importar, o
+registro declarativo é justamente o que torna a troca por `UNION` mecânica.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1205,3 +1205,43 @@ export interface BriefingPreferences {
   /** Texto pronto para a tela quando indisponível; `null` quando disponível. */
   briefing_whatsapp_indisponivel_motivo: string | null;
 }
+
+// ── Busca global ──────────────────────────────────────────────────────────────
+//
+// Sete tipos, e o critério de quem entra é ter tela de destino. Contas a pagar, cobranças e
+// produtos ficaram de fora porque nenhuma das três sabe receber uma busca pela URL — ver a
+// issue #138 e a spec `2026-08-18-busca-global-design.md` §2.
+
+export type SearchType =
+  | "client"
+  | "conversation"
+  | "contract"
+  | "quote"
+  | "legal_document"
+  | "page"
+  | "funnel";
+
+export interface SearchItem {
+  id: UUID;
+  title: string;
+  subtitle: string;
+  /** Caminho pronto para o router. Quem decide o destino é o backend, no registro. */
+  route: string;
+  /** Só em `depth=deep`: na camada rasa não há corpo de onde extrair trecho. */
+  snippet: string | null;
+}
+
+export interface SearchGroup {
+  type: SearchType;
+  has_more: boolean;
+  /**
+   * Só em `depth=deep`. Na camada rasa a contagem exata custaria sete `count()` por tecla — e
+   * `has_more` não tem como mentir sobre um número que não anuncia.
+   */
+  total: number | null;
+  items: SearchItem[];
+}
+
+export interface SearchResponse {
+  groups: SearchGroup[];
+}


### PR DESCRIPTION
Liga o campo *"Buscar cliente, projeto ou processo"* do `AppShell`, que nunca teve handler — o
próprio código dizia *"é decoração até alguém ligá-la"*. Não era regressão: era um `<input>` sem
`onChange`.

## O que muda para o dono

**A barra de cima acha e leva.** Digitou três letras, aparecem até 3 resultados por tipo, agrupados:
Clientes, Conversas, Contratos, Orçamentos, Jurídico, Sites, Funis. Setas percorrem a lista inteira
(atravessando grupos), `Enter` abre, `Esc` fecha, `Ctrl/Cmd+K` foca o campo.

**E existe onde procurar fundo.** `Enter` sem item selecionado abre `/busca`, que lê o CORPO:
documento jurídico, notas de cliente e orçamento, e o texto das mensagens do WhatsApp — com trecho
destacado e contagem exata por grupo.

**No celular** o campo continua escondido (a medição do #58 mostrou que a 360px ele vira um bolo
cinza de 52px). No lugar dele, uma lupa leva a `/busca`. O botão de menu deixa de usar ícone de
lupa — ele sempre abriu o menu, mas com a lupa de verdade ao lado seriam dois ícones iguais com
significados diferentes.

**O placeholder para de mentir:** vira *"Buscar cliente, contrato ou documento"*. Não existe entidade
"projeto" neste sistema, e nunca existiu.

## Um bug consertado de passagem

`crm/service.py` montava `f"%{search}%"` **sem escapar `%`**. Buscar `%` devolvia TODOS os clientes:
a tela respondia, a lista vinha cheia, e ninguém desconfiava. É o mesmo defeito que o #125 achou em
Contas a Pagar. O primitivo saiu de lá e virou `core/textsearch.py`, com três chamadores. O teste
novo reprova o `main` de hoje.

## Por que NÃO há migration

A pergunta "ilike aguenta ou precisa de `pg_trgm`?" foi **medida**, não estimada: banco descartável
com 5.000 clientes, 2.000 documentos e 300.000 mensagens, RLS ativa, rodando como papel
não-superusuário.

O índice GIN de trigrama **não é usado**. Nem forçando `enable_seqscan=off`. A mesma consulta com a
RLS fora do caminho: **0,7 ms contra 154 ms** — 220x. A causa está no catálogo do Postgres:

```
texteq      | leakproof = t     <- o operador =
texticlike  | leakproof = f     <- ILIKE
ts_match_vq | leakproof = f     <- o @@ do tsvector
```

Uma política RLS precisa ser avaliada ANTES de um operador não-leakproof, então o `ILIKE` vira
filtro pós-segurança e nenhum índice de texto entra no plano. Experimento de controle: trocando
`ILIKE` por `=`, o mesmo planejador usa o mesmo índice normalmente.

Consequência: **`pg_trgm` seria 47 MB de índice que não aceleraria nada**, e `tsvector` esbarra na
mesma parede. As duas saídas conhecidas (`ALTER FUNCTION ... LEAKPROOF` e `SECURITY DEFINER`) trocam
o isolamento do banco inteiro por milissegundos numa tela, e ficam documentadas como rejeitadas na
spec §5.2.

A alavanca que sobra é quantas linhas se varre — daí o recorte de 12 meses, **que vale só para
mensagens** e diz isso no rótulo. Cortar documento por data esconderia a petição de dois anos atrás,
que é justamente o que se procura por texto.

## Segurança

A RLS garante que o tenant é o certo. Ela **não** garante que este usuário pode ver este módulo —
isso é `require_module`. Uma rota cruzando sete módulos com um guard só seria a porta dos fundos do
RBAC, então cada entrada do registro declara seu módulo e o serviço pula o que o usuário não pode
ver, com o mesmo critério (dono, ou `allowed_modules` vazio, vê tudo).

Isolamento cross-tenant é validado no **Postgres real** (`pytest -m rls_e2e`), não em SQLite: os dois
clientes plantados casam com o mesmo termo, então RLS quebrada traria os dois juntos e reprovaria.

## Verificação

| | |
|---|---|
| `pytest -q` | 2241 passaram, 1 pulado (11min14s) |
| `pytest -m rls_e2e` | 2 passaram, com Postgres real em container |
| `vitest run` | 756 passaram (73 arquivos) |
| `playwright test` | 66 passaram |
| `tsc --noEmit` / `eslint --max-warnings 0` | limpos |

`TZ=UTC` **não** foi exercido: no Windows a variável não muda o fuso local do Python (verificado — o
processo lê `TZ` e o offset continua o da máquina). No lugar dela, o recorte é testado pelo caminho
que de fato importa neste projeto: dois tenants em fusos separados por 25 horas, exigindo que os
piso difiram em exatamente um dia. A primeira versão desse teste usava `>=` e passava com os dois
piso **idênticos** — que é o sintoma do bug. A versão estrita revelou que faltava o `TenantProfile`.

## Escopo

Contas a Pagar, Cobranças e Produtos ficaram **fora**, e o motivo é verificável: nenhuma das três
sabe receber uma busca pela URL. O `q` do #125 é estado React — `PagarPage` não usa
`useSearchParams`, e `/pagar?q=x` é inerte hoje. Virou a issue #138, que conserta também o botão
"voltar" e o link compartilhável.

Spec: `docs/superpowers/specs/2026-08-18-busca-global-design.md`
Plano: `docs/superpowers/plans/2026-08-18-busca-global.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
