### PR TITLE
feat(busca): Contas a Pagar entra na busca global, com destino que mostra a conta [#146]

### DIFF
--- a/apps/api/app/modules/search/registro.py
+++ b/apps/api/app/modules/search/registro.py
@@ -1,8 +1,10 @@
 """As entidades que a busca global enxerga — declarativas, num lugar só.
 
 Acrescentar um tipo é acrescentar uma entrada. O que NÃO entra aqui: lista sem endereço que saiba
-receber uma busca. Contas a pagar, cobranças e produtos ficaram de fora por isso — o `q` do #125 é
-estado React e `/pagar?q=x` é inerte hoje (spec §2, issue #138).
+receber uma busca. Cobranças e produtos ficam de fora por isso — nenhuma das duas hidrata o recorte
+a partir da URL, e mandar o clique para uma lista que ignora o filtro é pior que não oferecer o
+resultado (spec §2). Contas a pagar SAIU dessa lista: o PR #143 (issue #138) fez `/pagar` hidratar
+`q`, `status`, `de`/`ate`, `centro` e `categoria` do endereço, e por isso ela é a oitava entrada.
 
 A ORDEM das entradas é a ordem dos grupos na tela: gente primeiro, depois o diálogo, depois
 compromisso e dinheiro, depois o que se constrói. Ela mora aqui, e só aqui.
@@ -18,6 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+from urllib.parse import quote as _percentualiza
 
 from sqlalchemy import or_, select
 
@@ -27,6 +30,7 @@ from app.modules.crm.models import Client
 from app.modules.funnels.models import Funnel
 from app.modules.juridico.models import LegalDocument
 from app.modules.pages.models import Page
+from app.modules.payables.models import Payable
 from app.modules.quotes.models import Quote
 from app.modules.whatsapp_inbox.models import WhatsappChat, WhatsappMessage
 
@@ -61,7 +65,7 @@ def _predicado_da_conversa(padrao: str, escape: str, fundo: bool, corte: datetim
     conversa que o dono procura, então os dois entram.
 
     A subquery das mensagens devolve **chat_id**, não mensagens: é isso que faz quarenta mensagens
-    casando virarem UMA linha em vez de afogarem os outros seis tipos com o mesmo diálogo repetido.
+    casando virarem UMA linha em vez de afogarem os outros sete tipos com o mesmo diálogo repetido.
     """
     clientes = select(Client.id).where(Client.name.ilike(padrao, escape=escape))
     condicoes = [
@@ -77,6 +81,43 @@ def _predicado_da_conversa(padrao: str, escape: str, fundo: bool, corte: datetim
             mensagens = mensagens.where(WhatsappMessage.created_at >= corte)
         condicoes.append(WhatsappChat.id.in_(mensagens))
     return or_(*condicoes)
+
+
+def _titulo_da_conta(p) -> str:
+    """A descrição é o rótulo da conta; sem ela, o fornecedor é quem a identifica.
+
+    As duas colunas nascem `""` (não NULL), então o `or` encadeado é o teste certo — e o último
+    degrau existe porque uma conta só de valor e vencimento ainda precisa de linha legível.
+    """
+    return p.description or p.supplier or "Conta a pagar"
+
+
+def _subtitulo_da_conta(p) -> str:
+    """O fornecedor, quando ele já não É o título. Repetir a mesma palavra em duas linhas não
+    informa nada — nesse caso a categoria é o que diferencia duas contas do mesmo fornecedor."""
+    return (p.supplier if p.description else "") or p.category
+
+
+def _rota_da_conta(p) -> str:
+    """`/pagar` filtrado NA CONTA encontrada — com o recorte padrão neutralizado de propósito.
+
+    `q` sozinho não bastaria, e a spec §2 já tinha nomeado o motivo ao excluir Contas a Pagar:
+    *"a visão padrão é `status ∈ (open, scheduled)` dentro do horizonte, então uma conta paga
+    encontrada pela busca não estaria na tela para onde o clique levou"*. A busca não filtra por
+    status nem por data; o destino não pode filtrar. Então:
+
+    - `status=` (vazio) → `daUrl` devolve `[]`, que a tela lê como **todos os status**;
+    - `ate=` (vazio)   → `daUrl` devolve `null`, que a tela lê como **sem horizonte**.
+
+    Chave presente de valor vazio é o vocabulário que `filtros.ts` já usa para "escolhi vazio"
+    (contra "não escolhi", que é chave ausente) — isto não inventa sintaxe, usa a que existe.
+
+    O termo vem da LINHA, não da consulta: `rota` recebe o registro, e a descrição casa consigo
+    mesma no `ilike` da lista (que escapa curinga pelo mesmo `padrao_ilike`), então o clique
+    sempre aterrissa numa lista que contém a conta clicada.
+    """
+    termo = p.description or p.supplier or ""
+    return f"/pagar?q={_percentualiza(termo, safe='')}&status=&ate="
 
 
 REGISTRO: tuple[Entidade, ...] = (
@@ -130,6 +171,24 @@ REGISTRO: tuple[Entidade, ...] = (
         titulo=lambda q: q.title,
         subtitulo=lambda q: q.client_name or q.status,
         rota=lambda q: f"/orcamentos/{q.id}",
+    ),
+    Entidade(
+        tipo="payable",
+        modelo=Payable,
+        # O MESMO nome do guard das rotas do módulo (`payables/router.py:27`).
+        modulo="payables",
+        # Exatamente as duas colunas que o `q` da LISTA varre (`payables/service.py:355`). Casar
+        # aqui por uma terceira coluna (categoria, por exemplo) devolveria um resultado que o
+        # destino `/pagar?q=…` não mostraria — a armadilha do endereço inerte, por outra porta.
+        campos_rasos=(Payable.description, Payable.supplier),
+        # Boleto e código Pix não são prosa: ninguém procura uma conta digitando 44 dígitos, e
+        # varrer `payment_code` na camada funda só somaria custo sem somar resposta.
+        campos_fundos=(),
+        principal=Payable.description,
+        recencia=Payable.updated_at,
+        titulo=_titulo_da_conta,
+        subtitulo=_subtitulo_da_conta,
+        rota=_rota_da_conta,
     ),
     Entidade(
         tipo="legal_document",

--- a/apps/api/app/modules/search/router.py
+++ b/apps/api/app/modules/search/router.py
@@ -1,7 +1,7 @@
 """Busca global — a rota.
 
-**Sem `require_module` como guarda da rota, e isso é deliberado.** A busca cruza sete módulos; um
-guard só teria de escolher um deles e estaria errado nos outros seis. O RBAC entra como FILTRO por
+**Sem `require_module` como guarda da rota, e isso é deliberado.** A busca cruza oito módulos; um
+guard só teria de escolher um deles e estaria errado nos outros sete. O RBAC entra como FILTRO por
 entidade, dentro do serviço, com o MESMO critério de `require_module` — dono, ou `allowed_modules`
 vazio, vê tudo (spec §6.4).
 """

--- a/apps/api/app/modules/search/schemas.py
+++ b/apps/api/app/modules/search/schemas.py
@@ -18,7 +18,7 @@ class SearchItemOut(BaseModel):
 class SearchGroupOut(BaseModel):
     type: str
     has_more: bool
-    #: Só em `depth=deep`. Contar na camada rasa custaria sete `count()` por tecla — e `has_more`
+    #: Só em `depth=deep`. Contar na camada rasa custaria oito `count()` por tecla — e `has_more`
     #: não tem como mentir sobre um número que não anuncia (spec §6.1).
     total: int | None = None
     items: list[SearchItemOut]

--- a/apps/api/app/modules/search/service.py
+++ b/apps/api/app/modules/search/service.py
@@ -2,7 +2,7 @@
 
 **Sem `UNION`, e isso é decisão.** Como o resultado é agrupado por tipo (spec §9), não existe
 ranking global a calcular — não há nada para o banco juntar. Cada consulta fica trivial, sem cast
-entre sete modelos de formatos diferentes, e idêntica em SQLite e Postgres. É o que mantém isto
+entre oito modelos de formatos diferentes, e idêntica em SQLite e Postgres. É o que mantém isto
 coberto pelo `pytest -q` inteiro, que roda SQLite.
 
 **Sem índice de texto, e isso também é decisão medida.** Sob RLS, o Postgres não usa índice
@@ -22,7 +22,7 @@ from app.core.textsearch import ESCAPE, escapa_curinga, padrao_ilike
 from app.modules.search.registro import REGISTRO, Entidade
 from app.modules.settings.service import hoje_do_tenant
 
-#: Abaixo disto a busca não consulta o banco. Uma letra casa com quase tudo e custaria sete
+#: Abaixo disto a busca não consulta o banco. Uma letra casa com quase tudo e custaria oito
 #: varreduras por tecla — e o resultado seria ruído, não resposta.
 MIN_CARACTERES = 2
 

--- a/apps/api/tests/test_rls_isolation.py
+++ b/apps/api/tests/test_rls_isolation.py
@@ -205,10 +205,38 @@ def _insert_cliente(app_url: str, tenant_id: str, nome: str) -> None:
         engine.dispose()
 
 
+def _insert_conta_a_pagar(app_url: str, tenant_id: str, descricao: str) -> None:
+    """Insere uma conta a pagar com a GUC do tenant setada — espelha `_insert_cliente`.
+
+    Contas a Pagar entrou na busca no #146. Uma conta vazada mostra fornecedor e valor devido de
+    outro escritório: é vazamento financeiro, não cosmético. Por isso ela é seedada aqui e não só
+    no SQLite, onde a RLS não existe. Todas as demais colunas NOT NULL têm `server_default` desde
+    as migrations 0011/0024/0026 — este INSERT é deliberadamente mínimo para não fixar schema.
+    """
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                {"tid": tenant_id},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO payables (id, tenant_id, description, amount_cents, due_date, "
+                    "created_at, updated_at) "
+                    "VALUES (:id, :tid, :desc, 9900, DATE '2026-09-10', now(), now())"
+                ),
+                {"id": str(uuid4()), "tid": tenant_id, "desc": descricao},
+            )
+            conn.commit()
+    finally:
+        engine.dispose()
+
+
 def _busca_pela_otica_de(app_url: str, tenant_id: str, termo: str) -> set[str]:
     """Roda a busca global como `e1p_app` com a GUC do tenant — RLS real, não SQLite.
 
-    A busca cruza sete tabelas; o `pytest -q` roda SQLite, onde a RLS nem existe. Sem este teste,
+    A busca cruza oito tabelas; o `pytest -q` roda SQLite, onde a RLS nem existe. Sem este teste,
     "a busca não vaza entre tenants" seria opinião.
     """
     from sqlalchemy.orm import Session
@@ -252,10 +280,16 @@ def test_busca_global_nao_atravessa_tenant() -> None:
         # Nomes que casam com o MESMO termo: se a RLS falhasse, os dois viriam juntos.
         _insert_cliente(app_url, joao_tenant, "Ana do Joao")
         _insert_cliente(app_url, maria_tenant, "Ana da Maria")
+        # Duas TABELAS diferentes casando com o mesmo termo: a RLS tem de valer para as duas
+        # políticas, e não só para a de `clients` que já estava coberta.
+        _insert_conta_a_pagar(app_url, joao_tenant, "Anuidade do Joao")
+        _insert_conta_a_pagar(app_url, maria_tenant, "Anuidade da Maria")
 
-        assert _busca_pela_otica_de(app_url, joao_tenant, "ana") == {"Ana do Joao"}, (
-            "a busca do João trouxe a cliente da Maria"
-        )
-        assert _busca_pela_otica_de(app_url, maria_tenant, "ana") == {"Ana da Maria"}, (
-            "a busca da Maria trouxe a cliente do João"
-        )
+        assert _busca_pela_otica_de(app_url, joao_tenant, "an") == {
+            "Ana do Joao",
+            "Anuidade do Joao",
+        }, "a busca do João trouxe dado da Maria"
+        assert _busca_pela_otica_de(app_url, maria_tenant, "an") == {
+            "Ana da Maria",
+            "Anuidade da Maria",
+        }, "a busca da Maria trouxe dado do João"

--- a/apps/api/tests/test_search_deep.py
+++ b/apps/api/tests/test_search_deep.py
@@ -66,7 +66,7 @@ def test_funda_conta_o_total_exato(db):
 def test_uma_conversa_e_um_resultado_mesmo_com_quarenta_mensagens(db):
     """Spec §3: quarenta mensagens do mesmo chat saem como UMA linha.
 
-    O contrário afogaria os outros seis tipos com repetição do mesmo diálogo — que é exatamente o
+    O contrário afogaria os outros sete tipos com repetição do mesmo diálogo — que é exatamente o
     risco levantado ao decidir incluir mensagens na busca.
     """
     chat = WhatsappChat(tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net", title="Ana")

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -3,9 +3,13 @@
 SQLite, como todo o `pytest -q`. Isolamento cross-tenant é validado em Postgres real, no
 `test_rls_isolation.py` (marcador `rls_e2e`) — aqui a RLS nem existe.
 """
+from datetime import date
+
 from app.modules.contracts.models import Contract
 from app.modules.crm.models import Client
 from app.modules.juridico.models import LegalDocument
+from app.modules.payables.models import Payable
+from app.modules.quotes.models import Quote
 from app.modules.search.service import buscar
 from app.modules.whatsapp_inbox.models import WhatsappChat
 
@@ -19,6 +23,18 @@ def _cliente(db, name="Ana Souza", **kw):
     db.add(c)
     db.commit()
     return c
+
+
+def _conta(db, *, description="", supplier="", status="open", **kw):
+    """Conta mínima: `due_date`/`amount_cents` são NOT NULL e não interessam ao texto."""
+    p = Payable(
+        tenant_id=TENANT, description=description, supplier=supplier, status=status,
+        amount_cents=kw.pop("amount_cents", 12345), due_date=kw.pop("due_date", date(2026, 9, 10)),
+        **kw,
+    )
+    db.add(p)
+    db.commit()
+    return p
 
 
 def _por_tipo(grupos):
@@ -53,7 +69,7 @@ def test_porcento_nao_casa_com_tudo(db):
 
 
 def test_termo_curto_nao_devolve_nada(db):
-    """Uma letra casa com quase tudo e custaria sete varreduras por tecla."""
+    """Uma letra casa com quase tudo e custaria oito varreduras por tecla."""
     _cliente(db, name="Ana Souza")
 
     assert buscar(db, q="a", modulos_liberados=TODOS) == []
@@ -135,3 +151,116 @@ def test_modulo_bloqueado_nao_produz_grupo(db):
 
     assert "client" in tipos
     assert "legal_document" not in tipos, "sub-usuário sem juridico leria título de petição"
+
+
+# ── Contas a Pagar (#146) ─────────────────────────────────────────────────────────────────────
+#
+# Entrou na busca porque o PR #143 (issue #138) fez `/pagar` hidratar o recorte a partir da URL.
+# Antes disso o destino era inerte e o resultado seria pior que nenhum — spec §2 e a errata.
+
+
+def test_conta_a_pagar_casa_pela_descricao(db):
+    _conta(db, description="IOF sobre emprestimo", supplier="Banco Azul")
+    _conta(db, description="Aluguel da sala", supplier="Imobiliaria Norte")
+
+    grupos = _por_tipo(buscar(db, q="iof", modulos_liberados=TODOS))
+
+    assert "payable" in grupos, "buscar IOF tem de achar a conta de IOF"
+    assert [i.titulo for i in grupos["payable"].itens] == ["IOF sobre emprestimo"]
+
+
+def test_conta_a_pagar_casa_pelo_fornecedor(db):
+    """Quem procura *"o que eu pago para a Vivo"* digita o fornecedor, não a descrição."""
+    _conta(db, description="Internet da sala", supplier="Vivo Fibra")
+
+    grupos = _por_tipo(buscar(db, q="vivo", modulos_liberados=TODOS))
+
+    assert grupos["payable"].itens[0].titulo == "Internet da sala"
+    assert grupos["payable"].itens[0].subtitulo == "Vivo Fibra"
+
+
+def test_conta_sem_descricao_usa_o_fornecedor_como_titulo(db):
+    """As duas colunas nascem `""`; uma linha sem rótulo legível seria um resultado inútil."""
+    _conta(db, description="", supplier="Cartorio Central", category="Taxas")
+
+    item = _por_tipo(buscar(db, q="cartorio", modulos_liberados=TODOS))["payable"].itens[0]
+
+    assert item.titulo == "Cartorio Central"
+    assert item.subtitulo == "Taxas", "repetir o fornecedor nas duas linhas não informa nada"
+
+
+def test_o_destino_leva_para_a_lista_ja_filtrada_na_conta(db):
+    """O clique aterrissa na lista JÁ recortada — e com o recorte padrão desarmado.
+
+    `status=` e `ate=` vazios não são enfeite: `filtros.ts::daUrl` os lê como "todos os status" e
+    "sem horizonte". Sem eles, a visão padrão (`open`+`scheduled` dentro do mês seguinte) esconderia
+    justamente a conta **paga** que a busca acabou de encontrar — a objeção nominal da spec §2.
+    """
+    _conta(db, description="IOF sobre emprestimo", supplier="Banco Azul")
+
+    rota = _por_tipo(buscar(db, q="iof", modulos_liberados=TODOS))["payable"].itens[0].rota
+
+    assert rota == "/pagar?q=IOF%20sobre%20emprestimo&status=&ate="
+
+
+def test_o_destino_de_conta_paga_tambem_mostra_a_conta(db):
+    """O mesmo destino, agora sobre o caso que motivou desarmar o filtro."""
+    _conta(db, description="Alvara anual", supplier="Prefeitura", status="paid")
+
+    rota = _por_tipo(buscar(db, q="alvara", modulos_liberados=TODOS))["payable"].itens[0].rota
+
+    assert rota.startswith("/pagar?q=")
+    assert "status=" in rota, "sem `status=` a conta paga não aparece na tela de destino"
+    assert "ate=" in rota, "sem `ate=` o horizonte esconderia a conta de vencimento distante"
+
+
+def test_curinga_na_conta_nao_casa_com_tudo(db):
+    """Mesmo escape do `test_q_escapa_curinga_do_like` da listagem, pela mesma porta."""
+    _conta(db, description="Aluguel da sala", supplier="Imobiliaria Norte")
+    _conta(db, description="Taxa de 5% ao mes", supplier="Banco Azul")
+
+    so_o_literal = _por_tipo(buscar(db, q="5%", modulos_liberados=TODOS))
+
+    assert [i.titulo for i in so_o_literal["payable"].itens] == ["Taxa de 5% ao mes"]
+    assert buscar(db, q="%%", modulos_liberados=TODOS) == [], "curinga cru casaria com tudo"
+
+
+def test_conta_a_pagar_respeita_o_rbac(db):
+    """Sub-usuário sem `payables` não lê fornecedor nem valor devido pela porta da busca."""
+    _cliente(db, name="Ana Souza")
+    _conta(db, description="Ana Consultoria mensal", supplier="Ana Consultoria")
+
+    tipos = {g.tipo for g in buscar(db, q="ana", modulos_liberados=["crm"])}
+
+    assert "client" in tipos
+    assert "payable" not in tipos
+
+
+def test_conta_a_pagar_entra_entre_orcamento_e_juridico(db):
+    """A ordem dos grupos é a do registro, num lugar só — dinheiro junto de dinheiro."""
+    _cliente(db, name="Ana Souza")
+    db.add(Quote(tenant_id=TENANT, title="Orcamento da Ana"))
+    db.add(LegalDocument(tenant_id=TENANT, skill="peticao", title="Peticao da Ana"))
+    db.commit()
+    _conta(db, description="Ana Consultoria mensal")
+
+    tipos = [g.tipo for g in buscar(db, q="ana", modulos_liberados=TODOS)]
+
+    assert tipos == ["client", "quote", "payable", "legal_document"]
+
+
+def test_conta_nao_e_lida_mais_fundo_na_camada_funda(db):
+    """`payment_code` é linha digitável de boleto: ninguém procura conta por 44 dígitos.
+
+    Sem campo fundo, a camada funda acrescenta só a CONTAGEM exata — e é isso que este teste fixa,
+    para que ninguém acrescente `payment_code` a `campos_fundos` sem decidir a troca.
+    """
+    boleto = "34191790010104351004791020150008291070026000"
+    _conta(db, description="Aluguel da sala", payment_code=boleto)
+
+    funda = _por_tipo(buscar(db, q="34191790", modulos_liberados=TODOS, profundidade="deep"))
+    por_texto = _por_tipo(buscar(db, q="aluguel", modulos_liberados=TODOS, profundidade="deep"))
+
+    assert "payable" not in funda
+    assert por_texto["payable"].total == 1
+    assert por_texto["payable"].itens[0].trecho is None

--- a/apps/web/src/features/busca/BuscaGlobal.test.tsx
+++ b/apps/web/src/features/busca/BuscaGlobal.test.tsx
@@ -101,7 +101,7 @@ describe("BuscaGlobal", () => {
     montar();
     await userEvent.type(screen.getByRole("combobox"), "a");
 
-    // Uma letra casa com quase tudo: sete varreduras por tecla, para devolver ruído.
+    // Uma letra casa com quase tudo: oito varreduras por tecla, para devolver ruído.
     expect(get).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/features/busca/BuscaGlobal.tsx
+++ b/apps/web/src/features/busca/BuscaGlobal.tsx
@@ -10,7 +10,7 @@ const MIN_CARACTERES = 2;
 /**
  * A busca da barra de cima — camada rasa.
  *
- * Sete tipos, até 3 por grupo, agrupados na ordem que o backend manda. O objetivo aqui é "me leva
+ * Oito tipos, até 3 por grupo, agrupados na ordem que o backend manda. O objetivo aqui é "me leva
  * até a Ana" em uma tecla, sem ler nada. Procurar DENTRO de documento e mensagem é a página
  * `/busca`, e o rodapé (e o estado vazio) levam até ela.
  */

--- a/apps/web/src/features/busca/resultado.test.ts
+++ b/apps/web/src/features/busca/resultado.test.ts
@@ -23,10 +23,12 @@ describe("resultado da busca", () => {
     expect(grupos.map((g) => g.type)).toEqual(["client", "funnel"]);
   });
 
-  it("tem rótulo em português para os sete tipos", () => {
-    expect(Object.keys(ROTULOS)).toHaveLength(7);
+  it("tem rótulo em português para os oito tipos", () => {
+    expect(Object.keys(ROTULOS)).toHaveLength(8);
     expect(ROTULOS.legal_document).toBe("Jurídico");
     expect(ROTULOS.conversation).toBe("Conversas");
+    // Contas a Pagar entrou no #146, quando o PR #143 fez `/pagar` hidratar o recorte da URL.
+    expect(ROTULOS.payable).toBe("Contas a Pagar");
   });
 
   it("a sequência do teclado atravessa grupos", () => {

--- a/apps/web/src/features/busca/resultado.ts
+++ b/apps/web/src/features/busca/resultado.ts
@@ -12,6 +12,7 @@ export const ROTULOS: Record<SearchType, string> = {
   conversation: "Conversas",
   contract: "Contratos",
   quote: "Orçamentos",
+  payable: "Contas a Pagar",
   legal_document: "Jurídico",
   page: "Sites",
   funnel: "Funis",

--- a/apps/web/src/features/pagar/filtros.test.ts
+++ b/apps/web/src/features/pagar/filtros.test.ts
@@ -242,3 +242,35 @@ describe("apenasTexto — quem decide se o botao voltar tem o que desfazer", () 
     expect(apenasTexto(sujo, limpo)).toBe(false);
   });
 });
+
+describe("o destino que a busca global monta (#146)", () => {
+  /**
+   * A OUTRA METADE do contrato. O backend (`search/registro.py::_rota_da_conta`) monta a string;
+   * quem a interpreta é o `daUrl` daqui. Se as duas metades divergirem, nada quebra — o clique
+   * só passa a cair numa lista que não contém a conta clicada, que é exatamente o defeito mudo
+   * que manteve Contas a Pagar fora da busca até o PR #143.
+   */
+  const DA_BUSCA = "q=IOF%20sobre%20emprestimo&status=&ate=";
+
+  it("o termo volta inteiro, com espaços e tudo", () => {
+    expect(daUrl(new URLSearchParams(DA_BUSCA), PADRAO).q).toBe("IOF sobre emprestimo");
+  });
+
+  it("`status=` vazio significa TODOS os status — inclusive a conta já paga", () => {
+    // Sem isto, a visão padrão (`open`+`scheduled`) esconderia a conta paga que a busca achou.
+    expect(daUrl(new URLSearchParams(DA_BUSCA), PADRAO).status).toEqual([]);
+  });
+
+  it("`ate=` vazio significa SEM horizonte — a conta de vencimento distante aparece", () => {
+    expect(daUrl(new URLSearchParams(DA_BUSCA), PADRAO).ate).toBeNull();
+  });
+
+  it("e nada além disso é recortado: sem piso de data, sem centro, sem categoria", () => {
+    const f = daUrl(new URLSearchParams(DA_BUSCA), PADRAO);
+    const query = paraQuery(f, 50, 0);
+    expect(query.status).toBeUndefined();
+    expect(query.from).toBeUndefined();
+    expect(query.to).toBeUndefined();
+    expect(query.q).toBe("IOF sobre emprestimo");
+  });
+});

--- a/docs/superpowers/specs/2026-08-18-busca-global-design.md
+++ b/docs/superpowers/specs/2026-08-18-busca-global-design.md
@@ -48,6 +48,22 @@ incomoda quem só usa a tela, sem passar por busca nenhuma.
 Também fora: busca por tags, correção ortográfica, fuzzy, histórico de buscas recentes, e qualquer
 migration de índice — esta última porque a medição provou que não ajudaria (§5).
 
+> **ERRATA — 2026-08-19 (issue #146).** O parágrafo acima continua descrevendo fielmente o que se
+> sabia em 18/08, e por isso não foi reescrito. Mas a premissa dele caiu **no dia seguinte**: o
+> **PR #143** (issue #138) fez `PagarPage.tsx` usar `useSearchParams` e hidratar `q`, `status`,
+> `de`/`ate`, `centro` e `categoria` a partir do endereço. `/pagar?q=anthropic` **não é mais
+> inerte**, e a barra de endereço virou a fonte única do recorte da tela.
+>
+> Com isso **Contas a Pagar entrou na busca**, como a §7 previa: uma entrada no registro, sem
+> reescrita. São **oito** entidades, e não sete. O destino do resultado é
+> `/pagar?q=<descrição>&status=&ate=` — as duas chaves vazias existem exatamente para desarmar a
+> objeção que este parágrafo levanta: `status=` significa "todos os status" e `ate=` significa "sem
+> horizonte", de modo que a conta **paga** encontrada pela busca está, sim, na tela para onde o
+> clique leva.
+>
+> **Cobranças e produtos seguem fora**, e pelo motivo original intacto: nenhuma das duas lê o
+> próprio recorte da URL. O critério de admissão não mudou — só o placar.
+
 ## 3. As duas camadas — a decisão central
 
 São duas perguntas diferentes, e juntá-las numa superfície só é o que faz busca global ficar lenta

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1208,15 +1208,22 @@ export interface BriefingPreferences {
 
 // ── Busca global ──────────────────────────────────────────────────────────────
 //
-// Sete tipos, e o critério de quem entra é ter tela de destino. Contas a pagar, cobranças e
-// produtos ficaram de fora porque nenhuma das três sabe receber uma busca pela URL — ver a
-// issue #138 e a spec `2026-08-18-busca-global-design.md` §2.
+// Oito tipos, e o critério de quem entra é ter endereço que saiba RECEBER uma busca — não é "ter
+// tela de detalhe". Cobranças e produtos seguem de fora porque nenhuma das duas hidrata o próprio
+// recorte a partir da URL: o clique cairia numa lista que ignora o filtro, que a spec
+// `2026-08-18-busca-global-design.md` §2 (+ errata de 2026-08-19) considera pior que não oferecer
+// o resultado. Contas a pagar entrou na issue #146: o PR #143 (issue #138) fez `/pagar` ler `q`,
+// `status`, `de`/`ate`, `centro` e `categoria` do endereço, e o bloqueio dela deixou de existir.
+//
+// A ORDEM desta união é decorativa; quem manda na ordem dos grupos é o registro do backend
+// (`app/modules/search/registro.py`).
 
 export type SearchType =
   | "client"
   | "conversation"
   | "contract"
   | "quote"
+  | "payable"
   | "legal_document"
   | "page"
   | "funnel";
@@ -1235,7 +1242,7 @@ export interface SearchGroup {
   type: SearchType;
   has_more: boolean;
   /**
-   * Só em `depth=deep`. Na camada rasa a contagem exata custaria sete `count()` por tecla — e
+   * Só em `depth=deep`. Na camada rasa a contagem exata custaria oito `count()` por tecla — e
    * `has_more` não tem como mentir sobre um número que não anuncia.
    */
   total: number | null;


### PR DESCRIPTION
## Resumo

`features/busca/resultado.ts` listava **sete** tipos buscáveis. `payable` não estava lá — e ficou de
fora por um motivo que deixou de existir. A spec `2026-08-18-busca-global-design.md` §2 excluiu
Contas a Pagar **porque** `/pagar?q=termo` era inerte: a tela ignorava a query string. O PR #143
(issue #138) pagou isso. Agora são **oito**, e "buscar IOF não acha" deixa de ser comportamento
correto.

## A decisão que merece revisão: o destino não é `/pagar?q=…`

O enunciado da issue pedia `/pagar?q=…`. **O destino entregue é `/pagar?q=…&status=&ate=`**, e o
desvio é deliberado — a própria spec §2 já tinha nomeado a armadilha ao excluir o módulo:

> *"a visão padrão é `status ∈ (open, scheduled)` dentro do horizonte, então uma conta **paga**
> encontrada pela busca não estaria na tela para onde o clique levou"*

A busca não filtra por status nem por data; `filtroPadrao` filtra os dois. Com `q` sozinho, procurar
uma conta **paga** — ou que vence depois do mês seguinte — levaria a uma lista **vazia**. Seria o
endereço inerte de volta, entrando por outra porta.

`status=` e `ate=` como **chave presente de valor vazio** é o vocabulário que o `filtros.ts` do #143
já usa para "escolhi vazio" (contra "não escolhi", que é chave ausente): `daUrl` devolve `[]` (todos
os status) e `null` (sem horizonte). **Não inventa sintaxe — usa a que existe.**

O termo vem da **linha**, não da consulta: `Entidade.rota` recebe o registro, então o clique aterrissa
numa lista que contém a conta clicada, e não numa relida do que foi digitado.

## Alcance: a issue nomeou 2 arquivos de produção, são **3**

| Arquivo | O quê | A issue citou? |
|---|---|---|
| `search/registro.py` | a `Entidade` `payable` | sim |
| `busca/resultado.ts` | o rótulo em `ROTULOS` | sim |
| `shared-types/src/index.ts` | **a união `SearchType`** | **não** |

`ROTULOS` é `Record<SearchType, string>`: sem a união o TypeScript nem compila. Os outros 8 arquivos
que citam `legal_document` são testes, `juridico/models.py` e a migration 0027 — o literal como valor
de coluna, sem relação com busca.

**Afirmação viva corrigida:** o comentário de `shared-types` dizia *"Sete tipos… Contas a pagar…
ficaram de fora porque nenhuma das três sabe receber uma busca pela URL"* — falso desde o #143.
Mais 13 contadores em prosa (`sete` → `oito`, `outros seis` → `sete`) em `router.py`, `schemas.py`,
`service.py`, `BuscaGlobal.tsx` e testes. **Provado por AST**: com docstrings removidas, a árvore dos
três `.py` de produção é **idêntica** à de `main` — a mudança é só texto.

**A spec ganhou errata datada (2026-08-19), não reescrita.** O §2 original está intacto: `git diff`
da spec não tem **nenhuma linha removida**. Ele descreve o que se acreditava em 18/08, e continua
verdadeiro para aquela data.

## Prova por mutação

| Mutação | Compila? | Teste que morreu | Mensagem real |
|---|---|---|---|
| `Entidade(tipo="payable")` fora do `REGISTRO` | sim | `test_conta_a_pagar_casa_pela_descricao` (+7) | `buscar IOF tem de achar a conta de IOF` · `assert 'payable' in {}` |
| `_rota_da_conta` → `"/pagar"` | sim | `test_o_destino_leva_para_a_lista_ja_filtrada_na_conta` | `assert '/pagar' == '/pagar?q=IOF%20sobre%20emprestimo&status=&ate='` |
| só `&status=&ate=` removidos | sim | `test_o_destino_de_conta_paga_tambem_mostra_a_conta` | `sem 'status=' a conta paga não aparece na tela de destino` |
| `escapa_curinga` → `return termo` | sim | `test_curinga_na_conta_nao_casa_com_tudo` | `curinga cru casaria com tudo` |
| `\| "payable"` fora da união | **não** — é o ponto | gate `tsc` | `TS2353: 'payable' does not exist in type 'Record<SearchType, string>'` |
| rótulo → `"Contas a Receber"` | sim | `resultado > rótulo … oito tipos` | `expected 'Contas a Receber' to be 'Contas a Pagar'` |

**Duas ressalvas honestas:**

- **O escape não tem mutante exclusivo, e não deveria ter.** Ele mora em `core/textsearch.py`,
  primitivo compartilhado de propósito. Raio de explosão medido: **exatamente 2** testes. Não existe
  linha de escape específica de `payable` para mutar — ela é herdada pelo predicado genérico, que é
  o certo. (Curiosidade útil: `test_porcento_nao_casa_com_tudo` **sobrevive**, porque `q="%"` tem 1
  char e morre no `MIN_CARACTERES` antes de tocar o banco. O teste novo usa `%%`.)
- **A união dá morte de compilação, não de asserção.** União e `ROTULOS` são travados um no outro
  pelo `Record<>`. O mutante do rótulo existe para dar a morte em runtime que aquele não dá.

## Verificação

| Gate | Resultado |
|---|---|
| `ruff check .` | `All checks passed!` |
| `pytest -q` | `2250 passed, 1 skipped` |
| `pytest -m rls_e2e` | `65 passed` + 1 falha **ambiental** (ver abaixo) |
| `pnpm vitest run` | `794 passed` (73 arquivos) |
| `pnpm tsc --noEmit` / `eslint --max-warnings 0` | limpos |
| `E2E_PORT=5356 playwright test` | `92 passed` |

**A falha do `rls_e2e` não é deste diff:** `test_ai_usage_rls.py::test_ai_usage_cross_tenant_isolation`
caiu na suíte cheia e **passa isolada em 6,5s** — corrida na subida do container `ryuk`. Este diff não
toca uso de IA. Fica registrado em vez de escondido.

⚠️ **`TZ=UTC` não é troca de fuso real no Windows:** a variável chega ao Python mas `time.tzname`
não muda (o `test_search_deep.py` já documenta isso). O gate rodou, mas não exercita fuso nesta
máquina. Mitigação: o diff não tem data, `datetime.now` nem aritmética de calendário.

## Fora de escopo, registrado

- **Nenhum índice de texto, nenhuma migration.** `ILIKE` não é leakproof sob RLS: `pg_trgm`/`tsvector`
  não entram no plano. Já medido.
- **`payment_code` fora da camada funda.** Ninguém procura conta digitando 44 dígitos de boleto, e o
  `q` da lista de destino também não varre essa coluna. Tem teste travando a decisão.
- **`category` fora dos campos rasos.** Casa por exatamente as duas colunas que a lista de destino
  varre — casar por uma terceira devolveria resultado que o destino não mostra.
- **Cobranças e produtos seguem fora**, com o motivo original intacto: nenhuma das duas hidrata a URL.

Fecha #146.
