### PR TITLE
fix(config): comentario inline no .env ligava o storage S3 e derrubava todo upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,6 +597,64 @@ quebrar) — mudança que nenhuma régua vê é peso morto, e por isso ela não 
 - [x] **Storage S3-compatível dos Anexos** — os bytes podem sair do Postgres para um object storage S3 (`app/core/storage.py`, wrapper fino sobre `boto3` com `endpoint_url` configurável: AWS S3 real OU MinIO/B2/Wasabi barato, sem trocar código). **Dual-write/dual-read com fallback gracioso:** se `S3_BUCKET` está vazio (dev/CI/staging sem bucket), tudo continua no Postgres exatamente como antes (mesmo padrão fail-safe de WhatsApp/SMTP). Se configurado, anexo novo sobe pro bucket (`storage_key` setado, `data=None`); a leitura resolve a origem por linha, então anexo legado (pré-migração) continua baixando. Isolamento de tenant também no path da chave (`tenants/{tenant_id}/attachments/{id}/{filename}` via `build_key`), em complemento à RLS do metadado. Contrato HTTP dos 4 endpoints de `/attachments` e o componente `Attachments.tsx` **inalterados** (só persistência mudou). Migration 0039 (só estrutural: `storage_key` + `data` nullable — não toca em rede no boot). Backfill idempotente `python -m app.scripts.migrate_attachments_to_s3` (documentado em `docs/HOSTINGER-DEPLOY.md`, roda numa janela após configurar as envs). Faseável/não-bloqueante para o deploy.
   - **Dívida:** remover a coluna `data` (limpeza só depois do backfill 100% em produção); validação real contra um bucket S3/MinIO de verdade é manual (sem testcontainers p/ S3 no CI, mesma lacuna do RLS/Postgres).
 
