### PR TITLE
fix(web): a lixeira sai de dentro do card em 3 telas, e o escorregao de 10px para de navegar [#160]

### DIFF
--- a/apps/web/e2e/aninhamento-clicavel-360.spec.ts
+++ b/apps/web/e2e/aninhamento-clicavel-360.spec.ts
@@ -1,0 +1,354 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * A régua do ANINHAMENTO CLICÁVEL (#160) — o gêmeo estrutural do #149 (PR #159).
+ *
+ * Três telas de lista montavam a lixeira **dentro** do `<button>` que navega. Além de HTML
+ * inválido, isso carrega o mecanismo exato medido no #149: quando dois alvos clicáveis são
+ * aninhados, o navegador emite o `click` no **ANCESTRAL COMUM** de `mousedown` e `mouseup`. Um
+ * deslocamento de **10px** — o limiar medido no #149, com o trace do CI a 0,1px do cálculo — faz o
+ * toque na **lixeira** virar **navegação**, e nada reclama: o hit-target do Playwright está
+ * satisfeito, porque o `mousedown` acertou o alvo certo.
+ *
+ * ⚠️ **Esta régua mede o DESLOCAMENTO, não o CSS nem o markup.** `expect(html).toContain("<div")`
+ * seria a família do `toContain("flex-wrap")` que o CLAUDE.md §5.1 proíbe: passaria com a tela
+ * quebrada, porque a estrutura pode mudar de nome sem mudar de comportamento. O que esta régua
+ * pergunta é a única pergunta que importa para o dedo do dono: *o toque na lixeira, escorregando
+ * 10px, disparou a ação do card?*
+ *
+ * ⚠️ **A lixeira mantém o mesmo tamanho de antes, de propósito.** Engordá-la para os 44px do
+ * `alvosPequenos` faria o deslocamento de 10px cair DENTRO dela — e aí a régua mediria o
+ * *padding*, não o aninhamento: a mutação que re-aninha os botões SOBREVIVERIA verde. O alvo
+ * pequeno é dívida de outra issue; misturar as duas apagaria esta medição.
+ *
+ * ⚠️ **O gravador de cliques não é enfeite.** Um gesto que não emite `click` nenhum passaria em
+ * todas as asserções negativas abaixo — verde por não ter medido nada, o modo de falha do #123.
+ * Toda medição aqui exige, ANTES, que o navegador tenha emitido exatamente **1** `click`.
+ *
+ * ## O chip da `AgendaPage` fica FORA daqui, e a razão foi medida
+ *
+ * A issue #160 põe o `<div onClick>` dentro do `<button>` da célula do dia (`AgendaPage.tsx:224`,
+ * contornado no #159 e não removido) "nesta mesma família". Está certo quanto ao MECANISMO e
+ * errado quanto ao TAMANHO da correção — varrendo o mesmo gesto na `/agenda` em 20/08/2026,
+ * viewport 360×740, chip de **31,3×20,5px** dentro de uma célula de **44,3×92px**:
+ *
+ * | deslocamento | alvo do `click` | detalhe (certo) | "Novo evento" (errado) |
+ * |---|---|---|---|
+ * | 8px | o próprio chip | 1 | 0 |
+ * | 10px | o próprio chip | 1 | 0 |
+ * | 11px | o próprio chip | 1 | 0 |
+ * | **12px** | **o `<button>` da célula** | **0** | **1** |
+ * | 14 / 16 / 20px | o `<button>` da célula | 0 | 1 |
+ *
+ * Ou seja: o defeito é REAL na agenda também, mas o limiar lá é **12px**, não 10 — o chip tem meia
+ * altura de 10,25px, e é só isso que o separa. Não entra nesta PR por três motivos medidos:
+ *
+ * 1. **A correção é de outra natureza.** Nas três listas o alvo interno é um ícone de canto: vira
+ *    irmão com `position: absolute` e a caixa não se move (medido — `x`/`y` idênticos antes e
+ *    depois). Na agenda os chips são CONTEÚDO no fluxo da célula (até 3 por dia, mais o "+N"),
+ *    então desaninhar significa remontar a célula do calendário em camadas, mexendo na geometria
+ *    de 35 a 42 células de uma grade que já é apertada em 360px.
+ * 2. **Raio de explosão.** `AgendaPage` tem `agenda-evento-360.spec.ts`, `ficha-agenda-360.spec.ts`
+ *    e `AgendaPage.test.tsx` em cima dela, e o #159 acabou de mexer nesse arquivo.
+ * 3. **É outra decisão de desenho**, com outro limiar (12px) e outra prova por mutação. Juntar as
+ *    duas nesta PR misturaria uma correção mecânica de três linhas com um redesenho de grade.
+ *
+ * Fica como issue própria, com a tabela acima como enunciado pronto.
+ */
+
+/** O limiar medido no #149: 10px entre o `mousedown` e o `mouseup` já bastam. */
+const DESLOCAMENTO_PX = 10;
+
+/**
+ * ⚠️ **O pior caso de §5.1 aqui é o pior caso ALCANÇÁVEL, e a diferença foi medida.**
+ *
+ * O nome sem espaço de 80 chars que a régua de layout usa (`support/rotas.ts`) empurra a lixeira
+ * para **FORA da viewport de 360px** em duas das três telas — e uma lixeira fora da tela não pode
+ * ser tocada, então o gesto do #149 não teria o que medir. Medido em 20/08/2026, viewport 360×740:
+ *
+ * | tela | título | caixa do card | x da lixeira |
+ * |---|---|---|---|
+ * | `/funis` | 80 chars sem espaço | 312 (a caixa segura) | **760,7** — 400px fora |
+ * | `/juridico` | 33 chars com espaço | 312 | 310 ✅ |
+ * | `/juridico` | 46 chars com espaço | **399,7** | **397,7** — 38px fora |
+ * | `/juridico` | 61 chars com espaço | **468,7** | **466,7** — 107px fora |
+ * | `/marketing` | 49 chars com espaço | 148 | 158 ✅ |
+ *
+ * Esse transbordo é **outro defeito, de outra família** (a do #58/#144, alcançabilidade) e está
+ * FORA do alcance do #160 — o `scrollWidth` da página fica em **360** nos cinco casos, então
+ * nenhuma régua de LARGURA o enxerga, e `rotas-360.spec.ts` cataloga `/funis` e `/juridico` como
+ * rotas VAZIAS, sem dado nenhum na lista. Fica registrado aqui com número, não corrigido aqui.
+ *
+ * O que este arquivo mede é o ANINHAMENTO, e para isso a lixeira precisa estar na tela — daí a
+ * guarda de viewport no `beforeEach`, que faz a régua gritar se a fixture voltar a escapar em vez
+ * de passar verde por não ter medido nada.
+ */
+const NOME_FUNIL = "Captacao de clientes do segundo semestre para o escritorio em 2026";
+const TITULO_DOC = "Contrato de prestacao de servicos";
+const TOPICO_CARROSSEL = "Captacao de clientes do segundo semestre para 2026";
+
+type JanelaComGravador = Window & { __cliques?: string[] };
+
+/**
+ * Grava, com `capture` no `document`, QUAL elemento o navegador escolheu como alvo de cada `click`.
+ * É a leitura direta do mecanismo do #149 — o ancestral comum — e não uma inferência a partir do
+ * sintoma.
+ */
+async function armarGravadorDeCliques(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const janela = window as Window & { __cliques?: string[] };
+    janela.__cliques = [];
+    document.addEventListener(
+      "click",
+      (ev) => {
+        const alvo = ev.target as Element | null;
+        const marca = alvo?.closest("[data-testid]")?.getAttribute("data-testid") ?? "";
+        janela.__cliques?.push(`${alvo ? alvo.tagName.toLowerCase() : "?"}[${marca}]`);
+      },
+      true,
+    );
+  });
+}
+
+async function lerCliques(page: Page): Promise<string[]> {
+  return page.evaluate(() => (window as JanelaComGravador).__cliques ?? []);
+}
+
+/**
+ * O GESTO do #149: `mousedown` no centro do alvo INTERNO (a lixeira) e `mouseup` deslocado
+ * `DESLOCAMENTO_PX` na direção do centro do alvo EXTERNO (o card).
+ *
+ * A direção é calculada, não chutada: apontar para o centro do card garante que o `mouseup` caia
+ * DENTRO da caixa do externo nas duas versões — a desaninhada e a mutante —, que é o que torna a
+ * medição comparável. Um deslocamento fixo "para baixo" cairia fora do card em uma das três telas
+ * e a régua mediria coisas diferentes em cada uma.
+ */
+async function toqueQueEscorrega(page: Page, interno: Locator, externo: Locator): Promise<void> {
+  const caixaInterna = await interno.boundingBox();
+  const caixaExterna = await externo.boundingBox();
+  expect(caixaInterna, "a lixeira precisa estar na tela — sem caixa não há gesto").not.toBeNull();
+  expect(caixaExterna, "o card precisa estar na tela — sem caixa não há direção").not.toBeNull();
+
+  const x0 = caixaInterna!.x + caixaInterna!.width / 2;
+  const y0 = caixaInterna!.y + caixaInterna!.height / 2;
+  const dx = caixaExterna!.x + caixaExterna!.width / 2 - x0;
+  const dy = caixaExterna!.y + caixaExterna!.height / 2 - y0;
+  const norma = Math.hypot(dx, dy) || 1;
+
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  await page.mouse.move(x0 + (dx / norma) * DESLOCAMENTO_PX, y0 + (dy / norma) * DESLOCAMENTO_PX);
+  await page.mouse.up();
+}
+
+/** Coleta os DELETE que a tela disparou — é assim que se pergunta "a lixeira agiu?". */
+function coletarDeletes(page: Page): string[] {
+  const feitos: string[] = [];
+  page.on("request", (req) => {
+    if (req.method() === "DELETE") feitos.push(new URL(req.url()).pathname);
+  });
+  return feitos;
+}
+
+interface Tela {
+  nome: string;
+  rota: string;
+  /** Texto que PROVA que a lista desenhou antes de qualquer medição (§5.1: `marca`). */
+  marca: string;
+  mocks: Record<string, unknown>;
+  /** O card que NAVEGA — o alvo externo. */
+  externo: string;
+  /** A lixeira — o alvo interno. */
+  interno: string;
+  /** Para onde o card navega quando o toque acerta de verdade. */
+  destino: RegExp;
+  /** O caminho do DELETE que a lixeira dispara quando o toque acerta de verdade. */
+  apagar: string;
+}
+
+const ID = "x1";
+
+const TELAS: Tela[] = [
+  {
+    nome: "funis",
+    rota: "/funis",
+    marca: "Funis de Vendas",
+    mocks: {
+      "/funnels": [{ id: ID, name: NOME_FUNIL, node_count: 12, created_at: "2026-08-01T10:00:00Z" }],
+    },
+    externo: `abrir-funil-${ID}`,
+    interno: `excluir-funil-${ID}`,
+    destino: /\/funis\/x1$/,
+    apagar: `/api/funnels/${ID}`,
+  },
+  {
+    nome: "juridico",
+    rota: "/juridico",
+    marca: "Assistente Jurídico",
+    mocks: {
+      "/juridico/skills": [],
+      "/juridico/documents": [
+        {
+          id: ID,
+          skill: "contrato",
+          category: "contratos",
+          title: TITULO_DOC,
+          client_id: null,
+          client_name: null,
+          status: "ready",
+          created_at: "2026-08-01T10:00:00Z",
+        },
+      ],
+    },
+    externo: `abrir-documento-${ID}`,
+    interno: `excluir-documento-${ID}`,
+    destino: /\/juridico\/x1$/,
+    apagar: `/api/juridico/documents/${ID}`,
+  },
+  {
+    nome: "marketing",
+    rota: "/marketing",
+    marca: "Carrosséis",
+    mocks: {
+      "/marketing/carousels": [
+        {
+          id: ID,
+          tenant_id: "t1",
+          topic: TOPICO_CARROSSEL,
+          platform: "instagram",
+          slides: [
+            {
+              kind: "cover",
+              heading: "Diagnostico do escritorio",
+              body: "O que muda no segundo semestre",
+              secondary: "Fale com a gente",
+              highlight: "Diagnostico",
+              photo_url: "",
+              photo_position: "mid",
+            },
+          ],
+          status: "draft",
+          handle: "@escritorio1pessoa",
+          caption: TOPICO_CARROSSEL,
+          hashtags: "#escritorio1pessoa",
+          template: "editorial",
+          primary_color: "#123456",
+          bg_color: "#ffffff",
+          text_color: "#111111",
+          accent_color: "#ff0000",
+          font: "Inter",
+          created_at: "2026-08-01T10:00:00Z",
+        },
+      ],
+    },
+    externo: `abrir-carrossel-${ID}`,
+    interno: `excluir-carrossel-${ID}`,
+    destino: /\/marketing\/x1$/,
+    apagar: `/api/marketing/carousels/${ID}`,
+  },
+];
+
+for (const tela of TELAS) {
+  test.describe(`${tela.rota} — lixeira e card não se aninham`, () => {
+    test.beforeEach(async ({ page }) => {
+      await semearSessao(page);
+      await mockarApi(page, tela.mocks);
+      await page.goto(tela.rota);
+      // A `marca` (§5.1): medir uma tela que renderizou em branco passa em qualquer régua negativa.
+      await expect(page.getByRole("heading", { name: tela.marca })).toBeVisible();
+      await expect(page.getByTestId(tela.externo)).toBeVisible();
+      await expect(page.getByTestId(tela.interno)).toBeVisible();
+
+      // ⚠️ **A guarda de ALCANCE, e ela não é zelo — é a lição do parágrafo lá de cima.** Com a
+      // fixture de 80 chars sem espaço, a lixeira ia parar em **x=760,7** numa tela de 360 e o
+      // gesto do #149 batia no `<html>`: o card não navegava, o teste ficava VERDE, e o que ele
+      // media era o transbordo, não o aninhamento. `toBeVisible()` não acusa isso — o elemento
+      // está lá, com caixa e tudo, só que fora da tela.
+      const caixa = (await page.getByTestId(tela.interno).boundingBox())!;
+      expect(caixa.x, "a lixeira escapou pela ESQUERDA da viewport de 360px").toBeGreaterThanOrEqual(0);
+      expect(
+        caixa.x + caixa.width,
+        "a lixeira escapou pela DIREITA da viewport de 360px — a régua mediria o transbordo, não o aninhamento",
+      ).toBeLessThanOrEqual(360);
+
+      // E ela tem de ser MENOR que o deslocamento, senão o escorregão de 10px cai dentro dela e a
+      // régua vira um medidor de padding (ver o ⚠️ do cabeçalho).
+      expect(
+        Math.min(caixa.width, caixa.height) / 2,
+        `a lixeira ficou grande demais: o escorregão de ${DESLOCAMENTO_PX}px não sairia dela`,
+      ).toBeLessThan(DESLOCAMENTO_PX);
+    });
+
+    test(`o toque na lixeira que escorrega ${DESLOCAMENTO_PX}px NÃO dispara a ação do card`, async ({
+      page,
+    }) => {
+      const deletes = coletarDeletes(page);
+      await armarGravadorDeCliques(page);
+
+      await toqueQueEscorrega(page, page.getByTestId(tela.interno), page.getByTestId(tela.externo));
+
+      // Controle positivo do INSTRUMENTO, antes de qualquer asserção negativa: o gesto TEM de ter
+      // produzido um `click`. Zero cliques passaria em tudo que vem abaixo sem medir nada (#123).
+      await expect
+        .poll(async () => (await lerCliques(page)).length, {
+          message: "o gesto não emitiu click nenhum — a régua não mediu nada",
+        })
+        .toBe(1);
+
+      // ⚠️ **A segunda metade do controle, e ela foi medida na marra.** Na primeira versão desta
+      // régua o deslocamento não SAÍA da lixeira em duas das três telas: o `mouseup` caía dentro
+      // dela, o `click` ia para a própria lixeira, o `confirm` era dispensado pelo Playwright e o
+      // teste ficava VERDE com o defeito de pé — 14/15 passando contra o código aninhado. Sem esta
+      // linha, "a ação do card não aconteceu" não distingue "o aninhamento foi desfeito" de "o
+      // gesto nunca chegou a escorregar".
+      const [ondeCaiu] = await lerCliques(page);
+      expect(
+        ondeCaiu,
+        `o deslocamento de ${DESLOCAMENTO_PX}px não saiu da lixeira — a régua não mediu o aninhamento`,
+      ).not.toContain(tela.interno);
+
+      // A AFIRMAÇÃO da issue: a ação do EXTERNO não aconteceu.
+      await expect(page).toHaveURL(new RegExp(`${tela.rota}$`));
+
+      // E nem a do interno: escorregando, o toque não faz NADA — que é o resultado desejado.
+      // Antes, ele fazia a coisa ERRADA (navegava), e é essa a troca que a issue #160 compra.
+      expect(deletes).toEqual([]);
+    });
+
+    test("o toque certeiro na lixeira apaga, e não navega", async ({ page }) => {
+      const deletes = coletarDeletes(page);
+      page.on("dialog", (d) => d.accept());
+
+      await page.getByTestId(tela.interno).click();
+
+      await expect.poll(() => deletes).toEqual([tela.apagar]);
+      await expect(page).toHaveURL(new RegExp(`${tela.rota}$`));
+    });
+
+    test("o toque certeiro no card navega", async ({ page }) => {
+      await page.getByTestId(tela.externo).click();
+      await expect(page).toHaveURL(tela.destino);
+    });
+
+    test("os dois alvos são alcançáveis pelo TECLADO, um depois do outro", async ({ page }) => {
+      // A metade que a desaninhagem não pode custar. `<button>` dentro de `<button>` é HTML
+      // inválido justamente porque quebra a ordem de foco e faz o leitor de tela anunciar os dois
+      // controles como um só; trocar esse defeito por um `<div>` mudo seria trocar de defeito.
+      await page.getByTestId(tela.externo).focus();
+      await expect(page.getByTestId(tela.externo)).toBeFocused();
+      await page.keyboard.press("Tab");
+      await expect(page.getByTestId(tela.interno)).toBeFocused();
+
+      // E a lixeira tem NOME acessível — sem ele, o leitor de tela anuncia "botão" e pronto.
+      await expect(page.getByTestId(tela.interno)).toHaveAttribute("aria-label", /excluir/i);
+    });
+
+    test("o card ainda navega quando acionado pelo TECLADO", async ({ page }) => {
+      await page.getByTestId(tela.externo).focus();
+      await page.keyboard.press("Enter");
+      await expect(page).toHaveURL(tela.destino);
+    });
+  });
+}

