### PR TITLE
docs: a §5.2 fecha as duas dividas da #129 e registra a regra que fica [#136]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   Confirmação cruzada: `/branches/main` traz `"protected": true`, e `/rules/branches/main` volta `[]`
   — ou seja, a proteção é **branch protection clássica**, não ruleset; procurar em Rules não acha.
 
-### 5.2 A régua do fuso nos testes (issue #120, fechada em 2026-08-18)
+### 5.2 A régua do fuso nos testes (issues #120 e #129, fechadas em 2026-08-18; #136 em 2026-08-19)
 
 **Um teste sobre fuso do tenant que roda com o fuso do tenant IGUAL ao da máquina não testa fuso
 nenhum.** `apps/web/vitest.config.ts` fixa `env: { TZ: "America/Sao_Paulo" }` para a suíte inteira.
@@ -201,28 +201,51 @@ estava certa; o que faltava era um teste capaz de dizer isso.**
   `PagarPage` ficou no fuso do runner **com a razão escrita** (o campo vem de
   `dataPadrao={pagando.due_date}` — nenhum relógio participa) e ganhou só o relógio congelado, que
   é o que dá dentes ao `not.toBe(hoje)`.
-- ⚠️ **O achado que só apareceu quando o teste passou a poder falhar: `CobrancasPage` lê o relógio
-  do NAVEGADOR.** Ela passa `dataPadrao={hojeISO()}`, e `hojeISO` (`financeiro/contas.ts`) monta a
-  data pelas partes locais do `Date` — não consulta `useFuso()`. A tela não importa nada de
-  `store/auth`, então **mocar o fuso do tenant nela é mock inerte**. O teste hoje afirma o dia do
-  navegador (`DIA_DO_NAVEGADOR`, com o porquê ao lado) — é o que a tela faz, e agora está dito em
-  voz alta em vez de escondido atrás de dois relógios iguais. **Dívida aberta:** `hojeISO` contraria
-  a régua do PR #78 (o dia é o do tenant) e é compartilhada com `ContasSaldosPage`, `AccountModal`,
-  `EscolhaDaBaixa` (`aviso`/`max`) e `crm/ClientDetailPage` — pagá-la é uma mudança de produção com
-  cinco telas dentro, não um ajuste de teste. Quem pagar derruba também os dois testes de borda de
-  `financeiro/contas.test.ts` (`amanha`/`ontem` derivados de UTC), avisados no lugar.
-- ⚠️ **O segundo achado: um componente, dois relógios.** Com o tenant a leste, a bandeja de
-  `ComprovantePage` abre com o aviso *"Esta data é no futuro… será registrada como AGENDADA"* já
-  visível, sem o dono ter tocado em nada — o default do campo vem de `localToday(fuso)` (**tenant**)
-  e o `avisoDeDataFutura`/`tetoDaDataDeBaixa` da `EscolhaDaBaixa` comparam com `hojeISO()`
-  (**navegador**). Enquanto os dois fusos eram o mesmo valor, nenhum teste podia ver isso. Está
-  anotado no teste e **não** virou `expect`: travar o aviso pregaria o defeito na parede.
+- ✅ **Os dois achados da #129 viraram a issue #136 e estão PAGOS (2026-08-19).** Eram:
+  (1) `CobrancasPage` passava `dataPadrao={hojeISO()}` — o dia do NAVEGADOR — e não importava nada
+  de `store/auth`; (2) na bandeja de `ComprovantePage`, o default do campo vinha de
+  `localToday(fuso)` (**tenant**) e o `avisoDeDataFutura`/`tetoDaDataDeBaixa` comparavam com
+  `hojeISO()` (**navegador**), então com o tenant em Tóquio a tela abria acusando de futuro o valor
+  que ela mesma acabara de preencher. O alcance real era **15 call sites em 6 arquivos**, não as
+  "5 telas" do enunciado: `contas.ts` também lia o relógio por dentro de uma função pura.
+- ✅ **`hojeISO()` não existe mais.** Nenhum alias, nenhum `@deprecated`: todos os seus call sites
+  eram default ou validação de campo de data em tela de dinheiro — a classe que o PR #78 moveu para
+  o fuso do tenant. Uma segunda porta com esse nome é o convite a reintroduzir o defeito pelo
+  autocomplete. O comentário que dizia *"local (e não UTC) de propósito"* foi **substituído** (não
+  apagado) por um bloco em `contas.ts` explicando por que a frase ficou falsa: ela foi escrita antes
+  do #78 e opunha as duas únicas opções que existiam então — navegador e UTC —, sem considerar a
+  terceira, que hoje é a régua. Quem precisar de "hoje" numa tela: `today(useFuso())`.
+- ⚠️ **A regra que fica, e ela é maior que o fuso:** *default preenchido por um relógio e validado
+  por outro é defeito mesmo quando os dois relógios coincidem — a coincidência é ambiente, não
+  garantia.* O conserto do defeito 2 **não foi escolher qual relógio**: foi não haver dois.
+  `useEscolhaDaBaixa` resolve `today(useFuso())` **uma vez**, e o default, o `aviso` e o `max` bebem
+  todos dali; quem quer o campo em "hoje" passa a sentinela `HOJE_DO_TENANT` em vez de uma string
+  montada na tela. Não é convenção — é impossível divergir, porque não existe um segundo lugar de
+  onde divergir.
+- ⚠️ **Função pura não busca o "hoje" por dentro — recebe.** `impedimentoDaTransferencia` era
+  anunciada como PURA e chamava `hojeISO()` escondida atrás da assinatura; agora recebe `hojeYmd`
+  como 5º parâmetro, mesmo precedente de `filtroPadrao(hojeYmd)` em `pagar/filtros.ts`. É o que
+  torna o teste **capaz de afirmar sobre fuso**: enquanto o relógio mora dentro, um fuso distante
+  não tem o que matar.
+- ⚠️ **`useState(() => today(fuso))` é mutante EQUIVALENTE onde há efeito de reset.** Medido na
+  #136: mutar os inicializadores de `AccountModal`, `DeclararSaldoModal`, `LancarMovimentoModal` e
+  `TransferirModal` para o relógio do navegador **não mata teste nenhum** — o `useEffect` de
+  `[open]`/`[account]` sobrescreve o valor antes de qualquer paint. Quem for medir mutação nesses
+  arquivos deve mirar a **linha do efeito** (`setPostedAt(today(fuso))`), não o inicializador; nos
+  quatro casos a mutação do efeito mata. Não é motivo para apagar os inicializadores.
 - **Onde o `new Date()` vivo FICA, e por quê:** `agenda/AgendaPage.test.tsx` monta o evento de
   fixture a partir do relógio só para ele cair no mês que a tela abre — nenhum `expect` compara esse
   valor com o que a tela calculou, e a prova de agrupamento por dia do tenant mora em `grade.test.ts`.