+### O comentário do template LIGOU o storage S3 em produção (AWS, 2026-08-20)
+
+**A frase que dizia "storage S3 desligado" era exatamente o que o ligava.** `env_file` do Docker
+Compose **não** remove comentário na mesma linha do valor — tudo depois do `=` vira o valor. O
+`.env.prod.example` trazia `S3_BUCKET=   # vazio = storage S3 desligado (fallback Postgres)`, e o
+`.env.prod` da AWS foi preenchido copiando o template como ele estava. Dentro do container:
+
+| Variável | Valor real | Efeito |
+|---|---|---|
+| `S3_BUCKET` | `"# vazio = storage S3 desligado (fallback Postgres)"` | **não-vazio** → `is_configured()` devolve `True` |
+| `S3_ENDPOINT_URL` | `"# vazio = endpoint padrão da AWS; defina p/ MinIO/B2/Wasabi"` | boto3 → `ValueError: Invalid endpoint` |
+
+Resultado: **500 em TODO upload de anexo** — comprovante pelo celular, boleto e contrato de
+Pagar/Cobranças, e a mídia recebida no WhatsApp, que **falha CALADA**
+(`whatsapp_inbox/service.py` captura `Exception` amplo e registra a mensagem sem o anexo). Leitura
+de anexo antigo seguia funcionando — linha legada tem `storage_key` nulo e lê do Postgres —, e foi
+isso que fez o defeito parecer isolado no comprovante.
+
+- ⚠️ **A degradação graciosa da Story 3.5 estava CORRETA e foi derrotada pela configuração.** O
+  fallback nunca chegou a rodar: `is_configured()` lê só `s3_bucket`, e um bucket "preenchido" com
+  a própria frase que anuncia o desligamento satisfaz a condição. **Uma feature fail-safe só é
+  fail-safe até o env mentir sobre estar vazio.**
+- [x] **`Settings._descarta_comentario_do_template`** (`app/config.py`) — valor de env que começa com
+  `#` nos campos `S3_*` é **ausência de configuração**, e volta ao DEFAULT do campo (não a `""`:
+  para `s3_region` o desligado é `"auto"`, e zerá-la entregaria região vazia ao boto3).
+  - ⚠️ **Só o grupo S3, e a restrição é a decisão.** Segredo e senha podem legitimamente começar com
+    `#`; descartá-los trocaria este defeito por um pior — a app subindo em produção sem a
+    credencial que o operador configurou. Campo S3 novo entra em `_CAMPOS_S3`.
+  - **O descarte LOGA em WARNING, e isso tem teste próprio.** Degradar para o Postgres em silêncio
+    é como o defeito sobreviveu a um deploy inteiro sem ninguém notar; quem QUERIA o S3 ligado
+    precisa achar a linha no log.
+- [x] **`.env.prod.example`** — os comentários das duas linhas foram para **linha própria**, com o
+  aviso do mecanismo escrito ali. Eram as **únicas duas** linhas do template inteiro com
+  comentário inline (`grep -nE "^[A-Z_][A-Z0-9_]*=.*#"` dá zero agora).
+- **A correção em produção não precisa de deploy de código:** zerar as duas linhas do
+  `/opt/e1p/infra/.env.prod` e `docker compose up -d` **sem nomear serviço** (`api` e `worker` leem
+  o mesmo `env_file`; `restart` **não** relê o arquivo, só o `up` relê).
+- **Zerar é seguro:** o `put_object` sempre falhou ANTES do `commit`, então nenhuma linha de
+  `attachments` ficou com `storage_key` apontando para um bucket — não há byte órfão.
+
+⚠️ **A Hostinger nunca teve o defeito, e o motivo importa:** o `.env.prod` dela tem **33 linhas** (contra as ~100
+do template) e **nenhum `S3_BUCKET` nem `S3_ENDPOINT_URL`** — a única linha com "s3" é
+`BACKUP_S3_BUCKET`, que é o bucket do `rclone` do dump e nem é lida pelo `Settings`. Sem as
+variáveis, `s3_bucket` cai no default do pydantic e o storage fica desligado. Aquele arquivo foi
+escrito à MÃO; o da AWS foi montado a partir do `.env.prod.example`, e é só nisso que diferem. *"Lá
+funciona"* não contradiz o diagnóstico — é a previsão dele. **Regra que fica: o `.env.prod` é
+escrito à mão em cada servidor e NUNCA foi versionado, então dois ambientes com o mesmo commit
+podem divergir em qualquer variável.** Ao investigar diferença entre ambientes, compare o env
+antes de procurar no código — aqui o `git log` do caminho inteiro (`receipts.py`,
+`attachments/`, `core/storage.py`) mostrava zero mudanças desde o PR #71, de 04/08.
+
+- **Dívida:** nada impede a **próxima** variável não-S3 de cair na mesma armadilha — a guarda é
+  deliberadamente estreita, e o que protege o resto é só o template estar limpo hoje. Um teste que
+  varra `.env.prod.example` atrás de `^[A-Z_]+=.*#` fecharia a classe; não entrou aqui para não
+  misturar regra nova com a correção do incidente.
+- **Dívida:** `whatsapp_inbox` engole a falha de anexo em `except Exception` — durante a janela do
+  defeito, mídia recebida foi perdida sem sinal nenhum ao dono. Fora do escopo desta correção.
+
 ## Anexos: comprovante pelo share sheet do celular
 - [x] **Compartilhar comprovante do app do banco → Contas a Pagar** — o comprovante entra pelo
   compartilhamento nativo do celular, sem salvar arquivo antes. **Bandeja de staging** sem tabela

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -1,5 +1,18 @@
-from pydantic import model_validator
+import logging
+
+from pydantic import ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger("e1p.config")
+
+# Os campos do storage S3. Ver `_descarta_comentario_do_template` para o porquê deste grupo.
+_CAMPOS_S3 = (
+    "s3_endpoint_url",
+    "s3_bucket",
+    "s3_access_key_id",
+    "s3_secret_access_key",
+    "s3_region",
+)
 
 _DEV_SECRET = "dev-secret-change-in-production"  # noqa: S105 (sentinela do default de dev)
 _DEFAULT_ADMIN_PASSWORD = "trocar-no-primeiro-acesso"  # noqa: S105 (sentinela do default de dev)
@@ -76,6 +89,38 @@ class Settings(BaseSettings):
     s3_access_key_id: str = ""
     s3_secret_access_key: str = ""
     s3_region: str = "auto"
