### PR TITLE
fix(web): instante congelado que isola o TENANT, nao o navegador [#153]

### DIFF
--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -131,13 +131,24 @@ describe("CobrancasPage — Nova cobrança (Story 7.5, Task 2)", () => {
 // verdadeiro por construção, dissesse a tela o que dissesse. Agora o relógio é congelado e os
 // dias são strings literais: o teste passou a afirmar sobre a TELA, não sobre si mesmo.
 //
-// `2026-08-17T02:30:00Z` separa os três relógios do jeito que interessa aqui:
-//   · **navegador** (America/Sao_Paulo, o runner) → 16/08 23:30 → **2026-08-16**
+// ⚠️ **O instante era `2026-08-17T02:30:00Z`, e isolava o relógio ERRADO** (#153). Ali navegador
+// dava 16/08 enquanto UTC e tenant davam ambos 17/08: quem ficava sozinho era o NAVEGADOR, e o
+// teste era CEGO para UTC por construção. Medido: mutar `dataPadrao={HOJE_DO_TENANT}` para
+// `new Date().toISOString().slice(0, 10)` — o relógio UTC —, com `tsc --noEmit` limpo e o import
+// órfão removido, SOBREVIVIA aos 17 testes. UTC não é relógio hipotético: o CLAUDE.md §5.2 registra
+// que o comentário substituído pelo #78 opunha as duas únicas opções que existiam então, navegador
+// e UTC.
+//
+// `2026-08-17T16:00:00Z` isola o relógio do TENANT — o único que a tela pode legitimamente usar:
+//   · **navegador** (America/Sao_Paulo, o runner) → 17/08 13:00 → **2026-08-17**
 //   · **UTC**                                     → **2026-08-17**
-//   · **tenant em Asia/Tokyo**                    → 17/08 11:30 → **2026-08-17**
-// Com o esperado em 16/08, morre tanto quem passar a ler UTC quanto quem passar a ler o fuso do
-// tenant — e é exatamente essa segunda morte que expõe o que a tela faz hoje (ver abaixo).
-const INSTANTE = "2026-08-17T02:30:00Z";
+//   · **tenant em Asia/Tokyo**                    → 18/08 01:00 → **2026-08-18**
+// Nenhum instante separa os TRÊS dias: varridos os 48 instantes de meia em meia hora, Tóquio só
+// passa do dia de UTC a partir das 15:00Z e São Paulo só fica atrás antes das 03:00Z — faixas
+// mutuamente exclusivas. O que se escolhe é qual relógio fica sozinho, e o certo é o do tenant:
+// com o esperado em 18/08 e navegador/UTC colados em 17/08, um único literal mata AS DUAS
+// regressões de uma vez.
+const INSTANTE = "2026-08-17T16:00:00Z";
 
 /**
  * O dia que esta tela usa como default de "recebi direto na conta".
@@ -156,9 +167,18 @@ const INSTANTE = "2026-08-17T02:30:00Z";
  * máquina: os dois relógios voltariam a dar a mesma string por construção e nenhuma mutação
  * morreria. Foi essa coincidência que escondeu o defeito por meses (CLAUDE.md §5.2).
  *
- * No `INSTANTE` congelado: navegador 16/08, UTC 17/08, tenant em Tóquio **17/08**.
+ * No `INSTANTE` congelado: navegador 17/08, UTC 17/08, tenant em Tóquio **18/08** (#153).
  */
-const DIA_DO_TENANT = "2026-08-17";
+const DIA_DO_TENANT = "2026-08-18";
+
+/**
+ * O dia que navegador **e** UTC dão neste instante — os dois relógios errados, colados um no outro.
+ *
+ * É o literal que faz a asserção negativa valer por dois: `localYmd(new Date())` (navegador) e
+ * `toISOString().slice(0, 10)` (UTC) produzem AMBOS `2026-08-17` aqui, então qualquer uma das duas
+ * regressões cai na mesma linha. Não troque por um dos dois nomes: a coincidência é o mecanismo.
+ */
+const DIA_DOS_RELOGIOS_ERRADOS = "2026-08-17";
 
 const CONTA_BANCARIA = {
   id: "acc-1",
@@ -279,8 +299,9 @@ describe("CobrancasPage — recebimento fora do trilho (Story 8.15)", () => {
   });
 
   it("envia bank_account_id e received_on; o dia default é HOJE — hoje NO FUSO DO TENANT (#136)", async () => {
-    // Relógio congelado num instante em que navegador (16/08), UTC (17/08) e um tenant em Tóquio
-    // (17/08) discordam: sem isso a asserção compara o dia do navegador com o dia do navegador.
+    // Relógio congelado num instante em que o tenant em Tóquio (18/08) fica SOZINHO — navegador e
+    // UTC caem os dois em 17/08. Sem isso a asserção compara o dia do navegador com o dia do
+    // navegador; com o instante antigo (`02:30:00Z`) ela ainda era cega para UTC (#153).
     fusoDoTenant = FUSO_DISTANTE;
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date(INSTANTE));
@@ -298,9 +319,10 @@ describe("CobrancasPage — recebimento fora do trilho (Story 8.15)", () => {
     // o tenant está em Tóquio e o relógio, congelado.
     expect(dia.value).toBe(DIA_DO_TENANT);
     expect(dia.value).not.toBe(COBRANCA_ABERTA.due_date);
-    // O dia do navegador neste instante é 16/08. Afirmar que o campo NÃO o mostra é a metade que
-    // impede um "hoje" qualquer de passar por tenant.
-    expect(dia.value).not.toBe("2026-08-16");
+    // Navegador E UTC dão ambos 17/08 neste instante. Afirmar que o campo NÃO mostra esse dia é a
+    // metade que impede um "hoje" qualquer de passar por tenant — e mata as DUAS regressões, não só
+    // a do navegador (#153).
+    expect(dia.value).not.toBe(DIA_DOS_RELOGIOS_ERRADOS);
 
     await user.click(screen.getByRole("button", { name: /confirmar recebimento/i }));
 

--- a/apps/web/src/features/financeiro/contas.test.ts
+++ b/apps/web/src/features/financeiro/contas.test.ts
@@ -664,10 +664,18 @@ describe("Story 8.18 — impedimentoDaTransferencia: o que a tela consegue antec
   // asserções passam a conseguir afirmar.
   //
   // As bordas NÃO são mais derivadas de `Date.now()`/UTC — são literais do calendário do TENANT.
-  // `2026-08-17T02:30:00Z` separa os três relógios:
+  // `2026-08-17T02:30:00Z` isola o NAVEGADOR; o tenant e o UTC caem no MESMO dia:
   //   · **navegador** (America/Sao_Paulo, o runner do vitest) → 16/08 23:30 → `2026-08-16`
   //   · **UTC**                                               → `2026-08-17`
   //   · **tenant em Asia/Tokyo**                              → 17/08 11:30 → `2026-08-17`
+  //
+  // ⚠️ **Não copie este instante para uma tela que LÊ o relógio** (#153). Aqui ele é inofensivo:
+  // `impedimentoDaTransferencia` é PURA e recebe o hoje como 5º parâmetro, então a prova de fuso
+  // não depende do instante — quem a faz é o par de chamadas do último teste, que passa os dois
+  // "hoje" como literais explícitos. Medido: com o hoje lido POR DENTRO, tanto pelo navegador
+  // quanto por `toISOString()`, este arquivo fica vermelho. Num teste de TELA, porém, um instante
+  // que cola tenant e UTC no mesmo dia deixa a regressão para UTC passar verde por construção —
+  // foi o que aconteceu na `CobrancasPage`, que herdou justamente este literal.
   // O relógio fica congelado nesse instante **de propósito**: assim, quem devolver a leitura do
   // hoje para dentro da função (pelas partes locais de um `new Date()` ou por `toISOString()`)
   // muda o resultado e fica VERMELHO. Sem o congelamento, o dia real da máquina ficaria longe


### PR DESCRIPTION
## Resumo

Um instante congelado que separa o dia do **tenant** do dia do **navegador** ainda pode deixar o
**UTC** colado no do tenant — e aí uma regressão para UTC passa verde por construção. Era o caso da
`CobrancasPage`. Este PR troca o instante por um que isola o relógio do **tenant**, e um único
literal passa a matar as duas regressões.

Fecha #153.

## Alcance: a issue erra nos dois sentidos, e é o **encolhimento** que importa

| | Issue dizia | Medido | |
|---|---|---|---|
| Arquivos com `setSystemTime` em `apps/web/src` | 9 | **10** | o 10º é `crm/ClientDetailPage.test.tsx`, criado pelo próprio PR #152 que a issue cita |
| Arquivos com defeito real | 2 | **1** | só a `CobrancasPage`. `CockpitPage` **não** é cego para UTC |

A tabela de instantes da issue também erra em 3 linhas — e foi isso que a fez classificar mal:

| Arquivo | Issue dizia | É de verdade |
|---|---|---|
| `EscolherHorario.test.tsx` | `2026-10-15T12:00:00Z` | `2026-10-10T12:00:00Z` |
| `BlocoDaAgenda.test.tsx` | `2026-08-20T13:00:00Z` | `2026-08-16T12:00:00Z` |
| `ContasSaldosPage.test.tsx` | `2026-07-28T12:00:00Z` | `new Date(2026, 6, 30, 12, 0, 0)` — construtor **local**, não UTC |

**A causa do erro de classificação, e a régua que a substitui.** A issue classificou pelo *instante
principal* — o do `beforeEach` de topo. Mas em 5 dos arquivos esse `beforeEach` é **andaime de
determinismo**, com o tenant no fuso do runner de propósito, e a prova de fuso vive num `describe`
dedicado com instante próprio.

`CockpitPage` é o caso exemplar: o `2027-03-15T02:30:00Z` que a issue cita pertence ao teste que
prova *tenant ≠ UTC* e cujo comentário diz **"Não 'conserte' este trocando o fuso"**. O teste irmão
logo abaixo já usa `2027-03-14T22:30:00Z`, que isola o tenant.

> **A pergunta certa não é qual instante está no `beforeEach` de topo. É qual instante está no teste
> que tem `fusoDoTenant = FUSO_DISTANTE`.**

## O defeito, medido — e o mutante que sobrevive

`CobrancasPage`, no instante antigo `2026-08-17T02:30:00Z` (navegador 16/08, UTC 17/08, tenant 17/08):

| Mutação em `CobrancasPage.tsx`, `tsc --noEmit` limpo, import órfão removido | Resultado |
|---|---|
| `dataPadrao={HOJE_DO_TENANT}` → `{new Date().toISOString().slice(0, 10)}` | 🔴 **SOBREVIVEU — 17 passed** |

## O que muda

`INSTANTE` passa de `2026-08-17T02:30:00Z` para **`2026-08-17T16:00:00Z`**:

| | navegador (SP, o runner) | UTC | tenant (Tóquio) | quem fica sozinho |
|---|---|---|---|---|
| antes | 2026-08-16 | 2026-08-17 | 2026-08-17 | o **navegador** — cego para UTC |
| depois | 2026-08-17 | 2026-08-17 | **2026-08-18** | o **tenant** — mata os dois |

Nenhum instante separa os três dias: varridos os 48 instantes de meia em meia hora, Tóquio só passa
do dia de UTC a partir das 15:00Z e São Paulo só fica atrás antes das 03:00Z — **faixas mutuamente
exclusivas**. O que se escolhe é qual relógio fica sozinho, e o certo é o do tenant.

O literal `DIA_DO_TENANT` ganhou um irmão nomeado, `DIA_DOS_RELOGIOS_ERRADOS = "2026-08-17"`, porque
a coincidência entre navegador e UTC **é o mecanismo**, não um acidente a ser escondido.

## Prova por mutação

| Mutação (`tsc --noEmit` limpo) | Teste que morreu | Mensagem real |
|---|---|---|
| `dataPadrao={new Date().toISOString().slice(0, 10)}` (**UTC**) | `o dia default é HOJE — hoje NO FUSO DO TENANT (#136)` | `expected '2026-08-17' to be '2026-08-18'` |
| `dataPadrao={localYmd(new Date())}` (**navegador**) | mesmo teste | `expected '2026-08-17' to be '2026-08-18'` |

As duas morrem **na mesma linha** — é para isso que o instante foi escolhido.

⚠️ A mutação de UTC **não compila** sem tirar `HOJE_DO_TENANT` do import; e tirar a linha inteira
leva `DialogDeBaixa` junto e a morte passa a ser por `TS2304`, não pela asserção. Refeita de forma
independente na revisão, com o import podado corretamente: `tsc` exit 0, `1 failed | 16 passed`,
`expected '2026-08-17' to be '2026-08-18'`.

## Os que decidi NÃO mexer — razão medida, não presumida

Cada um levou **as duas** mutações (navegador e UTC), com `tsc` limpo:

| Arquivo | Resultado das mutações | Razão |
|---|---|---|
| `cockpit/CockpitPage.test.tsx` | UTC **2 failed**, navegador **1 failed** | **A issue errou.** O teste `pede o dia do TENANT, não o do NAVEGADOR` usa `22:30:00Z` (SP 14, UTC 14, Tóquio 15) e já isola o tenant. `expected '…day=2027-03-14' to be '…day=2027-03-15'` |
| `agenda/EscolherHorario.test.tsx` ⚠️ | ambas **1 failed** | A prova de fuso está em `2026-10-10T22:00:00Z`, tenant isolado. O `12:00:00Z` de topo é andaime |
| `crm/BlocoDaAgenda.test.tsx` ⚠️ | ambas **1 failed** | **A asserção é sobre HORA**, não sobre "hoje" — o teste de fuso nem chama `setSystemTime`. `Unable to find an element with the text: 21/08/2026 08:00` |
| `financeiro/ContasSaldosPage.test.tsx` ⚠️ | ambas **5 failed** | Já correto: o describe `#136` usa `18:00:00Z` e **já documenta** que os dois candidatos errados dão 17/08 |
| `crm/ClientDetailPage.test.tsx` (o 10º) | ambas **1 failed** | Já correto — é o **exemplar**; o conserto daqui foi copiado dele |
| `pagar/ComprovantePage.test.tsx` · `vima/EntradaDoDia.test.tsx` | — | instantes já isolam o tenant (aritmética conferida) |
| `pagar/PagarPage.test.tsx` | — | sem `FUSO_DISTANTE`; nenhum relógio de tenant participa |

**Exceção parcial — `financeiro/contas.test.ts`: só o comentário.** Ele usa o mesmo instante cego,
mas **não é defeito**: `impedimentoDaTransferencia` é pura e recebe o hoje como 5º parâmetro (medido:
mutando o hoje para dentro, navegador **2 failed**, UTC **1 failed** — ambas morrem). O texto porém
afirmava que aquele instante *"separa os três relógios"*, o que é falso — e **foi desse literal que a
`CobrancasPage` herdou o ponto cego**. Deixar a afirmação errada convida a próxima cópia. Mudança só
de comentário, então não há mutante a rodar para ela, e digo isso em vez de inventar um teste.

## Verde

```
Test Files  10 passed (10)      # os 10 arquivos com setSystemTime
     Tests  266 passed (266)
```

`tsc --noEmit` exit 0 · `eslint` exit 0 · **nenhum arquivo de produção tocado**
(`git diff --name-only | grep -v '\.test\.'` vem vazio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