-  `financeiro/contas.test.ts` compara duas strings numa função pura que resolve "hoje" sozinha: sem
-  dois relógios, um fuso distante não tem o que matar. **Ambos com a razão escrita no arquivo** —
-  sem ela, o próximo leitor que rodar o grep os "conserta" e enfraquece o que já estava certo.
+  **Com a razão escrita no arquivo** — sem ela, o próximo leitor que rodar o grep o "conserta" e
+  enfraquece o que já estava certo.
+  ⚠️ **`financeiro/contas.test.ts` SAIU desta lista** (#136). A justificativa antiga — *"compara
+  duas strings numa função pura que resolve 'hoje' sozinha; sem dois relógios, um fuso distante não
+  tem o que matar"* — era verdade **enquanto o hoje era interno**, e deixou de ser quando virou
+  parâmetro. Hoje o bloco roda com o relógio congelado e bordas literais do calendário do tenant.
+- **Dívida:** `crm/ClientDetailPage` **não tem arquivo de teste nenhum** — é a única das seis telas
+  tocadas pela #136 sem cobertura própria. O dia dela vem do mesmo `useEscolhaDaBaixa` provado por
+  `CobrancasPage`/`ComprovantePage`, então a leitura do relógio está coberta pela porta compartilhada;
+  o que falta é a tela.
 
 ### 5.3 O teste de mutação (`apps/web/stryker.config.mjs`, desde 2026-08-18)
 

--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -16,6 +16,24 @@ vi.mock("../../lib/api", () => ({
     "Erro inesperado",
 }));
 
+// ── A régua do fuso (CLAUDE.md §5.2, issues #120/#129/#136) ───────────────────────────────────
+//
+// ⚠️ **Este mock era INERTE até a #136 — e a razão de ele existir agora é o próprio conserto.**
+// Enquanto `CobrancasPage` montava o dia com `hojeISO()`, ela não tocava em `store/auth` e mocar o
+// fuso do tenant não mudava nada. Agora o dia vem de `today(useFuso())`, dentro do
+// `useEscolhaDaBaixa` — e sem este mock `useFuso()` cairia no `FUSO_PADRAO`
+// (`America/Sao_Paulo`), que é EXATAMENTE o `TZ` que o `vitest.config.ts` fixa para a máquina. Os
+// dois relógios voltariam a dar a mesma string por construção, a asserção de dia voltaria a ser
+// incapaz de falhar, e o defeito poderia ser reintroduzido sem nenhum teste vermelho.
+//
+// Nada mais de `store/auth` é consumido por esta tela (nem por `DialogDeBaixa`/`AccountModal`,
+// que só usam `useFuso`), então o mock total é seguro.
+let fusoDoTenant = "America/Sao_Paulo";
+/** Tóquio (UTC+9) está 12h à frente do runner — sob ele os dois caminhos discordam sobre o DIA. */
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+
 const emptySummary = {
   open_cents: 0,
   overdue_cents: 0,
@@ -52,7 +70,11 @@ beforeEach(() => {
 });
 
 // Só um teste congela o relógio; o resto da suíte roda no relógio real e não pode herdá-lo.
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  // Volta ao fuso "coincidente" para não contaminar os testes que não falam de fuso.
+  fusoDoTenant = "America/Sao_Paulo";
+});
 
 describe("CobrancasPage — Nova cobrança (Story 7.5, Task 2)", () => {
   it("caminho feliz: cria cobrança com valor + vencimento; POST com amount_cents coerente", async () => {
@@ -120,21 +142,23 @@ const INSTANTE = "2026-08-17T02:30:00Z";
 /**
  * O dia que esta tela usa como default de "recebi direto na conta".
  *
- * ⚠️ **É o dia do NAVEGADOR, e isso é um achado, não uma escolha desta suíte.** `CobrancasPage`
- * passa `dataPadrao={hojeISO()}`, e `hojeISO` (em `financeiro/contas.ts`) monta a data pelas
- * partes locais de um `Date` — o relógio de quem abriu o navegador. Ela **não** consulta
- * `useFuso()`/`today(fuso)`: a tela não importa nada de `store/auth`, então mocar o fuso do tenant
- * aqui seria um mock inerte. Enquanto o teste montava o esperado do mesmo jeito, essa divergência
- * era invisível — os dois lados eram o mesmo relógio.
+ * ✅ **A dívida foi PAGA (#136), e o literal mudou como o aviso anterior mandava.** Este bloco
+ * dizia: *"é o dia do NAVEGADOR, e isso é um achado; quando alguém pagar a dívida este teste fica
+ * VERMELHO com `expected '2026-08-17'` — troque o literal, em vez de 'consertar' de volta"*. É o
+ * que se fez: `CobrancasPage` passava `dataPadrao={hojeISO()}`, que montava a data pelas partes
+ * locais de um `Date` (o relógio de quem abriu o navegador); agora passa `HOJE_DO_TENANT` e quem
+ * resolve o dia é o `useEscolhaDaBaixa`, com `today(useFuso())` — o mesmo ponto que valida a data.
  *
- * A régua do e1p desde o PR #78 é o fuso do TENANT (`hoje_do_tenant`/`today(fuso)`). Se um dono em
- * viagem abrir a tela, o "dia em que o dinheiro caiu" vem do fuso do hotel, não do da empresa.
- * **Dívida registrada, fora do escopo da #129** (que é sobre testes incapazes de falhar; mexer em
- * `hojeISO` mexe em Contas & Saldos, `AccountModal`, `EscolhaDaBaixa` e `ClientDetailPage` junto).
- * Quando alguém a pagar, este teste fica VERMELHO com `expected '2026-08-17'` — e é esse o sinal
- * certo: troque o literal por `"2026-08-17"` e o nome do teste, em vez de "consertar" de volta.
+ * ⚠️ **O mock de `useFuso` abaixo deixou de ser inerte, e sem ele este teste voltaria a ser cego.**
+ * O aviso antigo estava certo ao dizer que mocar o fuso aqui não adiantava: a tela não tocava em
+ * `store/auth`. Agora toca — indiretamente, pelo componente de baixa. Sem o mock, `useFuso()` cai
+ * no `FUSO_PADRAO`, que é o MESMO `America/Sao_Paulo` que o `vitest.config.ts` fixa como fuso da
+ * máquina: os dois relógios voltariam a dar a mesma string por construção e nenhuma mutação
+ * morreria. Foi essa coincidência que escondeu o defeito por meses (CLAUDE.md §5.2).
+ *
+ * No `INSTANTE` congelado: navegador 16/08, UTC 17/08, tenant em Tóquio **17/08**.
  */
-const DIA_DO_NAVEGADOR = "2026-08-16";
+const DIA_DO_TENANT = "2026-08-17";
 
 const CONTA_BANCARIA = {
   id: "acc-1",
@@ -254,9 +278,10 @@ describe("CobrancasPage — recebimento fora do trilho (Story 8.15)", () => {
     expect(within(bloco).getByLabelText(/dia em que o dinheiro caiu na conta/i)).toBeInTheDocument();
   });
 
-  it("envia bank_account_id e received_on; o dia default é HOJE — hoje NO NAVEGADOR (ver `DIA_DO_NAVEGADOR`)", async () => {
+  it("envia bank_account_id e received_on; o dia default é HOJE — hoje NO FUSO DO TENANT (#136)", async () => {
     // Relógio congelado num instante em que navegador (16/08), UTC (17/08) e um tenant em Tóquio
     // (17/08) discordam: sem isso a asserção compara o dia do navegador com o dia do navegador.
+    fusoDoTenant = FUSO_DISTANTE;
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(INSTANTE));
     mockCobrancas([COBRANCA_ABERTA]);
@@ -267,17 +292,23 @@ describe("CobrancasPage — recebimento fora do trilho (Story 8.15)", () => {
     // O gesto aqui é "caiu na minha conta", um fato observado AGORA — diferente da baixa de Contas
     // a Pagar, que parte do vencimento (fundador F10). A assimetria é deliberada.
     //
-    // ⚠️ O QUE este `expect` agora denuncia: o "agora" desta tela é o do NAVEGADOR (`hojeISO()`),
-    // não o do tenant. Ver o comentário de `DIA_DO_NAVEGADOR` — é dívida registrada, não descuido.
-    expect(dia.value).toBe(DIA_DO_NAVEGADOR);
+    // ⚠️ E o "agora" é o do DONO (#136). Este `expect` afirmava `DIA_DO_NAVEGADOR = "2026-08-16"` e
+    // vinha com a instrução de trocar o literal quando a dívida fosse paga. Foi trocado. Devolver a
+    // leitura para o relógio do navegador (ou para UTC) deixa esta linha VERMELHA — é para isso que
+    // o tenant está em Tóquio e o relógio, congelado.
+    expect(dia.value).toBe(DIA_DO_TENANT);
     expect(dia.value).not.toBe(COBRANCA_ABERTA.due_date);
+    // O dia do navegador neste instante é 16/08. Afirmar que o campo NÃO o mostra é a metade que
+    // impede um "hoje" qualquer de passar por tenant.
+    expect(dia.value).not.toBe("2026-08-16");
 
     await user.click(screen.getByRole("button", { name: /confirmar recebimento/i }));
 
     await waitFor(() => expect(api.post).toHaveBeenCalled());
+    // E o dia do tenant é o que VIAJA — não basta a tela mostrar certo e mandar outra coisa.
     expect(vi.mocked(api.post).mock.calls[0]).toEqual([
       "/receivables/charges/c-1/settle-externally",
-      { bank_account_id: "acc-1", received_on: DIA_DO_NAVEGADOR },
+      { bank_account_id: "acc-1", received_on: DIA_DO_TENANT },
     ]);
   });
 

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -8,12 +8,12 @@ import { pluralize } from "../../lib/pluralize";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
-import { type BankAccount, hojeISO } from "../financeiro/contas";
+import type { BankAccount } from "../financeiro/contas";
 import type { CostCenter } from "../financeiro/costCenters";
 import CostCenterSelect from "../financeiro/CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
 import { VOCAB_ENTRADA } from "../pagar/baixa";
-import { DialogDeBaixa } from "../pagar/EscolhaDaBaixa";
+import { DialogDeBaixa, HOJE_DO_TENANT } from "../pagar/EscolhaDaBaixa";
 import { rotuloDaRota } from "./rota";
 import { formatDay } from "../../lib/datetime";
 
@@ -279,7 +279,12 @@ export default function CobrancasPage() {
           valor={`${brl(recebendo.amount_cents)} · vence ${formatDay(recebendo.due_date)}`}
           // Default = HOJE (não o vencimento): o gesto aqui é "caiu na minha conta", um fato que o
           // dono está observando agora — a assimetria com a baixa de Contas a Pagar é deliberada.
-          dataPadrao={hojeISO()}
+          // ⚠️ **`HOJE_DO_TENANT`, não um hoje montado aqui** (#136). Esta tela passava
+          // `hojeISO()`, que monta a data pelas partes locais de um `new Date()` — o dia de quem
+          // abriu o NAVEGADOR. Para um dono em viagem, o "dia em que o dinheiro caiu" vinha do
+          // fuso do hotel, e perto da virada sempre vinha errado. Quem resolve o hoje agora é o
+          // `useEscolhaDaBaixa`, no fuso do tenant e no MESMO ponto em que valida a data.
+          dataPadrao={HOJE_DO_TENANT}
           vocab={VOCAB_ENTRADA}
           acao="Confirmar recebimento"
           acaoEmCurso="Registrando…"

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -19,9 +19,8 @@ import { rotaDaCobranca } from "../cobrancas/rota";
 import BlocoDaAgenda from "./BlocoDaAgenda";
 import BlocoDaConversa from "./BlocoDaConversa";
 import ClientTimeline from "./ClientTimeline";
-import { hojeISO } from "../financeiro/contas";
 import { VOCAB_ENTRADA } from "../pagar/baixa";
-import { DialogDeBaixa } from "../pagar/EscolhaDaBaixa";
+import { DialogDeBaixa, HOJE_DO_TENANT } from "../pagar/EscolhaDaBaixa";
 
 const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 /** Aceita as DUAS espécies: `"2026-08-05"` (data de calendário) e ISO completo (instante). */
@@ -247,7 +246,9 @@ export default function ClientDetailPage() {
           titulo="Recebi direto na conta"
           descricao={recebendo.description || client.name}
           valor={`${brl(recebendo.amount_cents)} · vence ${dt(recebendo.due_date, fuso)}`}
-          dataPadrao={hojeISO()}
+          // `HOJE_DO_TENANT`: o hoje é resolvido (e validado) no fuso do tenant, dentro do
+          // `useEscolhaDaBaixa` — não montado aqui pelo relógio do navegador (#136).
+          dataPadrao={HOJE_DO_TENANT}
           vocab={VOCAB_ENTRADA}
           acao="Confirmar recebimento"
           acaoEmCurso="Registrando…"

--- a/apps/web/src/features/financeiro/AccountModal.tsx
+++ b/apps/web/src/features/financeiro/AccountModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
+import { today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
 import {
   avisoContasPagasAnteriores,
   type BankAccount,
@@ -8,7 +10,6 @@ import {
   centsToInput,
   diaAnteriorISO,
   formatDateBR,
-  hojeISO,
   KIND_CHECKING,
   parseCentsBRL,
   type PayablesPaidBefore,
@@ -75,7 +76,10 @@ export default function AccountModal({
   // Story 8.21 — o ATO. `null` significa **ainda não escolheu** e só existe no CADASTRO:
   // é ele que mantém o salvar desabilitado até o dono dizer se sabe o saldo ou não.
   const [saldoConhecido, setSaldoConhecido] = useState<boolean | null>(null);
-  const [openingDate, setOpeningDate] = useState(hojeISO);
+  // ⚠️ **O fuso do TENANT, não o do navegador** (#136): a data de abertura é um fato da EMPRESA,
+  // e até a #136 nascia do relógio da máquina de quem abriu a tela (`hojeISO()`).
+  const fuso = useFuso();
+  const [openingDate, setOpeningDate] = useState(() => today(fuso));
   const [isPrimary, setIsPrimary] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -94,11 +98,11 @@ export default function AccountModal({
     setOpening(editing ? centsToInput(editing.opening_balance_cents) : "");
     // Edição carrega o estado atual (vem do AC5b); cadastro exige escolha explícita.
     setSaldoConhecido(editing ? editing.opening_balance_is_known : null);
-    setOpeningDate(editing?.opening_date ?? hojeISO());
+    setOpeningDate(editing?.opening_date ?? today(fuso));
     setIsPrimary(editing?.is_primary ?? false);
     setError(null);
     setPagasAntes(null);
-  }, [open, editing]);
+  }, [open, editing, fuso]);
 
   // **Recuo** = a data escolhida é ANTERIOR à data de abertura atual da conta. Estritamente: data
   // igual não é recuo (o formulário reenvia o corpo inteiro a cada salvamento, e exigir

--- a/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
@@ -37,6 +37,20 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: () => "Erro inesperado",
 }));
 
+// ── A régua do fuso (CLAUDE.md §5.2, issues #120/#129/#136) ───────────────────────────────────
+//
+// ⚠️ **Este mock nasceu com a #136, e sem ele metade das asserções de data desta suíte seria
+// incapaz de falhar.** A tela tinha OITO leituras de `hojeISO()` — o relógio do NAVEGADOR — e
+// agora tem uma só origem, `today(useFuso())`. Sem mocar, `useFuso()` cai no `FUSO_PADRAO`
+// (`America/Sao_Paulo`), que é EXATAMENTE o `TZ` que o `vitest.config.ts` fixa para a máquina:
+// os dois relógios voltariam a dar a mesma string por construção. Nada mais de `store/auth` é
+// consumido por esta tela nem pelo `AccountModal`, então o mock total é seguro.
+let fusoDoTenant = "America/Sao_Paulo";
+/** Tóquio (UTC+9) está 12h à frente do runner — sob ele os dois caminhos discordam sobre o DIA. */
+const FUSO_DISTANTE = "Asia/Tokyo";
+
+vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+
 function conta(over: Partial<BankAccount> = {}): BankAccount {
   return {
     id: "acc-1",
@@ -132,6 +146,7 @@ function renderPage() {
 
 beforeEach(() => {
   vi.mocked(api.get).mockReset();
+  fusoDoTenant = "America/Sao_Paulo";
 });
 
 describe("⚠️ D-6 — os dois totais de saldo bancário do produto não podem ter o mesmo nome", () => {
@@ -1104,5 +1119,145 @@ describe("Onda 3 — a conta principal passa a poder ser escolhida", () => {
     await waitFor(() =>
       expect(api.post).toHaveBeenCalledWith("/bank/accounts/a/set-primary"),
     );
+  });
+});
+
+
+// ── #136 — os quatro campos de data desta tela leem UM relógio, e é o do TENANT ───────────────
+
+/**
+ * A tela tinha **oito** leituras de `hojeISO()` — mais do que qualquer outro arquivo do
+ * frontend —, e todas montavam o dia pelas partes locais de um `new Date()`: o relógio de quem
+ * abriu o NAVEGADOR. Nenhuma delas era coberta por asserção capaz de falhar, porque a suíte
+ * rodava com o fuso do tenant igual ao da máquina (CLAUDE.md §5.2).
+ *
+ * A oitava era a pior: `impedimentoDaTransferencia` — uma função anunciada como PURA — chamava
+ * `hojeISO()` por DENTRO. Ou seja, o campo "Data" da transferência era **preenchido** por um
+ * relógio e **validado** por outro. Num tenant a leste isso não é teórico: o dia do dono já é o
+ * amanhã do navegador, e a tela nascia com a transferência BARRADA por "a data não pode ser
+ * futura" — recusando o valor que ela mesma acabara de escrever. É o defeito 2 da #136 na camada
+ * de baixo, e é o que o último teste deste bloco mede.
+ */
+describe("#136 — o dia desta tela é o do TENANT, e é UM só", () => {
+  /**
+   * `2026-08-17T18:00:00Z` → **Tóquio 18/08 03:00** · **São Paulo (runner) 17/08 15:00** · **UTC
+   * 17/08**. Com Tóquio (+9) e São Paulo (−3) não dá para separar os três dias no mesmo instante;
+   * o que importa é que o dia do TENANT difira dos dois candidatos errados — e difere: tanto
+   * voltar para o relógio do navegador quanto para `toISOString()` devolve 17/08 e mata o teste.
+   */
+  const INSTANTE = "2026-08-17T18:00:00Z";
+  const DIA_DO_TENANT = "2026-08-18";
+  const DIA_DO_NAVEGADOR = "2026-08-17";
+
+  const duasContas = [
+    conta({ id: "a", name: "Itaú PJ", kind: "checking", saldo_derivado_cents: 4_000_000 }),
+    conta({ id: "b", name: "Poupança", kind: "savings", saldo_derivado_cents: 2_000_000 }),
+  ];
+
+  beforeEach(() => {
+    fusoDoTenant = FUSO_DISTANTE;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(INSTANTE));
+    vi.mocked(api.post).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("o cartão e os totais são apurados no dia do DONO, não no de quem abriu o navegador", async () => {
+    mockApi([conta({ id: "a", name: "Itaú PJ", saldo_derivado_cents: 4_000_000 })]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Itaú PJ")).toBeInTheDocument());
+    // 18/08 é o dia do tenant; 17/08 é o do navegador E o de UTC. Só um dos três passa.
+    expect(screen.getByText("Saldo em 18/08")).toBeInTheDocument();
+    expect(screen.getByText(/apuradas em 18\/08\/2026/)).toBeInTheDocument();
+    expect(screen.queryByText("Saldo em 17/08")).toBeNull();
+  });
+
+  it("'Declarar saldo' nasce no dia do tenant — e é ele que viaja no corpo", async () => {
+    const user = userEvent.setup();
+    mockApi([conta({ id: "acc-1" })]);
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByText("Declarar saldo"));
+    const dia = (await screen.findByLabelText("Dia")) as HTMLInputElement;
+    expect(dia.value).toBe(DIA_DO_TENANT);
+    expect(dia.value).not.toBe(DIA_DO_NAVEGADOR);
+
+    // "Declarar saldo" é o rótulo do gatilho no cartão E do botão dentro do modal — `getByRole`
+    // global acharia os dois (mesma armadilha documentada em `botaoLancar`, mais acima).
+    const titulo = screen.getByText("Declarar saldo — Itaú PJ");
+    const painel = titulo.parentElement?.parentElement as HTMLElement;
+    await user.click(within(painel).getByRole("button", { name: "Declarar saldo" }));
+    await waitFor(() => expect(api.post).toHaveBeenCalled());
+    expect(vi.mocked(api.post).mock.calls[0][1]).toMatchObject({
+      reference_date: DIA_DO_TENANT,
+    });
+  });
+
+  it("'Lançar movimento' nasce no dia do tenant", async () => {
+    const user = userEvent.setup();
+    mockApi([conta({ id: "acc-1" })]);
+    renderPage();
+
+    await user.click(await screen.findByText("Lançar movimento"));
+    await waitFor(() =>
+      expect(screen.getByText("Lançar movimento — Itaú PJ")).toBeInTheDocument(),
+    );
+    const data = screen.getByLabelText("Data") as HTMLInputElement;
+    expect(data.value).toBe(DIA_DO_TENANT);
+    expect(data.value).not.toBe(DIA_DO_NAVEGADOR);
+  });
+
+  it("'Nova conta' abre com a data de abertura no dia do tenant", async () => {
+    // A data de abertura é um fato da EMPRESA — e até a #136 nascia do relógio da máquina de quem
+    // abriu a tela. O `AccountModal` é o mesmo componente que a `EscolhaDaBaixa` embute no cadastro
+    // de conta durante uma baixa, então este default vale para as cinco telas de dinheiro.
+    const user = userEvent.setup();
+    mockApi([]);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Cadastrar primeira conta" }));
+    await waitFor(() => expect(screen.getByText("Nova conta")).toBeInTheDocument());
+
+    const abertura = screen.getByLabelText("Data de abertura") as HTMLInputElement;
+    expect(abertura.value).toBe(DIA_DO_TENANT);
+    expect(abertura.value).not.toBe(DIA_DO_NAVEGADOR);
+  });
+
+  it("⚠️ 'Transferir' NÃO nasce barrada: o mesmo relógio preenche o campo e valida o campo", async () => {
+    // ── O coração da #136 nesta tela ─────────────────────────────────────────────────────────
+    // Com o default vindo do tenant (18/08) e a guarda de data futura lendo o navegador (17/08),
+    // `impedimentoDaTransferencia` devolvia "A data não pode ser futura…" **na abertura do
+    // modal**, com o botão desabilitado, sobre um dia que para o dono é simplesmente hoje.
+    const user = userEvent.setup();
+    mockApi(duasContas);
+    renderPage();
+    await screen.findByText("Itaú PJ");
+
+    await user.click(screen.getAllByRole("button", { name: TRANSFERIR_LABEL })[0]);
+    const data = (await screen.findByLabelText("Data")) as HTMLInputElement;
+    expect(data.value).toBe(DIA_DO_TENANT);
+
+    fireEvent.change(screen.getByLabelText("Valor (R$)"), { target: { value: "1.000,00" } });
+
+    const botao = screen.getByRole("button", { name: "Registrar transferência" });
+    expect(screen.queryByText(/não pode ser futura/i)).toBeNull();
+    expect(botao).toBeEnabled();
+
+    // E a guarda continua VIVA — ela não sumiu, parou de mentir. Um dia à frente do hoje DO
+    // TENANT ainda barra. Sem esta metade, apagar a guarda inteira deixaria o teste verde.
+    fireEvent.change(data, { target: { value: "2026-08-19" } });
+    expect(screen.getByText(/não pode ser futura/i)).toBeInTheDocument();
+    expect(botao).toBeDisabled();
+
+    // E o dia que é futuro só para o NAVEGADOR (18/08) segue liberado: é aqui que se lê de qual
+    // relógio a VALIDAÇÃO bebe, e não só o default.
+    fireEvent.change(data, { target: { value: DIA_DO_TENANT } });
+    expect(screen.queryByText(/não pode ser futura/i)).toBeNull();
+    expect(botao).toBeEnabled();
   });
 });

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -12,6 +12,8 @@ import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react
 import { Link } from "react-router-dom";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
+import { today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
 import { usePrimaryAction } from "../../store/pageActions";
 // ⚠️ O cadastro/edição de conta MUDOU DE ARQUIVO na Story 8.13 (`./AccountModal`), sem mudar de
 // comportamento: o fluxo "409 acionável → cadastro embutido → retoma a baixa" das telas de baixa
@@ -28,7 +30,6 @@ import {
   type DuplicataAcionavel,
   formatBRL,
   formatDateBR,
-  hojeISO,
   impedimentoDaTransferencia,
   isIgnored,
   kindDaTransferencia,
@@ -324,6 +325,9 @@ export default function ContasSaldosPage() {
  * Aqui os recortes têm nomes próprios e cada um diz o que inclui.
  */
 function TotaisCard({ resumo }: { resumo: ResumoSaldo[] }) {
+  // ⚠️ **A data de apuração é a do TENANT** (#136). Era `hojeISO()` — o dia do navegador —, e num
+  // dono a leste o card anunciava um saldo "apurado em" um dia que a empresa ainda não vivera.
+  const hoje = today(useFuso());
   return (
     <div className="rounded-2xl bg-white p-5 shadow-sm">
       <div className="flex flex-wrap gap-x-10 gap-y-4">
@@ -340,7 +344,7 @@ function TotaisCard({ resumo }: { resumo: ResumoSaldo[] }) {
         ))}
       </div>
       <p className="mt-4 text-xs text-neutral-400">
-        Somas das contas ativas, apuradas em {formatDateBR(hojeISO())}. A lista abaixo mostra conta
+        Somas das contas ativas, apuradas em {formatDateBR(hoje)}. A lista abaixo mostra conta
         por conta — o total nunca aparece sozinho.
       </p>
     </div>
@@ -375,6 +379,10 @@ function AccountCard({
   children?: ReactNode;
 }) {
   const arquivada = account.archived_at !== null;
+  // "Saldo em {dia}" no fuso do TENANT (#136) — o corte de data do saldo derivado é do backend,
+  // que já usa `hoje_do_tenant`; rotulá-lo com o dia do navegador dizia um dia diferente do que
+  // o número representa.
+  const hoje = today(useFuso());
   return (
     <li
       className={`rounded-2xl bg-white p-5 shadow-sm ${selected ? "ring-2 ring-primary-200" : ""}`}
@@ -421,7 +429,7 @@ function AccountCard({
           {/* Story 8.10 — a DATA em que este número foi apurado, colada nele pelo mesmo motivo que
               a origem: um saldo sem a data em que foi apurado é um número que não dá para conferir.
               Até a 8.10 não havia data a mostrar, porque o saldo era "todo o histórico". */}
-          <p className="text-xs text-neutral-400">{saldoApuradoEm(hojeISO())}</p>
+          <p className="text-xs text-neutral-400">{saldoApuradoEm(hoje)}</p>
           <p className="mt-1 text-xs text-neutral-500">
             {checkpoint
               ? `Saldo declarado em ${formatDateBR(checkpoint.reference_date)}: ${formatBRL(checkpoint.balance_cents)}`
@@ -902,17 +910,19 @@ function DeclararSaldoModal({
   onClose: () => void;
   onSaved: () => void;
 }) {
-  const [referenceDate, setReferenceDate] = useState(hojeISO);
+  // Um relógio só, e é o do tenant (#136): o default do campo e o reset do efeito abaixo.
+  const fuso = useFuso();
+  const [referenceDate, setReferenceDate] = useState(() => today(fuso));
   const [balance, setBalance] = useState("0,00");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!account) return;
-    setReferenceDate(hojeISO());
+    setReferenceDate(today(fuso));
     setBalance(centsToInput(account.saldo_derivado_cents));
     setError(null);
-  }, [account]);
+  }, [account, fuso]);
 
   async function save() {
     if (!account) return;
@@ -974,7 +984,9 @@ function LancarMovimentoModal({
   onClose: () => void;
   onSaved: () => void;
 }) {
-  const [postedAt, setPostedAt] = useState(hojeISO);
+  // Um relógio só, e é o do tenant (#136).
+  const fuso = useFuso();
+  const [postedAt, setPostedAt] = useState(() => today(fuso));
   const [entrada, setEntrada] = useState(false);
   const [value, setValue] = useState("0,00");
   const [description, setDescription] = useState("");
@@ -990,7 +1002,7 @@ function LancarMovimentoModal({
 
   useEffect(() => {
     if (!account) return;
-    setPostedAt(hojeISO());
+    setPostedAt(today(fuso));
     // Saída é o default: o foco declarado do épico é achar SAÍDA não lançada (REQ-14).
     setEntrada(false);
     setValue("0,00");
@@ -1000,7 +1012,7 @@ function LancarMovimentoModal({
     setNaturezaLivre("");
     setError(null);
     setDuplicata(null);
-  }, [account]);
+  }, [account, fuso]);
 
   const cents = parseCentsBRL(value);
   // O valor COM SINAL — calculado uma vez e usado tanto no resumo quanto no envio, para que o que
@@ -1182,7 +1194,12 @@ function TransferirModal({
   const [fromId, setFromId] = useState("");
   const [toId, setToId] = useState("");
   const [value, setValue] = useState("0,00");
-  const [postedAt, setPostedAt] = useState(hojeISO);
+  // ⚠️ **O MESMO relógio preenche o campo e valida o campo** (#136). Antes, o default vinha daqui
+  // (`hojeISO()`, navegador) e a guarda de data futura vinha de DENTRO de
+  // `impedimentoDaTransferencia`, que chamava `hojeISO()` por conta própria: dois relógios numa
+  // função "pura". Agora o hoje do tenant é resolvido uma vez e passado adiante.
+  const fuso = useFuso();
+  const [postedAt, setPostedAt] = useState(() => today(fuso));
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -1198,15 +1215,15 @@ function TransferirModal({
     // O destino nasce na primeira conta que NÃO é a origem — nunca igual a ela, que é 422.
     setToId(elegiveis.find((a) => a.id !== origem)?.id ?? "");
     setValue("0,00");
-    setPostedAt(hojeISO());
+    setPostedAt(today(fuso));
     setDescription("");
     setError(null);
-  }, [open, origemInicialId, elegiveis]);
+  }, [open, origemInicialId, elegiveis, fuso]);
 
   const origem = elegiveis.find((a) => a.id === fromId) ?? null;
   const destino = elegiveis.find((a) => a.id === toId) ?? null;
   const cents = parseCentsBRL(value);
-  const impedimento = impedimentoDaTransferencia(origem, destino, cents, postedAt);
+  const impedimento = impedimentoDaTransferencia(origem, destino, cents, postedAt, today(fuso));
   const aviso = avisoDestinoAplicacao(destino);
 
   async function save() {

--- a/apps/web/src/features/financeiro/contas.test.ts
+++ b/apps/web/src/features/financeiro/contas.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   ACAO_BAIXAR_PAYABLE,
   acaoBaixarPayable,
@@ -13,7 +13,6 @@ import {
   diaAnteriorISO,
   DISPONIVEL_CAIXA_LABEL,
   formatDateBR,
-  hojeISO,
   impedimentoDaTransferencia,
   isIgnored,
   isOrigemDoSistema,
@@ -654,45 +653,80 @@ describe("Story 8.18 — avisoDestinoAplicacao: obrigatório, e silêncio no res
 describe("Story 8.18 — impedimentoDaTransferencia: o que a tela consegue antecipar, e só isso", () => {
   const a = conta({ id: "a", kind: KIND_CHECKING });
   const b = conta({ id: "b", kind: KIND_SAVINGS });
-  // ⚠️ **`hojeISO()` e `Date.now()` ficam aqui de propósito — não é a classe da #120/#129.**
-  // `impedimentoDaTransferencia` compara duas STRINGS `YYYY-MM-DD` e resolve "hoje" chamando
-  // `hojeISO()` ela mesma; não existe fuso de tenant nesta função (nem `useFuso`, nem `today(tz)`),
-  // então não há dois relógios a confundir e um fuso distante não teria o que matar. Congelar o
-  // relógio aqui só amarraria o teste a um literal sem ganhar poder de detecção.
+
+  // ⚠️ **A dívida anotada aqui pelo PR #133 foi PAGA (#136), e por isso os literais mudaram.**
+  // Até então esta função resolvia "hoje" chamando `hojeISO()` por DENTRO — uma função anunciada
+  // como PURA lendo o relógio do navegador escondida atrás da assinatura. O aviso antigo dizia que
+  // um fuso distante "não teria o que matar" e que congelar o relógio "só amarraria o teste a um
+  // literal sem ganhar poder de detecção": as duas frases eram verdade enquanto o hoje era interno,
+  // e as duas deixaram de ser quando ele virou o 5º parâmetro. Agora o hoje entra de fora, do mesmo
+  // `today(useFuso())` que preenche o campo na `TransferirModal` — e é exatamente isso que estas
+  // asserções passam a conseguir afirmar.
   //
-  // ⚠️ O que estas asserções NÃO aguentam: se um dia `hojeISO()` virar o dia do TENANT (a dívida
-  // anotada em `cobrancas/CobrancasPage.test.tsx`), o `amanha`/`ontem` derivados de UTC abaixo
-  // passam a poder empatar com o "hoje" da função — num tenant a leste, o dia UTC seguinte JÁ é
-  // hoje. Quem pagar aquela dívida derruba estes dois testes e tem de derivar as bordas do mesmo
-  // relógio que a função passar a usar. É o aviso, não um convite a "consertar" antes da hora.
-  const HOJE = hojeISO();
+  // As bordas NÃO são mais derivadas de `Date.now()`/UTC — são literais do calendário do TENANT.
+  // `2026-08-17T02:30:00Z` separa os três relógios:
+  //   · **navegador** (America/Sao_Paulo, o runner do vitest) → 16/08 23:30 → `2026-08-16`
+  //   · **UTC**                                               → `2026-08-17`
+  //   · **tenant em Asia/Tokyo**                              → 17/08 11:30 → `2026-08-17`
+  // O relógio fica congelado nesse instante **de propósito**: assim, quem devolver a leitura do
+  // hoje para dentro da função (pelas partes locais de um `new Date()` ou por `toISOString()`)
+  // muda o resultado e fica VERMELHO. Sem o congelamento, o dia real da máquina ficaria longe
+  // destes literais e a divergência seria acidente de calendário, não medição.
+  const INSTANTE = "2026-08-17T02:30:00Z";
+  const HOJE = "2026-08-17"; // o dia do TENANT (Tóquio) — que é o AMANHÃ do navegador
+  const AMANHA = "2026-08-18";
+  const ONTEM = "2026-08-16"; // o HOJE do navegador — que para o tenant já é ontem
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(INSTANTE));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
 
   it("sem as duas contas, pede as duas", () => {
-    expect(impedimentoDaTransferencia(null, b, 100, HOJE)).toMatch(/origem e a de destino/);
-    expect(impedimentoDaTransferencia(a, null, 100, HOJE)).toMatch(/origem e a de destino/);
+    expect(impedimentoDaTransferencia(null, b, 100, HOJE, HOJE)).toMatch(/origem e a de destino/);
+    expect(impedimentoDaTransferencia(a, null, 100, HOJE, HOJE)).toMatch(/origem e a de destino/);
   });
 
   it("mesma conta nos dois lados é impedimento — não moveria dinheiro nenhum", () => {
-    expect(impedimentoDaTransferencia(a, a, 100, HOJE)).toMatch(/a mesma/);
+    expect(impedimentoDaTransferencia(a, a, 100, HOJE, HOJE)).toMatch(/a mesma/);
   });
 
   it("valor zero ou negativo é impedimento — o sinal vive nas pernas", () => {
-    expect(impedimentoDaTransferencia(a, b, 0, HOJE)).toMatch(/maior que zero/);
-    expect(impedimentoDaTransferencia(a, b, -100, HOJE)).toMatch(/maior que zero/);
+    expect(impedimentoDaTransferencia(a, b, 0, HOJE, HOJE)).toMatch(/maior que zero/);
+    expect(impedimentoDaTransferencia(a, b, -100, HOJE, HOJE)).toMatch(/maior que zero/);
   });
 
   it("data futura é impedimento — o mesmo 422 que `create_transfer` aplica no backend", () => {
     // A tela antecipa a guarda para não montar uma parede um clique adiante; quem a APLICA é o
     // backend (achado A-3: ela não pode viver na guarda genérica do módulo, que aceita futuro para
     // origem de sistema desde a Story 8.14).
-    const amanha = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
-    expect(impedimentoDaTransferencia(a, b, 100, amanha)).toMatch(/não pode ser futura/);
+    expect(impedimentoDaTransferencia(a, b, 100, AMANHA, HOJE)).toMatch(/não pode ser futura/);
   });
 
   it("tudo certo → `null`, inclusive HOJE (a borda aceita)", () => {
-    expect(impedimentoDaTransferencia(a, b, 100_00, HOJE)).toBeNull();
-    const ontem = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    expect(impedimentoDaTransferencia(a, b, 100_00, ontem)).toBeNull();
+    expect(impedimentoDaTransferencia(a, b, 100_00, HOJE, HOJE)).toBeNull();
+    expect(impedimentoDaTransferencia(a, b, 100_00, ONTEM, HOJE)).toBeNull();
+  });
+
+  it("o hoje é o do TENANT e vem de FORA: o dia que o navegador ainda não viveu é aceito", () => {
+    // A asserção que a #136 acrescenta, e a única daqui que morre se o hoje voltar para dentro da
+    // função. Com o relógio congelado em `INSTANTE`, o navegador do runner está em 16/08 e o tenant
+    // de Tóquio já está em 17/08. Um dono em Tóquio registrando a transferência do dia DELE manda
+    // `postedAt = "2026-08-17"`.
+    //
+    // · hoje vindo de fora (o do tenant) → isso é HOJE → passa.
+    // · hoje lido por dentro pelo relógio do NAVEGADOR (o defeito) → isso é FUTURO → a tela
+    //   barraria com "a data não pode ser futura" o valor que ela mesma acabou de preencher.
+    expect(impedimentoDaTransferencia(a, b, 100_00, "2026-08-17", HOJE)).toBeNull();
+    // O par contrário fecha a tenaz: com o hoje do NAVEGADOR o MESMO dia é recusado. Sem ele, a
+    // asserção acima passaria com qualquer hoje grande o bastante, e não provaria de qual relógio
+    // o valor veio.
+    expect(impedimentoDaTransferencia(a, b, 100_00, "2026-08-17", "2026-08-16")).toMatch(
+      /não pode ser futura/,
+    );
   });
 });
 

--- a/apps/web/src/features/financeiro/contas.ts
+++ b/apps/web/src/features/financeiro/contas.ts
@@ -414,19 +414,28 @@ export function avisoDestinoAplicacao(destino: BankAccount | null): string | nul
  * não futura) — e **só** essas. As demais (conta arquivada, data anterior à abertura) dependem de
  * dado que a tela tem, mas cuja mensagem o backend escreve melhor: duplicar a redação aqui criaria
  * duas frases para a mesma regra, e a daqui envelheceria primeiro.
+ *
+ * ⚠️ **`hojeYmd` é PARÂMETRO, e isso é o conserto da #136.** Até então esta função chamava
+ * `hojeISO()` por dentro — ou seja, uma função "pura" lia o relógio do NAVEGADOR escondida atrás da
+ * assinatura. O `postedAt` que a tela oferece já nasce no fuso do tenant; comparar contra o dia da
+ * máquina de quem abriu a página é o mesmo defeito de dois relógios da bandeja de comprovantes, só
+ * que na camada de baixo — e, num tenant a leste, ele barra com "a data não pode ser futura" o
+ * valor que a própria tela acabou de preencher. Recebendo o hoje de fora, o teste consegue afirmar
+ * sobre fuso. Mesmo precedente de `filtroPadrao(hojeYmd)` em `pagar/filtros.ts`.
  */
 export function impedimentoDaTransferencia(
   origem: BankAccount | null,
   destino: BankAccount | null,
   cents: number,
   postedAt: string,
+  hojeYmd: string,
 ): string | null {
   if (!origem || !destino) return "Escolha a conta de origem e a de destino.";
   if (origem.id === destino.id) {
     return "A conta de origem e a de destino são a mesma — isso não moveria dinheiro nenhum.";
   }
   if (cents <= 0) return "Informe um valor maior que zero.";
-  if (postedAt > hojeISO()) {
+  if (postedAt > hojeYmd) {
     return "A data não pode ser futura: registre a transferência no dia em que ela cair.";
   }
   return null;
@@ -664,19 +673,26 @@ export function centsToInput(cents: number): string {
   return (cents / 100).toFixed(2).replace(".", ",");
 }
 
-/**
- * Hoje como data de CALENDÁRIO local (`YYYY-MM-DD`), para default de campo de data.
- *
- * Local (e não UTC) de propósito: o usuário está declarando "o saldo de hoje" olhando para o
- * calendário dele. Isto é default de FORMULÁRIO — não tem nada a ver com o casamento de evento
- * all-day do `CLAUDE.md` §6.0, que compara datas já gravadas e continua sendo feito por string.
- */
-export function hojeISO(): string {
-  const d = new Date();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${d.getFullYear()}-${mm}-${dd}`;
-}
+// ── `hojeISO()` foi REMOVIDA (#136) — a explicação que ela carregava ficou falsa ──────────────
+//
+// A função montava `YYYY-MM-DD` pelas partes locais de um `new Date()`, e o comentário dela dizia
+// que "local (e não UTC)" era de propósito, porque "o usuário está declarando o saldo de HOJE
+// olhando para o calendário DELE". Essa frase foi escrita antes do PR #78 e opunha as duas únicas
+// opções que existiam então: o relógio do navegador e o UTC cru. Ela nunca considerou a terceira,
+// que desde o #78 é a régua do e1p — o relógio do **tenant** (`hoje_do_tenant(db)` no backend,
+// `today(fuso)` de `lib/datetime.ts` no frontend).
+//
+// Com a régua nova, "o calendário DELE" deixou de ser o do navegador: o dono viajando lê o dia do
+// hotel, e o dia da empresa é o do fuso do tenant. Por isso a função não vira `@deprecated` nem
+// sobra "para usos legítimos": não restou nenhum. Todos os seus 15 call sites eram default ou
+// validação de campo de data em tela de dinheiro — exatamente a classe que o #78 moveu. Um alias
+// depreciado seria um convite a reintroduzir o defeito com o autocomplete, e o defeito 2 da #136
+// (default preenchido por um relógio e validado por outro) nasceu de exatamente esse tipo de
+// segunda porta.
+//
+// Quem precisar de "hoje" numa tela: `today(useFuso())`. Quem precisar dele numa função PURA:
+// receba-o como argumento (ver `impedimentoDaTransferencia` acima e `filtroPadrao(hojeYmd)` em
+// `pagar/filtros.ts`), nunca o busque por dentro.
 
 // ── Story 8.10 — a data em que o saldo foi apurado ───────────────────────────────────────────
 

--- a/apps/web/src/features/pagar/ComprovantePage.test.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.test.tsx
@@ -426,19 +426,46 @@ describe("ComprovantePage — a escolha da baixa (Story 8.13)", () => {
     // no mesmo fuso os dois lados eram iguais por construção. Agora o tenant está em Tóquio e o
     // relógio congelado: 18/08 para o dono, 17/08 para o navegador e para o UTC.
     expect(campoDia().value).toBe(DIA_DO_TENANT);
-    // ⚠️ **Achado que só aparece com os dois fusos separados, e que este teste NÃO afirma de
-    // propósito:** rodando com o tenant em Tóquio, a bandeja abre com o aviso "Esta data é no
-    // futuro… será registrada como AGENDADA" já visível, sem o dono ter tocado em nada. É o mesmo
-    // componente lendo DOIS relógios: o default vem de `localToday(fuso)` (tenant) e o
-    // `avisoDeDataFutura` compara com `hojeISO()` (navegador, via `EscolhaDaBaixa`). Fixar isso é
-    // mudar produção — a mesma dívida do `hojeISO` anotada em `cobrancas/CobrancasPage.test.tsx` e
-    // no CLAUDE.md §5.2 —, e travar o aviso num `expect` aqui pregaria o defeito na parede.
     // ⚠️ **[Story 8.14] mudança de expectativa, e ela é a CORREÇÃO.** Este teste afirmava
     // `max === hoje()`. O teto era faseamento (garantir que não existisse `paid` com data futura
     // enquanto `scheduled` não existisse) e saiu no commit em que `scheduled` nasceu. A bandeja
     // herdou a mudança **sem ser editada**: as três telas de baixa compartilham `baixa.ts`, e é
     // esse o retorno de ter uma implementação só.
     expect(campoDia().getAttribute("max")).toBeNull();
+  });
+
+  it("⚠️ a bandeja NÃO abre acusando de futuro o dia que ela mesma preencheu (#136)", async () => {
+    // ── O defeito 2 da #136, agora fixado num `expect` ────────────────────────────────────────
+    //
+    // O PR #133 ACHOU isto e deliberadamente não afirmou nada: com o tenant em Tóquio, a bandeja
+    // abria com "Esta data é no futuro… será registrada como AGENDADA" **já visível, sem o dono
+    // tocar em nada**. Um componente, dois relógios: o default vinha de `localToday(fuso)` (o
+    // tenant, 18/08) e o `avisoDeDataFutura` comparava com `hojeISO()` (o navegador, 17/08) — a
+    // tela acusava de errado o valor que ela mesma acabara de escrever. Travar o aviso num
+    // `expect` naquele momento pregaria o defeito na parede; agora que a dívida foi paga, o que
+    // se prega é a AUSÊNCIA dele.
+    //
+    // Este teste é o guardião do invariante: **default e validação bebem do mesmo relógio.** Ele
+    // morre se alguém devolver um segundo "hoje" ao fluxo da baixa — e morre com o defeito exato
+    // que existia em produção, não com um proxy dele.
+    fusoDoTenant = FUSO_DISTANTE;
+    congelarRelogio();
+    await escolherCandidata();
+
+    // Ponto de partida: o campo está no dia do tenant, intocado.
+    expect(campoDia().value).toBe(DIA_DO_TENANT);
+    expect(screen.queryByText(/esta data é no futuro/i)).toBeNull();
+
+    // E o aviso continua FUNCIONANDO — ele não sumiu, só parou de mentir. Um dia realmente à
+    // frente do hoje DO TENANT ainda avisa. Sem esta metade, apagar `avisoDeDataFutura` inteiro
+    // deixaria a primeira metade verde.
+    fireEvent.change(campoDia(), { target: { value: "2026-08-19" } });
+    expect(screen.getByText(/esta data é no futuro/i)).toBeTruthy();
+
+    // E o dia que é futuro só para o NAVEGADOR (18/08 é amanhã em São Paulo, hoje em Tóquio) NÃO
+    // avisa: é aqui que se lê de qual relógio a validação bebe.
+    fireEvent.change(campoDia(), { target: { value: DIA_DO_TENANT } });
+    expect(screen.queryByText(/esta data é no futuro/i)).toBeNull();
   });
 
   it("o dia é EDITÁVEL e é o valor editado que viaja", async () => {

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -9,6 +9,7 @@ import {
   CadastroDeContaEmbutido,
   EscolhaDaBaixa,
   type EscolhaDaBaixaState,
+  HOJE_DO_TENANT,
   useEscolhaDaBaixa,
 } from "./EscolhaDaBaixa";
 
@@ -56,7 +57,9 @@ function chip(p: Payable): { label: string; cls: string } {
  * toque por conta, e a ação principal fixa no rodapé.
  */
 export default function ComprovantePage() {
-  const fuso = useFuso();
+  // ⚠️ **Esta tela não resolve mais "hoje" por conta própria** (#136): o `useEscolhaDaBaixa` abaixo
+  // é quem o faz, no fuso do tenant, no mesmo ponto em que valida a data. `useFuso()` continua
+  // sendo usado por `NovaContaEmbutida` (o `due_date` de uma conta NOVA, que é outra pergunta).
   const { id = "" } = useParams();
   const navigate = useNavigate();
   const [candidates, setCandidates] = useState<Payable[]>([]);
@@ -82,7 +85,12 @@ export default function ComprovantePage() {
    * O que mudou é que "hoje" deixou de ser decisão invisível do backend: virou um campo **visível
    * e editável**, dentro da barra fixa, ao lado do botão. O usuário confirma; não constrói.
    */
-  const escolha = useEscolhaDaBaixa(localToday(fuso));
+  // ⚠️ **`HOJE_DO_TENANT`, e não `localToday(fuso)`** (#136). O valor é o mesmo — o dia do tenant —,
+  // mas a ORIGEM passou a ser uma só: quem preenche o campo é o mesmo ponto que valida a data
+  // (`avisoDeDataFutura`/`tetoDaDataDeBaixa`). Era essa duplicação que fazia a bandeja abrir, com o
+  // tenant em Tóquio, já acusando "Esta data é no futuro… será registrada como AGENDADA" sobre o
+  // valor que ela mesma acabara de escrever.
+  const escolha = useEscolhaDaBaixa(HOJE_DO_TENANT);
 
   // Identifica QUAL comprovante está na tela. Não existe `GET /payables/receipts/{id}`, mas a
   // bandeja é curta por construção (teto de 30), então filtrar a lista basta e evita rota nova.

--- a/apps/web/src/features/pagar/EscolhaDaBaixa.tsx
+++ b/apps/web/src/features/pagar/EscolhaDaBaixa.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import Modal from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
+import { today } from "../../lib/datetime";
+import { useFuso } from "../../store/auth";
 import AccountModal from "../financeiro/AccountModal";
 import type { BankAccount } from "../financeiro/contas";
-import { hojeISO } from "../financeiro/contas";
 import {
   acaoCadastrarConta,
   type ContaDeBaixa,
@@ -57,6 +58,8 @@ export interface EscolhaDaBaixaState {
   rotulo: (base: string) => string;
   /** Aviso de data futura (não bloqueia — o 422 do backend é quem recusa). */
   aviso: string | null;
+  /** "Hoje" no fuso do TENANT — o ÚNICO relógio desta escolha (#136). Ver `HOJE_DO_TENANT`. */
+  hoje: string;
   /** Corpo pronto para `POST /pay` e para os dois corpos da bandeja. */
   corpo: () => { bank_account_id: string; paid_on: string };
   /** O cadastro embutido está aberto? */
@@ -75,20 +78,45 @@ export interface EscolhaDaBaixaState {
 }
 
 /**
+ * O `dataPadrao` de quem quer que o campo nasça em **hoje**.
+ *
+ * ⚠️ **Não é "sem default": é "o default é hoje, e quem resolve o hoje é este componente"** — que é
+ * o conserto do defeito 2 da #136. Antes, cada tela montava o próprio hoje e o passava pronto,
+ * enquanto a validação (`avisoDeDataFutura`, `tetoDaDataDeBaixa`) resolvia o dela por dentro: dois
+ * relógios num componente só. Com o tenant em Tóquio a bandeja abria já acusando *"Esta data é no
+ * futuro… será registrada como AGENDADA"* sobre o valor que ela mesma acabara de preencher.
+ *
+ * Passar o sentinela em vez de uma string faz com que **exista uma chamada só** de `today(fuso)`
+ * para o default E para a validação. Não é convenção: é impossível divergir, porque não há um
+ * segundo lugar de onde divergir. Quem passa uma STRING está declarando outra coisa (o `due_date`
+ * da conta, em `PagarPage`/`FilaPagamentos`) — e essa continua sendo uma escolha explícita.
+ */
+export const HOJE_DO_TENANT = null;
+
+/**
  * Carrega as contas ativas, pré-seleciona a primária e guarda a data escolhida.
  *
  * @param dataPadrao data inicial do campo. **`PagarPage`/`FilaPagamentos` passam o `due_date` da
  *   conta** (fundador F10: *"deixar habilitado no vencimento, pois se estiver fazendo retroativo,
- *   pq não deu certo no dia"*); **a bandeja passa hoje**, porque o comprovante chega pelo share
- *   sheet no instante do pagamento (ver a nota em `payables/receipts.py::link_receipt`).
+ *   pq não deu certo no dia"*); **a bandeja, as Cobranças e a ficha do cliente passam
+ *   `HOJE_DO_TENANT`**, porque ali o gesto é um fato observado AGORA (o comprovante chega pelo
+ *   share sheet no instante do pagamento — ver a nota em `payables/receipts.py::link_receipt`).
  */
 export function useEscolhaDaBaixa(
-  dataPadrao: string,
+  dataPadrao: string | typeof HOJE_DO_TENANT,
   vocab: VocabularioDaBaixa = VOCAB_SAIDA,
 ): EscolhaDaBaixaState {
+  // ⚠️ **UM relógio, e ele é o do TENANT** (#136, régua do PR #78 e do CLAUDE.md §5.2). Este é o
+  // único ponto do fluxo de baixa que resolve "hoje": o default do campo, o `aviso` e o teto do
+  // `max` bebem todos daqui. Trocar por `new Date()` local, ou por `toISOString()` (UTC), é
+  // regressão — e os testes de `ComprovantePage`/`CobrancasPage` rodam com o tenant em Tóquio
+  // justamente para que essa troca fique VERMELHA em vez de invisível.
+  const hoje = today(useFuso());
+  const inicial = dataPadrao ?? hoje;
+
   const [contas, setContas] = useState<ContaDeBaixa[]>([]);
   const [contaId, setContaId] = useState("");
-  const [data, setData] = useState(dataPadrao);
+  const [data, setData] = useState(inicial);
   const [cadastrando, setCadastrando] = useState(false);
 
   const recarregar = useCallback(async () => {
@@ -110,10 +138,12 @@ export function useEscolhaDaBaixa(
     recarregar();
   }, [recarregar]);
 
-  // A data padrão muda quando a tela troca de conta a pagar (cada uma tem seu vencimento).
+  // A data padrão muda quando a tela troca de conta a pagar (cada uma tem seu vencimento). Com
+  // `HOJE_DO_TENANT`, `inicial` é o próprio `hoje` — string estável dentro do dia, então o efeito
+  // não redispara a cada render.
   useEffect(() => {
-    setData(dataPadrao);
-  }, [dataPadrao]);
+    setData(inicial);
+  }, [inicial]);
 
   const semConta = contas.length === 0;
   const nomeConta = nomeDaConta(contas, contaId);
@@ -129,7 +159,8 @@ export function useEscolhaDaBaixa(
     nomeConta,
     vocab,
     rotulo: (base: string) => rotuloDaAcao(base, nomeConta, vocab.preposicao),
-    aviso: avisoDeDataFutura(data, hojeISO(), vocab),
+    aviso: avisoDeDataFutura(data, hoje, vocab),
+    hoje,
     corpo: () => ({ bank_account_id: contaId, paid_on: data }),
     cadastrando,
     abrirCadastro: () => setCadastrando(true),
@@ -236,7 +267,7 @@ export function EscolhaDaBaixa({
             // grava a conta como `scheduled`. A chamada FICA (em vez de a linha sumir) porque é
             // ela que documenta a decisão e é a ela que se volta se o teto precisar retornar; um
             // `max` apagado do JSX não deixa rastro nenhum.
-            max={tetoDaDataDeBaixa(hojeISO())}
+            max={tetoDaDataDeBaixa(estado.hoje)}
             aria-label={estado.vocab.ariaData}
             className={campo}
           />
@@ -289,8 +320,9 @@ export function DialogDeBaixa({
   descricao: string;
   valor: string;
   /** Default do campo de data: o `due_date` da conta (AC1/AC7), nunca hoje, nunca `now()`.
-   *  No recebimento fora do trilho (8.15) é **hoje** — o dono está olhando o extrato agora. */
-  dataPadrao: string;
+   *  No recebimento fora do trilho (8.15) é **hoje** — o dono está olhando o extrato agora —, e aí
+   *  se passa `HOJE_DO_TENANT`, nunca um hoje montado pela tela (#136). */
+  dataPadrao: string | typeof HOJE_DO_TENANT;
   onClose: () => void;
   /** Faz o POST. Devolve a promise para o dialog tratar erro/estado — inclusive o 409 acionável. */
   onPago: (corpo: { bank_account_id: string; paid_on: string }) => Promise<void>;


### PR DESCRIPTION
## O que aconteceu

O e1p vive no fuso do **tenant** desde o PR #78: `hoje_do_tenant(db)` no backend e `lib/datetime.ts`
no frontend são as âncoras únicas, e ler o relógio do navegador é regressão. **Seis arquivos ficaram
de fora.**

O PR #133 (issue #129) achou os dois defeitos e **deliberadamente não os corrigiu**: escreveu testes
que fixam e denunciam o comportamento atual, com instrução de trocar o literal quando a dívida fosse
paga. Este PR paga.

**Defeito 1 —** `CobrancasPage` passava `dataPadrao={hojeISO()}`, e `hojeISO` montava a data pelas
partes locais de um `new Date()`. A tela não importava nada de `store/auth`.

**Defeito 2 — um componente, dois relógios.** Na bandeja de `ComprovantePage`/`EscolhaDaBaixa`, o
**default** do campo vinha de `localToday(fuso)` (tenant) e a **validação** (`avisoDeDataFutura`,
`tetoDaDataDeBaixa`) de `hojeISO()` (navegador). Com o tenant em Tóquio, a bandeja abria com o aviso
*"Esta data é no futuro… será registrada como AGENDADA"* **já visível, sem o dono tocar em nada**:
a tela acusava de errado o valor que ela mesma acabara de preencher.

## O alcance medido — maior que o enunciado

A issue dizia "5 telas". São **15 call sites em 6 arquivos**:

| Arquivo | Sites | Estava no enunciado? |
|---|---|---|
| `cobrancas/CobrancasPage.tsx` | 1 | sim |
| `crm/ClientDetailPage.tsx` | 1 | sim |
| `financeiro/AccountModal.tsx` | 2 | sim |
| `financeiro/ContasSaldosPage.tsx` | 8 | sim |
| `pagar/EscolhaDaBaixa.tsx` | 2 | sim |
| **`financeiro/contas.ts`** | **1** (+ a definição) | **não** |

**`contas.ts:429` é o pior dos seis, porque a assinatura mentia.**
`impedimentoDaTransferencia(origem, destino, cents, postedAt)` era anunciada como **pura** e resolvia
"hoje" chamando `hojeISO()` por dentro. O efeito em produção não era teórico: na `TransferirModal` o
campo era **preenchido** pelo tenant e **validado** pelo navegador, então num tenant a leste a
transferência nascia barrada com *"A data não pode ser futura"* sobre o dia que para o dono é hoje —
botão desabilitado, antes de qualquer clique. Agora recebe `hojeYmd` como 5º parâmetro, mesmo
precedente de `filtroPadrao(hojeYmd)` em `pagar/filtros.ts`.

## A correção

**O conserto do defeito 2 não foi escolher qual relógio — foi não haver dois.**

`useEscolhaDaBaixa` resolve `today(useFuso())` **uma vez**; o default, o `aviso` e o `max` bebem todos
dali. Quem quer o campo em "hoje" passa a sentinela `HOJE_DO_TENANT` em vez de uma string montada na
tela. Não é convenção que alguém possa esquecer: **não existe um segundo lugar de onde divergir.**

**`hojeISO()` foi removida** — sem alias e sem `@deprecated`. Nenhum uso legítimo sobrou: os 15 sites
eram default ou validação de campo de data em tela de dinheiro, exatamente a classe que o #78 moveu.
Uma segunda porta com esse nome é o convite a reintroduzir o defeito pelo autocomplete — e o defeito
2 nasceu de uma segunda porta.

O comentário dela foi **substituído, não apagado**. Ele dizia "local (e não UTC) de propósito" porque
foi escrito **antes** do #78, quando só existiam duas opções — navegador e UTC. Nunca considerou a
terceira, que hoje é a régua. O bloco novo em `contas.ts` diz isso e aponta para `today(useFuso())`.

## O teste que parecia feito e não estava

Depois do fix, **`CobrancasPage.test.tsx` continuou verde com o literal errado.** O arquivo não
mockava `useFuso`, então caía no `FUSO_PADRAO` — o mesmo `America/Sao_Paulo` que o `vitest.config.ts`
fixa para a suíte. Mesmo diagnóstico em `ContasSaldosPage.test.tsx`: **8 dos 15 sites corrigidos não
tinham nenhuma asserção capaz de falhar.**

É a armadilha do §5.2 na prática — enquanto o fuso do tenant e o do runner são o mesmo valor, os dois
relógios produzem a mesma string **por construção**. Por isso o 2º commit acrescenta o mock de
`useFuso` e um bloco com o tenant em Tóquio nos dois arquivos. Sem ele o trabalho pareceria feito e
nenhuma mutação morreria.

## Verificação — por mutação, não por leitura

Todas compilam (`tsc --noEmit` limpo sob mutação) e foram revertidas por cópia de arquivo.

| # | Mutação (em produção) | Teste que morreu | Mensagem real |
|---|---|---|---|
| **M1** | `EscolhaDaBaixa`: `today(useFuso())` → relógio do navegador (o estado exato pré-#136) | 4 testes | `expected '2026-08-16' to be '2026-08-17'` · `expected '2026-08-17' to be '2026-08-18'` ×2 |
| M2 | mesmo ponto → `toISOString().slice(0,10)` (UTC) | 3 testes | `expected '2026-08-17' to be '2026-08-18'` |
| **M3** | **só a VALIDAÇÃO volta ao navegador** — o defeito 2 literal | `⚠️ a bandeja NÃO abre acusando de futuro o dia que ela mesma preencheu (#136)` | `expected <p …(1)></p> to be null` |
| **M4** | `contas.ts`: a função pura volta a ler o relógio por dentro | 3 testes | `expected 'A data não pode ser futura…' to be null` ×2 |
| M5 | `ContasSaldosPage` passa o relógio do navegador para a função pura | `⚠️ 'Transferir' NÃO nasce barrada` | `expected <p …(1)></p> to be null` |
| M6 | `TotaisCard`/`AccountCard` → navegador | `o cartão e os totais são apurados no dia do DONO` | `Unable to find an element with the text: /apuradas em 18\/08\/2026/` |
| M7b–M10b | os quatro modais, **na linha do efeito** → navegador | um teste cada | `expected '2026-08-17' to be '2026-08-18'` |

**M1 é a mutação central que a issue exige** — com o tenant em fuso distante, voltar ao navegador
mata. **M3 é a que mais importa depois dela:** reintroduz o defeito 2 exatamente como estava em
produção, e **só o teste novo o pega** — as outras 25 asserções do arquivo seguem verdes.

**Mutantes equivalentes, documentados e não "consertados":** mutar os `useState(() => today(fuso))`
dos quatro modais não mata nada — o `useEffect` de `[open]`/`[account]` sobrescreve o inicializador
antes de qualquer paint. Os dois programas são o mesmo programa. Mirei a linha do **efeito** (versões
`b`), onde a mutação mata, e registrei a armadilha no §5.2 para quem for medir mutação nesses arquivos.

Gates:

```
lint        eslint . --max-warnings 0     ok
typecheck   tsc --noEmit                  ok
test        73 arquivos / 763 testes      ok
e2e         66 passed (35.6s)             ok
```

## Escopo

12 arquivos, +473/−120. O `CLAUDE.md` §5.2 entra porque a dívida estava **escrita lá** pelo #133 como
afirmação viva, e ficaria falsa: os dois achados agora estão pagos, e `contas.test.ts` **sai** da
lista de exceções de `new Date()` — a justificativa antiga ("função pura que resolve 'hoje' sozinha;
sem dois relógios, um fuso distante não tem o que matar") era verdade enquanto o hoje era interno, e
deixou de ser quando virou parâmetro.

## O que isto NÃO resolve

`PagarPage`/`FilaPagamentos` não mudaram: passam `due_date` explicitamente e nenhum relógio participa.
`localYmd` e `AgendaPage` seguem intactos — são a exceção legítima já escrita no §5.2.

**`crm/ClientDetailPage` não tem arquivo de teste nenhum** — única das seis telas sem cobertura
própria. A leitura do relógio dela está coberta pela porta compartilhada (M1/M3 matam via
Cobranças/Comprovante), mas nada específico da tela é verificado. Vai como issue separada.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