--- a/apps/web/src/features/funis/FunisPage.tsx
+++ b/apps/web/src/features/funis/FunisPage.tsx
@@ -44,24 +44,41 @@ export default function FunisPage() {
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {funnels.map((f) => (
-            <button
-              key={f.id}
-              onClick={() => navigate(`/funis/${f.id}`)}
-              className="group flex items-center justify-between rounded-2xl bg-white p-5 text-left shadow-sm transition hover:shadow-md"
-            >
-              <div className="flex items-center gap-3">
-                <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary-50 text-primary-600">
-                  <Workflow size={18} />
-                </span>
-                <div>
-                  <p className="font-semibold text-neutral-800">{f.name}</p>
-                  <p className="text-xs text-neutral-400">{f.node_count} componentes</p>
+            // ⚠️ A lixeira é IRMÃ do card, nunca filha (#160). `<button>` dentro de `<button>` não
+            // é só HTML inválido: quando dois alvos clicáveis são aninhados, o navegador emite o
+            // `click` no ANCESTRAL COMUM de `mousedown` e `mouseup`, e **10px de deslocamento já
+            // bastam** (limiar medido no #149) para o toque na lixeira virar NAVEGAÇÃO. Aqui o
+            // ancestral comum é esta `<div>` sem handler, então o escorregão não faz nada — que é
+            // a troca que a issue compra. Medido em `e2e/aninhamento-clicavel-360.spec.ts`.
+            //
+            // ⚠️ Trocar o `<button>` de fora por `<div role="button">` NÃO resolveria: o `click`
+            // continuaria caindo nele e o `onClick` continuaria disparando. O que desarma o
+            // mecanismo é o parentesco, não a tag.
+            <div key={f.id} className="relative">
+              <button
+                data-testid={`abrir-funil-${f.id}`}
+                onClick={() => navigate(`/funis/${f.id}`)}
+                className="group flex w-full items-center rounded-2xl bg-white p-5 pr-14 text-left shadow-sm transition hover:shadow-md"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary-50 text-primary-600">
+                    <Workflow size={18} />
+                  </span>
+                  <div>
+                    <p className="font-semibold text-neutral-800">{f.name}</p>
+                    <p className="text-xs text-neutral-400">{f.node_count} componentes</p>
+                  </div>
                 </div>
-              </div>
-              <button onClick={(e) => remove(e, f.id)} className="text-neutral-300 hover:text-danger">
+              </button>
+              <button
+                data-testid={`excluir-funil-${f.id}`}
+                aria-label={`Excluir ${f.name}`}
+                onClick={(e) => remove(e, f.id)}
+                className="absolute right-5 top-1/2 -translate-y-1/2 text-neutral-300 hover:text-danger"
+              >
                 <Trash2 size={16} />
               </button>
-            </button>
+            </div>
           ))}
         </div>
       )}

