### PR TITLE
feat(infra): um deploy so para os dois ambientes, com o alvo detectado e o resultado provado

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2921,6 +2921,49 @@ migration.
 - **Dívida (a que NÃO fecha):** as 46 perguntas seguem nunca validadas com dono real. Não é
   instrumentável; é conversa com dono.
 
+## Deploy: o script detecta o ambiente — e a lista de compose files vem do LABEL
+
+`infra/scripts/deploy.sh` sobe uma versão nova no ambiente em que o host roda, sem flag de
+ambiente: ele lê o label `com.docker.compose.project.config_files` do `infra-api-1`, que registra
+**todos** os arquivos com que a stack foi criada. Escolher o compose errado no host errado deixa
+de existir quando ninguém escolhe.
+
+- ⚠️ **A lista de compose files era CRAVADA no script, e isso derrubou a produção em 2026-08-20.**
+  A instância da AWS tem três arquivos **não versionados** (assim `git pull` nunca conflita):
+  `DEPLOY-AWS.md` (o runbook real daquela máquina), `infra/docker-compose.override.yml` e
+  `infra/Caddyfile.single`. O override monta o `Caddyfile.single` no lugar do `infra/Caddyfile`
+  versionado, que tem o bloco wildcard `*.{$ROOT_DOMAIN}` exigindo `CLOUDFLARE_API_TOKEN` — **vazio
+  ali de propósito**. Recriar o `caddy` sem o override fez o Caddy **recusar a config INTEIRA**
+  (`missing API token`) e derrubar **também o domínio único**, com o certificado dele intacto em
+  disco. ~40 min fora do ar. É a **issue #151**.
+  - Um placeholder não salva: o plugin da Cloudflare valida o **formato** do token (40 chars
+    `[A-Za-z0-9_-]`), e passando no formato a sobreposição do wildcard com o domínio principal
+    (`DOMAIN=e1p.criativaeduca.com.br` é subdomínio de `ROOT_DOMAIN=criativaeduca.com.br`) continua
+    impedindo o TLS. Medido, nos dois passos.
+- ⚠️ **`--env-file` é obrigatório nos DOIS perfis, e a exceção que existia era falsa.** O script
+  dizia que a AWS *"resolve o env por env_file: interno, nao precisa da flag"*. Os dois compose
+  files usam `${VAR}` para as senhas, e **interpolação não vem do `env_file:` de serviço** — sem a
+  flag o compose morre em `required variable APP_DB_PASSWORD is missing` antes de listar um
+  serviço sequer.
+- **`COMPOSE_ARQ` (o arquivo primário) sobreviveu**, e só para o `COMPOSE_FILE` que o `backup.sh`
+  consome; tudo que roda compose usa `COMPOSE_ARGS`, derivado do label.
+
+> **A regra que fica, e ela é maior que este script:** **o repositório descreve o deploy
+> CANÔNICO; a máquina carrega os desvios que ninguém commitou.** Esses desvios são invisíveis a
+> qualquer leitura do repo, e um container rodando há dias pode estar servindo uma config que
+> **não existe mais em disco** — o defeito só aparece na recriação, longe da mudança que o causou.
+> Antes de qualquer comando que recrie container: `git status` no checkout do servidor e procure
+> um `DEPLOY*.md` local. É a mesma família do comentário inline no `.env.prod` (§Anexos) e da
+> config do webhook da Evolution em memória (§WhatsApp): **estado em memória divergindo do estado
+> em disco**, três vezes no mesmo repositório.
+
+- **Dívida:** nada no repo REPROVA um deploy que ignore o override — a garantia é o script, e quem
+  rodar compose à mão continua exposto. O conserto de verdade é a **issue #151**: enquanto o
+  `infra/Caddyfile` tiver o bloco wildcard incondicional, aquela instância depende de um arquivo
+  local para subir.
+- **Dívida:** o `CLOUDFLARE_API_TOKEN` segue vazio na AWS. Correto hoje (sem wildcard, sem DNS-01);
+  vira problema no dia em que subdomínio por tenant entrar em uso.
+
 ## 6.0 Correções importantes
 - **[CORRIGIDO 2026-08-05] O sistema inteiro passou a viver no fuso do tenant (era UTC).** O sintoma que o fundador viu foi a linha do tempo do Funil exibindo `Aguardando até 2026-08-05T11:11:32.812731+00:00` — formato de máquina e 3h adiantado. A investigação achou **três** defeitos com a mesma raiz: existia infra de fuso (`core/tz.py` + `tenant.timezone`, migration 0044) mas só 3 módulos a consumiam.
   1. **Texto para humano com UTC cru.** `funnels/engine.py` interpolava `resume_at.isoformat()` na mensagem; `contracts/service.py` montava a variável `{{DATA}}` com `datetime.now(UTC)` — um contrato criado às 22h saía datado do dia seguinte, e essa é a data que vale juridicamente.

