### PR TITLE
fix(infra): bloco opcional do Caddyfile sai do arquivo base e entra por env [#151]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,23 @@ jobs:
       - name: Instalar dependências
         run: pip install -r apps/api/requirements.txt
 
+      # Gate do Caddyfile (issue #151) — mora AQUI, e não no `test-in-prod-image`, porque aquele
+      # job roda a suíte DENTRO da imagem da API, onde só `apps/api` foi copiado: `infra/` não
+      # existe lá e o gate se auto-pula (na primeira versão ele nem se pulava — estourava
+      # `IndexError` num `parents[3]` fixo e derrubava a COLETA inteira). Este job tem o checkout
+      # completo e é required em `main`.
+      #
+      # A guarda abaixo reprova o SKIP, mesma lógica do `rls_e2e` logo abaixo: um gate que se pula
+      # sozinho fica verde sem proteger nada, e o silêncio é indistinguível de aprovação.
+      - name: Gate do Caddyfile (bloco opcional fora do arquivo base)
+        run: |
+          set -uo pipefail
+          cd apps/api
+          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py --junitxml=caddy-gate.xml
+          rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("caddy-gate.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"caddy-gate: coletados={t} executados={ex} skipped={k}"); ok=ex>=1; ok or print("::error::O gate do Caddyfile foi PULADO (infra/ nao alcancavel a partir do teste). Ele existe para reprovar bloco que exige config externa no arquivo base; pulado, nao protege nada (issue #151)."); sys.exit(0 if ok else 1)'
+
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem
       # reeditar este ci.yml (mesma lógica do canário anti-regressão da Story 6.1). Sobe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2988,6 +2988,58 @@ migration.
 
 > Já corrigidos na fundação: guarda de boot p/ JWT_SECRET fraco em produção; RLS fail-closed (valida tenant_id); IntegrityError→409 no register (race); /me revalida is_active e não reemite token; e-mail case-insensitive; alinhamento de `created_at`/`role` com shared-types.
 
+## Infra: o Caddyfile parou de ser tudo-ou-nada (issue #151, 2026-08-20)
+
+**O parse do Caddyfile é ALL-OR-NOTHING, e o `.env.prod.example` prometia o contrário.** O bloco
+wildcard usa `dns cloudflare {$CLOUDFLARE_API_TOKEN}`; com o token vazio o Caddy recusa o arquivo
+**INTEIRO** (`missing API token`) e **nem o domínio único sobe**, com o certificado dele intacto em
+disco. O comentário do template dizia *"vazio = wildcard não emite o certificado (domínio único
+segue normal)"* — uma degradação graciosa que **não existia**. Derrubou a produção por ~40 min em
+2026-08-20, e o contorno tinha sido um Caddyfile local não versionado, que some no primeiro
+`git pull`.
+
+- [x] **`infra/Caddyfile` guarda só o que SEMPRE funciona** (domínio único, HTTP-01) e termina em
+  `import /etc/caddy/conf.d/*.caddy`. Os blocos que dependem de configuração externa mudaram para
+  `infra/caddy/optional/` — `wildcard.caddy` e `monitor.caddy`.
+- [x] **A ativação é por ENV, nunca por arquivo criado à mão no servidor.** `infra/caddy/entrypoint.sh`
+  copia para `conf.d/` só o que a env pede: wildcard exige `CLOUDFLARE_API_TOKEN` **e**
+  `ROOT_DOMAIN` (sem o segundo o endereço vira `*.`, inválido); monitor exige
+  `MONITORING_ENABLED=true`. **A opção 1 da issue, ao pé da letra, pedia que o operador criasse os
+  arquivos** — seria trocar esta armadilha pela classe que custou os 40 minutos: config que vive
+  só na máquina, invisível a qualquer leitura do repo.
+  - O entrypoint **apaga e recria** `conf.d/` a cada arranque (recriar container não pode herdar
+    bloco de antes) e **anuncia em log** o que ligou e o que não ligou. Desligar em silêncio é como
+    o defeito irmão do `.env` sobreviveu a um deploy inteiro.
+  - `caddy:2-alpine` tem `ENTRYPOINT` **null** e o `CMD` completo, então o script recebe o comando
+    oficial como `"$@"` e faz `exec "$@"` — nada da imagem base é reescrito.
+- ⚠️ **Glob de `import` sem correspondência é NO-OP, e isso foi MEDIDO, não suposto.**
+  `caddy validate` com `conf.d` vazio devolve `Valid configuration` e um `warn` (*"No files matching
+  import glob pattern"*). É esse fato que torna a degradação real em vez de documental — e o repo
+  já pagou seis vezes por supor comportamento de terceiro (§WhatsApp Evolution).
+- **Validado com o binário real, na imagem com o plugin**, em cinco cenários: sem token · token +
+  `ROOT_DOMAIN` (wildcard entra) · token **sem** `ROOT_DOMAIN` (guarda) · só `ROOT_DOMAIN` ·
+  `MONITORING_ENABLED=true`. Os cinco: `Valid configuration`. **Controle positivo:** alimentar o
+  formato ANTIGO (wildcard inline) com token vazio reproduz o erro de produção palavra por palavra.
+- ⚠️ **`ROOT_DOMAIN` pode ser domínio-PAI de `DOMAIN`, e aí o wildcard COBRE o domínio único.** Em
+  produção `DOMAIN=e1p.criativaeduca.com.br` e `ROOT_DOMAIN=criativaeduca.com.br`: com um token
+  inválido, o principal deixa de receber certificado mesmo tendo o dele em disco. Um placeholder
+  com formato válido (40 chars) **passa** na validação do plugin e não salva — medido.
+- [x] **Gate de texto** (`tests/test_caddyfile_blocos_opcionais.py`, 5 asserções): o arquivo base não
+  pode conter diretiva que exija config externa, precisa ter o `import`, e **todo arquivo em
+  `optional/` precisa de um ramo no entrypoint** — bloco versionado que nenhuma env alcança é falha
+  silenciosa perfeita, a família da `capabilities.py` sem consumidor. Com controle positivo, para o
+  gate não passar por vacuidade se alguém apagar os dois arquivos. Provado por mutação: devolver o
+  wildcard ao arquivo base deixa o gate **vermelho**.
+
+- **Dívida:** a validação de verdade (build da imagem + `caddy validate` nos cinco cenários) é
+  **manual, com Docker, e não roda no CI** — o gate que roda é de texto. Um job que buildasse a
+  imagem por PR pagaria ~2 min de `xcaddy` em toda mudança do repo; a troca não foi feita, e fica
+  registrada em vez de escondida.
+- **Dívida:** o `docker-compose.override.yml` da AWS pode perder o bloco `caddy:` depois que isto
+  for deployado — mas só **depois**, e conferindo que o wildcard segue desligado lá
+  (`CLOUDFLARE_API_TOKEN` vazio de propósito). Enquanto o override existir, ele vence: monta o
+  `Caddyfile.single`, que não tem o `import` e portanto ignora os opcionais — **seguro, só redundante**.
+
 ## 7. Materiais de referência (fora do repo)
 - Spec mestre: `/Volumes/Extreme SSD/2026_e1p/Configuração do software.docx`
 - Design Figma exportado: `/Volumes/Extreme SSD/2026_Downloads de JUNHO/crm_export/` (PNGs do "Portal")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3030,9 +3030,20 @@ segue normal)"* — uma degradação graciosa que **não existia**. Derrubou a p
   silenciosa perfeita, a família da `capabilities.py` sem consumidor. Com controle positivo, para o
   gate não passar por vacuidade se alguém apagar os dois arquivos. Provado por mutação: devolver o
   wildcard ao arquivo base deixa o gate **vermelho**.
+  - ⚠️ **Ele roda no job `cross-tenant-rls`, NÃO no `test-in-prod-image`, e isso não é arbitrário.**
+    Aquele job roda a suíte **dentro da imagem da API**, onde só `apps/api` foi copiado: `infra/`
+    não existe lá. Na primeira versão o teste resolvia a raiz com `parents[3]` fixo e estourou
+    `IndexError` **na COLETA** — 66 testes deselecionados, exit 2, o job inteiro vermelho por um
+    gate que nem era sobre a API. Hoje ele **sobe procurando `infra/Caddyfile`** e se pula quando
+    não o acha.
+  - ⚠️ **E o SKIP é REPROVADO no job que importa.** A etapa do `ci.yml` confere `executados >= 1`
+    pelo junit, igual à guarda do `rls_e2e`: um gate que se pula sozinho fica verde sem proteger
+    nada, e silêncio é indistinguível de aprovação. **Regra que fica: teste que lê arquivo FORA
+    de `apps/api` não pode viver só no `pytest` da imagem — ou ele se pula, ou ele quebra a
+    coleta.**
 
 - **Dívida:** a validação de verdade (build da imagem + `caddy validate` nos cinco cenários) é
-  **manual, com Docker, e não roda no CI** — o gate que roda é de texto. Um job que buildasse a
+  **manual, com Docker, e não roda no CI** — o que roda é o gate de TEXTO. Um job que buildasse a
   imagem por PR pagaria ~2 min de `xcaddy` em toda mudança do repo; a troca não foi feita, e fica
   registrada em vez de escondida.
 - **Dívida:** o `docker-compose.override.yml` da AWS pode perder o bloco `caddy:` depois que isto

--- a/apps/api/tests/test_caddyfile_blocos_opcionais.py
+++ b/apps/api/tests/test_caddyfile_blocos_opcionais.py
@@ -13,14 +13,43 @@ devolve `Valid configuration` com um `warn`, não erro).
 Este gate é de TEXTO, e é o que impede alguém de mover um bloco de volta para dentro do arquivo
 principal — a validação de verdade (build da imagem + `caddy validate` nos cinco cenários) é
 manual, com Docker, e não roda no CI. Ver a dívida no CLAUDE.md.
+
+Ele roda no job **`cross-tenant-rls`** do `ci.yml` (checkout completo, required em `main`), e a
+etapa de lá REPROVA o skip: um gate que se pula sozinho fica verde sem proteger nada.
 """
 import pathlib
 
 import pytest
 
-INFRA = pathlib.Path(__file__).resolve().parents[3] / "infra"
-CADDYFILE = INFRA / "Caddyfile"
-OPCIONAIS = INFRA / "caddy" / "optional"
+
+def _acha_infra() -> pathlib.Path | None:
+    """Sobe a partir deste arquivo procurando `infra/Caddyfile`.
+
+    NÃO use `parents[3]`: o job `test-in-prod-image` roda a suíte DENTRO da imagem da API, onde
+    só `apps/api` foi copiado — a árvore é mais rasa e o índice fixo estoura com `IndexError`,
+    derrubando a COLETA inteira (66 testes deselecionados, exit 2). Aconteceu no primeiro CI
+    deste gate.
+    """
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "infra"
+        if (candidato / "Caddyfile").is_file():
+            return candidato
+    return None
+
+
+INFRA = _acha_infra()
+
+# Sem `infra/` alcançável estamos dentro da imagem de produção, e não há o que aferir. O gate
+# roda de verdade no job `cross-tenant-rls` do ci.yml, que tem o checkout completo — lá um
+# skip DERRUBA o job (guarda anti-vacuidade, mesmo padrão do `rls_e2e`). Se este skip começar a
+# aparecer naquele job, o gate parou de gatear e é isso que se conserta, não o skip.
+pytestmark = pytest.mark.skipif(
+    INFRA is None,
+    reason="infra/ fora do alcance (imagem de produção) — este gate roda no job cross-tenant-rls",
+)
+
+CADDYFILE = (INFRA or pathlib.Path(".")) / "Caddyfile"
+OPCIONAIS = (INFRA or pathlib.Path(".")) / "caddy" / "optional"
 
 # Diretivas que EXIGEM configuração externa para adaptar. Nenhuma pode estar no arquivo base.
 # `dns <provider>` cobre o caso real (cloudflare) e o próximo provedor de DNS que aparecer.

--- a/apps/api/tests/test_caddyfile_blocos_opcionais.py
+++ b/apps/api/tests/test_caddyfile_blocos_opcionais.py
@@ -1,0 +1,74 @@
+"""Gate estrutural do Caddyfile: nenhum bloco que dependa de config externa mora nele (issue #151).
+
+**O parse do Caddyfile é ALL-OR-NOTHING.** Um bloco que falha ao adaptar derruba o arquivo
+INTEIRO — não só aquele bloco. Com `CLOUDFLARE_API_TOKEN` vazio, o `dns cloudflare {$...}` do
+wildcard fazia o Caddy recusar tudo (`missing API token`) e **nem o domínio único subia**, mesmo
+com o certificado dele intacto em disco. Em 2026-08-20 isso derrubou a produção por ~40 min.
+
+Por isso os blocos opcionais mudaram de casa: vivem em `infra/caddy/optional/`, entram em
+`/etc/caddy/conf.d/` só quando a env correspondente está preenchida (`infra/caddy/entrypoint.sh`),
+e o Caddyfile os puxa por `import`. Glob sem correspondência é **no-op** (medido: `caddy validate`
+devolve `Valid configuration` com um `warn`, não erro).
+
+Este gate é de TEXTO, e é o que impede alguém de mover um bloco de volta para dentro do arquivo
+principal — a validação de verdade (build da imagem + `caddy validate` nos cinco cenários) é
+manual, com Docker, e não roda no CI. Ver a dívida no CLAUDE.md.
+"""
+import pathlib
+
+import pytest
+
+INFRA = pathlib.Path(__file__).resolve().parents[3] / "infra"
+CADDYFILE = INFRA / "Caddyfile"
+OPCIONAIS = INFRA / "caddy" / "optional"
+
+# Diretivas que EXIGEM configuração externa para adaptar. Nenhuma pode estar no arquivo base.
+# `dns <provider>` cobre o caso real (cloudflare) e o próximo provedor de DNS que aparecer.
+_DIRETIVAS_QUE_EXIGEM_CONFIG = ("dns cloudflare", "{$CLOUDFLARE_API_TOKEN}")
+
+
+def test_caddyfile_base_nao_tem_bloco_que_exige_config_externa():
+    texto = CADDYFILE.read_text(encoding="utf-8")
+    # Só as linhas de CÓDIGO: o cabeçalho explica o defeito e cita o nome da diretiva de
+    # propósito, e um gate que reprovasse o comentário obrigaria a apagar a explicação.
+    codigo = "\n".join(
+        linha for linha in texto.splitlines() if not linha.lstrip().startswith("#")
+    )
+    for diretiva in _DIRETIVAS_QUE_EXIGEM_CONFIG:
+        assert diretiva not in codigo, (
+            f"`{diretiva}` voltou para o infra/Caddyfile. O parse é all-or-nothing: com a env "
+            "vazia, isto derruba a config INTEIRA e o domínio único para de ser servido "
+            "(issue #151). O bloco pertence a infra/caddy/optional/, ativado por env."
+        )
+
+
+def test_caddyfile_base_importa_os_opcionais():
+    codigo = CADDYFILE.read_text(encoding="utf-8")
+    assert "import /etc/caddy/conf.d/*.caddy" in codigo, (
+        "sem o import, os blocos de infra/caddy/optional/ nunca entram e o wildcard deixa de "
+        "existir mesmo com token configurado — a feature some em silêncio."
+    )
+
+
+def test_todo_bloco_opcional_e_ativado_pelo_entrypoint():
+    """Arquivo em `optional/` sem ramo no entrypoint é bloco que NUNCA entra.
+
+    Falha silenciosa perfeita: o arquivo existe, está versionado, parece ativo, e nenhuma env
+    o alcança. Mesma família da `capabilities.py` sem consumidor (§WhatsApp item 12).
+    """
+    entrypoint = (INFRA / "caddy" / "entrypoint.sh").read_text(encoding="utf-8")
+    blocos = sorted(p.name for p in OPCIONAIS.glob("*.caddy"))
+    assert blocos, "nenhum bloco opcional encontrado — o diretório sumiu?"
+    for nome in blocos:
+        assert f"ativa {nome}" in entrypoint, (
+            f"`{nome}` está em optional/ e o entrypoint nunca o ativa: ele jamais entra em "
+            "conf.d/, e a ausência não quebra nada — some sem sintoma."
+        )
+
+
+@pytest.mark.parametrize("nome", ["wildcard.caddy", "monitor.caddy"])
+def test_o_bloco_opcional_existe_e_nao_esta_vazio(nome: str):
+    """Controle positivo do gate acima: sem isto, apagar os dois arquivos deixaria
+    `test_todo_bloco_opcional_e_ativado_pelo_entrypoint` verde por vacuidade."""
+    conteudo = (OPCIONAIS / nome).read_text(encoding="utf-8")
+    assert "{" in conteudo, f"{nome} não tem bloco de site nenhum"

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -34,9 +34,18 @@ FRONTEND_URL=https://app.seudominio.com
 # Wildcard de subdomínio por tenant (Story 4.4) — TLS `*.${ROOT_DOMAIN}` via desafio DNS-01.
 # Token da Cloudflare com escopo MÍNIMO: Zone.DNS -> Edit na zona do ROOT_DOMAIN (menor
 # privilégio). Necessário só p/ o bloco wildcard do Caddyfile (o domínio único usa HTTP-01,
-# não precisa dele). Vazio = wildcard não emite o certificado (domínio único segue normal).
+# não precisa dele).
+# VAZIO = o bloco wildcard nem entra na config, e o domínio único segue normal (issue #151).
+# Isso passou a ser VERDADE em 2026-08-20: antes, token vazio derrubava a config INTEIRA do
+# Caddy e nem o domínio único subia — esta linha descrevia uma degradação que não existia.
 # Pré-requisito: DNS de ${ROOT_DOMAIN} gerido pela Cloudflare (ver docs/HOSTINGER-DEPLOY.md §8).
 CLOUDFLARE_API_TOKEN=
+
+# Painel de monitoramento (Uptime Kuma) publicado em `monitor.${DOMAIN}` pelo Caddy próprio.
+# Só ligue junto com o `docker-compose.monitoring.yml`: sem o container o proxy não tem destino,
+# e sem registro DNS para `monitor.${DOMAIN}` o Caddy tenta emitir certificado em loop
+# (NXDOMAIN a cada tentativa). Vazio/ausente = bloco não entra na config.
+# MONITORING_ENABLED=true
 
 # Google (Meet/Calendar OAuth) — app OAuth GLOBAL da plataforma. Vazio = integração indisponível
 # (a Agenda segue com o campo manual de reunião). Se preencher o trio abaixo (ativar o Google),

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,6 +1,11 @@
-# Domínio único (IV1 da Story 4.4): topologia atual, SEM alteração de comportamento.
-# TLS automático via desafio HTTP-01 (Let's Encrypt) — o que já funciona hoje. Nenhuma
-# regressão: este bloco não usa DNS-01.
+# Domínio único (IV1 da Story 4.4): a topologia que SEMPRE funciona, sem pré-requisito
+# externo nenhum. TLS automático via desafio HTTP-01 (Let's Encrypt).
+#
+# Tudo que depende de configuração externa (token da Cloudflare, container de monitoramento)
+# vive em `caddy/optional/` e só entra em `conf.d/` quando a env correspondente está
+# preenchida — ver `caddy/entrypoint.sh` e a issue #151. O parse do Caddyfile é
+# ALL-OR-NOTHING: um bloco que falha ao adaptar derruba o arquivo INTEIRO, e foi assim que
+# um `CLOUDFLARE_API_TOKEN` vazio deixou o domínio único sem servir nada.
 {$DOMAIN} {
 	encode gzip
 
@@ -15,37 +20,8 @@
 	}
 }
 
-# Painel de monitoramento (Uptime Kuma) — Story 3.4, topologia Caddy próprio (opção B).
-# Só é usado se o docker-compose.monitoring.yml for subido na MESMA rede deste Caddy
-# (ver docs/HOSTINGER-DEPLOY.md §8). Na topologia de produção real (Traefik compartilhado)
-# quem publica monitor.<domínio> é o Traefik via labels do compose de monitoramento — lá
-# este arquivo Caddyfile nem é usado.
-monitor.{$DOMAIN} {
-	encode gzip
-	reverse_proxy uptime-kuma:3001
-}
-
-# Wildcard por tenant (`*.{$ROOT_DOMAIN}`, ex.: `*.e1p.com`) — white-label por subdomínio.
-# TLS via desafio DNS-01 (Cloudflare): OBRIGATÓRIO para certificado curinga — o Let's Encrypt
-# NÃO emite wildcard via HTTP-01, só via DNS-01. Só ESTE bloco usa DNS-01; o domínio único
-# acima permanece com HTTP-01 automático (sem regressão, IV1).
-# Requer, no .env.prod: CLOUDFLARE_API_TOKEN (escopo Zone.DNS Edit na zona) e ROOT_DOMAIN,
-# com o DNS de ROOT_DOMAIN gerido pela Cloudflare (ver docs/HOSTINGER-DEPLOY.md §8).
-# Mesmo roteamento do bloco acima (/api → api:8000, resto → web:80). A resolução de tenant
-# por subdomínio acontece no BACKEND a partir do JWT (RLS) — nunca do Host header, que é
-# controlável pelo cliente (ver apps/api/app/core/subdomain.py, Regra de Ouro nº 1).
-*.{$ROOT_DOMAIN} {
-	encode gzip
-
-	tls {
-		dns cloudflare {$CLOUDFLARE_API_TOKEN}
-	}
-
-	handle_path /api/* {
-		reverse_proxy api:8000
-	}
-
-	handle {
-		reverse_proxy web:80
-	}
-}
+# Blocos OPCIONAIS, montados pelo entrypoint conforme o .env.prod.
+# ⚠️ Glob sem correspondência é NO-OP, não erro — medido com `caddy validate` no binário real
+# (`caddy:2-alpine`, conf.d vazio → "Valid configuration"). É isso que torna a degradação
+# graciosa real em vez de documental.
+import /etc/caddy/conf.d/*.caddy

--- a/infra/caddy/Dockerfile
+++ b/infra/caddy/Dockerfile
@@ -13,3 +13,16 @@ RUN xcaddy build --with github.com/caddy-dns/cloudflare
 
 FROM caddy:2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# Blocos OPCIONAIS do Caddyfile + o entrypoint que decide quais entram (issue #151).
+# Eles ficam na IMAGEM, versionados no repo — a ativacao e por ENV, nunca por arquivo criado
+# a mao no servidor. Config que vive so na maquina e invisivel a qualquer leitura do
+# repositorio, e o defeito so aparece na recriacao do container.
+COPY optional/ /etc/caddy/optional/
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# A imagem oficial tem ENTRYPOINT null e o CMD completo (`caddy run --config ... --adapter
+# caddyfile`). Pondo o entrypoint aqui, esse CMD chega ao script como "$@" e e repassado com
+# `exec` — nada da imagem base precisa ser reescrito.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/infra/caddy/entrypoint.sh
+++ b/infra/caddy/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Monta os blocos OPCIONAIS do Caddyfile conforme o ambiente, e só então arranca o Caddy.
+#
+# Por que existe (issue #151): o parse do Caddyfile é ALL-OR-NOTHING. O bloco wildcard usa
+# `dns cloudflare {$CLOUDFLARE_API_TOKEN}` e, com o token vazio, o Caddy recusa o arquivo
+# INTEIRO (`missing API token`) — nem o domínio único sobe, mesmo com o certificado dele
+# intacto em disco. Em 2026-08-20 isso derrubou a produção por ~40 min, e o contorno tinha
+# sido um Caddyfile local não versionado, que some no primeiro `git pull`.
+#
+# A ativação é por ENV, nunca por arquivo criado à mão no servidor: config que vive só na
+# máquina é invisível a qualquer leitura do repositório e o defeito só aparece na recriação
+# do container, longe da mudança que o causou.
+set -eu
+
+CONF_D=/etc/caddy/conf.d
+OPCIONAIS=/etc/caddy/optional
+
+# Idempotente: recriar o container não pode acumular nem herdar bloco de um arranque anterior.
+rm -rf "$CONF_D"
+mkdir -p "$CONF_D"
+
+ativa() {
+	cp "$OPCIONAIS/$1" "$CONF_D/$1"
+	echo "caddy/entrypoint: bloco ATIVADO -> $1"
+}
+
+# Wildcard exige os DOIS: sem ROOT_DOMAIN o endereço do site vira `*.` (inválido); sem token
+# o Caddy recusa a config inteira. Um `[ -n ]` só deixaria metade da armadilha de pé.
+if [ -n "${CLOUDFLARE_API_TOKEN:-}" ] && [ -n "${ROOT_DOMAIN:-}" ]; then
+	ativa wildcard.caddy
+else
+	echo "caddy/entrypoint: wildcard DESLIGADO (CLOUDFLARE_API_TOKEN e/ou ROOT_DOMAIN vazios) - o dominio unico segue normal"
+fi
+
+if [ "${MONITORING_ENABLED:-}" = "true" ]; then
+	ativa monitor.caddy
+else
+	echo "caddy/entrypoint: monitor DESLIGADO (MONITORING_ENABLED != true)"
+fi
+
+# O CMD da imagem oficial (`caddy run --config /etc/caddy/Caddyfile --adapter caddyfile`)
+# chega aqui como "$@" — repassar em vez de reescrever evita divergir da imagem base.
+exec "$@"

--- a/infra/caddy/optional/monitor.caddy
+++ b/infra/caddy/optional/monitor.caddy
@@ -1,0 +1,14 @@
+# Painel de monitoramento (Uptime Kuma) — Story 3.4, topologia Caddy próprio (opção B).
+# ATIVADO pelo entrypoint quando MONITORING_ENABLED=true.
+#
+# Sem o `docker-compose.monitoring.yml` no ar, o container `uptime-kuma` NÃO existe e
+# `monitor.<domínio>` normalmente não tem registro DNS — o Caddy tentaria emitir certificado
+# para ele em loop (NXDOMAIN a cada tentativa), enchendo o log e queimando rate limit do
+# Let's Encrypt sem nunca conseguir. Por isso é opt-in, não default.
+#
+# Na topologia de produção com Traefik compartilhado quem publica `monitor.<domínio>` é o
+# Traefik, via labels do compose de monitoramento — lá este arquivo nem é usado.
+monitor.{$DOMAIN} {
+	encode gzip
+	reverse_proxy uptime-kuma:3001
+}

--- a/infra/caddy/optional/wildcard.caddy
+++ b/infra/caddy/optional/wildcard.caddy
@@ -1,0 +1,31 @@
+# Wildcard por tenant (`*.{$ROOT_DOMAIN}`, ex.: `*.e1p.com`) — white-label por subdomínio.
+# ATIVADO pelo entrypoint quando CLOUDFLARE_API_TOKEN **e** ROOT_DOMAIN estão preenchidos.
+#
+# TLS via desafio DNS-01 (Cloudflare): OBRIGATÓRIO para certificado curinga — o Let's Encrypt
+# NÃO emite wildcard via HTTP-01, só via DNS-01. Só ESTE bloco usa DNS-01; o domínio único
+# continua com HTTP-01 automático (sem regressão, IV1).
+# Pré-requisito: DNS de ROOT_DOMAIN gerido pela Cloudflare (ver docs/HOSTINGER-DEPLOY.md §8),
+# e o token com escopo Zone.DNS -> Edit na zona.
+#
+# Mesmo roteamento do domínio único (/api → api:8000, resto → web:80). A resolução de tenant
+# por subdomínio acontece no BACKEND a partir do JWT (RLS) — nunca do Host header, que é
+# controlável pelo cliente (ver apps/api/app/core/subdomain.py, Regra de Ouro nº 1).
+#
+# ⚠️ Se ROOT_DOMAIN for domínio-PAI de DOMAIN (ex.: DOMAIN=app.exemplo.com,
+# ROOT_DOMAIN=exemplo.com), este bloco COBRE o domínio único — e com o token inválido nem o
+# principal recebe certificado. Foi o que aconteceu em produção em 2026-08-20.
+*.{$ROOT_DOMAIN} {
+	encode gzip
+
+	tls {
+		dns cloudflare {$CLOUDFLARE_API_TOKEN}
+	}
+
+	handle_path /api/* {
+		reverse_proxy api:8000
+	}
+
+	handle {
+		reverse_proxy web:80
+	}
+}

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -115,9 +115,10 @@ services:
     # HTTP-01 automático, sem regressão (IV1).
     build: ./caddy
     restart: always
-    # env_file: injeta DOMAIN, ROOT_DOMAIN e CLOUDFLARE_API_TOKEN (lidos pelo Caddyfile via
-    # {$DOMAIN}/{$ROOT_DOMAIN}/{$CLOUDFLARE_API_TOKEN}). Preencha ROOT_DOMAIN e o token no
-    # .env.prod (ver .env.prod.example) — sem o token, o bloco wildcard não emite o cert.
+    # env_file: injeta DOMAIN, ROOT_DOMAIN, CLOUDFLARE_API_TOKEN e MONITORING_ENABLED. Os três
+    # últimos são lidos pelo `caddy/entrypoint.sh`, que decide quais blocos OPCIONAIS entram em
+    # /etc/caddy/conf.d/ (issue #151): sem token o wildcard nem entra na config, e o domínio
+    # único segue normal — antes, token vazio derrubava a config INTEIRA do Caddy.
     env_file:
       - .env.prod
     ports:


### PR DESCRIPTION
Fecha #151.

## O defeito

O parse do Caddyfile é **all-or-nothing**. Com `CLOUDFLARE_API_TOKEN` vazio, o `dns cloudflare {$CLOUDFLARE_API_TOKEN}` do bloco wildcard faz o Caddy recusar o arquivo **inteiro**:

```
Error: adapting config using caddyfile: parsing caddyfile tokens for 'tls': missing API token
```

**Nem o domínio único sobe** — com o certificado dele intacto em disco. E o `.env.prod.example` prometia o contrário: *"vazio = wildcard não emite o certificado (domínio único segue normal)"*. Uma degradação graciosa que não existia.

Isso derrubou a produção por **~40 min em 2026-08-20**, e o contorno tinha sido um Caddyfile local não versionado — que some no primeiro `git pull`.

## O desenho, e o desvio deliberado da opção 1

A issue oferece três caminhos. Este PR segue o **1** (`import conf.d/*.caddy`), com uma diferença:

> A opção 1, ao pé da letra, diz *"o operador cria só os que quiser"* — arquivos criados à mão no servidor. Isso trocaria esta armadilha pela **classe que custou os 40 minutos**: config que vive só na máquina, invisível a qualquer leitura do repositório, cujo defeito só aparece na recriação do container.

Então os blocos são **versionados e vão na imagem**; só a **ativação** é por env.

| Arquivo | Entra em `conf.d/` quando |
|---|---|
| `infra/caddy/optional/wildcard.caddy` | `CLOUDFLARE_API_TOKEN` **e** `ROOT_DOMAIN` preenchidos |
| `infra/caddy/optional/monitor.caddy` | `MONITORING_ENABLED=true` |

`infra/caddy/entrypoint.sh` apaga e recria `conf.d/` a cada arranque (recriar container não pode herdar bloco de antes) e **anuncia em log** o que ligou e o que não ligou — desligar em silêncio é como o defeito irmão do `.env` sobreviveu a um deploy inteiro.

`caddy:2-alpine` tem `ENTRYPOINT` **null** e o `CMD` completo, então o script recebe o comando oficial como `"$@"` e faz `exec "$@"` — nada da imagem base é reescrito.

⚠️ **O wildcard exige os DOIS.** Sem `ROOT_DOMAIN` o endereço vira `*.`, inválido; sem token o Caddy recusa tudo. Um `[ -n ]` só deixaria metade da armadilha de pé.

## Medido, não suposto

O repo já pagou seis vezes por supor comportamento de terceiro (§WhatsApp Evolution), então tudo abaixo foi verificado com o binário real, na imagem com o plugin:

| Verificação | Resultado |
|---|---|
| `import` com glob sem correspondência | **`Valid configuration`** + um `warn` — no-op, não erro |
| sem token | `Valid configuration`, `conf.d` vazio |
| token + `ROOT_DOMAIN` | `Valid configuration`, `conf.d: wildcard.caddy` |
| token **sem** `ROOT_DOMAIN` (a guarda) | `Valid configuration`, `conf.d` vazio |
| só `ROOT_DOMAIN`, sem token | `Valid configuration`, `conf.d` vazio |
| `MONITORING_ENABLED=true` | `Valid configuration`, `conf.d: monitor.caddy` |
| **Controle positivo:** formato antigo (wildcard inline) + token vazio | reproduz `missing API token` palavra por palavra |

## Gate

`apps/api/tests/test_caddyfile_blocos_opcionais.py` (5 asserções): o arquivo base não pode conter diretiva que exija config externa, precisa ter o `import`, e **todo arquivo em `optional/` precisa de um ramo no entrypoint** — bloco versionado que nenhuma env alcança é falha silenciosa perfeita, a família da `capabilities.py` sem consumidor. Com controle positivo, para não passar por vacuidade se alguém apagar os dois arquivos.

**Provado por mutação:** devolver o wildcard ao arquivo base deixa o gate vermelho; restaurar (por cópia, nunca `git checkout`) devolve o verde.

O gate ignora **comentários** de propósito: o cabeçalho do Caddyfile explica o defeito e cita o nome da diretiva, e um gate que reprovasse o comentário obrigaria a apagar a explicação.

## Verificação

| Gate | Resultado |
|---|---|
| `ruff check .` | `All checks passed!` |
| `pytest -q` | **2255 passed, 1 skipped** (o skip é `rls_e2e`, que exige Docker) |

⚠️ Na primeira corrida da suíte, 4 testes de `test_migration_0069_facts_rls.py` deram erro de **Docker** (`APIError: 500 ... /exec/.../start`) — eu estava buildando a imagem do Caddy em paralelo. Rerodados com o Docker ocioso: **4 passed**. Não há relação com este diff, que não toca migration nenhuma.

## Dívida declarada

- **A validação de verdade não roda no CI.** O gate que roda é de texto; o `caddy validate` nos seis cenários é manual, com Docker. Um job que buildasse a imagem por PR pagaria ~2 min de `xcaddy` em toda mudança do repo — a troca não foi feita, e fica registrada em vez de escondida.
- **O `docker-compose.override.yml` da AWS ainda vence enquanto existir**: ele monta o `Caddyfile.single`, que não tem o `import` e portanto ignora os opcionais — seguro, só redundante. Remover o bloco `caddy:` de lá é passo operacional **depois** do deploy, conferindo que o wildcard segue desligado naquela instância.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
