### PR TITLE
test(web): o e2e roda em UM worker por padrao, porque o paralelo inventa falhas [#147]

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -24,6 +24,19 @@ const PORTA = Number(process.env.E2E_PORT ?? 5273);
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
+  // ⚠️ **`workers: 1` é o PADRÃO de propósito (#147), e custa 87s.** Com a concorrência default
+  // (metade dos núcleos), a suíte INVENTA falhas: medindo uma mutação em 18/08/2026, o paralelo
+  // deu **14 vermelhos** espalhados por specs sem relação — agenda, busca, pagar, shell —
+  // contra os **2** que a mesma mutação produz serialmente. Baseline 66/66 verde nos dois casos.
+  //
+  // Não é lentidão trocada por nada: a prova por mutação é o critério de aceite deste repo, e quem
+  // lê 14 mortos onde há 2 conclui que a mutação alcança o que ela não alcança — e desenha o teste
+  // errado. O modo de falha oposto, ruído que ESCONDE um mutante sobrevivente, seria pior ainda.
+  //
+  // Medido (12 núcleos, 66 specs): **39,1s** em paralelo · **2,1min** com 1 worker.
+  // O opt-out é explícito, para quem sabe o que está trocando: `pnpm e2e -- --workers=6`.
+  // No CI o efeito é nulo — o runner tem 2 vCPU, então metade já era 1.
+  workers: 1,
   forbidOnly: Boolean(process.env.CI),
   retries: 0,
   // O `html` no CI NÃO é enfeite: sem ele o diretório `playwright-report/` nunca é criado, e o

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -24,7 +24,7 @@ const PORTA = Number(process.env.E2E_PORT ?? 5273);
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  // ⚠️ **`workers: 1` é o PADRÃO de propósito (#147), e custa 87s.** Com a concorrência default
+  // ⚠️ **`workers: 1` é o PADRÃO de propósito (#147), e custa ~41s.** Com a concorrência default
   // (metade dos núcleos), a suíte INVENTA falhas: medindo uma mutação em 18/08/2026, o paralelo
   // deu **14 vermelhos** espalhados por specs sem relação — agenda, busca, pagar, shell —
   // contra os **2** que a mesma mutação produz serialmente. Baseline 66/66 verde nos dois casos.
@@ -33,7 +33,13 @@ export default defineConfig({
   // lê 14 mortos onde há 2 conclui que a mutação alcança o que ela não alcança — e desenha o teste
   // errado. O modo de falha oposto, ruído que ESCONDE um mutante sobrevivente, seria pior ainda.
   //
-  // Medido (12 núcleos, 66 specs): **39,1s** em paralelo · **2,1min** com 1 worker.
+  // Medido em máquina OCIOSA (12 núcleos, 92 specs, uma medição após a outra):
+  // **49,0s** com 6 workers · **1,5min** com 1. Cerca de 1,8×, ~41s a mais.
+  //
+  // ⚠️ Meça isto com a máquina PARADA. A primeira medição saiu 3× (87s) porque foi tomada com
+  // outros processos pesados rodando, e a contenção pune o serial muito mais que o paralelo
+  // (1,9s/spec sob carga contra 0,98s/spec ocioso). Sob carga, o custo parece o dobro do que é.
+  //
   // O opt-out é explícito, para quem sabe o que está trocando: `pnpm e2e -- --workers=6`.
   // No CI o efeito é nulo — o runner tem 2 vCPU, então metade já era 1.
   workers: 1,


### PR DESCRIPTION
## O que aconteceu

`playwright.config.ts` tinha `fullyParallel: true` e **nenhum `workers`**, então o Playwright usava
metade dos núcleos. Com essa concorrência, a suíte produzia falhas **que não eram do código sob
teste**.

Medido durante o PR #141 (issue #135), ao atribuir falha a uma mutação:

| Execução | Falhas |
|---|---|
| Baseline, sem mutação | 0 (66/66 verdes) |
| Mutação, `fullyParallel` (6 workers) | **14**, espalhadas por agenda, busca, pagar, shell |
| **A mesma mutação**, `--workers=1` | **2** — exatamente as esperadas |

As 12 extras eram contenção. **O modo de falha é caro:** quem mede mutação lê 14 vermelhos, conclui
que a mutação alcança o que ela não alcança, e desenha o teste errado. O modo oposto — ruído que
*esconde* um mutante sobrevivente — seria pior ainda.

A prova por mutação é o critério de aceite deste repo. Se o número de mortos depende de quantos
núcleos a máquina tinha naquele minuto, **a régua da régua está solta.**

## A correção

`workers: 1` como padrão, com a razão e o custo escritos no arquivo.

O raciocínio: o padrão deve ser o modo **correto**, e a pressa deve ser opt-in consciente. Quem pede
velocidade sabe o que está trocando (`pnpm e2e -- --workers=6`); quem confia no padrão não deveria
receber um número de falhas que depende do hardware.

Considerei e rejeitei a alternativa de deixar paralelo e serializar só ao medir mutação: depende de a
pessoa **lembrar**, e o sintoma (14 falhas plausíveis em specs vizinhos) não se anuncia como ruído.

## O custo, medido e não estimado

Máquina **ociosa** (12 núcleos, 92 specs, uma medição logo após a outra):

| | Tempo |
|---|---|
| Paralelo (6 workers) | **49,0s** |
| `workers: 1` | **1,5 min** |

**Cerca de 1,8× mais lento**, ~41s a mais por execução — e isso recai sobre toda execução verde de
rotina, não só sobre as de mutação.

### ⚠️ Correção: a primeira medição deste PR estava errada

A versão inicial deste PR dizia **3× / 87s**. Aquele número foi tomado com **três agentes rodando na
mesma máquina**, e a contenção pune o serial muito mais que o paralelo: **1,9s/spec sob carga contra
0,98s/spec ocioso**. Refeito com a máquina parada, o custo real é **metade** do que eu havia
publicado.

Quem for rediscutir esta decisão precisa medir com a máquina PARADA — o aviso ficou escrito ao lado
do número, no próprio arquivo, porque foi a armadilha em que eu caí.

**No CI o efeito é nulo:** o runner tem 2 vCPU, então metade já era 1.

## Verificação

```
lint        eslint . --max-warnings 0     ok
typecheck   tsc --noEmit                  ok
test        73 arquivos / 790 testes      ok
e2e         92 passed (1.4m)              ok
```

(Com `origin/main` já contendo os PRs #141, #142 e #143 — a base foi atualizada três vezes ao longo
da revisão, e os gates foram rerodados à mão a cada uma.)

A prova de que a config faz o que diz não é o relógio, é o próprio Playwright anunciando:

```
Running 92 tests using 1 worker
```

Conferi isso explicitamente **porque o relógio me enganou**: 92 specs em 1,4min parecia rápido demais
para serial, o que me fez desconfiar de que a config não estivesse valendo. Estava — o que mudou foi
a máquina ter ficado ociosa. Foi essa desconfiança que descobriu o erro de medição acima.

## O que isto NÃO resolve

**Serial não é sinônimo de determinístico, e eu tenho a medição para provar.** Das duas execuções
completas da suíte com `workers: 1` neste branch, **uma falhou** em
`ficha-agenda-360.spec.ts:130 › o título sem espaço não vaza pela caixa do compromisso`; a outra deu
66/66. Isolado, o spec passou 3/3.

Ou seja: este PR remove o ruído de **contenção**, e não o flake que já existia. É provavelmente a
mesma família do flake de `agenda-evento-360` que o PR #137 documentou e não conseguiu reproduzir
(20 repetições, 80 passed).

**Erro meu no processo:** rodei a suíte de novo antes de copiar `test-results/`, e o Playwright limpa
esse diretório no início de cada execução — então o trace e o screenshot daquela falha se perderam.
Era exatamente o material que o #137 tornou disponível. Da próxima ocorrência, copiar primeiro.

Isso merece issue própria e **não** foi consertado aqui: seria escopo diferente, e misturar um flake
de agenda com uma mudança de concorrência esconderia os dois.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
