### PR TITLE
fix: /financeiro/centros-custo deixa de cortar texto em 360px [#157]

### DIFF
--- a/apps/web/e2e/centros-custo-360.spec.ts
+++ b/apps/web/e2e/centros-custo-360.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { medirPagina, textoForaDaTela } from "./support/medidas";
+import { LONGO } from "./support/rotas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * `/financeiro/centros-custo` medida pela régua de TEXTO CORTADO (#157) — a classe do `R$ 3.` no
+ * lugar de `R$ 3.000,00`, não a de alcançabilidade que o #156 fechou nesta mesma rota.
+ *
+ * ⚠️ **As duas réguas desta rota olham para defeitos OPOSTOS, e o #156 não cobre este.**
+ * `alcance-360.spec.ts` pergunta se o dedo chega ao controle; ali «Editar» e «Arquivar» estavam
+ * INTEIRAMENTE fora e o `flex-wrap` do #156 os trouxe de volta. Mas o `flex-wrap` só reposiciona
+ * caixa — a TINTA continuou recortada: medido em 20/08/2026, 14 elementos de texto terminando
+ * além da borda do cartão, com a página inteira ainda dizendo `scrollWidth === 360` porque
+ * `overflow-hidden` engole o excesso em silêncio. Nenhuma régua verde via isso.
+ *
+ * ⚠️ **A armadilha já medida no #156, para quem for mexer aqui.** Pôr `break-words` no rótulo do
+ * centro NÃO muda número nenhum: o `<span>` é item de flex com `min-width: auto`, então ele
+ * CRESCE em vez de transbordar, e o `scrollWidth` do próprio elemento (que é o que a régua lê
+ * quando `overflow-x` é `visible`) continua igual ao `clientWidth`. Quem vê o defeito do rótulo é
+ * a BORDA do cartão. O que destrava é `min-w-0` na cadeia de flex ACIMA dele — sem isso o
+ * `break-words` é peso morto.
+ *
+ * ⚠️ **`overflow-x-auto` na tabela NÃO deixa esta régua verde, e isso foi medido, não suposto.**
+ * `textoForaDaTela` compara a borda do texto com a do ancestral que RECORTA — e um deslizador
+ * recorta. Medido em 20/08/2026 com `overflow-x-auto` + `min-w-[36rem]` no lugar do
+ * `overflow-hidden`: **12 cortes** na tabela, os mesmos de antes com 1,5px a menos por causa da
+ * barra. É a mesma conclusão que a `InvestimentosPage` já tinha escrito com outras palavras — em
+ * 360px uma tabela de 4 colunas não cabe, e a saída não é fazer a rolagem funcionar melhor, é não
+ * precisar dela. Por isso o comparativo vira CARTÃO abaixo de `sm`, e a tabela (que é o formato
+ * certo no desktop, onde se compara sócio com sócio lado a lado) só existe a partir dali.
+ */
+
+// Pior caso plausível, e é o MESMO da fixture do #144/#156 (`support/rotas.ts`) de propósito: o
+// número desta issue tem de ser comparável ao que aquele PR mediu. 74 chars sem espaço, hífen ou
+// barra, dentro dos 120 que `cost_centers/schemas.py` aceita.
+const CENTROS = [
+  {
+    id: "cc1",
+    tenant_id: "t1",
+    name: LONGO,
+    kind: "operacional",
+    archived_at: null,
+    created_at: "2026-01-01T10:00:00Z",
+  },
+];
+
+// `by-cost-center` devolve OBJETO (com `[]`, o default de `mockarApi`, a tela quebraria no
+// primeiro campo e mediria uma página em branco). Valores de 6 dígitos + o bucket sintético
+// "Não atribuído", que é o caso que o dono mais lê.
+const RELATORIO = {
+  start: "2026-08-01",
+  end: "2026-08-31",
+  buckets: [
+    {
+      cost_center_id: "cc1",
+      name: LONGO,
+      kind: "operacional",
+      receita_cents: 123456789,
+      resultado_cents: -98765432,
+      lancamentos: 42,
+    },
+    {
+      cost_center_id: null,
+      name: "Não atribuído",
+      kind: null,
+      receita_cents: 0,
+      resultado_cents: -1234567,
+      lancamentos: 3,
+    },
+  ],
+  notes: [],
+};
+
+const LISTA = '[data-testid="lista-centros"]';
+const COMPARATIVO = '[data-testid="comparativo-centros"]';
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/cost-centers": CENTROS,
+    "/financial-intelligence/by-cost-center": RELATORIO,
+  });
+  await page.goto("/financeiro/centros-custo");
+  // A `marca`: sem ela, "360" e "[]" significariam "não desenhou nada".
+  await expect(page.getByTestId("comparativo-centros")).toBeVisible();
+  await expect(page.getByTestId("lista-centros")).toBeVisible();
+});
+
+test("a página não rola de lado", async ({ page }) => {
+  // Verde ANTES e DEPOIS do conserto — está aqui como CONTRASTE, não como cobertura: é o
+  // `scrollWidth === 360` desta linha que fazia o defeito parecer inexistente enquanto 14
+  // elementos de texto terminavam fora da borda do cartão.
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+test("o nome e o tipo do centro na LISTA não ficam fora da borda do cartão", async ({ page }) => {
+  const cortes = await textoForaDaTela(page, LISTA);
+  expect(cortes, JSON.stringify(cortes, null, 2)).toEqual([]);
+});
+
+test("nenhum valor do COMPARATIVO existe só depois de rolar de lado", async ({ page }) => {
+  const cortes = await textoForaDaTela(page, COMPARATIVO);
+  expect(cortes, JSON.stringify(cortes, null, 2)).toEqual([]);
+});
+
+test("o comparativo mostra o valor INTEIRO, com o separador de milhar", async ({ page }) => {
+  // O defeito da 2b-ii em uma asserção, e ela é sobre TINTA: o texto "R$ 1.234.567,89" está no
+  // DOM mesmo recortado, então `toContainText` sozinho não prova nada. O que prova é a caixa do
+  // elemento que o contém terminar dentro dos 360px.
+  const valor = page.getByTestId("comparativo-centros").getByText("R$ 1.234.567,89", { exact: true });
+  await expect(valor).toBeVisible();
+  const caixa = await valor.boundingBox();
+  expect(caixa).not.toBeNull();
+  expect(caixa!.x).toBeGreaterThanOrEqual(0);
+  expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
+});
+
+test("a régua enxerga uma isca plantada DENTRO de cada uma das duas superfícies", async ({
+  page,
+}) => {
+  // Controle positivo. `[]` não distingue "nada vaza" de "nada foi medido" — e aqui o risco é
+  // concreto: o conserto troca a `<table>` por cartões abaixo de `sm`, então um seletor que
+  // dependesse de `td`/`tr` passaria a casar com NADA e o teste ficaria verde por cegueira. Por
+  // isso a isca entra pelos `data-testid` da LINHA, que sobrevivem aos dois desenhos.
+  //
+  // `white-space: nowrap` de propósito: com `break-words` na cadeia consertada, uma isca comum
+  // quebraria e o controle positivo morreria junto com o defeito.
+  const plantarEMedir = async (secao: string, linha: string) => {
+    await page.locator(`${secao} ${linha}`).first().evaluate((el) => {
+      const isca = document.createElement("span");
+      isca.textContent = "x".repeat(120);
+      isca.style.whiteSpace = "nowrap";
+      el.append(isca);
+    });
+    const cortes = await textoForaDaTela(page, secao);
+    return cortes.filter((c) => c.texto.startsWith("x"));
+  };
+
+  expect(await plantarEMedir(LISTA, '[data-testid="item-centro"]')).toHaveLength(1);
+  expect(await plantarEMedir(COMPARATIVO, '[data-testid="linha-centro"]')).toHaveLength(1);
+});
+
+test("um escopo podre aparece como RUÍDO, nunca como aprovação", async ({ page }) => {
+  // A outra metade do controle positivo: se `LISTA`/`COMPARATIVO` deixassem de casar, a régua cai
+  // no DOCUMENTO INTEIRO em vez de devolver `[]` (ver `textoForaDaTela`). Sem esta linha, um
+  // `data-testid` renomeado transformaria os dois testes acima em verde permanente.
+  //
+  // A isca é plantada no `body` e não se apoia em nenhum corte pré-existente da tela: depois do
+  // conserto a rota não tem mais nenhum, e um controle que dependesse disso morreria exatamente
+  // quando o produto ficasse certo.
+  await page.evaluate(() => {
+    const isca = document.createElement("span");
+    isca.textContent = "x".repeat(120);
+    isca.style.whiteSpace = "nowrap";
+    document.body.append(isca);
+  });
+  const cortes = await textoForaDaTela(page, ".seletor-que-nao-existe");
+  expect(cortes.filter((c) => c.texto.startsWith("x"))).toHaveLength(1);
+});

--- a/apps/web/e2e/centros-custo-360.spec.ts
+++ b/apps/web/e2e/centros-custo-360.spec.ts
@@ -126,6 +126,20 @@ test("o comparativo mostra o valor INTEIRO, com o separador de milhar", async ({
   expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
 });
 
+test("no desktop quem aparece é a TABELA, e ela sozinha", async ({ page }) => {
+  // A OUTRA METADE do par `sm:hidden` / `hidden sm:table` — e ela é invisível para um gate que só
+  // mede 360px. Medido em 20/08/2026: tirar o `sm:hidden` do `<ul>` dos cartões não move um pixel
+  // aqui, o mutante SOBREVIVE aos cinco testes acima, e ainda assim põe cartão e tabela na mesma
+  // tela a partir de 640px. Por isso esta é a única linha do arquivo que troca a viewport: sem
+  // ela, metade do conserto ficaria sem régua.
+  await page.setViewportSize({ width: 900, height: 740 });
+  await expect(page.getByTestId("comparativo-centros").getByRole("table")).toBeVisible();
+  await expect(page.getByTestId("comparativo-centros").locator("ul")).toBeHidden();
+  // `linha-centro` marca a linha nos DOIS desenhos. Duas visíveis = as duas `<tr>` da tabela e
+  // nenhum cartão; quatro seria o defeito.
+  await expect(page.getByTestId("linha-centro").locator("visible=true")).toHaveCount(2);
+});
+
 test("a régua enxerga uma isca plantada DENTRO de cada uma das duas superfícies", async ({
   page,
 }) => {

--- a/apps/web/e2e/centros-custo-360.spec.ts
+++ b/apps/web/e2e/centros-custo-360.spec.ts
@@ -109,8 +109,17 @@ test("o comparativo mostra o valor INTEIRO, com o separador de milhar", async ({
   // O defeito da 2b-ii em uma asserção, e ela é sobre TINTA: o texto "R$ 1.234.567,89" está no
   // DOM mesmo recortado, então `toContainText` sozinho não prova nada. O que prova é a caixa do
   // elemento que o contém terminar dentro dos 360px.
-  const valor = page.getByTestId("comparativo-centros").getByText("R$ 1.234.567,89", { exact: true });
-  await expect(valor).toBeVisible();
+  //
+  // `visible=true` porque o comparativo tem DOIS desenhos do mesmo dado no DOM (cartão < `sm`,
+  // tabela >= `sm`) e o valor casa nos dois. Medir o que está `display: none` daria `null` e o
+  // teste morreria pelo motivo errado. Depois de filtrar tem de sobrar EXATAMENTE um: dois
+  // visíveis significaria que os dois desenhos estão na tela ao mesmo tempo — o defeito que o
+  // par `sm:hidden` / `hidden sm:table` existe para evitar.
+  const valor = page
+    .getByTestId("comparativo-centros")
+    .getByText("R$ 1.234.567,89", { exact: true })
+    .locator("visible=true");
+  await expect(valor).toHaveCount(1);
   const caixa = await valor.boundingBox();
   expect(caixa).not.toBeNull();
   expect(caixa!.x).toBeGreaterThanOrEqual(0);

--- a/apps/web/src/features/financeiro/CentrosCustoPage.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.tsx
@@ -1,5 +1,5 @@
 import { Archive, Pencil } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
@@ -103,31 +103,37 @@ export default function CentrosCustoPage() {
               // INTEIRAMENTE fora, sem rolagem de escape. Nao dava para editar nem arquivar um
               // centro de custo no celular. Medido em #144.
               //
-              // O NOME em si continua cortado (215,5px sobrando, e a tabela comparativa abaixo
-              // corta ate 699,5px): e a outra classe, a de `textoForaDaTela`, e nao ha regua
-              // verde para ela nesta rota. Tentar consertar aqui de carona ficaria sem medicao —
-              // `break-words` no rotulo, medido, NAO muda o numero (o span e item de flex com
-              // `min-width: auto`), e mudanca que nenhuma regua ve e peso morto.
+              // ⚠️ **O `min-w-0` dos dois `<span>` abaixo é que faz o `break-words` valer algo**
+              // (#157). Item de flex nasce com `min-width: auto`, ou seja, não encolhe abaixo do
+              // seu min-content — e o min-content de um nome de 74 chars SEM espaço é o nome
+              // inteiro. Enquanto isso valer, o span CRESCE em vez de transbordar: o
+              // `scrollWidth` dele continua igual ao `clientWidth`, e a régua que lê `scrollWidth`
+              // não acusa nada. Quem via o defeito era a BORDA do cartão — 215,5px de nome e
+              // 301,4px do pill terminando fora dela, com a página inteira ainda medindo 360
+              // porque o `overflow-hidden` do cartão engolia o excesso em silêncio.
+              //
+              // `min-w-0` sozinho também não basta: encolhida a caixa, o texto sem espaço não tem
+              // onde quebrar e vaza como tinta. Os dois juntos, medidos, zeram os dois cortes.
               <li
                 key={c.id}
                 data-testid="item-centro"
                 className="flex flex-wrap items-center justify-between gap-2 px-5 py-3"
               >
-                <span className="flex items-center gap-2">
+                <span className="flex min-w-0 items-center gap-2">
                   <span
                     className={
                       c.archived_at
-                        ? "text-sm text-neutral-400 line-through"
-                        : "text-sm font-medium text-neutral-800"
+                        ? "min-w-0 break-words text-sm text-neutral-400 line-through"
+                        : "min-w-0 break-words text-sm font-medium text-neutral-800"
                     }
                   >
                     {c.name}
                   </span>
-                  <span className="rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
+                  <span className="whitespace-nowrap rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
                     {kindLabel(c.kind)}
                   </span>
                   {c.archived_at && (
-                    <span className="rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
+                    <span className="whitespace-nowrap rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
                       Arquivado
                     </span>
                   )}
@@ -171,7 +177,26 @@ export default function CentrosCustoPage() {
   );
 }
 
-/** Comparativo do mês: resultado por centro de custo lado a lado (inclui "Não atribuído"). */
+/**
+ * Comparativo do mês: resultado por centro de custo lado a lado (inclui "Não atribuído").
+ *
+ * ⚠️ **DOIS desenhos do mesmo dado, e a escolha foi MEDIDA (#157), não preferida.** Abaixo de
+ * `sm` saem cartões; de `sm` para cima, a tabela — que é o formato certo no desktop, onde o ponto
+ * deste card é justamente comparar sócio com sócio lado a lado.
+ *
+ * O caminho óbvio seria dar deslizador à tabela, como a DRE (`DrePage.tsx:131`). **Medido em
+ * 20/08/2026: não resolve.** Trocando o `overflow-hidden` por `overflow-x-auto` + `min-w-[36rem]`,
+ * a régua de `textoForaDaTela` continua acusando os MESMOS 12 cortes, com os MESMOS números
+ * (306,5 / 443,3 / 572,3 / 699,5). E não é fresta da régua: ela compara a borda do texto com a do
+ * ancestral que RECORTA, e um deslizador recorta. O que o `overflow-x-auto` muda é que o dono
+ * PODE alcançar o valor — não que ele o LEIA. Num comparativo o valor é *a* informação, e
+ * informação que exige rolagem lateral para existir é informação que o dono não lê.
+ *
+ * É a mesma conclusão que a `InvestimentosPage` já escreveu com outras palavras ("a lição do #58
+ * era role, não corte; a daqui é mais funda: em 360px uma tabela de 3 colunas não cabe, e a saída
+ * não é fazer a rolagem funcionar melhor — é não precisar dela"). Aqui são 4 colunas, uma delas um
+ * nome livre de até 120 chars.
+ */
 function ComparativeCard({ report }: { report: CostCenterReport }) {
   return (
     <div data-testid="comparativo-centros" className="overflow-hidden rounded-2xl bg-white shadow-sm">
@@ -181,7 +206,17 @@ function ComparativeCard({ report }: { report: CostCenterReport }) {
           Mesma fórmula/exclusões da DRE (regime de competência). Compare sócios/áreas lado a lado.
         </p>
       </div>
-      <table className="w-full text-sm">
+
+      {/* Abaixo de `sm`: um cartão por centro. Este `sm:hidden` e o `hidden sm:table` da tabela
+          são um PAR — quebrar um só põe os dois desenhos na tela ao mesmo tempo, e a régua acusa
+          os 12 cortes de volta. */}
+      <ul className="divide-y divide-neutral-50 sm:hidden">
+        {report.buckets.map((b) => (
+          <Cartao key={b.cost_center_id ?? "__nao_atribuido__"} bucket={b} />
+        ))}
+      </ul>
+
+      <table className="hidden w-full text-sm sm:table">
         <thead>
           <tr className="border-b border-neutral-100 text-left text-xs uppercase text-neutral-400">
             <th className="px-5 py-2 font-medium">Centro de custo</th>
@@ -200,9 +235,59 @@ function ComparativeCard({ report }: { report: CostCenterReport }) {
   );
 }
 
+/** Tom do resultado — uma definição só, para o cartão e a linha não divergirem no 1º ajuste. */
+const tomDoResultado = (bucket: CostCenterBucket) =>
+  bucket.resultado_cents < 0 ? "text-danger" : "text-emerald-600";
+
+/**
+ * O mesmo bucket em 360px. Rótulo à esquerda, valor à direita com `whitespace-nowrap` — o padrão
+ * que a `InvestimentosPage` fixou depois do "R$ 3." no lugar de "R$ 3.000,00".
+ *
+ * `min-w-0` no nome pelo mesmo motivo do cartão da lista: sem ele o item de flex não encolhe
+ * abaixo do min-content, e o `break-words` ao lado vira peso morto.
+ */
+function Cartao({ bucket }: { bucket: CostCenterBucket }) {
+  const unassigned = bucket.cost_center_id === null;
+  return (
+    <li data-testid="linha-centro" className={`px-5 py-3 ${unassigned ? "bg-amber-50" : ""}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="min-w-0 break-words text-sm font-medium text-neutral-800">
+          {bucket.name}
+        </span>
+        {bucket.kind && !unassigned && (
+          <span className="whitespace-nowrap rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">
+            {kindLabel(bucket.kind)}
+          </span>
+        )}
+      </div>
+      <dl className="mt-2 space-y-1 text-xs">
+        <LinhaDoCartao rotulo="Receita">
+          <span className="tabular-nums text-neutral-600">{formatBRL(bucket.receita_cents)}</span>
+        </LinhaDoCartao>
+        <LinhaDoCartao rotulo="Resultado">
+          <span className={`font-medium tabular-nums ${tomDoResultado(bucket)}`}>
+            {formatBRL(bucket.resultado_cents)}
+          </span>
+        </LinhaDoCartao>
+        <LinhaDoCartao rotulo="Lançamentos">
+          <span className="tabular-nums text-neutral-500">{bucket.lancamentos}</span>
+        </LinhaDoCartao>
+      </dl>
+    </li>
+  );
+}
+
+function LinhaDoCartao({ rotulo, children }: { rotulo: string; children: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <dt className="text-neutral-400">{rotulo}</dt>
+      <dd className="whitespace-nowrap">{children}</dd>
+    </div>
+  );
+}
+
 function Row({ bucket }: { bucket: CostCenterBucket }) {
   const unassigned = bucket.cost_center_id === null;
-  const negative = bucket.resultado_cents < 0;
   return (
     <tr
       data-testid="linha-centro"
@@ -217,7 +302,7 @@ function Row({ bucket }: { bucket: CostCenterBucket }) {
         )}
       </td>
       <td className="px-5 py-2.5 tabular-nums text-neutral-600">{formatBRL(bucket.receita_cents)}</td>
-      <td className={`px-5 py-2.5 tabular-nums font-medium ${negative ? "text-danger" : "text-emerald-600"}`}>
+      <td className={`px-5 py-2.5 font-medium tabular-nums ${tomDoResultado(bucket)}`}>
         {formatBRL(bucket.resultado_cents)}
       </td>
       <td className="px-5 py-2.5 tabular-nums text-neutral-500">{bucket.lancamentos}</td>

--- a/apps/web/src/features/financeiro/CentrosCustoPage.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.tsx
@@ -95,7 +95,7 @@ export default function CentrosCustoPage() {
           Nenhum centro de custo ainda. Clique em "Novo centro de custo".
         </p>
       ) : (
-        <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+        <div data-testid="lista-centros" className="overflow-hidden rounded-2xl bg-white shadow-sm">
           <ul className="divide-y divide-neutral-50">
             {centers.map((c) => (
               // Sem o `flex-wrap` desta linha, um nome longo empurrava as duas acoes para fora
@@ -108,7 +108,11 @@ export default function CentrosCustoPage() {
               // verde para ela nesta rota. Tentar consertar aqui de carona ficaria sem medicao —
               // `break-words` no rotulo, medido, NAO muda o numero (o span e item de flex com
               // `min-width: auto`), e mudanca que nenhuma regua ve e peso morto.
-              <li key={c.id} className="flex flex-wrap items-center justify-between gap-2 px-5 py-3">
+              <li
+                key={c.id}
+                data-testid="item-centro"
+                className="flex flex-wrap items-center justify-between gap-2 px-5 py-3"
+              >
                 <span className="flex items-center gap-2">
                   <span
                     className={
@@ -170,7 +174,7 @@ export default function CentrosCustoPage() {
 /** Comparativo do mês: resultado por centro de custo lado a lado (inclui "Não atribuído"). */
 function ComparativeCard({ report }: { report: CostCenterReport }) {
   return (
-    <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
+    <div data-testid="comparativo-centros" className="overflow-hidden rounded-2xl bg-white shadow-sm">
       <div className="border-b border-neutral-100 px-5 py-3">
         <h2 className="font-semibold text-neutral-800">Resultado por centro de custo (este mês)</h2>
         <p className="text-xs text-neutral-400">
@@ -200,7 +204,10 @@ function Row({ bucket }: { bucket: CostCenterBucket }) {
   const unassigned = bucket.cost_center_id === null;
   const negative = bucket.resultado_cents < 0;
   return (
-    <tr className={`border-b border-neutral-50 last:border-0 ${unassigned ? "bg-amber-50" : ""}`}>
+    <tr
+      data-testid="linha-centro"
+      className={`border-b border-neutral-50 last:border-0 ${unassigned ? "bg-amber-50" : ""}`}
+    >
       <td className="px-5 py-2.5 text-neutral-800">
         {bucket.name}
         {bucket.kind && !unassigned && (


### PR DESCRIPTION
## Resumo

`/financeiro/centros-custo` cortava **texto** em 360×740 — a classe do `textoForaDaTela` (o defeito do
"R$ 3." no lugar de "R$ 3.000,00"), não a de alcançabilidade que o #156 fechou nesta mesma rota. Este
PR escreve a régua que **mede**, vê-a vermelha, e só então conserta.

Fecha #157.

## Alcance: **14**, não 13

O 14º é o pill `«operacional»` do cartão da lista — a tabela da issue enumerou o nome do centro mas
não o pill ao lado dele. Os 13 originais estão todos confirmados, com os números exatos.

| # | Superfície | Elemento | Sobra ANTES | Sobra DEPOIS |
|---|---|---|---|---|
| 1 | LISTA | `span` nome do centro | **215,5px** | −105,9 |
| 2 | LISTA | `span` pill «operacional» — **fora da conta da issue** | **301,4px** | −20,0 |
| 3 | COMPARATIVO | `th «Centro de custo»` | **306,5px** | n/a (a tabela sai do 360px) |
| 4 | | `th «Receita»` | **443,3px** | −254,0 |
| 5 | | `th «Resultado»` | **572,3px** | −239,8 |
| 6 | | `th «Lançamentos»` | **699,5px** | −222,2 |
| 7 | | `span` pill «operacional» da linha | **286,5px** | −214,1 |
| 8–14 | | as 7 células de valor (`R$ 1.234.567,89`, `-R$ 987.654,32`, `42`, `Não atribuído`, …) | 306,5 a **699,5px** | −20,0 a −203,5 |

A folga mais apertada depois é **−20px** — o padding direito do próprio cartão.

**Por que nenhuma régua verde via isso:** a página media `scrollWidth === 360` **antes e depois**. O
`overflow-hidden` engolia os 14 em silêncio. É a armadilha já registrada no §5.1 — *o `scrollWidth`
NÃO vê o defeito do título, a BORDA vê*.

**Varredura da rota inteira** (2 centros, um arquivado com nome de 83 chars, modal de edição aberto):
`textoForaDaTela` = `[]`, `controlesInalcancaveis` = `[]`. **1 tabela na rota, 0 deslizadores** — não
há outra tabela sem deslizador aqui.

## Vermelho antes do conserto

Commit `8f1fcc9`, só o spec, contra a produção intacta:

```
  ok 1 › a página não rola de lado
  x  2 › o nome e o tipo do centro na LISTA não ficam fora da borda do cartão
  x  3 › nenhum valor do COMPARATIVO existe só depois de rolar de lado
  x  4 › o comparativo mostra o valor INTEIRO, com o separador de milhar
  ok 5 › a régua enxerga uma isca plantada DENTRO de cada uma das duas superfícies
  ok 6 › um escopo podre aparece como RUÍDO, nunca como aprovação
  3 failed / 3 passed (26.7s)
```

`Received + 12` na LISTA · `Received + 62` no COMPARATIVO · `Expected: <= 360 / Received: 779.296875`
na caixa do valor.

## A decisão: reflow em cartões, e a razão é **medida**, não preferida

O deslizador foi aplicado **primeiro**, para medir em vez de supor. `overflow-hidden` →
`overflow-x-auto` + `min-w-[36rem]`:

> **12 cortes, com os MESMOS números** — 306,5 / 443,3 / 572,3 / 699,5. **Zero diferença.**

Não é fresta da régua: `textoForaDaTela` compara a borda do texto com a do ancestral que **recorta**,
e um deslizador recorta. O `overflow-x-auto` muda se o dono **alcança** o valor, não se ele o **lê** —
e num comparativo o valor *é* a informação. É a mesma conclusão que a `InvestimentosPage` já
escreveu: *"a lição do #58 era role, não corte; a daqui é mais funda — em 360px uma tabela de 3
colunas não cabe, e a saída não é fazer a rolagem funcionar melhor, é não precisar dela"*. Aqui são
**4** colunas, uma delas nome livre de até 120 chars.

Solução: cartões abaixo de `sm`, tabela de `sm` para cima — porque é no desktop que a tabela cumpre o
que promete, comparar sócio com sócio lado a lado. Na LISTA, `min-w-0` na cadeia de flex +
`break-words`.

⚠️ **A armadilha do #156 confirmada:** `break-words` sozinho não muda número nenhum, e `min-w-0`
sozinho também não — M2 e M5 abaixo mostram que **cada um sozinho deixa corte**.

## Prova por mutação — 5 mutantes, 5 mortos (todos compilam, `tsc` exit 0)

| Mutação | Spec que morreu | Mensagem real |
|---|---|---|
| M1: `flex min-w-0 items-center` → `flex items-center` | teste 2 | `Received + 12`: `forcaFora 215.5` + `301.4` — **os números originais de volta** |
| M2: tira `break-words` do rótulo (mantém `min-w-0`) | teste 2 | `forcaFora: 215` |
| M3: `hidden w-full text-sm sm:table` → `w-full text-sm` | testes 3 **e** 4 | 12 cortes (306,5 / 443,3 / 572,3 / 699,5) + `toHaveCount(1) failed / Received: 2` |
| M4: tira `sm:hidden` do `<ul>` dos cartões | teste 5 (desktop) | `toBeHidden() failed / Received: visible` |
| M5: tira `min-w-0` do nome dentro do cartão | teste 3 | `forcaFora: 215.5` |

**M4 sobreviveu na primeira rodada, e isso valeu um commit extra** (`d2743dd`). `sm:hidden` é
**inerte em 360px** — não move um pixel — mas põe cartão e tabela na mesma tela a partir de 640px:
metade do conserto estava sem régua. Uma linha de `setViewportSize({width: 900})` fecha.

M3 foi **refeita de forma independente na revisão**: `tsc` exit 0, testes 3 e 4 vermelhos, com
`forcaFora` 306.5 / 443.3 / 572.3 / 699.5 / 286.5 — exatamente os números da issue.

## Verde

`7 passed (17.2s)` · `tsc` OK · `eslint` OK · `vitest costCenters` 7/7 · as duas réguas vizinhas da
mesma rota (`alcance-360` + `rotas-360`) **61 passed**.

## Achado FORA do escopo — vira issue nova, não commit escondido aqui

**A régua de alvo tocável (44px, classe do #56) está vermelha nesta rota.** `alvosPequenos` devolve
**3**, e nenhum spec desta rota faz essa pergunta hoje:

| Elemento | Medido |
|---|---|
| `input[type=checkbox]` «Mostrar arquivados» | **13 × 13px** |
| `button «Editar»` do cartão | 49,6 × **16px** |
| `button «Arquivar»` do cartão | 64,3 × **16px** |

Os dois botões são exatamente os que o #156 tornou *alcançáveis* — alcançáveis mas de 16px de altura.
O checkbox de 13×13 é a forma literal do defeito do PR #56 (conta marcada como paga sem o dono ver).
Terceira régua desta tela, merece issue própria com o mesmo rito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
