### PR TITLE
fix: quarto cartao 'Agendado para entrar' na ficha do cliente [#154]

### DIFF
--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -338,29 +338,48 @@ describe("ClientDetailPage — a montagem (issue #145)", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
-// 2. O resumo financeiro — TRÊS somas com recortes DIFERENTES sobre a MESMA lista
+// 2. O resumo financeiro — QUATRO somas com recortes DIFERENTES sobre a MESMA lista
+//
+// ⚠️ **Eram TRÊS até a issue #154, e as três não cobriam a lista.** `ChargeStatus` tem quatro
+// valores (`open` | `scheduled` | `paid` | `canceled`) e os três recortes originais só alcançavam
+// três deles: a cobrança `scheduled` sumia da ficha inteira. O quarto cartão é o espelho do que a
+// `CobrancasPage` já fazia desde a Story 8.15 — mesmo rótulo, mesma semântica, mesmo sumiço no
+// zero. Ver a nota em `CobrancasPage.tsx`.
+//
+// ⚠️ **O teste que "congelava" o defeito só congelava os TRÊS números, não a AUSÊNCIA do quarto.**
+// Medido na issue #154: com o cartão novo em pé, as três asserções antigas continuavam VERDES —
+// o defeito estava preso pelo NOME do teste, não pelas asserções dele. É por isso que o bloco
+// abaixo afirma o cartão que EXISTE e o que NÃO existe, nunca só as somas.
 // ══════════════════════════════════════════════════════════════════════════════════════════════
 
-describe("ClientDetailPage — as três somas do resumo (issue #145)", () => {
+describe("ClientDetailPage — as quatro somas do resumo (issues #145, #154)", () => {
   it("'a vencer' EXCLUI a vencida; 'Vencido' é só ela; 'Recebido' é só o que foi pago", async () => {
-    // Os três recortes andam sobre a mesma lista de seis cobranças e têm de dar TRÊS números
+    // Os quatro recortes andam sobre a mesma lista de seis cobranças e têm de dar QUATRO números
     // diferentes. Por isso as fixtures têm valores distintos: se `openSum` passasse a somar
     // também a vencida (`!c.is_overdue` → `true`) daria R$ 1.500,00, e a linha abaixo morre.
     renderFicha();
     await screen.findByRole("heading", { name: "Joana Ré" });
 
     // Aberta (R$ 1.000,00) — sem a vencida, sem a agendada, sem a cancelada.
+    // ⚠️ O valor EXATO é o que mata a mutação que joga a agendada neste cartão: R$ 1.300,00.
     expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
     // Só a vencida (R$ 500,00). O recorte aqui é `is_overdue`, e NÃO `status === "open"`.
     expect(valorDoCartao("Vencido")).toBe("R$ 500,00");
     // As duas pagas (R$ 200,00 + R$ 700,00), pelas DUAS rotas: a de banco e a do trilho.
+    // Somar a agendada aqui daria R$ 1.200,00 — o outro cartão errado possível.
     expect(valorDoCartao("Recebido")).toBe("R$ 900,00");
+    // [#154] E a agendada (R$ 300,00) tem o SEU: quatro números, quatro recortes.
+    expect(valorDoCartao("Agendado para entrar")).toBe("R$ 300,00");
   });
 
-  it("a cobrança AGENDADA e a CANCELADA não entram em soma nenhuma", async () => {
-    // O caso que expõe o recorte `status === "open"` do `openSum`: `scheduled` e `canceled` não
-    // são "a vencer", não são "vencido" e não são "recebido". Trocar o recorte por
-    // `status !== "paid"` somaria R$ 700,00 aqui e a primeira linha morre.
+  it("[#154] a AGENDADA tem cartão PRÓPRIO; a CANCELADA continua fora de TUDO", async () => {
+    // O caso que expõe os recortes por status: `scheduled` não é "a vencer" (exige `status ===
+    // "open"`), não é "vencido" e não é "recebido" — e por não caber em nenhum dos três é que ela
+    // precisou de cartão próprio, exatamente como na `CobrancasPage`.
+    //
+    // `canceled` é DIFERENTE e continua fora dos quatro: não é dinheiro que vai entrar. Este teste
+    // é o que impede o conserto de #154 de arrastar a cancelada junto — os R$ 400,00 dela não
+    // aparecem em cartão nenhum, e o cartão novo lê R$ 300,00, nunca R$ 700,00.
     ficha.charges = [ABERTA, AGENDADA, CANCELADA];
     renderFicha();
     await screen.findByRole("heading", { name: "Joana Ré" });
@@ -368,6 +387,25 @@ describe("ClientDetailPage — as três somas do resumo (issue #145)", () => {
     expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
     expect(valorDoCartao("Vencido")).toBe("R$ 0,00");
     expect(valorDoCartao("Recebido")).toBe("R$ 0,00");
+    expect(valorDoCartao("Agendado para entrar")).toBe("R$ 300,00");
+
+    // A cancelada (R$ 400,00) não é o valor de NENHUM dos quatro cartões. Um `queryByText` solto
+    // não serviria: o valor também vive na linha da cobrança, e o teste passaria por acidente.
+    const cartoes = ["A receber (a vencer)", "Vencido", "Recebido", "Agendado para entrar"];
+    expect(cartoes.map(valorDoCartao)).not.toContain("R$ 400,00");
+  });
+
+  it("[#154] o cartão 'Agendado para entrar' SOME quando é zero (espelho da CobrancasPage)", async () => {
+    // Mesma disciplina anti-ruído da 8.14/8.15: na ficha do dono que nunca recebeu com data
+    // futura, um cartão eternamente zerado é peso de ERP. Sem o `scheduledSum > 0`, o rótulo
+    // apareceria aqui com R$ 0,00.
+    ficha.charges = [ABERTA, PAGA_TRILHO, CANCELADA];
+    renderFicha();
+    await screen.findByRole("heading", { name: "Joana Ré" });
+
+    // Os três de sempre continuam em pé — o sumiço é SÓ do quarto.
+    expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
+    expect(screen.queryByText("Agendado para entrar")).toBeNull();
   });
 });
 

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -66,6 +66,15 @@ export default function ClientDetailPage() {
   const openSum = charges.filter((c) => c.status === "open" && !c.is_overdue).reduce((a, c) => a + c.amount_cents, 0);
   const overdueSum = charges.filter((c) => c.is_overdue).reduce((a, c) => a + c.amount_cents, 0);
   const paidSum = charges.filter((c) => c.status === "paid").reduce((a, c) => a + c.amount_cents, 0);
+  // [issue #154] A QUARTA soma, e ela existe porque as três de cima **não cobrem a lista**.
+  // `ChargeStatus` tem quatro valores (`open` | `scheduled` | `paid` | `canceled`) e os recortes
+  // acima só alcançam três deles: uma cobrança `scheduled` não é "a vencer" (o recorte exige
+  // `status === "open"`), não é "Vencido" (`is_overdue` nasce `false` fora de `open`) e não é
+  // "Recebido" (o dinheiro ainda não caiu). Sem este cartão ela **some da ficha** — o mesmo modo
+  // de falha que a `CobrancasPage` eliminou na Story 8.15 e que o `scheduled_cents` do backend
+  // (`receivables/service.py`) já calcula para a tela irmã.
+  // `canceled` ficar fora de tudo é DIFERENTE e está certo: não é dinheiro que vai entrar.
+  const scheduledSum = charges.filter((c) => c.status === "scheduled").reduce((a, c) => a + c.amount_cents, 0);
 
   async function protest(cid: string) {
     await api.post(`/receivables/charges/${cid}/protest`);
@@ -111,6 +120,14 @@ export default function ClientDetailPage() {
         <Stat label="A receber (a vencer)" value={brl(openSum)} tone="text-neutral-700" />
         <Stat label="Vencido" value={brl(overdueSum)} tone="text-danger" />
         <Stat label="Recebido" value={brl(paidSum)} tone="text-accent-700" />
+        {/* [issue #154] Espelho EXATO do quarto cartão da `CobrancasPage` (Story 8.15): mesmo
+            rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
+            Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
+            ação de dinheiro, e uma terceira convenção para o mesmo estado seria a assimetria que
+            esta issue existe para fechar. */}
+        {scheduledSum > 0 && (
+          <Stat label="Agendado para entrar" value={brl(scheduledSum)} tone="text-amber-700" />
+        )}
       </div>
 
       {/* Histórico — primeiro bloco de propósito: é a história que dá sentido às seções


### PR DESCRIPTION
## Resumo

A ficha do cliente recortava a lista de cobranças em três somas — `open && !is_overdue`, `is_overdue`
e `paid` — e `ChargeStatus` tem **quatro** valores. Uma cobrança `scheduled` não caía em nenhuma das
três: sumia da tela. Este PR dá a ela o quarto cartão, espelhando o que a `CobrancasPage` já fazia.

Fecha #154.

## O diagnóstico, medido

Com `[aberta R$ 1.000,00 · agendada R$ 300,00 · cancelada R$ 400,00]`, a ficha lia:

| Cartão | Antes | Depois |
|---|---|---|
| A receber (a vencer) | R$ 1.000,00 | R$ 1.000,00 |
| Vencido | R$ 0,00 | R$ 0,00 |
| Recebido | R$ 0,00 | R$ 0,00 |
| **Agendado para entrar** | **não existia** | **R$ 300,00** |

`is_overdue` não podia salvar a agendada: `receivables/service.py:163` é
`charge.status == STATUS_OPEN and charge.due_date < today` — fora de `open` ele nasce `false`.

A **lista** já estava certa desde a Story 8.15 (`ChargeRow` tem o ramo `scheduled` com o badge
"Agendado"). O defeito era só do **resumo**: a linha aparecia, o dinheiro não somava em lugar nenhum.

## Alcance: o enunciado apontava 3 linhas, e **é o teto, não só o piso**

| O que foi medido | Resultado |
|---|---|
| Somatórios por `status`/`is_overdue` na ficha | **3, e só 3** — `ClientDetailPage.tsx:66-68`. As outras 18 linhas que o grep devolve são `StatusBadge` de contrato/orçamento/documento/jornada (outras entidades), a `ChargeRow` e um `.filter(Boolean)` de tags |
| Outros componentes da ficha que recortem cobrança | **0** — `BlocoDaAgenda`, `BlocoDaConversa`, `ClientTimeline` não tocam em `Charge` |
| Status fora dos recortes além de `scheduled` | **nenhum** — `ChargeStatus = "open" \| "scheduled" \| "paid" \| "canceled"` (`packages/shared-types/src/index.ts:401`), e o backend (`receivables/models.py:41`) tem os mesmos quatro. Não há quinto status escondido |

`canceled` ficar fora de tudo continua correto e continua exigido por teste — não é dinheiro que vai
entrar.

## ⚠️ Uma premissa do enunciado está errada, e vale corrigir por escrito

A issue afirma que o teste `a cobrança AGENDADA e a CANCELADA não entram em soma nenhuma` congelava o
comportamento e *"é ele que fica vermelho"*. **Não fica.** Medido: com o cartão novo em pé ele passa.

As três asserções dele só fixam `A receber = R$ 1.000,00`, `Vencido = R$ 0,00` e
`Recebido = R$ 0,00` — e o conserto não muda nenhuma das três. **Nada ali afirmava a ausência do
quarto cartão.** O defeito estava preso pelo *nome* do teste, não pelas asserções.

Para não consertar em silêncio, a asserção que faltava foi acrescentada e o vermelho foi observado
antes de reescrever o bloco:

```
FAIL  a cobrança AGENDADA e a CANCELADA não entram em soma nenhuma
AssertionError: expected <p class="text-sm text-neutral-500"></p> to be null
- Expected:  null
+ Received:  <p class="text-sm text-neutral-500">Agendado para entrar</p>
 ❯ src/features/crm/ClientDetailPage.test.tsx:372:56
```

O teste reescrito agora exige a ausência da cancelada de fato:
`expect(cartoes.map(valorDoCartao)).not.toContain("R$ 400,00")`.

## O que muda

`ClientDetailPage.tsx` — uma soma e um cartão condicional, espelho exato de
`CobrancasPage.tsx:157-165`: mesmo rótulo literal, mesmo `text-amber-700`, mesmo sumiço no zero.

```tsx
const scheduledSum = charges.filter((c) => c.status === "scheduled").reduce((a, c) => a + c.amount_cents, 0);
...
{scheduledSum > 0 && <Stat label="Agendado para entrar" value={brl(scheduledSum)} tone="text-amber-700" />}
```

A ficha e a tela de cobranças são a **mesma ação de dinheiro** — uma terceira convenção para o mesmo
estado seria a assimetria que esta issue existe para fechar.

## Prova por mutação — 5 de 5 mortas

Todas com `tsc --noEmit` limpo. A primeira tentativa de (a) foi **descartada e refeita**: remover só
o cartão deixava `TS6133: 'scheduledSum' is declared but its value is never read`, e mutação que não
compila mata por erro de módulo, não pela asserção.

| # | Mutação na produção | Testes mortos | Mensagem real |
|---|---|---|---|
| a | Remove o cartão **e** a soma | 2 | `Unable to find an element with the text: Agendado para entrar` |
| b | Filtro `scheduled` → `canceled` | 3 | `expected 'R$ 400,00' to be 'R$ 300,00'` |
| c | `scheduled` somado em "A receber (a vencer)" | 2 | `expected 'R$ 1.300,00' to be 'R$ 1.000,00'` |
| d | Guarda `scheduledSum > 0` → `>= 0` | 1 | `expected <p class="text-sm text-neutral-500"></p> to be null` |
| e | `scheduled` somado em "Recebido" | 2 | `expected 'R$ 1.200,00' to be 'R$ 900,00'` |

Nenhum mutante equivalente a documentar. A mutação (c) foi **refeita de forma independente na
revisão**, com o mesmo resultado: `2 failed | 31 passed`, `expected 'R$ 1.300,00' to be 'R$ 1.000,00'`.

## Verde

```
Test Files  1 passed (1)
     Tests  33 passed (33)      # baseline 32, +1 pelo sumiço no zero
```

`tsc --noEmit` exit 0 · `eslint` sem saída nos dois arquivos.

## Fora de escopo, registrado e não commitado

O rótulo `"Agendado para entrar"` aparece como literal solto em **3 call sites**, enquanto
`features/financeiro/contas.ts:541` já define `AGENDADO_ENTRADA_LABEL`. Manter o literal aqui foi
deliberado — acoplar `crm` a `financeiro` por um rótulo seria pior —, mas a dívida é real e merece
issue própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