--- a/apps/web/src/features/juridico/JuridicoPage.tsx
+++ b/apps/web/src/features/juridico/JuridicoPage.tsx
@@ -53,27 +53,35 @@ export default function JuridicoPage() {
           <h2 className="text-sm font-semibold text-neutral-700">Documentos recentes</h2>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {docs.slice(0, 6).map((d) => (
-              <button
-                key={d.id}
-                onClick={() => navigate(`/juridico/${d.id}`)}
-                className="flex items-start gap-3 rounded-xl bg-white p-3 text-left shadow-sm transition hover:shadow-md"
-              >
-                <FileText className="mt-0.5 shrink-0 text-primary-600" size={18} />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-neutral-700">{d.title}</p>
-                  <p className="text-xs text-neutral-400">
-                    {categoryLabel(d.category)}
-                    {d.client_name ? ` · ${d.client_name}` : ""}
-                    {d.status === "failed" ? " · falhou" : ""}
-                  </p>
-                </div>
+              // ⚠️ A lixeira é IRMÃ do card, nunca filha (#160) — ver o comentário longo em
+              // `funis/FunisPage.tsx`. Resumo: com os dois alvos aninhados, 10px de deslocamento
+              // entre `mousedown` e `mouseup` fazem o navegador emitir o `click` no ancestral
+              // comum, e o toque na lixeira vira navegação (#149).
+              <div key={d.id} className="relative">
                 <button
+                  data-testid={`abrir-documento-${d.id}`}
+                  onClick={() => navigate(`/juridico/${d.id}`)}
+                  className="flex w-full items-start gap-3 rounded-xl bg-white p-3 pr-9 text-left shadow-sm transition hover:shadow-md"
+                >
+                  <FileText className="mt-0.5 shrink-0 text-primary-600" size={18} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-neutral-700">{d.title}</p>
+                    <p className="text-xs text-neutral-400">
+                      {categoryLabel(d.category)}
+                      {d.client_name ? ` · ${d.client_name}` : ""}
+                      {d.status === "failed" ? " · falhou" : ""}
+                    </p>
+                  </div>
+                </button>
+                <button
+                  data-testid={`excluir-documento-${d.id}`}
+                  aria-label={`Excluir ${d.title}`}
                   onClick={(e) => removeDoc(e, d.id)}
-                  className="shrink-0 text-neutral-300 hover:text-danger"
+                  className="absolute right-3 top-3 text-neutral-300 hover:text-danger"
                 >
                   <Trash2 size={14} />
                 </button>
-              </button>
+              </div>
             ))}
           </div>
         </section>

--- a/apps/web/src/features/marketing/MarketingPage.tsx
+++ b/apps/web/src/features/marketing/MarketingPage.tsx
@@ -45,26 +45,37 @@ export default function MarketingPage() {
       ) : (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           {carousels.map((c) => (
-            <button
-              key={c.id}
-              onClick={() => navigate(`/marketing/${c.id}`)}
-              className="group text-left"
-            >
-              <div className="flex justify-center overflow-hidden rounded-2xl shadow-sm transition group-hover:shadow-md">
-                <CarouselThumb slides={c.slides} style={c} display={240} />
-              </div>
-              <div className="mt-2 flex items-start justify-between gap-2">
-                <div className="min-w-0">
+            // ⚠️ A lixeira é IRMÃ do card, nunca filha (#160) — ver o comentário longo em
+            // `funis/FunisPage.tsx`. Resumo: com os dois alvos aninhados, 10px de deslocamento
+            // entre `mousedown` e `mouseup` fazem o navegador emitir o `click` no ancestral
+            // comum, e o toque na lixeira vira navegação (#149). Esta era a ÚNICA das três telas
+            // em que o defeito já aparecia com um título de tamanho comum — nas outras duas a
+            // lixeira ia parar fora da viewport de 360px antes de o escorregão poder acontecer.
+            <div key={c.id} className="relative">
+              <button
+                data-testid={`abrir-carrossel-${c.id}`}
+                onClick={() => navigate(`/marketing/${c.id}`)}
+                className="group block w-full text-left"
+              >
+                <div className="flex justify-center overflow-hidden rounded-2xl shadow-sm transition group-hover:shadow-md">
+                  <CarouselThumb slides={c.slides} style={c} display={240} />
+                </div>
+                <div className="mt-2 min-w-0 pr-6">
                   <p className="truncate text-sm font-medium text-neutral-700">{c.topic}</p>
                   <p className="text-xs text-neutral-400">
                     {c.slides.length} slides · {c.status === "ready" ? "Pronto" : "Rascunho"}
                   </p>
                 </div>
-                <button onClick={(e) => remove(e, c.id)} className="shrink-0 text-neutral-300 hover:text-danger">
-                  <Trash2 size={14} />
-                </button>
-              </div>
-            </button>
+              </button>
+              <button
+                data-testid={`excluir-carrossel-${c.id}`}
+                aria-label={`Excluir ${c.topic}`}
+                onClick={(e) => remove(e, c.id)}
+                className="absolute bottom-0 right-0 text-neutral-300 hover:text-danger"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Resumo

Três telas montavam um `<button>` **dentro** de outro `<button>`. Não é só HTML inválido: quando dois
alvos clicáveis são aninhados, o navegador emite o `click` no **ancestral comum** de `mousedown` e
`mouseup` — e **10px de deslocamento bastam** (limiar medido no #149) para o toque na **lixeira**
virar **navegação**. Nenhum spec clicava nesses botões, então não havia flake para denunciar: havia
só o defeito, esperando o dedo de um usuário numa lista que rolou.

Fecha #160.

## Alcance: **4**, e bate com o enunciado

Medido com parser de JSX próprio (strip de comentários e strings preservando offsets, pilha de tags,
`{}` balanceadas nos atributos), 88 `.tsx` não-teste:

| arquivo:linha | o que | dentro de |
|---|---|---|
| `funis/FunisPage.tsx:61` | `<button onClick>` | `<button>` da 47 |
| `juridico/JuridicoPage.tsx:70` | `<button onClick>` | `<button>` da 56 |
| `marketing/MarketingPage.tsx:63` | `<button onClick>` | `<button>` da 48 |
| `agenda/AgendaPage.tsx:224` | `<div onClick>` | `<button>` da 208 |

O scanner também procura `href`, `role="button"`, `tabIndex` e `<a>` dentro de `<a>` — **nada além
desses 4**. Depois deste PR: **1** (só o chip da agenda).

⚠️ **`grep` mente aqui.** Um `grep '<button'` ingênuo devolve **296** linhas; um contador de
profundidade que ignora auto-fechamento ainda devolve **7**. Os extras são `<button ... />`
auto-fechados e um `<button>` escrito **dentro de um comentário** em `AgendaPage.tsx:226`. Só o
filtro estrutural chega a 4.

## ⚠️ Duas coisas que este PR contesta no enunciado

**1. A opção "o alvo externo vira `<div>` com handler" NÃO conserta.** O `click` é emitido no
ancestral comum — se o externo virar `<div onClick>`, o handler dispara igual. **O que desarma o
mecanismo é o parentesco, não a tag.**

O conserto é o outro caminho: *o interno sai do fluxo do externo*. A lixeira vira **irmã** dentro de
um `<div className="relative">` **sem handler**. Bônus de acessibilidade: os dois seguem `<button>`
nativo (foco e teclado nativos, provado por 2 testes por tela), e cada lixeira ganhou `aria-label` —
antes eram ícones sem nome acessível.

**2. A primeira régua ficou 14/15 VERDE contra o código aninhado.** O deslocamento de 10px não
*saía* da lixeira em `/funis` e `/juridico`: o `click` caía nela, o `confirm` era dispensado pelo
Playwright, e o teste passava **com o defeito de pé**. Só `/marketing` acusava.

Por isso a régua final tem **dois controles positivos do instrumento**: o gesto tem de emitir
exatamente **1** `click`, **e** esse `click` tem de ter saído da lixeira. Mais uma guarda: a lixeira
tem de estar dentro dos 360px e ter meia-extensão < 10px — senão a régua viraria medidor de padding e
a mutação sobreviveria.

## Prova por mutação — uma por tela, `tsc --noEmit` exit 0 nas três

Cada uma matou **1 e só 1** teste (14 passed / 1 failed):

| Mutação | Spec que morreu | Mensagem real |
|---|---|---|
| `FunisPage` re-aninhada | `/funis … escorrega 10px NÃO dispara a ação do card` | `Expected pattern: /\/funis$/` · `Received string: "…/funis/x1"` |
| `JuridicoPage` re-aninhada | `/juridico … escorrega 10px …` | `Expected pattern: /\/juridico$/` · `Received string: "…/juridico/x1"` |
| `MarketingPage` re-aninhada | `/marketing … escorrega 10px …` | `Expected pattern: /\/marketing$/` · `Received string: "…/marketing/x1"` |

**Refeita de forma independente na revisão**, por outro caminho — devolvendo o `onClick` de navegação
ao `<div>` ancestral em vez de re-aninhar o markup, que é o mecanismo puro: `tsc` exit 0, **1 failed |
14 passed**, e o vermelho **só em `/funis`**, a tela mutada.

## Saídas reais

- Playwright (spec deste PR): **15 passed (43,4s)**, exit 0
- Playwright (este spec + `alcance-360` + `busca-360` + `rotas-360`): **80 passed (1,4min)**, exit 0
- vitest: **74 arquivos, 826 passed (47,4s)**, exit 0
- `eslint . --max-warnings 0` exit 0 · `tsc --noEmit` exit 0

## O chip da agenda fica FORA, e a razão é medida

Varrido o mesmo gesto na `/agenda` (chip 31,3×20,5 numa célula 44,3×92):

| deslocamento | alvo do click | detalhe (certo) | "Novo evento" (errado) |
|---|---|---|---|
| 8 / 10 / 11px | o próprio chip | 1 | 0 |
| **12px** | **`<button>` da célula** | **0** | **1** |
| 14 / 16 / 20px | `<button>` da célula | 0 | 1 |

O defeito é real lá, mas o **limiar é 12px, não 10** — a meia-altura do chip é 10,25px, e é só isso
que o separa. Fica fora porque: (a) nas listas o alvo interno é ícone de canto e vira irmão absoluto
com caixa idêntica, medido; na agenda os chips são conteúdo **no fluxo** da célula, e desaninhar =
remontar a grade de 35–42 células em 360px; (b) `AgendaPage` tem 3 suítes em cima e o #159 acabou de
mexer nela; (c) outro limiar, outra prova. A tabela está no cabeçalho do spec como enunciado pronto.

## Achado adjacente — NÃO corrigido, vira issue nova

Com título longo, o card de `/funis` e `/juridico` transborda a viewport de 360px e **leva a lixeira
junto**:

| Rota | Título | `x` da borda |
|---|---|---|
| `/funis` | 80 chars sem espaço | **760,7** (400px fora) |
| `/juridico` | 33 chars | 312 ✅ |
| `/juridico` | 46 chars | **399,7** |
| `/juridico` | 61 chars | **468,7** (lixeira a 466,7) |

O `scrollWidth` da página fica em **360** nos cinco casos: **nenhuma régua de largura enxerga isso**,
e `rotas-360.spec.ts` cataloga `/funis` e `/juridico` como rotas *vazias*. Família do #58/#144.

## Mudança visual

Em `/marketing` a lixeira desce 22px (do topo para o rodapé do bloco de legenda). Em `/funis` e
`/juridico` as caixas ficaram **idênticas**, medidas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
