### PR TITLE
test(web): medir a URL real do recorte de Contas a Pagar [#138]

### DIFF
--- a/apps/web/e2e/pagar-url.spec.ts
+++ b/apps/web/e2e/pagar-url.spec.ts
@@ -1,0 +1,229 @@
+import { expect, type Page, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O recorte de Contas a Pagar na BARRA DE ENDEREÇO — link compartilhável e botão "voltar" (#138).
+ *
+ * ⚠️ **Por que este arquivo existe, e por que ele é Playwright e não vitest.** As outras camadas
+ * são cegas à URL: o pytest monta a query crua já na forma certa, o vitest assere o objeto antes de
+ * qualquer navegação, e o mock do gate de layout devolve payload fixo seja qual for a query. Um
+ * teste que só olhasse o estado de React passaria com a barra de endereço VAZIA — que era
+ * exatamente o defeito (`/pagar?q=anthropic` inerte). A mesma fresta escondeu o `status[]` até o
+ * #125. Aqui o navegador de verdade navega, e o histórico de verdade empilha.
+ *
+ * Segue o precedente do `busca-url.spec.ts`: rede mockada por `page.route`, asserções sobre a query
+ * string REAL que saiu no request.
+ */
+
+const BASE = {
+  tenant_id: "00000000-0000-4000-8000-000000000002",
+  category: "Ferramentas",
+  supplier: "Fornecedor Internacional de Tecnologia Ltda",
+  amount_cents: 118_573_04,
+  competence_date: null,
+  chart_account_id: null,
+  contract_id: null,
+  cost_center_id: null,
+  is_overdue: false,
+  paid_at: null,
+  recurrence: "none",
+  recurrence_count: 0,
+  recurrence_group: null,
+  payment_code: "",
+  attachment_url: "",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+/** Uma conta por status, com descrições DISTINTAS: é a descrição que a medição procura na tela. */
+const CONTAS = [
+  { ...BASE, id: "b-open", description: "Conta ABERTA", due_date: "2026-09-20", status: "open" },
+  {
+    ...BASE,
+    id: "b-sched",
+    description: "Conta AGENDADA",
+    due_date: "2026-09-21",
+    status: "scheduled",
+  },
+  {
+    ...BASE,
+    id: "b-paid",
+    description: "Conta PAGA",
+    due_date: "2026-08-10",
+    status: "paid",
+    paid_at: "2026-08-10T12:00:00Z",
+  },
+  {
+    ...BASE,
+    id: "b-canc",
+    description: "Conta CANCELADA",
+    due_date: "2026-09-22",
+    status: "canceled",
+  },
+];
+
+/**
+ * Rede mockada que **obedece à query string**, em vez de devolver payload fixo.
+ *
+ * É essa obediência que transforma "a lista mostra pagas" numa medição de ponta a ponta: URL →
+ * hidratação → `paraQuery` → request → lista renderizada. Com payload fixo, a linha "Conta PAGA"
+ * apareceria mesmo se a hidratação não existisse, e o teste seria decorativo.
+ *
+ * A rota específica é registrada DEPOIS de `mockarApi` de propósito: no Playwright o handler mais
+ * recente vence, então esta ganha da rota-curinga para `/payables/bills`.
+ */
+async function mockarPagar(page: Page): Promise<string[]> {
+  await mockarApi(page, {
+    "/payables/summary": {
+      open_cents: 18_575_704,
+      overdue_cents: 0,
+      week_cents: 1_800_000,
+      month_cents: 18_575_704,
+      paid_month_cents: 562_541,
+      scheduled_cents: 0,
+    },
+    "/payables/receipts": [],
+    "/chart-of-accounts": [{ id: "ca-1", categoria: "Ferramentas", grupo: "DESPESA" }],
+    "/cost-centers": [{ id: "cc-1", name: "Técnica e Infraestrutura" }],
+  });
+
+  const urls: string[] = [];
+  await page.route("**/api/payables/bills*", async (route) => {
+    const url = new URL(route.request().url());
+    urls.push(url.search);
+    const pedidos = url.searchParams.getAll("status");
+    const q = (url.searchParams.get("q") ?? "").toLowerCase();
+    const itens = CONTAS.filter(
+      (c) =>
+        (pedidos.length === 0 || pedidos.includes(c.status)) &&
+        (q === "" || c.description.toLowerCase().includes(q)),
+    );
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({ items: itens, total: itens.length }),
+    });
+  });
+  return urls;
+}
+
+/** A última query que a lista realmente pediu ao servidor. */
+const ultima = (urls: string[]) => decodeURIComponent(urls[urls.length - 1] ?? "");
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+});
+
+test("/pagar?status=paid abre FILTRADO: a lista vem com pagas, e só", async ({ page }) => {
+  const urls = await mockarPagar(page);
+  await page.goto("/pagar?status=paid");
+
+  // O que o dono vê. Era isto que não acontecia: o endereço parecia filtrar e não filtrava.
+  await expect(page.getByText("Conta PAGA")).toBeVisible();
+  await expect(page.getByText("Conta ABERTA")).toHaveCount(0);
+
+  // E o que saiu no fio — o recorte do endereço chegou ao servidor, sem herdar o padrão.
+  const query = ultima(urls);
+  expect(query, `query real: ${query}`).toContain("status=paid");
+  expect(query, `query real: ${query}`).not.toContain("status=open");
+  expect(query, "colchete = o FastAPI ignora o parâmetro em silêncio (#125)").not.toContain("[]");
+
+  // O controle da tela mostra o recorte do endereço, não o padrão.
+  await expect(page.getByLabel("Status")).toHaveValue("paid");
+});
+
+test("o `status` da URL é REPETÍVEL: dois recortes chegam os dois", async ({ page }) => {
+  const urls = await mockarPagar(page);
+  await page.goto("/pagar?status=open&status=canceled");
+
+  // Ler só o primeiro `status` devolveria uma lista sem canceladas, silenciosamente.
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+  await expect(page.getByText("Conta CANCELADA")).toBeVisible();
+  await expect(page.getByText("Conta PAGA")).toHaveCount(0);
+
+  const query = ultima(urls);
+  expect(query, `query real: ${query}`).toContain("status=open");
+  expect(query, `query real: ${query}`).toContain("status=canceled");
+});
+
+test("sem query, abre no padrão de 'o que eu devo' — os DOIS status, sem colchete", async ({
+  page,
+}) => {
+  const urls = await mockarPagar(page);
+  await page.goto("/pagar");
+
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+  await expect(page.getByText("Conta AGENDADA")).toBeVisible();
+
+  const query = ultima(urls);
+  expect(query, `query real: ${query}`).toContain("status=open");
+  expect(query, `query real: ${query}`).toContain("status=scheduled");
+  expect(query, `query real: ${query}`).not.toContain("[]");
+
+  // URL vazia é o filtro padrão: escrever o default de volta seria poluição no endereço.
+  expect(new URL(page.url()).search).toBe("");
+});
+
+test("`?q=` filtra de verdade — o link com texto não é mais inerte", async ({ page }) => {
+  const urls = await mockarPagar(page);
+  // O termo recorta DENTRO do status padrão (aberta + agendada): as duas contas caberiam, e é o
+  // `q` que decide. Um termo que casasse só com uma paga seria cortado pelo status e o teste
+  // passaria verde sem o `q` ter feito nada.
+  await page.goto("/pagar?q=ABERTA");
+
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+  await expect(page.getByText("Conta AGENDADA")).toHaveCount(0);
+  expect(ultima(urls), `query real: ${ultima(urls)}`).toContain("q=ABERTA");
+  await expect(page.getByLabel("Buscar fornecedor ou descrição")).toHaveValue("ABERTA");
+});
+
+test("trocar o status ESCREVE na URL, e o botão voltar devolve o recorte anterior", async ({
+  page,
+}) => {
+  const urls = await mockarPagar(page);
+  await page.goto("/pagar");
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+
+  await page.getByLabel("Status").selectOption("paid");
+
+  // 1. O recorte foi para o endereço — é o que se manda por WhatsApp e vira favorito.
+  await expect.poll(() => new URL(page.url()).searchParams.getAll("status")).toEqual(["paid"]);
+  await expect(page.getByText("Conta PAGA")).toBeVisible();
+  await expect(page.getByText("Conta ABERTA")).toHaveCount(0);
+
+  // 2. E criou entrada no histórico: "voltar" desfaz o FILTRO, não sai da tela.
+  await page.goBack();
+
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+  await expect(page.getByText("Conta PAGA")).toHaveCount(0);
+  expect(new URL(page.url()).pathname, "voltar saiu da tela inteira").toBe("/pagar");
+  expect(new URL(page.url()).search).toBe("");
+  // A lista foi REBUSCADA no recorte anterior, não só repintada com dado velho.
+  const query = ultima(urls);
+  expect(query, `query real: ${query}`).toContain("status=open");
+});
+
+test("digitar no texto REESCREVE a URL: um voltar não desfaz letra por letra", async ({ page }) => {
+  await mockarPagar(page);
+  await page.goto("/pagar"); // histórico: [padrão]
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+
+  await page.getByLabel("Status").selectOption("paid"); // EMPILHA: [padrão, ?status=paid]
+  await expect.poll(() => new URL(page.url()).searchParams.get("status")).toBe("paid");
+
+  // Nove teclas. Com `push` seriam nove entradas de histórico, e sair de «anthropic» custaria
+  // nove cliques em "voltar".
+  await page
+    .getByLabel("Buscar fornecedor ou descrição")
+    .pressSequentially("anthropic", { delay: 30 });
+  await expect.poll(() => new URL(page.url()).searchParams.get("q")).toBe("anthropic");
+  await expect(page.getByLabel("Buscar fornecedor ou descrição")).toHaveValue("anthropic");
+
+  // UM voltar tem de pular a digitação inteira e cair no estado ANTERIOR ao `?status=paid`.
+  // Se o texto empilhasse, este voltar devolveria «anthropi» — ou seja, o `status` ainda estaria
+  // no endereço e o `q` teria perdido só a última letra.
+  await page.goBack();
+
+  await expect.poll(() => new URL(page.url()).search).toBe("");
+  await expect(page.getByText("Conta ABERTA")).toBeVisible();
+});

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -1,7 +1,7 @@
 import type { Contract, Payable, PayablesPage, PayablesSummary } from "@e1p/shared-types";
 import { Copy, Paperclip } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
