### PR TITLE
fix: fixar TZ no job de mutação e dar nome ao vermelho [#169]

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -62,6 +62,46 @@ jobs:
     # ~21 min em 12 vCPU; o runner tem 2. O teto existe para não queimar horas num laço infinito
     # que escapou do `timeoutMS` do Stryker, não para apertar a medição.
     timeout-minutes: 120
+
+    # ── FUSO, NO NIVEL DO JOB (issue #169) ──────────────────────────────────────────────────────
+    # O runner do GitHub roda em UTC. Este job abortou nas suas DUAS unicas execucoes (19 e
+    # 20/08/2026), sempre no dry run do Stryker, e sempre com a mesma notícia:
+    #
+    #     expected '2026-10-11' to be '2026-10-10' // Object.is equality
+    #
+    # A asserção é de `src/features/agenda/grade.test.ts:468`, e ela esta CERTA: o proprio
+    # comentario dela nomeia a dependencia ("o TZ que a suite fixa"). O defeito era o ambiente
+    # deste job, nao o teste.
+    #
+    # ⚠️ E por que o `env: { TZ }` do `vitest.config.ts` nao bastava — isto foi MEDIDO em
+    # 20/08/2026 (vitest 2.1.9, Node 24, maquina forcada para `TZ=UTC`), nao inferido:
+    #
+    #     pool                | `grade.test.ts`
+    #     --------------------|----------------
+    #     default (`forks`)   | 40 passed
+    #     `threads`           | 1 failed  <-- o que o Stryker monta
+    #
+    # `@stryker-mutator/vitest-runner` FORCA `pool: 'threads'` para rodar com um worker so
+    # (`dist/src/vitest-test-runner.js`, `#getVitestPoolConfig`). E o `env` do vitest so troca o
+    # fuso de verdade quando ele nasce COM o processo — o que o pool `forks` faz e o `threads` nao
+    # tem como fazer: uma thread nasce dentro de um processo que ja escolheu seu fuso, e escrever
+    # em `process.env` depois nao reabre essa escolha. Medido dentro da thread: `process.env.TZ`
+    # dizia "America/Sao_Paulo" e o relogio dizia UTC. O env CHEGA — chega tarde.
+    #
+    # Fixar aqui resolve na raiz: a variavel existe ANTES de o Node comecar, entao vale para
+    # qualquer pool, qualquer runner e qualquer runner de teste futuro.
+    #
+    # ⚠️ No JOB, e nao num `step`: os DOIS passos que rodam teste dependem disto — `pnpm test` e
+    # `pnpm mutation` — e uma variavel por step e exatamente a guarda que alguem esquece de
+    # repetir no terceiro. E nao no topo do arquivo (nivel de workflow) porque o alcance certo e
+    # este job: um segundo job futuro (publicar relatorio, abrir issue de sobreviventes) nao
+    # deve herdar em silencio um fuso que nao lhe diz respeito.
+    #
+    # America/Sao_Paulo, e nao UTC, porque e o fuso em que o e1p vive (CLAUDE.md) e o que a suite
+    # ja exige. Reproduzir aqui o ambiente da suite e o ponto.
+    env:
+      TZ: America/Sao_Paulo
+
     defaults:
       run:
         working-directory: apps/web

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -6,6 +6,53 @@
 // Stories 7.4/7.5 — sem precisar de import por arquivo nem de mudança no tsconfig.
 import "@testing-library/jest-dom/vitest";
 
+// ── GUARDA DE AMBIENTE: o fuso efetivo (issue #169) ────────────────────────────────────────────
+//
+// O job `Mutation (noturno)` abortou nas suas duas unicas execucoes (19 e 20/08/2026), sempre no
+// dry run do Stryker, e a unica notícia que o log deu foi esta:
+//
+//     expected '2026-10-11' to be '2026-10-10' // Object.is equality
+//
+// A causa era o fuso — o runner do GitHub roda em UTC — mas a mensagem fala de uma DATA de
+// agenda. Quem le procura bug em `grade.ts`, nao configuracao de job. Duas noites de vermelho
+// sem ninguem saber que o que faltava era um `TZ`. Este bloco faz o sintoma dizer o proprio nome.
+//
+// ⚠️ Por que AQUI, no setup, e nao num `*.test.ts` proprio — isto foi MEDIDO, nao suposto.
+// O `@stryker-mutator/vitest-runner` monta o vitest com `bail: 1`. Com a suite em UTC, o arquivo
+// que reprova primeiro e `grade.test.ts`, e a corrida PARA ali: numa medicao de 20/08/2026 com um
+// guarda em arquivo separado, o resultado foi `1 failed | 10 passed | 7 skipped` — o guarda caiu
+// entre os SETE PULADOS e nunca apareceu. Guarda que depende da ordem dos arquivos nao guarda
+// nada. `setupFiles` roda antes de CADA arquivo, entao este erro nasce no primeiro deles,
+// qualquer que seja.
+//
+// ⚠️ E por que `Intl...resolvedOptions()` e NAO `process.env.TZ`: os dois DISCORDAM, e e nessa
+// discordancia que o defeito mora. Medido em 20/08/2026 (vitest 2.1.9, Node 24, maquina em UTC),
+// dentro do pool `threads` que o Stryker forca: `process.env.TZ` = "America/Sao_Paulo" e o fuso
+// efetivo = "UTC". O `env` do vitest CHEGA — chega tarde. Afirmar o env aqui daria VERDE no
+// cenario exato que este guarda existe para pegar.
+const FUSO_ESPERADO = "America/Sao_Paulo";
+const fusoEfetivo = Intl.DateTimeFormat().resolvedOptions().timeZone;
+if (fusoEfetivo !== FUSO_ESPERADO) {
+  throw new Error(
+    [
+      `FUSO ERRADO NA SUITE: o fuso EFETIVO deste processo e "${fusoEfetivo}", e a suite exige "${FUSO_ESPERADO}".`,
+      "Nao e bug de agenda, de data nem de `grade.ts`: e o AMBIENTE.",
+      "",
+      "Diagnostico (os dois valores DISCORDAM quando o defeito e este):",
+      `  process.env.TZ ........ ${JSON.stringify(process.env.TZ)}`,
+      `  fuso efetivo .......... ${JSON.stringify(fusoEfetivo)}`,
+      "",
+      "Se `process.env.TZ` ja esta certo e o efetivo nao, o `env` do vitest chegou TARDE: e o caso",
+      "do pool `threads`, que `@stryker-mutator/vitest-runner` forca. Uma thread nasce dentro de um",
+      "processo que ja escolheu seu fuso, e escrever em `process.env` depois nao reabre a escolha.",
+      "",
+      "Conserto: fixar `TZ` FORA do Node — `env:` no nivel do job em `.github/workflows/`, ou a",
+      "variavel do shell antes de chamar o vitest. Nunca so no `env` do `vitest.config.ts`.",
+    ].join("\n"),
+  );
+}
+
+
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 


### PR DESCRIPTION
## Resumo

O job `Mutation (noturno)` nunca produziu um número: as duas execuções que existem abortaram **antes
de mutar qualquer coisa**, no dry run do Stryker. Este PR fixa o fuso no nível do job e dá **nome ao
vermelho**, para que a próxima vez que o fuso não chegar o sintoma se anuncie como fuso em vez de
como uma data errada num teste de agenda.

Fecha #169. Primeiro número de mutação de `grade.ts`: **95,45%** (167 killed, 1 timeout, 8 survived).

## A inferência do enunciado estava errada — e a perna foi fechada

A issue marcou como **não medido** que o `@stryker-mutator/vitest-runner` *"não repassa o `env` ao
processo de teste"*, porque `pnpm mutation` morria localmente com `'stryker' não é reconhecido`.

O binário **está** instalado (`@stryker-mutator/core` e `vitest-runner` 10.0.0, presentes em
`node_modules/.bin/stryker`). Rodado de verdade:

| Cenário | Resultado |
|---|---|
| `TZ=UTC` | reproduziu o erro do CI **byte a byte**: `expected '2026-10-11' to be '2026-10-10'` → `ConfigError: There were failed tests in the initial test run.` |
| `TZ=America/Sao_Paulo` | **completou** — `95.45%`, 167 killed, 1 timeout, 8 survived, em 2min38s |

**O `env` chega — chega tarde.** Medido de dentro da thread: `process.env.TZ` vale
`"America/Sao_Paulo"` **e** o fuso efetivo vale `"UTC"`. A fonte explica: em
`node_modules/@stryker-mutator/vitest-runner/dist/src/vitest-test-runner.js` (`#getVitestPoolConfig`)
o runner **força `pool: 'threads'`** para rodar com um worker só. Uma thread nasce dentro de um
processo que já escolheu seu fuso, e escrever em `process.env` depois não reabre a escolha. Sob
`forks` (default do vitest 2) o mesmo `env` funciona — `grade.test.ts`: **40 passed** com `forks`,
**1 failed** com `threads`.

Isso não muda o conserto — o `env` no job vale para qualquer pool —, mas muda o motivo escrito no
código, que antes teria ficado errado.

## O que muda

**1. `.github/workflows/mutation.yml`** — `env: TZ: America/Sao_Paulo` no job. Robusto por não
depender do runner repassar coisa nenhuma.

**2. `apps/web/src/test-setup.ts`** — o guarda que dá nome ao vermelho. Ele afirma
`Intl.DateTimeFormat().resolvedOptions().timeZone`, **não** `process.env.TZ`: afirmar o env daria
verde exatamente no cenário que ele existe para pegar (env certo, fuso efetivo errado).

⚠️ O guarda nasceu como arquivo próprio (`src/ambiente-fuso.test.ts`) e **foi medido não servindo**:
o runner monta o vitest com `bail: 1`, `grade.test.ts` reprova primeiro e o resultado foi
`1 failed | 10 passed | 7 skipped` — o guarda caiu entre os **sete pulados** e nunca apareceu. Guarda
que depende da ordem dos arquivos não guarda nada. Movido para `setupFiles`, que roda antes de
**cada** arquivo.

`grade.test.ts:468` **não foi tocado**. A asserção está certa; o defeito era o ambiente do job.

## Alcance medido

**Workflows: 2 arquivos, 6 jobs. Nenhum fixava `TZ`** (grep: zero ocorrências antes deste commit).

| Workflow / job | Roda teste de front? | Veredito |
|---|---|---|
| `mutation.yml` / `mutation` | sim | **era o quebrado** — corrigido aqui |
| `ci.yml` / `frontend` | sim | verde **por sorte estrutural**: `pnpm test` só passa porque o pool default do vitest 2 é `forks`, e `pnpm e2e` é imune por conta própria (`timezoneId` no `playwright.config.ts`). Dependência latente — **issue nova**, não mexido aqui |
| `ci.yml` / `test-in-prod-image`, `cross-tenant-rls`, `secret-scan`, `sast-semgrep` | não | fora da classe |

**Testes dependentes do `TZ` implícito — a contagem da issue era piso mesmo:**

- No escopo da **mutação** (`.test.ts`, config do Stryker): **1 de 377** — só `grade.test.ts:468`.
- Varrendo os **21 arquivos sensíveis a fuso** (incluindo `.tsx`): **6 falhas em 3 arquivos** —
  `grade.test.ts` (1), `NewEventModal.test.tsx` (3), `BlocoDaAgenda.test.tsx` (2). Os 5 extras vivem
  em `.tsx`, que `vitest.mutation.config.ts` exclui — por isso nunca apareceram no job. Não quebram
  hoje; quebrariam sob qualquer runner que force `threads`. **Issue nova**, nada commitado por eles.

## Prova por parse do YAML

Diff visual não é prova. `yaml.safe_load` antes e depois, achatado e comparado chave a chave:

```
removido/alterado no ANTES:   {}
adicionado/alterado no DEPOIS: {".jobs.mutation.env.TZ": "America/Sao_Paulo"}
```

Uma chave adicionada, nada removido, nada alterado — `steps`, `on` e `concurrency` idênticos.

## Prova por mutação — medida pelo PowerShell

⚠️ Pelo Git Bash o `TZ` **não chega ao Node** nesta máquina e a varredura devolveria zero quebras,
parecendo aprovação. Tudo abaixo foi medido com `$env:TZ` no PowerShell, com controle explícito
(`node -e` confirmando `TZ env = UTC | resolvido = UTC` antes de cada rodada).

| Mutação | O que morreu | Mensagem real |
|---|---|---|
| `$env:TZ='UTC'` + `--pool=threads` (o cenário do CI) | todos os arquivos, via setup | `Error: FUSO ERRADO NA SUITE: o fuso EFETIVO deste processo e "UTC", e a suite exige "America/Sao_Paulo".` seguido de `process.env.TZ ... "America/Sao_Paulo"` / `fuso efetivo ... "UTC"` |
| `$env:TZ='America/Sao_Paulo'` + `threads` (pós-conserto) | nada | `Test Files 1 passed · Tests 40 passed` |
| sem forçar `TZ`, pool default (dia a dia) | nada | verde |

As duas primeiras linhas foram **refeitas de forma independente na revisão**, com o mesmo resultado.

## Um tropeço que vale registrar

A primeira escrita do guarda passou o `\n` do `.join("\n")` por um heredoc que o converteu em quebra
de linha real. O vitest reportou 27 `FAIL` **sem nunca mostrar a mensagem do guarda** — para quem
olhasse só a contagem de vermelhos, pareceria "o guarda funcionou". Pego por ir atrás do texto e não
o encontrar; o escape foi reconstruído por `chr()` e os bytes conferidos no disco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