--- a/docs/AWS-DEPLOYMENT.md
+++ b/docs/AWS-DEPLOYMENT.md
@@ -35,6 +35,23 @@ backup, reconstrói e então **prova** o resultado (health, alembic e hash do bu
 produção ele exige confirmação digitada. `--dry-run` mostra o plano sem executar. É o mesmo script
 em dev e em prod — só muda o host de destino.
 
+⚠️ **Ele deriva os compose files do label da stack em pé, e isso NÃO é detalhe.** Esta instância
+tem um `infra/docker-compose.override.yml` **não versionado** (monta um `Caddyfile.single`, sem o
+bloco wildcard) e um runbook local em `/opt/e1p/DEPLOY-AWS.md`. Rodar o compose à mão com um `-f`
+só **descarta o override**: o Caddy volta com o `infra/Caddyfile` versionado, exige o
+`CLOUDFLARE_API_TOKEN` que aqui é vazio de propósito, **recusa a config inteira** e derruba também
+o domínio único — aconteceu em 2026-08-20, ~40 min fora do ar. Ver issue #151.
+
+**À mão, os DOIS `-f` são obrigatórios**, e o `--env-file` também (o `docker-compose.prod.yml` usa
+`${VAR}` para as senhas, e interpolação não vem do `env_file:` de serviço):
+
+```bash
+cd /opt/e1p/infra && docker compose --env-file .env.prod   -f docker-compose.prod.yml -f docker-compose.override.yml up -d
+```
+
+Antes de qualquer comando de deploy à mão: `git status` no `/opt/e1p` e leia o runbook local — o
+que está no repositório é o deploy canônico, não necessariamente o desta máquina.
+
 ---
 
 Filosofia: **começar barato e portável, escalar quando o tráfego justificar.** Tudo é container 12-factor,

--- a/docs/AWS-DEPLOYMENT.md
+++ b/docs/AWS-DEPLOYMENT.md
@@ -1,7 +1,46 @@
 # Deploy AWS — e1p (custo-consciente)
 
+> ## ⚠️ Como está HOJE (2026-08-20) — leia antes do resto
+>
+> O que está de fato em produção **não é** a Fase A descrita abaixo. A AWS foi provisionada pelo
+> time do sócio como **uma EC2 só, com toda a stack em Docker Compose** — o mesmo formato da VPS:
+>
+> | | Planejado abaixo | Real hoje |
+> |---|---|---|
+> | Frontend | S3 + CloudFront | container `web` atrás do Caddy, na mesma EC2 |
+> | Banco | RDS `t4g.micro` | `postgres:16-alpine` **em container**, na mesma EC2 |
+> | Arquivos | S3 | `bytea` dentro do Postgres |
+> | Fila | SQS | worker + Redis na mesma EC2 |
+> | Segredos | SSM | `.env` no host |
+> | IaC | Terraform | provisionado à mão |
+>
+> Confere com o planejado apenas o host: `t4g` **Graviton/ARM**, com o Compose de `docker-compose.prod.yml`.
+> Domínio: **https://e1p.criativaeduca.com.br**. A VPS Hostinger (`e1p.doroeventos.com.br`) passou a
+> ser **dev/teste** na mesma data.
+>
+> **Consequências operacionais que valem hoje**, e não quando a Fase A existir:
+> - **Backup é só local** (`/opt/e1p-backups`, diário às 03:15). Não há `rclone`/offsite na AWS —
+>   a VPS de dev tem, a produção não. Se a instância morrer, morrem app e banco juntos.
+> - Imagens precisam buildar em **arm64**; dependência com binário só-amd64 não sobe.
+> - Deploy é o `infra/scripts/deploy.sh` (abaixo), não pipeline.
+
+## Deploy de uma nova versão (o de hoje)
+
+```bash
+ssh -t -i ~/.ssh/e1p_aws_prod flavio@<host> "cd /opt/e1p && ./infra/scripts/deploy.sh"
+```
+
+O script **detecta o ambiente sozinho** pelo compose file da stack em pé, roda o gate de CI, faz
+backup, reconstrói e então **prova** o resultado (health, alembic e hash do bundle servido). Em
+produção ele exige confirmação digitada. `--dry-run` mostra o plano sem executar. É o mesmo script
+em dev e em prod — só muda o host de destino.
+
+---
+
 Filosofia: **começar barato e portável, escalar quando o tráfego justificar.** Tudo é container 12-factor,
 então trocar o alvo de deploy não exige reescrever a aplicação.
+
+> O que segue é o **plano** de destino, ainda não construído. Mantido como direção, não como descrição.
 
 ## Fase A — Início enxuto (~US$30-45/mês)
 | Componente | Serviço | Notas de custo |

--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -125,7 +125,8 @@ pro IP da VPS (`dig +short app.seudominio.com`) e se a porta 80 está mesmo aces
 > `infra/scripts/deploy.sh` **detecta o ambiente** pelo label
 > `com.docker.compose.project.config_files` da stack em pé — que é exatamente a conferência que a
 > nota "Qual compose file?" abaixo manda fazer à mão — e daí deriva o compose, o `--env-file` e o
-> domínio. Ele também: exige os 4 jobs de CI verdes no SHA alvo, faz backup, reconstrói **sem
+> domínio. Ele também: exige **todos** os checks de CI verdes no SHA alvo (por lista de exclusão —
+> só `mutation`, que é noturno, fica de fora; um check novo bloqueia até ser decidido), faz backup, reconstrói **sem
 > nomear serviço** e **prova** o resultado (health, alembic, e o hash do bundle servido, que
 > precisa ter mudado se e somente se o diff tocou `apps/web`). `--dry-run` imprime o plano.
 >

--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -115,6 +115,23 @@ pro IP da VPS (`dig +short app.seudominio.com`) e se a porta 80 está mesmo aces
     exige uma conta/número aprovados na Meta Cloud API (não coberto por testes automatizados).
 
 ## 5. Atualizações (deploy de uma nova versão)
+
+> ### Use o script — o passo a passo abaixo é a referência do que ele faz
+>
+> ```bash
+> ssh -t root@<host> "cd /opt/e1p && ./infra/scripts/deploy.sh"
+> ```
+>
+> `infra/scripts/deploy.sh` **detecta o ambiente** pelo label
+> `com.docker.compose.project.config_files` da stack em pé — que é exatamente a conferência que a
+> nota "Qual compose file?" abaixo manda fazer à mão — e daí deriva o compose, o `--env-file` e o
+> domínio. Ele também: exige os 4 jobs de CI verdes no SHA alvo, faz backup, reconstrói **sem
+> nomear serviço** e **prova** o resultado (health, alembic, e o hash do bundle servido, que
+> precisa ter mudado se e somente se o diff tocou `apps/web`). `--dry-run` imprime o plano.
+>
+> **Esta VPS é dev/teste desde 2026-08-20**; a produção é a AWS (`docs/AWS-DEPLOYMENT.md`). O mesmo
+> script serve as duas — muda só o host. Em produção ele exige confirmação digitada.
+
 > **Antes de dar `git pull` + rebuild em produção, confirme que o CI está VERDE** no
 > commit/branch que será deployado (`.github/workflows/ci.yml` — jobs `test-in-prod-image`
 > e `cross-tenant-rls`). O CI roda a suíte DENTRO da imagem de produção (pega drift

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -16,7 +16,6 @@
 set -euo pipefail
 
 REPO_GH="educacaocriativa/escritorio-1-pessoa"
-JOBS_EXIGIDOS=(secret-scan frontend test-in-prod-image cross-tenant-rls)
 # Normalmente a raiz e deduzida da posicao do proprio script. E1P_RAIZ existe para rodar uma
 # copia de fora do checkout (validar uma versao do script antes de ela estar mergeada, p.ex.).
 RAIZ="${E1P_RAIZ:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
@@ -89,7 +88,11 @@ bundle_servido() {
 
 git fetch origin --quiet
 SHA_ANTES="$(git rev-parse HEAD)"
-SHA_ALVO="$(git rev-parse "origin/$REF" 2>/dev/null || git rev-parse "$REF" 2>/dev/null || true)"
+# --verify --quiet e obrigatorio aqui: `git rev-parse <ref-inexistente>` ECOA o argumento no
+# stdout antes de falhar, entao um `a || b` sem ele concatena as duas saidas e devolve um
+# "SHA" de duas linhas que envenena todo comando seguinte.
+SHA_ALVO="$(git rev-parse --verify --quiet "origin/$REF^{commit}" \
+  || git rev-parse --verify --quiet "$REF^{commit}" || true)"
 [[ -n "$SHA_ALVO" ]] || morre "nao consegui resolver a ref '$REF'"
 
 if [[ "$SHA_ANTES" == "$SHA_ALVO" ]]; then
@@ -120,12 +123,28 @@ else
   CI_URL="https://api.github.com/repos/$REPO_GH/commits/$SHA_ALVO/check-runs"
   CI_JSON="$(curl -sS --max-time 30 "$CI_URL" 2>/dev/null || true)"
   [[ -n "$CI_JSON" ]] || morre "nao consegui consultar o CI (rede?). Use --skip-ci se souber o que esta fazendo."
-  FILTRO='[.check_runs[]? | select(.name==$n)] | last | .conclusion // "ausente"'
-  for job in "${JOBS_EXIGIDOS[@]}"; do
-    concl="$(printf '%s' "$CI_JSON" | jq -r --arg n "$job" "$FILTRO")"
-    [[ "$concl" == "success" ]] || morre "o job $job esta '$concl' em ${SHA_ALVO:0:7} - so subimos versao com CI verde."
-    ok "$job"
-  done
+
+  # Exigimos TODOS os checks do commit, MENOS os listados em IGNORADOS. E uma lista de exclusao
+  # de proposito, nao de inclusao: uma lista de inclusao desatualiza CALADA (quando `sast-semgrep`
+  # entrou no ci.yml, um gate por inclusao teria seguido aprovando sem ele). Por exclusao o erro
+  # aparece: um check novo BLOQUEIA o deploy uma vez, e ai se decide conscientemente o que fazer.
+  #
+  # `mutation` esta fora porque o mutation.yml roda por agendamento noturno (`on: schedule`), nao
+  # em PR — o resultado dele e sinal para investigar, nunca condicao para deployar.
+  IGNORADOS='^(mutation)$'
+  ULTIMO_POR_NOME="[.check_runs[]? | select(.name | test(\"$IGNORADOS\") | not)] | group_by(.name) | map(max_by(.started_at))"
+  VERDE='(.conclusion=="success" or .conclusion=="skipped" or .conclusion=="neutral")'
+
+  qtd="$(printf '%s' "$CI_JSON" | jq -r "$ULTIMO_POR_NOME | length")"
+  (( qtd > 0 )) || morre "nenhum check encontrado para ${SHA_ALVO:0:7} - o CI chegou a rodar nesse commit?"
+
+  rodando="$(printf '%s' "$CI_JSON" | jq -r "$ULTIMO_POR_NOME | [.[] | select(.status!=\"completed\") | .name] | join(\", \")")"
+  [[ -z "$rodando" ]] || morre "o CI ainda esta rodando em ${SHA_ALVO:0:7}: $rodando"
+
+  ruins="$(printf '%s' "$CI_JSON" | jq -r "$ULTIMO_POR_NOME | [.[] | select($VERDE | not) | .name + \"=\" + (.conclusion // \"?\")] | join(\", \")")"
+  [[ -z "$ruins" ]] || morre "check reprovado em ${SHA_ALVO:0:7}: $ruins - so subimos versao com CI verde."
+
+  ok "$qtd checks verdes: $(printf '%s' "$CI_JSON" | jq -r "$ULTIMO_POR_NOME | [.[].name] | sort | join(\", \")")"
 fi
 
 # --- 4. Retrato do "antes" ----------------------------------------------------

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -57,27 +57,48 @@ tem_prod=0
 if (( tem_traefik )); then
   PERFIL="hostinger"
   COMPOSE_ARQ="docker-compose.traefik.yml"
-  # o .traefik.yml usa ${VAR:?}; sem --env-file o compose nem consegue listar os servicos
-  COMPOSE_FLAGS=(--env-file .env.prod)
   DOMINIO="e1p.doroeventos.com.br"
   EH_PROD=0
   PAPEL="desenvolvimento/teste"
 else
   PERFIL="aws"
   COMPOSE_ARQ="docker-compose.prod.yml"
-  # este resolve o env por env_file: interno, nao precisa da flag
-  COMPOSE_FLAGS=()
   DOMINIO="e1p.criativaeduca.com.br"
   EH_PROD=1
   PAPEL="PRODUCAO"
 fi
-ok "perfil $PERFIL ($PAPEL) - $COMPOSE_ARQ - https://$DOMINIO"
+
+# Os compose files vem do PROPRIO label, nao de uma lista escrita aqui: a stack em pe registra
+# TODOS os arquivos com que foi criada, override local incluso. Detectar em vez de escolher e a
+# premissa deste script, e este era o unico ponto em que ela nao valia.
+#
+# Cravar a lista custou a producao em 2026-08-20: a AWS tem um `docker-compose.override.yml`
+# NAO versionado (monta um Caddyfile sem o bloco wildcard, que exige um CLOUDFLARE_API_TOKEN
+# vazio ali de proposito). Recriar sem ele fez o Caddy recusar a config INTEIRA -- `missing API
+# token` -- e derrubar ate o dominio unico, com o certificado dele intacto em disco. ~40 min
+# fora do ar. Ver issue #151 e /opt/e1p/DEPLOY-AWS.md (runbook local, nao versionado).
+COMPOSE_ARGS=()
+IFS=',' read -ra _arqs <<< "$LABELS"
+for _a in "${_arqs[@]}"; do
+  _a="${_a#"${_a%%[![:space:]]*}"}"; _a="${_a%"${_a##*[![:space:]]}"}"
+  [[ -n "$_a" ]] && COMPOSE_ARGS+=(-f "$_a")
+done
+(( ${#COMPOSE_ARGS[@]} )) || morre "nao consegui derivar os compose files de: $LABELS"
+
+# --env-file e obrigatorio nos DOIS perfis, e a excecao que existia aqui era falsa: os dois
+# compose files usam ${VAR} para as senhas, e interpolacao NAO vem do `env_file:` de servico.
+# Sem a flag o compose morre em "required variable APP_DB_PASSWORD is missing" antes de
+# conseguir listar um servico sequer (medido na AWS em 2026-08-20).
+COMPOSE_FLAGS=(--env-file .env.prod)
+
+ok "perfil $PERFIL ($PAPEL) - https://$DOMINIO"
+ok "compose: ${COMPOSE_ARGS[*]}"
 
 # O superusuario do Postgres nao e "postgres" aqui; perguntar ao container evita chutar.
 PG_USER="$(docker exec infra-postgres-1 printenv POSTGRES_USER)"
 PG_DB="$(docker exec infra-postgres-1 printenv POSTGRES_DB)"
 psql_() { docker exec infra-postgres-1 psql -U "$PG_USER" -d "$PG_DB" -tAc "$1"; }
-compose_() { (cd "$RAIZ/infra" && docker compose "${COMPOSE_FLAGS[@]}" -f "$COMPOSE_ARQ" "$@"); }
+compose_() { (cd "$RAIZ/infra" && docker compose "${COMPOSE_FLAGS[@]}" "${COMPOSE_ARGS[@]}" "$@"); }
 bundle_servido() {
   curl -sS --max-time 20 "https://$DOMINIO/" 2>/dev/null \
     | grep -oE '/assets/index-[A-Za-z0-9_-]+[.]js' | head -1 || true
@@ -156,7 +177,7 @@ ok "bundle:  ${BUNDLE_ANTES:-(nao identificado)}"
 
 if (( DRY_RUN )); then
   titulo "DRY-RUN - nada foi alterado"
-  echo "  faria: docker compose ${COMPOSE_FLAGS[*]} -f $COMPOSE_ARQ up -d --build"
+  echo "  faria: docker compose ${COMPOSE_FLAGS[*]} ${COMPOSE_ARGS[*]} up -d --build"
   if (( EH_PROD || MIGRATION )); then echo "  faria: backup antes"; fi
   exit 0
 fi

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# deploy.sh — sobe uma nova versao do e1p no ambiente em que ESTE host roda.
+#
+# O ambiente NAO e passado por flag: ele e detectado a partir do compose file com que a stack
+# em pe foi criada (o mesmo label que o runbook manda conferir a mao). Escolher o compose errado
+# no host errado e o modo de errar mais caro daqui, e ele deixa de existir quando ninguem escolhe.
+#
+#   ./infra/scripts/deploy.sh                 # deploya origin/main
+#   ./infra/scripts/deploy.sh --ref <sha>     # deploya uma versao especifica
+#   ./infra/scripts/deploy.sh --dry-run       # imprime o plano e sai, sem tocar em nada
+#   ./infra/scripts/deploy.sh --skip-ci       # pula o gate de CI (grita ao fazer)
+#
+# Roda SEMPRE no servidor. Da sua maquina, em uma linha:
+#   ssh -t <host> "cd /opt/e1p && ./infra/scripts/deploy.sh"
+#   (o -t aloca terminal; sem ele a confirmacao de producao nao funciona)
+set -euo pipefail
+
+REPO_GH="educacaocriativa/escritorio-1-pessoa"
+JOBS_EXIGIDOS=(secret-scan frontend test-in-prod-image cross-tenant-rls)
+# Normalmente a raiz e deduzida da posicao do proprio script. E1P_RAIZ existe para rodar uma
+# copia de fora do checkout (validar uma versao do script antes de ela estar mergeada, p.ex.).
+RAIZ="${E1P_RAIZ:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+REF="main"
+DRY_RUN=0
+PULA_CI=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref) REF="${2:?--ref exige um valor}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --skip-ci) PULA_CI=1; shift ;;
+    -h|--help) sed -n '2,15p' "${BASH_SOURCE[0]}" | cut -c3-; exit 0 ;;
+    *) echo "flag desconhecida: $1" >&2; exit 2 ;;
+  esac
+done
+
+titulo() { printf '\n=== %s ===\n' "$*"; }
+ok()     { printf '  OK   %s\n' "$*"; }
+aviso()  { printf '  !    %s\n' "$*"; }
+morre()  { printf '\nABORTADO: %s\n' "$*" >&2; exit 1; }
+
+cd "$RAIZ"
+
+# --- 1. Qual ambiente e este? -------------------------------------------------
+titulo "Ambiente"
+
+LABEL_CHAVE='{{index .Config.Labels "com.docker.compose.project.config_files"}}'
+LABELS="$(docker inspect infra-api-1 --format "$LABEL_CHAVE" 2>/dev/null || true)"
+[[ -n "$LABELS" ]] || morre "nao achei o container infra-api-1. A stack esta de pe neste host?"
+
+tem_traefik=0
+tem_prod=0
+[[ "$LABELS" == *docker-compose.traefik.yml* ]] && tem_traefik=1
+[[ "$LABELS" == *docker-compose.prod.yml* ]] && tem_prod=1
+(( tem_traefik + tem_prod == 1 )) || morre "nao identifiquei o ambiente a partir de: $LABELS"
+
+if (( tem_traefik )); then
+  PERFIL="hostinger"
+  COMPOSE_ARQ="docker-compose.traefik.yml"
+  # o .traefik.yml usa ${VAR:?}; sem --env-file o compose nem consegue listar os servicos
+  COMPOSE_FLAGS=(--env-file .env.prod)
+  DOMINIO="e1p.doroeventos.com.br"
+  EH_PROD=0
+  PAPEL="desenvolvimento/teste"
+else
+  PERFIL="aws"
+  COMPOSE_ARQ="docker-compose.prod.yml"
+  # este resolve o env por env_file: interno, nao precisa da flag
+  COMPOSE_FLAGS=()
+  DOMINIO="e1p.criativaeduca.com.br"
+  EH_PROD=1
+  PAPEL="PRODUCAO"
+fi
+ok "perfil $PERFIL ($PAPEL) - $COMPOSE_ARQ - https://$DOMINIO"
+
+# O superusuario do Postgres nao e "postgres" aqui; perguntar ao container evita chutar.
+PG_USER="$(docker exec infra-postgres-1 printenv POSTGRES_USER)"
+PG_DB="$(docker exec infra-postgres-1 printenv POSTGRES_DB)"
+psql_() { docker exec infra-postgres-1 psql -U "$PG_USER" -d "$PG_DB" -tAc "$1"; }
+compose_() { (cd "$RAIZ/infra" && docker compose "${COMPOSE_FLAGS[@]}" -f "$COMPOSE_ARQ" "$@"); }
+bundle_servido() {
+  curl -sS --max-time 20 "https://$DOMINIO/" 2>/dev/null \
+    | grep -oE '/assets/index-[A-Za-z0-9_-]+[.]js' | head -1 || true
+}
+
+# --- 2. O checkout esta limpo? ------------------------------------------------
+[[ -z "$(git status --porcelain)" ]] || morre "ha mudancas nao commitadas em $RAIZ - resolva antes de deployar"
+
+git fetch origin --quiet
+SHA_ANTES="$(git rev-parse HEAD)"
+SHA_ALVO="$(git rev-parse "origin/$REF" 2>/dev/null || git rev-parse "$REF" 2>/dev/null || true)"
+[[ -n "$SHA_ALVO" ]] || morre "nao consegui resolver a ref '$REF'"
+
+if [[ "$SHA_ANTES" == "$SHA_ALVO" ]]; then
+  ok "ja esta em $(git log --oneline -1 "$SHA_ALVO")"
+  printf '\nNada a fazer.\n'
+  exit 0
+fi
+
+titulo "O que vai subir"
+echo "  de:   $(git log --oneline -1 "$SHA_ANTES")"
+echo "  para: $(git log --oneline -1 "$SHA_ALVO")"
+echo "  ($(git rev-list --count "$SHA_ANTES..$SHA_ALVO") commits)"
+
+MIGRATION=0
+FRONT=0
+git diff --name-only "$SHA_ANTES..$SHA_ALVO" -- apps/api/migrations/versions | grep -q . && MIGRATION=1
+git diff --name-only "$SHA_ANTES..$SHA_ALVO" -- apps/web packages | grep -q . && FRONT=1
+if (( MIGRATION )); then aviso "traz migration - backup obrigatorio"; else ok "sem migration"; fi
+if (( FRONT )); then ok "mexe no front - o bundle DEVE mudar"; else ok "nao mexe no front - o bundle deve permanecer igual"; fi
+
+# --- 3. O CI passou nessa versao? ---------------------------------------------
+titulo "CI"
+if (( PULA_CI )); then
+  aviso "GATE DE CI PULADO por --skip-ci. Voce esta subindo codigo nao verificado."
+else
+  # check-runs, NAO /status: o endpoint legado devolve "pending" num commit inteiramente verde,
+  # porque este repo reporta por check-runs. Usar /status bloquearia todo deploy.
+  CI_URL="https://api.github.com/repos/$REPO_GH/commits/$SHA_ALVO/check-runs"
+  CI_JSON="$(curl -sS --max-time 30 "$CI_URL" 2>/dev/null || true)"
+  [[ -n "$CI_JSON" ]] || morre "nao consegui consultar o CI (rede?). Use --skip-ci se souber o que esta fazendo."
+  FILTRO='[.check_runs[]? | select(.name==$n)] | last | .conclusion // "ausente"'
+  for job in "${JOBS_EXIGIDOS[@]}"; do
+    concl="$(printf '%s' "$CI_JSON" | jq -r --arg n "$job" "$FILTRO")"
+    [[ "$concl" == "success" ]] || morre "o job $job esta '$concl' em ${SHA_ALVO:0:7} - so subimos versao com CI verde."
+    ok "$job"
+  done
+fi
+
+# --- 4. Retrato do "antes" ----------------------------------------------------
+titulo "Antes"
+ALEMBIC_ANTES="$(psql_ 'select version_num from alembic_version' | tr -d '[:space:]')"
+BUNDLE_ANTES="$(bundle_servido)"
+ok "alembic: ${ALEMBIC_ANTES:-?}"
+ok "bundle:  ${BUNDLE_ANTES:-(nao identificado)}"
+
+if (( DRY_RUN )); then
+  titulo "DRY-RUN - nada foi alterado"
+  echo "  faria: docker compose ${COMPOSE_FLAGS[*]} -f $COMPOSE_ARQ up -d --build"
+  if (( EH_PROD || MIGRATION )); then echo "  faria: backup antes"; fi
+  exit 0
+fi
+
+if (( EH_PROD )); then
+  titulo "Confirmacao"
+  echo "  Isto e PRODUCAO ($DOMINIO)."
+  read -r -p "  Digite aws para seguir: " resp
+  [[ "$resp" == "aws" ]] || morre "confirmacao nao conferiu"
+fi
+
+# --- 5. Backup ----------------------------------------------------------------
+titulo "Backup"
+ULTIMO_BKP=""
+if (( EH_PROD || MIGRATION )); then
+  if COMPOSE_FILE="$RAIZ/infra/$COMPOSE_ARQ" "$RAIZ/infra/scripts/backup.sh" >/dev/null 2>&1; then
+    ULTIMO_BKP="$(ls -t /opt/e1p-backups/* 2>/dev/null | head -1 || true)"
+    ok "backup feito: ${ULTIMO_BKP:-/opt/e1p-backups/}"
+  else
+    morre "o backup falhou - nao sigo sem rede de seguranca"
+  fi
+else
+  ok "dispensado (dev, sem migration)"
+fi
+
+# --- 6. Atualizar e reconstruir ----------------------------------------------
+titulo "Deploy"
+if [[ "$REF" == "main" ]]; then
+  git checkout --quiet main
+  git merge --ff-only origin/main
+else
+  git checkout --quiet --detach "$SHA_ALVO"
+fi
+ok "checkout em $(git rev-parse --short HEAD)"
+
+# Sem nomear servico de proposito: "up -d --build web" reconstroi SO o nomeado e deixa o resto
+# servindo build velho, silenciosamente. E nunca --remove-orphans: o mesmo project name e
+# compartilhado com o compose de monitoring, e a flag mataria o Uptime Kuma.
+compose_ up -d --build
+
+# --- 7. Provar que subiu ------------------------------------------------------
+titulo "Verificacao"
+printf '  aguardando a API responder'
+saude=""
+for _ in $(seq 1 30); do
+  saude="$(curl -sS --max-time 5 "https://$DOMINIO/api/health" 2>/dev/null || true)"
+  case "$saude" in *status*ok*) break ;; esac
+  printf '.'
+  sleep 4
+done
+printf '\n'
+case "$saude" in
+  *status*ok*) ok "health: $saude" ;;
+  *) morre "a API nao respondeu saudavel a tempo. Backup: ${ULTIMO_BKP:-/opt/e1p-backups/} | voltar para: ${SHA_ANTES:0:7}" ;;
+esac
+
+caidos="$(compose_ ps --format '{{.Name}} {{.State}}' 2>/dev/null | grep -v ' running' || true)"
+if [[ -z "$caidos" ]]; then ok "todos os containers de pe"; else aviso "fora do ar: $caidos"; fi
+
+ALEMBIC_DEPOIS="$(psql_ 'select version_num from alembic_version' | tr -d '[:space:]')"
+HEAD_REPO="$(ls apps/api/migrations/versions/*.py | sed 's|.*/||' | grep -oE '^[0-9]+' | sort -n | tail -1)"
+if [[ "$ALEMBIC_DEPOIS" == "$HEAD_REPO" ]]; then
+  ok "alembic: $ALEMBIC_ANTES -> $ALEMBIC_DEPOIS (head do repo)"
+else
+  morre "alembic ficou em '$ALEMBIC_DEPOIS' mas o repo pede '$HEAD_REPO' - a migration nao aplicou."
+fi
+
+BUNDLE_DEPOIS="$(bundle_servido)"
+if (( FRONT )); then
+  if [[ -n "$BUNDLE_DEPOIS" && "$BUNDLE_DEPOIS" != "$BUNDLE_ANTES" ]]; then
+    ok "bundle mudou: ${BUNDLE_ANTES:-?} -> $BUNDLE_DEPOIS"
+  else
+    morre "o diff mexe no front mas o bundle servido continua '$BUNDLE_DEPOIS' - o web esta servindo build velho."
+  fi
+else
+  if [[ "$BUNDLE_DEPOIS" == "$BUNDLE_ANTES" ]]; then
+    ok "bundle inalterado, como esperado"
+  else
+    aviso "o bundle mudou ($BUNDLE_ANTES -> $BUNDLE_DEPOIS) sem o diff tocar o front - vale entender."
+  fi
+fi
+
+titulo "Pronto"
+echo "  $PERFIL: ${SHA_ANTES:0:7} -> $(git rev-parse --short HEAD)  ($DOMINIO)"


### PR DESCRIPTION
## Por quê

Depois da migração da produção para a AWS (2026-08-20), passaram a existir **dois ambientes com formatos diferentes** — a AWS com `docker-compose.prod.yml` (Caddy) e a Hostinger, agora dev, com `docker-compose.traefik.yml` (que exige `--env-file .env.prod`). O deploy era manual em ambos, e o runbook mandava **escolher o compose file a dedo** conferindo um label do container.

Escolher errado no host errado é o modo de errar mais caro daqui. Este PR faz esse modo de errar deixar de existir: ninguém escolhe.

## O que muda

`infra/scripts/deploy.sh` — um script, os dois ambientes:

```bash
ssh -t <host> "cd /opt/e1p && ./infra/scripts/deploy.sh"
```

Ele **detecta o ambiente** lendo `com.docker.compose.project.config_files` da stack em pé — exatamente a conferência que o runbook manda fazer manualmente — e daí deriva compose, `--env-file` e domínio. Label irreconhecível aborta; nunca chuta.

E ele **prova o que fez**, em vez de só executar:

| Etapa | O que faz |
|---|---|
| Gate de CI | exige **todos** os checks verdes no SHA alvo |
| Backup | sempre em prod; em dev só quando o diff traz migration |
| Rebuild | `up -d --build` **sem nomear serviço**, nunca `--remove-orphans` |
| Verificação | health + `alembic_version` = head do repo + hash do bundle servido |

Flags: `--dry-run` (imprime o plano, não executa), `--ref <sha>`, `--skip-ci` (grita ao usar).

## Três decisões que valem revisão

**1. O gate de CI cobra por lista de EXCLUSÃO, não de inclusão.** A primeira versão listava os 4 jobs que eu conhecia — e já nascia incompleta, porque o `ci.yml` tem 5: `sast-semgrep` entrou depois e o gate seguiria aprovando sem ele, calado. Agora todo check do commit é cobrado, menos os nomeados. A direção do erro é o ponto: por inclusão, um gate novo passa despercebido; por exclusão, um check novo bloqueia uma vez e a decisão vira consciente. A única exceção é `mutation`, que roda por `on: schedule` e não em PR.

**1b. E usa `check-runs`, não `/status`.** O endpoint legado devolve `pending` num commit **inteiramente verde** neste repo, porque aqui se reporta por check-runs. Um gate ingênuo bloquearia todo deploy, para sempre. Está comentado no código para ninguém "simplificar" de volta.

**2. A prova do front é o hash do bundle, não um literal escolhido a dedo.** O runbook manda grepar no bundle servido um literal que só existe no build novo — o que exige julgamento humano a cada deploy e erra fácil. O script compara `/assets/index-<hash>.js` antes e depois, e cobra a direção certa: mudou **se e somente se** o diff tocou `apps/web`. Bundle igual com front alterado é falha; bundle diferente sem front alterado é aviso.

**3. Não há rollback automático.** Rollback de migration não é automático de verdade, e automatizá-lo daria falsa confiança. Ao falhar, o script imprime o caminho do backup e o SHA anterior.

## Validação

Rodado **de verdade** na Hostinger (que virou dev exatamente para isto), não só em dry-run:

- perfil `hostinger` detectado sozinho → compose do Traefik + `--env-file`
- checks de CI verdes em `e134fa9`
- deploy `7c6c539` → `e134fa9` (3 commits)
- **bundle mudou** `/assets/index-CuSsIePW.js` → `/assets/index-BFwJl0PH.js`
- `alembic 0079` = head do repo
- o aviso de "orphan containers" apareceu e `--remove-orphans` **não** foi passado: `infra-uptime-kuma-1` seguiu `Up 8 days (healthy)`, e `axisgov-*`, `nexus-publica`, `doro-site` intactos

## Docs

- `HOSTINGER-DEPLOY.md` §5 passa a apontar para o script, e registra que esta VPS é **dev** desde 20/08.
- `AWS-DEPLOYMENT.md` ganha um bloco de realidade no topo. Ele descrevia uma Fase A (RDS, S3+CloudFront, SQS, Terraform) que **não é o que existe**: a produção é uma EC2 única com tudo em Compose e o Postgres em container. Quem lesse tiraria conclusão errada sobre onde os dados moram. O plano fica, marcado como plano.

Fica registrada ali também uma lacuna real que este PR **não** fecha: **a produção não tem backup offsite.** A Hostinger tem `rclone`; a AWS não. O backup diário roda, mas fica na mesma instância que o banco.

## Nota para quem for deployar na AWS depois do merge

Ovo e galinha: o script só chega ao servidor por `git pull`, que é o que ele faz. Para a primeira vez existe `E1P_RAIZ`, que permite rodar uma cópia de fora do checkout:

```bash
scp infra/scripts/deploy.sh <host>:/tmp/ && ssh -t <host> "E1P_RAIZ=/opt/e1p bash /tmp/deploy.sh"
```

Da segunda em diante, usa-se a cópia versionada normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