+
+    @field_validator(*_CAMPOS_S3, mode="before")
+    @classmethod
+    def _descarta_comentario_do_template(cls, v: object, info: ValidationInfo) -> object:
+        """Valor que é só o comentário do template não é configuração — é a AUSÊNCIA dela.
+
+        `env_file` do Docker Compose **não** remove comentário na mesma linha do valor: tudo
+        depois do `=` vira o valor. Copiado do `.env.prod.example`, `S3_BUCKET=  # vazio =
+        storage S3 desligado` chega ao container como a própria frase — não-vazia — e
+        `storage.is_configured()` responde True. O upload segue para o S3 com um
+        `S3_ENDPOINT_URL` igualmente comentado e morre em `ValueError: Invalid endpoint`,
+        devolvendo 500 em TODO anexo. Foi o que aconteceu na AWS em 2026-08-20: a frase que
+        dizia "storage S3 desligado" era exatamente o que ligava o storage.
+
+        Devolve o DEFAULT do campo, não `""`: para `s3_region` o desligado é `"auto"`, e zerá-la
+        entregaria uma região vazia ao boto3.
+
+        ⚠️ **Só o grupo S3.** Segredo e senha podem legitimamente começar com `#`, e descartá-los
+        trocaria este defeito por um pior — a app subindo em produção sem a credencial que o
+        operador configurou. Se um campo novo do S3 nascer, acrescente-o a `_CAMPOS_S3`.
+        """
+        if isinstance(v, str) and v.lstrip().startswith("#"):
+            nome = (info.field_name or "").upper()
+            logger.warning(
+                "%s recebeu um comentário como valor (%r) e foi IGNORADO — comentário em "
+                "env_file precisa estar em linha própria. Se você queria o storage S3 ligado, "
+                "corrija o .env; os anexos continuam no Postgres.",
+                nome,
+                v[:60],
+            )
+            return cls.model_fields[info.field_name].default  # type: ignore[index]
+        return v
 
     # OAuth Google (Meet/Calendar) — app OAuth GLOBAL da plataforma (um Google Cloud project
     # para todos os tenants). Vazio = integração indisponível (fail-safe: o sistema segue

--- a/apps/api/tests/test_attachments_s3.py
+++ b/apps/api/tests/test_attachments_s3.py
@@ -10,6 +10,7 @@ import io
 import pytest
 from fastapi.testclient import TestClient
 