@@ -16,7 +16,7 @@ import FiltrosDaLista from "./FiltrosDaLista";
 import { camposDaCopia, type CamposDaConta } from "./duplicar";
 import { formatDay, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
-import { type FiltroPagar, filtroPadrao, paraQuery } from "./filtros";
+import { apenasTexto, daUrl, type FiltroPagar, filtroPadrao, paraQuery, paraUrl } from "./filtros";
 
 /** Grupos DRE cabíveis numa DESPESA (Contas a Pagar nunca lança em Receita). */
 const EXPENSE_GROUPS = GRUPOS_DRE.filter((g) => g !== "RECEITA");
@@ -107,7 +107,25 @@ export default function PagarPage() {
   // Comprovantes que chegaram pelo celular e ainda não foram vinculados a nenhuma conta.
   const [inbox, setInbox] = useState<{ id: string }[]>([]);
   const fuso = useFuso();
-  const [filtro, setFiltro] = useState<FiltroPagar>(() => filtroPadrao(today(fuso)));
+  // ⚠️ **O recorte mora na URL, não em `useState` (#138).** Enquanto ele era estado de React,
+  // `/pagar?q=anthropic` era um endereço INERTE (parecia filtrar e não filtrava), F5 apagava o
+  // recorte, não havia link para mandar a outra pessoa, e "voltar" saía da tela inteira em vez de
+  // desfazer o filtro — porque filtrar nunca criava entrada no histórico. Mesmo padrão de
+  // `busca/BuscaPage.tsx`: a barra de endereço é a ÚNICA fonte da verdade, então o botão "voltar"
+  // do navegador funciona de graça (ele muda `location.search`, e a lista rerenderiza).
+  const [params, setParams] = useSearchParams();
+  const padrao = useMemo(() => filtroPadrao(today(fuso)), [fuso]);
+  const filtro = useMemo(() => daUrl(params, padrao), [params, padrao]);
+
+  const trocarFiltro = useCallback(
+    (novo: FiltroPagar) => {
+      // `replace` só quando NADA além do texto mudou: uma entrada de histórico por tecla digitada
+      // encheria o "voltar" de estados intermediários. Trocar status ou aplicar período é gesto
+      // deliberado e EMPILHA — é ele que dá ao botão "voltar" o que desfazer.
+      setParams(paraUrl(novo, padrao), { replace: apenasTexto(filtro, novo) });
+    },
+    [filtro, padrao, setParams],
+  );
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [carregando, setCarregando] = useState(false);
@@ -252,7 +270,7 @@ export default function PagarPage() {
 
       <FiltrosDaLista
         valor={filtro}
-        onChange={setFiltro}
+        onChange={trocarFiltro}
         categorias={chartAccounts}
         centros={costCenters}
       />

--- a/apps/web/src/features/pagar/filtros.test.ts
+++ b/apps/web/src/features/pagar/filtros.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { fimDoMesSeguinte, filtroPadrao, paraQuery } from "./filtros";
+import {
+  apenasTexto,
+  daUrl,
+  fimDoMesSeguinte,
+  filtroPadrao,
+  type FiltroPagar,
+  paraQuery,
+  paraUrl,
+} from "./filtros";
 
 describe("fimDoMesSeguinte", () => {
   it("agosto devolve o fim de setembro", () => {
@@ -68,5 +76,169 @@ describe("paraQuery", () => {
     const q = paraQuery(filtroPadrao("2026-08-18"), 50, 100);
     expect(q.limit).toBe(50);
     expect(q.offset).toBe(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O recorte na BARRA DE ENDERECO (#138)
+//
+// Estes testes medem a IDA E VOLTA. Um teste que so olhasse o estado de React
+// passaria com a URL vazia — foi exatamente essa fresta que deixou
+// `/pagar?q=anthropic` inerte. Aqui a unidade sob teste E a query string.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PADRAO = filtroPadrao("2026-08-18"); // ate = 2026-09-30
+
+/** A volta completa: filtro → query string → filtro. Tem de devolver o mesmo recorte. */
+function idaEVolta(f: FiltroPagar): FiltroPagar {
+  return daUrl(new URLSearchParams(paraUrl(f, PADRAO).toString()), PADRAO);
+}
+
+describe("paraUrl", () => {
+  it("URL vazia e o filtro padrao: nada do default e escrito", () => {
+    // Um `?status=open&status=scheduled&ate=2026-09-30` que so repete o default seria poluicao
+    // que o dono le toda vez. E congelaria o favorito: `ate` omitido acompanha o horizonte movel.
+    expect(paraUrl(PADRAO, PADRAO).toString()).toBe("");
+  });
+
+  it("escreve o `status` REPETIVEL, uma chave por valor", () => {
+    const f = { ...PADRAO, status: ["open" as const, "paid" as const] };
+    // Nunca `status[]` (o FastAPI ignora em silencio, #125) nem `status=open,paid`.
+    expect(paraUrl(f, PADRAO).toString()).toBe("status=open&status=paid");
+  });
+
+  it("OMITE a chave de texto vazia, em vez de mandar `?q=`", () => {
+    const f = { ...PADRAO, q: "", centroDeCusto: "", categoria: "" };
+    const u = paraUrl(f, PADRAO);
+    expect(u.has("q")).toBe(false);
+    expect(u.has("centro")).toBe(false);
+    expect(u.has("categoria")).toBe(false);
+  });
+
+  it("escreve os tres textos quando eles existem, pelos nomes da TELA", () => {
+    const f = { ...PADRAO, q: "anthropic", centroDeCusto: "cc-1", categoria: "ca-1" };
+    const u = paraUrl(f, PADRAO);
+    expect(u.get("q")).toBe("anthropic");
+    // `centro`/`categoria`, e nao `cost_center_id`/`chart_account_id`: a URL e digitada a mao.
+    expect(u.get("centro")).toBe("cc-1");
+    expect(u.get("categoria")).toBe("ca-1");
+    expect(u.has("cost_center_id")).toBe(false);
+    expect(u.has("chart_account_id")).toBe(false);
+  });
+
+  it("`ate: null` com padrao COM teto vira chave presente de valor vazio", () => {
+    // "sem teto" e um VALOR escolhido (a tela faz isso ao trocar para Pago), nao vazio. Omitir a
+    // chave devolveria o teto do padrao na volta, e o recorte compartilhado seria outro.
+    expect(paraUrl({ ...PADRAO, ate: null }, PADRAO).toString()).toBe("ate=");
+  });
+
+  it("`status: []` (todos) vira chave presente de valor vazio, pelo mesmo motivo", () => {
+    expect(paraUrl({ ...PADRAO, status: [] }, PADRAO).toString()).toBe("status=");
+  });
+});
+
+describe("daUrl", () => {
+  it("URL vazia devolve o filtro padrao inteiro", () => {
+    expect(daUrl(new URLSearchParams(""), PADRAO)).toEqual(PADRAO);
+  });
+
+  it("`?q=anthropic` filtra o texto e PRESERVA o resto do padrao", () => {
+    const f = daUrl(new URLSearchParams("q=anthropic"), PADRAO);
+    expect(f.q).toBe("anthropic");
+    expect(f.status).toEqual(["open", "scheduled"]);
+    expect(f.ate).toBe("2026-09-30");
+  });
+
+  it("le o `status` REPETIVEL como lista, na ordem em que veio", () => {
+    expect(daUrl(new URLSearchParams("status=open&status=scheduled"), PADRAO).status).toEqual([
+      "open",
+      "scheduled",
+    ]);
+  });
+
+  it("`?status=paid` troca o recorte inteiro, sem herdar o do padrao", () => {
+    expect(daUrl(new URLSearchParams("status=paid"), PADRAO).status).toEqual(["paid"]);
+  });
+
+  it("descarta status inventado, em vez de mandar lixo ao servidor", () => {
+    expect(daUrl(new URLSearchParams("status=paid&status=xpto"), PADRAO).status).toEqual(["paid"]);
+  });
+
+  it("`?ate=` (vazio) e SEM TETO, nao o teto do padrao", () => {
+    expect(daUrl(new URLSearchParams("ate="), PADRAO).ate).toBeNull();
+    expect(daUrl(new URLSearchParams(""), PADRAO).ate).toBe("2026-09-30");
+  });
+
+  it("a data da URL segue STRING — nada de `new Date` no caminho", () => {
+    // Reconstruir um `Date` devolveria a conta ao relogio do NAVEGADOR. Em UTC-3 a data voltaria
+    // um dia. O valor tem de sair identico ao que entrou, caractere por caractere.
+    const f = daUrl(new URLSearchParams("de=2026-01-01&ate=2026-12-31"), PADRAO);
+    expect(f.de).toBe("2026-01-01");
+    expect(f.ate).toBe("2026-12-31");
+  });
+});
+
+describe("ida e volta URL <-> FiltroPagar", () => {
+  const casos: [string, FiltroPagar][] = [
+    ["o padrao", PADRAO],
+    ["so o texto", { ...PADRAO, q: "anthropic" }],
+    ["dois status (repetivel)", { ...PADRAO, status: ["open", "paid"] }],
+    ["um status so", { ...PADRAO, status: ["canceled"] }],
+    ["nenhum status (todos)", { ...PADRAO, status: [] }],
+    ["historico sem teto", { ...PADRAO, status: ["paid"], ate: null }],
+    ["periodo fechado", { ...PADRAO, de: "2026-01-01", ate: "2026-12-31" }],
+    [
+      "tudo junto",
+      {
+        status: ["open", "scheduled", "paid"],
+        de: "2026-02-01",
+        ate: null,
+        q: "energia elétrica",
+        centroDeCusto: "cc-1",
+        categoria: "ca-1",
+      },
+    ],
+  ];
+
+  for (const [nome, f] of casos) {
+    it(`volta identico: ${nome}`, () => {
+      expect(idaEVolta(f)).toEqual(f);
+    });
+  }
+
+  it("o que vai para a URL ainda serve o axios com os nomes da API", () => {
+    // As duas serializacoes convivem: a URL fala com o dono, `paraQuery` fala com o FastAPI.
+    const f = idaEVolta({ ...PADRAO, q: "anthropic", centroDeCusto: "cc-1", categoria: "ca-1" });
+    const q = paraQuery(f, 50, 0);
+    expect(q.q).toBe("anthropic");
+    expect(q.cost_center_id).toBe("cc-1");
+    expect(q.chart_account_id).toBe("ca-1");
+  });
+});
+
+describe("apenasTexto — quem decide se o botao voltar tem o que desfazer", () => {
+  it("mudar SO o texto e digitacao: a URL se reescreve", () => {
+    // Uma entrada de historico por tecla obrigaria o dono a apertar "voltar" nove vezes.
+    expect(apenasTexto(PADRAO, { ...PADRAO, q: "anthropic" })).toBe(true);
+  });
+
+  it("trocar o status e gesto deliberado: EMPILHA", () => {
+    expect(apenasTexto(PADRAO, { ...PADRAO, status: ["paid"] })).toBe(false);
+  });
+
+  it("aplicar um periodo e gesto deliberado: EMPILHA", () => {
+    expect(apenasTexto(PADRAO, { ...PADRAO, ate: null })).toBe(false);
+    expect(apenasTexto(PADRAO, { ...PADRAO, de: "2026-01-01" })).toBe(false);
+  });
+
+  it("escolher centro de custo ou categoria EMPILHA", () => {
+    expect(apenasTexto(PADRAO, { ...PADRAO, centroDeCusto: "cc-1" })).toBe(false);
+    expect(apenasTexto(PADRAO, { ...PADRAO, categoria: "ca-1" })).toBe(false);
+  });
+
+  it("'Limpar filtros' mexe em quatro campos: EMPILHA, e o voltar desfaz a limpeza", () => {
+    const sujo = { ...PADRAO, q: "x", centroDeCusto: "cc-1", categoria: "ca-1", de: "2026-01-01" };
+    const limpo = { ...sujo, q: "", centroDeCusto: "", categoria: "", de: null };
+    expect(apenasTexto(sujo, limpo)).toBe(false);
   });
 });

--- a/apps/web/src/features/pagar/filtros.ts
+++ b/apps/web/src/features/pagar/filtros.ts
@@ -71,3 +71,102 @@ export function paraQuery(
   if (f.categoria) q.chart_account_id = f.categoria;
   return q;
 }
+
+/** Os quatro status que existem. Tudo o que chega da URL fora desta lista é lixo e é descartado. */
+const STATUS_VALIDOS: readonly string[] = ["open", "scheduled", "paid", "canceled"];
+
+function mesmoStatus(a: PayableStatus[], b: PayableStatus[]): boolean {
+  return a.length === b.length && a.every((s, i) => s === b[i]);
+}
+
+/**
+ * As chaves do recorte na BARRA DE ENDEREÇO — e ela fala a língua da TELA, não a da API.
+ *
+ * `de`/`ate`/`centro`/`categoria`, e **não** `from`/`to`/`cost_center_id`/`chart_account_id`. As
+ * duas serializações existem de propósito e não devem convergir:
+ *
+ * - `paraQuery` fala com o FastAPI. Aqueles nomes são contrato de servidor: mudam quando a rota
+ *   muda, e devem mesmo.
+ * - `paraUrl` fala com o DONO. O endereço é digitado à mão, mandado por WhatsApp e virado favorito.
+ *   Um link salvo hoje não pode quebrar porque a API renomeou um parâmetro interno, e ninguém
+ *   escreve `chart_account_id=` na barra de endereço de propósito.
+ *
+ * As chaves são exatamente os campos de `FiltroPagar` (com `centro`/`categoria` pelos nomes curtos
+ * que a tela já usa nos rótulos), o que torna a ida e volta uma CÓPIA, não uma tradução: não há
+ * tabela de-para para sair de sincronia entre as duas direções.
+ */
+
+/**
+ * `FiltroPagar` → query string, **omitindo tudo o que é igual ao padrão**.
+ *
+ * Só o que o dono realmente escolheu aparece no endereço: `/pagar` limpo é a visão padrão, e um
+ * `?status=open&status=scheduled&ate=2026-09-30` que só repete o default seria poluição que o dono
+ * teria de ler toda vez.
+ *
+ * ⚠️ Isso também é o que mantém o favorito VIVO: `ate` omitido acompanha o horizonte móvel
+ * ("fim do mês que vem", recalculado no fuso do tenant a cada abertura), enquanto um `ate=` escrito
+ * na URL é uma data FIXA que o dono pediu. Escrever o default congelaria o favorito na data do dia
+ * em que ele foi salvo.
+ *
+ * Três campos de texto (`q`, `centro`, `categoria`) têm `""` como padrão: para eles vazio é o
+ * default e a chave é OMITIDA, nunca mandada como `?q=`. Já `status: []` ("todos") e `de`/`ate`
+ * `null` ("sem limite") são VALORES escolhidos, não vazio — quando diferem do padrão eles viram
+ * chave presente de valor vazio (`?ate=`), que é o único jeito de a volta ser fiel.
+ */
+export function paraUrl(f: FiltroPagar, padrao: FiltroPagar): URLSearchParams {
+  const u = new URLSearchParams();
+  if (!mesmoStatus(f.status, padrao.status)) {
+    // Repetível: `?status=open&status=scheduled`. Nunca `status[]` nem `status=open,scheduled` —
+    // o primeiro o FastAPI ignora em silêncio (#125), o segundo obrigaria a inventar um separador.
+    if (f.status.length === 0) u.set("status", "");
+    else for (const s of f.status) u.append("status", s);
+  }
+  if (f.de !== padrao.de) u.set("de", f.de ?? "");
+  if (f.ate !== padrao.ate) u.set("ate", f.ate ?? "");
+  if (f.q !== padrao.q) u.set("q", f.q);
+  if (f.centroDeCusto !== padrao.centroDeCusto) u.set("centro", f.centroDeCusto);
+  if (f.categoria !== padrao.categoria) u.set("categoria", f.categoria);
+  return u;
+}
+
+/**
+ * Query string → `FiltroPagar`. O que a URL não diz, o `padrao` diz — URL vazia é o filtro padrão.
+ *
+ * ⚠️ **Nenhuma data é reconstruída aqui.** `de`/`ate` chegam como string `YYYY-MM-DD` e seguem
+ * string até o axios. Passar por `new Date` devolveria a conta ao relógio do NAVEGADOR, e o e1p
+ * vive no fuso do tenant desde o #78 — o mesmo motivo pelo qual `fimDoMesSeguinte` faz aritmética
+ * de string ali em cima.
+ */
+export function daUrl(params: URLSearchParams, padrao: FiltroPagar): FiltroPagar {
+  const status = params.has("status")
+    ? (params.getAll("status").filter((s) => STATUS_VALIDOS.includes(s)) as PayableStatus[])
+    : padrao.status;
+  const data = (chave: string, queda: string | null) =>
+    params.has(chave) ? params.get(chave) || null : queda;
+  return {
+    status,
+    de: data("de", padrao.de),
+    ate: data("ate", padrao.ate),
+    q: params.get("q") ?? padrao.q,
+    centroDeCusto: params.get("centro") ?? padrao.centroDeCusto,
+    categoria: params.get("categoria") ?? padrao.categoria,
+  };
+}
+
+/**
+ * Nenhum campo além do `q` mudou? Então foi digitação, e a URL se REESCREVE em vez de empilhar.
+ *
+ * É esta função que decide se o botão "voltar" tem o que desfazer. Uma entrada de histórico por
+ * tecla digitada obrigaria o dono a apertar "voltar" nove vezes para sair de «anthropic»; já trocar
+ * o status ou aplicar um período é um gesto deliberado, e desfazê-lo é exatamente o que ele espera
+ * do botão. Sem essa distinção, "voltar" ou sai da tela inteira ou não sai nunca.
+ */
+export function apenasTexto(antes: FiltroPagar, depois: FiltroPagar): boolean {
+  return (
+    mesmoStatus(antes.status, depois.status) &&
+    antes.de === depois.de &&
+    antes.ate === depois.ate &&
+    antes.centroDeCusto === depois.centroDeCusto &&
+    antes.categoria === depois.categoria
+  );
+}


### PR DESCRIPTION
## O que aconteceu

O recorte da lista de Contas a Pagar (`status`, `q`, `de`/`ate`, centro de custo, categoria) vivia em
`useState` e **nunca chegava à barra de endereço**. `filtros.ts` serializava para os `params` do axios
— a chamada da API —, e nada escrevia na URL.

Quatro consequências, todas visíveis para o dono:

1. **`/pagar?q=anthropic` era inerte** — o endereço parecia filtrar e não filtrava.
2. **O botão "voltar" não desfazia filtro:** saía da tela inteira, porque filtrar nunca criou entrada
   no histórico.
3. **Não dava para mandar link filtrado** nem favoritar "o que vence esta semana".
4. **F5 apagava o recorte.**

## A correção

`PagarPage` passa a **hidratar** o filtro de `useSearchParams` e a **escrever de volta** a cada
mudança. O filtro deixou de ser `useState` e virou derivado da URL:

```tsx
const padrao = useMemo(() => filtroPadrao(today(fuso)), [fuso]);
const filtro = useMemo(() => daUrl(params, padrao), [params, padrao]);
```

**A barra de endereço é a única fonte da verdade** — sem estado espelho. É o padrão que a
`busca/BuscaPage.tsx` estabeleceu no #140, e segui-lo é o que faz o botão "voltar" funcionar de graça:
ele muda `location.search`, e a lista rerenderiza.

`filtros.ts` ganha `paraUrl`, `daUrl` e `apenasTexto`. Elas recebem o `padrao` por parâmetro e não
conhecem a `PagarPage`, então servem para Cobranças e Produtos quando for a vez deles.

### A URL fala a língua da TELA

`de`/`ate`/`centro`/`categoria`, e **não** `from`/`to`/`cost_center_id`/`chart_account_id`. As duas
serializações existem de propósito e não devem convergir:

- `paraQuery` fala com o FastAPI. Aqueles nomes são **contrato de servidor**: mudam quando a rota
  muda, e devem mesmo.
- `paraUrl` fala com o **dono**. O endereço é digitado à mão, mandado por WhatsApp e virado favorito.
  Um link salvo hoje não pode quebrar porque a API renomeou um parâmetro interno — e ninguém escreve
  `chart_account_id=` na barra de endereço de propósito.

As chaves são exatamente os campos de `FiltroPagar`, o que torna a ida e volta uma **cópia, não uma
tradução**: não há tabela de-para para sair de sincronia entre as duas direções.

### Vazio nem sempre é o padrão

O caso difícil que essa escolha abriu, resolvido explicitamente:

- `q`/`centro`/`categoria` vazios **são** o default → chave **omitida**, nunca `?q=`.
- `status: []` ("todos") e `ate: null` ("sem teto") são **valores escolhidos** — a tela produz
  `ate: null` toda vez que se troca para "Pago". Omiti-los devolveria o teto do padrão na volta, e o
  link compartilhado mostraria **outro recorte**. Eles viram chave presente de valor vazio (`?ate=`).

Escrever o default também **congelaria o favorito**: `ate` omitido acompanha o horizonte móvel
("fim do mês que vem", recalculado no fuso do tenant a cada abertura); um `ate=` escrito é uma data
fixa que o dono pediu.

### O botão voltar precisa ter o que desfazer

`replace: true` só quando **nada além do texto** mudou. Uma entrada de histórico por tecla digitada
obrigaria o dono a apertar "voltar" nove vezes para sair de «anthropic». Trocar status ou aplicar
período é gesto deliberado e **empilha**.

Aqui divergi da `BuscaPage` de propósito: ela usa `replace: true` para tudo, inclusive o `<select>`.
Copiar isso deixaria o botão voltar sem nada para desfazer — a consequência #2 da issue.

### O relógio do tenant não voltou a ser o do navegador

`de`/`ate` chegam da URL como string `YYYY-MM-DD` e **seguem string** até o axios. Nenhuma data é
reconstruída com `new Date` — o mesmo motivo pelo qual `fimDoMesSeguinte` faz aritmética de string.
O e1p vive no fuso do tenant desde o #78.

## Verificação — por mutação, não por leitura

| # | Mutação (em produção) | Teste que morreu | Mensagem real |
|---|---|---|---|
| M1 | hidratação removida (`filtro = useMemo(() => padrao)`) | e2e `/pagar?status=paid abre FILTRADO` (+4) | `Locator: getByText('Conta PAGA')` / `Expected: visible` / `element(s) not found` |
| M2 | escrita de volta removida | e2e `trocar o status ESCREVE na URL…voltar` | `- Array [ "paid" ]` / `+ Array []` |
| M3 | `replace` invertido | e2e `digitar no texto REESCREVE a URL` | `Expected: "" / Received: "?status=paid&ate=&q=anthropi"` |
| M4a | `daUrl`: `getAll("status").slice(0, 1)` | vitest `le o status REPETIVEL` + e2e | `expected [ 'open' ] to deeply equal [ 'open', 'scheduled' ]` |
| M4b | `paraUrl`: escreve só `f.status[0]` | vitest `escreve o status REPETIVEL` | `expected 'status=open' to be 'status=open&status=paid'` |
| M5 | default deixa de ser omitido | vitest `URL vazia e o filtro padrao` (+4) | `expected 'q=' to be ''` |
| M6 | `ate: null` omitido em vez de `ate=` | vitest `ate: null … valor vazio` + `volta identico` | `expected '' to be 'ate='` |

**M3 é a que vale o PR:** com o `replace` invertido, um `goBack` devolveu `q=anthropi` — perdeu
**exatamente uma letra digitada**. É literalmente "o voltar desfaz letra por letra", medido e não
argumentado.

M1 não valeu na primeira tentativa: morreu de `TS6133: 'daUrl' is declared but its value is never
read`, ou seja, por erro de módulo e não pela asserção. Completei a mutação removendo o import morto
antes de medir. As seis compilam e passam no lint. **Nenhum mutante equivalente.**

Gates:

```
lint        eslint . --max-warnings 0     ok
typecheck   tsc --noEmit                  ok
test        73 arquivos / 783 testes      ok
e2e         72 passed (39.6s)             ok
```

`filtros.test.ts` foi de 12 → 39 testes. `pagar-url.spec.ts` é novo, com 6 specs.

**A URL é medida de verdade.** pytest, vitest e o mock e2e são todos cegos à query string — a fresta
que o #125 documentou. Os specs afirmam sobre `new URL(page.url()).search`, não sobre estado React.

## Escopo

4 arquivos, +523/−5, tudo dentro de `features/pagar` + o spec novo.

## O que isto NÃO resolve

**Cobranças e Produtos seguem sem o recorte na URL** — e sem `q`. A própria issue diz que o padrão
vale "depois" para eles, e ampliar aqui seria commit escondido. `paraUrl`/`daUrl`/`apenasTexto`
ficaram genéricas para quando for a vez.

Agora que `/pagar?q=` funciona, **Contas a Pagar pode entrar na busca global** — ela ficou de fora da
spec `2026-08-18-busca-global-design.md` §2 exatamente porque o destino era inerte. Falta o lado
servidor. Vai como issue separada.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