+from app.config import Settings
 from app.core import storage
 
 REGISTER = {
@@ -141,3 +142,44 @@ def test_build_key_sanitizes_filename():
     key = storage.build_key("tenant-xxxx", "att-9", "../../etc/passwd")
     assert key.startswith("tenants/tenant-xxxx/attachments/att-9/")
     assert "/../" not in key
+
+
+# --- Regressão de produção (2026-08-20): comentário inline no .env ligou o S3 na AWS ---
+#
+# `env_file` do Docker Compose NÃO remove comentário na mesma linha do valor: tudo depois do `=`
+# vira o valor. O `.env.prod.example` trazia `S3_BUCKET=   # vazio = storage S3 desligado`, então
+# dentro do container o bucket era a própria frase — NÃO-vazia — e `is_configured()` respondia
+# True. O upload seguia para o S3 com um `S3_ENDPOINT_URL` igualmente comentado e morria em
+# `ValueError: Invalid endpoint`, devolvendo 500 em TODO anexo (comprovante, boleto, mídia de
+# WhatsApp). A frase que dizia "storage S3 desligado" era exatamente o que ligava o storage.
+
+_COMENTARIO_BUCKET = "# vazio = storage S3 desligado (fallback Postgres)"
+_COMENTARIO_ENDPOINT = "# vazio = endpoint padrão da AWS; defina p/ MinIO/B2/Wasabi"
+
+
+def test_bucket_que_e_so_comentario_mantem_o_storage_desligado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Um bucket que é só o comentário do template = intenção de DESLIGADO, não de ligado."""
+    monkeypatch.setattr(storage, "settings", Settings(s3_bucket=_COMENTARIO_BUCKET))
+    assert storage.is_configured() is False
+
+
+def test_endpoint_que_e_so_comentario_nao_chega_ao_boto3() -> None:
+    """Bucket real + endpoint comentado: o endpoint é neutralizado, não repassado ao boto3.
+
+    Sem isto, `boto3.client(endpoint_url="# vazio = ...")` levanta ValueError e derruba o
+    upload inteiro mesmo com o S3 legitimamente configurado.
+    """
+    s = Settings(s3_bucket="e1p-anexos", s3_endpoint_url=_COMENTARIO_ENDPOINT)
+    assert s.s3_endpoint_url == ""
+
+
+def test_o_descarte_do_comentario_nao_e_silencioso(caplog: pytest.LogCaptureFixture) -> None:
+    """Degradar para o Postgres em silêncio é como o defeito sobrevive a um deploy inteiro.
+
+    Quem QUERIA o S3 ligado precisa achar a linha no log; quem não queria não perde nada.
+    """
+    with caplog.at_level("WARNING", logger="e1p.config"):
+        Settings(s3_bucket=_COMENTARIO_BUCKET)
+    assert any("S3_BUCKET" in r.message for r in caplog.records)

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -93,8 +93,12 @@ BACKUP_RETENTION_DAYS_REMOTE=30
 # para ativar: pode ser AWS S3 real OU um provedor S3-compatível mais barato (MinIO self-hosted,
 # Backblaze B2, Wasabi) via S3_ENDPOINT_URL — sem trocar código, só configuração. Depois de
 # configurar, rode o backfill dos anexos legados (ver docs/HOSTINGER-DEPLOY.md).
-S3_ENDPOINT_URL=          # vazio = endpoint padrão da AWS; defina p/ MinIO/B2/Wasabi
-S3_BUCKET=               # vazio = storage S3 desligado (fallback Postgres)
+# ATENÇÃO: `env_file` do Docker Compose NÃO remove comentário na mesma linha do valor — tudo
+# depois do `=` vira o valor. Comentário aqui mora em LINHA PRÓPRIA, sempre.
+# S3_ENDPOINT_URL vazio = endpoint padrão da AWS; preencha p/ MinIO/B2/Wasabi.
+S3_ENDPOINT_URL=
+# S3_BUCKET vazio = storage S3 desligado (fallback Postgres).
+S3_BUCKET=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_REGION=auto


### PR DESCRIPTION
## O incidente

Em produção (AWS), **todo upload de anexo devolvia 500**. O traceback imprimia o valor literal:

```
ValueError: Invalid endpoint: # vazio = endpoint padrão da AWS; defina p/ MinIO/B2/Wasabi
```

`env_file` do Docker Compose **não** remove comentário na mesma linha do valor — tudo depois do `=` vira o valor. O `.env.prod` da AWS foi preenchido copiando o `.env.prod.example`, que trazia:

```
S3_ENDPOINT_URL=          # vazio = endpoint padrão da AWS; defina p/ MinIO/B2/Wasabi
S3_BUCKET=               # vazio = storage S3 desligado (fallback Postgres)
```

| Variável | Valor real no container | Efeito |
|---|---|---|
| `S3_BUCKET` | `"# vazio = storage S3 desligado (fallback Postgres)"` | **não-vazio** → `is_configured()` devolve `True` |
| `S3_ENDPOINT_URL` | `"# vazio = endpoint padrão da AWS…"` | boto3 → `ValueError: Invalid endpoint` |

**A frase que dizia "storage S3 desligado" era exatamente o que ligava o storage.** A degradação graciosa da Story 3.5 estava correta e foi derrotada por um env que mente sobre estar vazio.

**Alcance:** comprovante pelo celular, boleto/contrato de Pagar e Cobranças, e mídia recebida no WhatsApp — esta **falhando calada** (`except Exception` amplo em `whatsapp_inbox/service.py`). Leitura de anexo antigo seguia funcionando (linha legada tem `storage_key` nulo), e foi isso que fez o defeito parecer isolado no comprovante.

**Por que ninguém notou:** o mesmo arquivo é lido por dois parsers com comportamentos opostos — `infra/scripts/backup.sh` faz `source` (o bash **corta** comentário inline) e o Compose usa `env_file` (**não** corta).

## O que muda

- **`Settings._descarta_comentario_do_template`** — valor `S3_*` começando com `#` volta ao **default do campo**, não a `""` (para `s3_region` o desligado é `"auto"`; zerá-la entregaria região vazia ao boto3). Loga **WARNING**: degradar em silêncio é como o defeito sobreviveu a um deploy inteiro.
  - ⚠️ **Só o grupo S3, e a restrição é a decisão.** Segredo e senha podem legitimamente começar com `#`; descartá-los faria a app subir em produção sem a credencial que o operador configurou — pior que o defeito original.
- **`.env.prod.example`** — comentários em linha própria, com o aviso do mecanismo. Eram as **únicas duas** linhas do template com comentário inline.
- **3 testes** escritos antes da correção, vermelhos pelos motivos certos (`assert True is False`, `assert '# vazio = en…' == ''`, WARNING ausente).
- Entrada no `CLAUDE.md` (§5 passo 4).

## Verificação

| Gate | Resultado |
|---|---|
| `ruff check .` | `All checks passed!` |
| `pytest -q` | **2253 passed, 1 skipped** (o skip é `rls_e2e`, que exige Docker) |

Produção já foi corrigida à mão em 2026-08-20 zerando as duas linhas; este PR impede a reincidência no próximo `.env` copiado do template.

## Dívida declarada

- A guarda é **estreita de propósito**: nada impede a próxima variável não-S3 de cair na mesma armadilha. Um teste varrendo `.env.prod.example` atrás de `^[A-Z_]+=.*#` fecharia a classe — não entrou aqui para não misturar regra nova com a correção do incidente.
- `whatsapp_inbox` engole a falha de anexo em `except Exception`: durante a janela do defeito, mídia recebida foi perdida sem sinal ao dono. Pré-existente, fora de escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
