### PR TITLE
fix: guarda GanchoDaVima por forma, nao por veracidade [#161]

### DIFF
--- a/apps/web/src/features/dna/GanchoDaVima.test.tsx
+++ b/apps/web/src/features/dna/GanchoDaVima.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import GanchoDaVima from "./GanchoDaVima";
 
@@ -20,23 +20,58 @@ const PERGUNTA = {
   ],
 };
 
+/**
+ * Monta o gancho com `data` como resposta de `/dna/pendente` e SÓ DEVOLVE depois que o `.then()`
+ * do axios e o `setState` correspondente já rodaram.
+ *
+ * Sem esse flush, `expect(container).toBeEmptyDOMElement()` passaria no instante 0 — antes de o
+ * componente ter chance de renderizar o card fantasma — e o teste aprovaria a regressão que
+ * existe para pegar. O `waitFor` sozinho não resolve: ele para na PRIMEIRA passada.
+ */
+async function montar(data: unknown) {
+  vi.mocked(api.get).mockResolvedValue({ data });
+  const utils = render(<GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />);
+  await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return utils;
+}
+
+/**
+ * Erros que o React reportou durante o teste.
+ *
+ * Um payload sem forma não pode só deixar o DOM vazio — `PerguntaDaVima` faz `.map` em `opcoes`,
+ * e um estouro no RENDER também esvazia o container (o React desmonta a árvore sem error
+ * boundary). Sem esta lista, `toBeEmptyDOMElement()` aprovaria a tela hospedeira caindo, que é o
+ * oposto do "falha em silêncio, sempre" — medido: sob a mutação `data ?? null`, os dois casos de
+ * `opcoes` passavam verdes com `TypeError: Cannot read properties of undefined (reading 'map')`
+ * no stderr.
+ */
+let errosDoReact: unknown[][] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  errosDoReact = [];
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errosDoReact.push(args);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("GanchoDaVima", () => {
   it("não renderiza nada quando não há pergunta para hoje", async () => {
-    vi.mocked(api.get).mockResolvedValue({ data: null });
-    const { container } = render(
-      <GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />,
-    );
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    const { container } = await montar(null);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("some depois de responder, sem recarregar a tela", async () => {
-    vi.mocked(api.get).mockResolvedValue({ data: PERGUNTA });
     vi.mocked(api.put).mockResolvedValue({ data: {} });
-
-    render(<GanchoDaVima gancho="briefing.ausencia.comercial.card.parado" />);
-    await waitFor(() =>
-      expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument(),
-    );
+    await montar(PERGUNTA);
+    expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "5 dias" }));
     await waitFor(() =>
@@ -47,6 +82,69 @@ describe("GanchoDaVima", () => {
   it("erro na busca não derruba a tela hospedeira", async () => {
     vi.mocked(api.get).mockRejectedValue(new Error("403"));
     const { container } = render(<GanchoDaVima gancho="qualquer" />);
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // ── Guarda por forma (issue #161) ────────────────────────────────────────────
+  //
+  // O card fantasma custou 101px de deslocamento acima da dobra em SEIS telas (agenda, cobrancas,
+  // crm, orcamentos, pagar, vima). Cada caso abaixo é um payload que `data ?? null` deixava passar
+  // e que a guarda por veracidade (`if (!pergunta)`) não pegava.
+  describe("payload sem forma de pergunta não vira card", () => {
+    const INVALIDOS: [string, unknown][] = [
+      // O gatilho literal do #149: `mockarApi` devolvia `[]` para rota não mapeada, e `[]` é truthy.
+      ["array vazio (rota não mapeada no mock e2e)", []],
+      ["array com um objeto bem formado dentro", [PERGUNTA]],
+      ["objeto vazio", {}],
+      ["zero", 0],
+      ["string vazia", ""],
+      ["string não vazia", "sem pergunta hoje"],
+      ["true", true],
+      ["null", null],
+      ["undefined", undefined],
+      // Bem formado por fora, fantasma por dentro: é EXATAMENTE o desenho do card quebrado da
+      // issue — parágrafo vazio + "Responder depois" pendurado. Rejeitar é o certo; aceitar seria
+      // consertar o `??` e continuar entregando o mesmo pixel errado.
+      ["texto vazio", { ...PERGUNTA, texto: "" }],
+      ["texto só com espaço", { ...PERGUNTA, texto: "   " }],
+      ["texto ausente", { ...PERGUNTA, texto: undefined }],
+      ["texto não-string", { ...PERGUNTA, texto: 42 }],
+      ["key ausente", { ...PERGUNTA, key: undefined }],
+      ["key não-string", { ...PERGUNTA, key: 42 }],
+      ["key vazia", { ...PERGUNTA, key: "" }],
+      ["classe fora do par calibracao/retrato", { ...PERGUNTA, classe: "inventada" }],
+      ["classe ausente", { ...PERGUNTA, classe: undefined }],
+      ["formato desconhecido", { ...PERGUNTA, formato: "slider" }],
+      ["formato ausente", { ...PERGUNTA, formato: undefined }],
+      // Sem este, `PerguntaDaVima` faz `.map` em `undefined` e ESTOURA no render — e render não
+      // cai no `.catch()` da promise: derrubaria a tela hospedeira inteira.
+      ["opcoes ausente", { ...PERGUNTA, opcoes: undefined }],
+      ["opcoes não-array", { ...PERGUNTA, opcoes: { rotulo: "5 dias" } }],
+    ];
+
+    it.each(INVALIDOS)("%s → nada renderizado, sem estourar", async (_nome, data) => {
+      const { container } = await montar(data);
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByRole("button", { name: "Responder depois" })).not.toBeInTheDocument();
+      // DOM vazio por guarda, não por árvore desmontada depois de um estouro no render.
+      expect(errosDoReact).toEqual([]);
+    });
+  });
+
+  it("pergunta com forma completa ainda renderiza o card", async () => {
+    await montar(PERGUNTA);
+    expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Responder depois" })).toBeInTheDocument();
+  });
+
+  // `opcoes: []` é legítimo no contrato (`formato: "texto"` não tem opções) — a guarda é de forma,
+  // não de conteúdo, e inventar "escolha precisa de ao menos uma opção" seria regra nova.
+  it("aceita opcoes vazia (formato texto)", async () => {
+    await montar({ ...PERGUNTA, formato: "texto", opcoes: [] });
+    expect(screen.getByText("Há quanto tempo te incomoda?")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/dna/GanchoDaVima.tsx
+++ b/apps/web/src/features/dna/GanchoDaVima.tsx
@@ -3,12 +3,60 @@ import { useEffect, useState } from "react";
 import { api } from "../../lib/api";
 import PerguntaDaVima from "./PerguntaDaVima";
 
+const CLASSES = ["calibracao", "retrato"] as const;
+const FORMATOS = ["escolha", "escolha_multipla", "texto"] as const;
+
+/**
+ * A resposta de `/dna/pendente` tem a FORMA de uma pergunta?
+ *
+ * `data ?? null` só protegia contra `null`/`undefined`. Qualquer outro valor — `[]` de uma
+ * consulta vazia, `{}` de um erro serializado, uma mudança de contrato — é *truthy*, passa pela
+ * guarda `if (!pergunta)` e renderiza um card FANTASMA: parágrafo sem texto e o botão "Responder
+ * depois" pendurado no nada, medido em **101px** de deslocamento acima da dobra de 740px, nas
+ * seis telas que montam o gancho (issue #161, causa do flake do #149).
+ *
+ * A checagem é por FORMA, nunca por veracidade: valida só o que o contrato `PerguntaOut`
+ * (`apps/api/app/modules/dna/schemas.py`) declara obrigatório E que o caminho de render consome.
+ *
+ * - `key`: vira a URL do `PUT /dna/{key}` — sem ela o card existe mas não sabe responder.
+ * - `texto`: é o parágrafo. Vazio (ou só espaço) É o card fantasma da issue, com objeto bem
+ *   formado em volta — por isso `{ texto: "" }` é REJEITADO, não aceito.
+ * - `classe`: escolhe a promessa que a tela faz ao dono ("muda amanhã" vs. "fica guardado"). Um
+ *   valor fora do par cai no ramo `retrato` em silêncio — prometer errado é exatamente o erro que
+ *   as duas classes existem para impedir (ver `PerguntaDaVima`).
+ * - `formato`: fora dos três, o corpo não renderiza e sobra o mesmo card sem conteúdo.
+ * - `opcoes`: `PerguntaDaVima` faz `.map` nela. Se não for array, o React ESTOURA no render — e
+ *   render não cai no `.catch()` da promise, então derrubaria a tela hospedeira, quebrando o
+ *   "falha em silêncio, sempre" que este componente promete.
+ *
+ * `eixo` fica de fora de propósito: é obrigatório no contrato, mas nenhum pixel depende dele.
+ * Validá-lo só se sustentaria num teste tautológico, e predicado sem consequência é dívida.
+ *
+ * O acesso é por `p?.`, sem um `typeof data === "object"` na frente: em `null`, `undefined`, `0`
+ * ou `""` a cadeia devolve `undefined` e o primeiro predicado já reprova. Uma guarda de tipo
+ * separada seria um predicado que nenhum teste consegue matar — o `.catch()` da promise a
+ * cobriria em silêncio — e predicado sem rede é dívida, não proteção.
+ */
+function ehPergunta(data: unknown): data is DnaPergunta {
+  const p = data as Record<string, unknown> | null | undefined;
+  return (
+    typeof p?.key === "string" &&
+    p.key !== "" &&
+    typeof p.texto === "string" &&
+    p.texto.trim() !== "" &&
+    CLASSES.includes(p.classe as DnaPergunta["classe"]) &&
+    FORMATOS.includes(p.formato as DnaPergunta["formato"]) &&
+    Array.isArray(p.opcoes)
+  );
+}
+
 /**
  * A pergunta do DNA colada ao contexto que a torna óbvia.
  *
  * **Falha em silêncio, sempre.** Um 403 (sub-usuário sem `settings`) ou uma rede ruim não podem
  * derrubar a tela hospedeira — o DNA é acessório em toda superfície onde aparece. Erro aqui
- * significa "não pergunta hoje", nunca "quebra o briefing".
+ * significa "não pergunta hoje", nunca "quebra o briefing". Payload inesperado entra nessa mesma
+ * regra: sem forma de pergunta, não há card.
  *
  * A cadência inteira mora no servidor (`dna/cadencia.py`): uma pergunta por dia no produto
  * inteiro, pulada em quarentena de 7 dias. O componente só mostra o que lhe deram.
@@ -21,7 +69,7 @@ export default function GanchoDaVima({ gancho }: { gancho: string }) {
     api
       .get<DnaPergunta | null>("/dna/pendente", { params: { gancho } })
       .then(({ data }) => {
-        if (vivo) setPergunta(data ?? null);
+        if (vivo) setPergunta(ehPergunta(data) ? data : null);
       })
       .catch(() => {
         if (vivo) setPergunta(null);


### PR DESCRIPTION
## Resumo

`GanchoDaVima` fazia `setPergunta(data ?? null)`. O `??` só protege contra `null` e `undefined` —
**qualquer outro valor passa**, inclusive os *truthy* vazios. A guarda seguinte
(`if (!pergunta) return null`) então não pega, e o componente renderiza um **card fantasma**:
parágrafo sem texto e um botão "Responder depois" pendurado no nada, medido em **101px** de
deslocamento acima da dobra, em **seis telas**.

Este PR troca a guarda de **veracidade** por **forma**. Fecha #161.

## Por que ainda importa com o mock do #159 consertado

O mock era o *gatilho*, não a causa. Hoje o endpoint devolve objeto ou `null` e a produção não
reproduz — mas isso é propriedade do **servidor**, não garantia do **componente**. Uma mudança de
contrato, uma resposta de erro serializada ou um `[]` de consulta vazia voltam a montar o card.

## Alcance

**6 telas montam o gancho** — bate com a issue:

| Tela | Arquivo:linha | Gancho |
|---|---|---|
| agenda | `agenda/AgendaPage.tsx:93` | `agenda.evento.criado` |
| cobranças | `cobrancas/CobrancasPage.tsx:150` | `receivables.cobranca.criada` |
| crm | `crm/CrmPage.tsx:66` | `crm.cliente.criado` |
| orçamentos | `orcamentos/OrcamentosPage.tsx:53` | `quotes.orcamento.criado` |
| pagar | `pagar/PagarPage.tsx:415` | `payables.conta.criada` |
| vima | `vima/BriefingPage.tsx:177` | `briefing.ausencia.${kind}` |

**Dívida do `/vima` — CONFIRMADA.** Nenhum spec faz `page.goto("/vima")` e a rota não está em `CASOS`
(`e2e/support/rotas.ts:137-169`). É a única das seis sem régua nenhuma. É `e2e/`, então fora do escopo
deste PR — está na issue nova que acompanha o #164.

## O que muda

Guarda por forma, validando só o que o contrato declara obrigatório **E** que o caminho de render
consome. Contrato lido na fonte antes de fixar: `apps/api/app/modules/dna/schemas.py:21-27`
(`PerguntaOut`) + `packages/shared-types/src/index.ts:1182`.

```ts
typeof p?.key === "string" && p.key !== "" &&
typeof p.texto === "string" && p.texto.trim() !== "" &&
CLASSES.includes(p.classe) && FORMATOS.includes(p.formato) &&
Array.isArray(p.opcoes)
```

Cada predicado tem consequência de pixel, e está escrito qual: `key` vira a URL do `PUT`; `texto` é o
parágrafo; `classe` escolhe a **promessa que a tela faz ao dono** (*"muda amanhã"* vs. *"fica
guardado"*) e um valor fora do par cai no ramo `retrato` em silêncio; `formato` fora dos três deixa o
corpo sem renderizar; `opcoes` é `.map`-ada por `PerguntaDaVima` e um não-array **estoura no render**
— e render não cai no `.catch()` da promise, então derrubaria a tela hospedeira.

`eixo` fica **de fora de propósito**: obrigatório no contrato, mas nenhum pixel depende dele.
Validá-lo só se sustentaria num teste tautológico, e predicado sem consequência é dívida.

**`{ texto: "" }` é REJEITADO.** Medido no HTML: um objeto bem formado com texto vazio desenha
`<p></p>` + "Responder depois", que é **letra por letra** o card quebrado que a issue descreve.
Aceitá-lo seria consertar o `??` e continuar entregando o mesmo pixel errado. `opcoes: []` é
**aceito** (legítimo para `formato: "texto"`), com teste positivo.

## Prova por mutação — nenhum predicado ficou sem rede

| Mutação | Testes mortos | Mensagem real |
|---|---|---|
| **Reverter tudo para `setPergunta(data ?? null)`** | **18 de 27** | `expect(element).toBeEmptyDOMElement()` → `Received: "<div class="mt-2">…<p class="text-base font-medium text-neutral-800"></p><p>Fica guardado…</p><button>Responder depois</button></div>"` — **o card fantasma literal** |
| `typeof p?.key === "string"` → `p?.key !== undefined` | `key não-string` | `toBeEmptyDOMElement()` … card completo |
| `p.key !== ""` removido | `key vazia` | idem |
| `typeof p.texto === "string"` → `String(p.texto).trim()` | `texto não-string`, `texto ausente` | `Received: "…<p class="text-base font-medium text-neutral-800"></p>…"` — parágrafo vazio |
| `p.texto.trim() !== ""` removido | `texto vazio`, `texto só com espaço` | idem |
| `CLASSES.includes(...)` → `CLASSES.length > 0` | `classe ausente`, `classe fora do par` | `Received: "…Fica guardado para a Vima te conhecer melhor.…"` — **a promessa errada ao dono** |
| `FORMATOS.includes(...)` → `FORMATOS.length > 0` | `formato ausente`, `formato desconhecido` | `Received: "…<p>Há quanto tempo…</p><p>Isso muda o seu resumo…</p><button>Responder depois</button>"` — sem corpo, só o botão pendurado |
| `Array.isArray(p.opcoes)` → `p.opcoes !== null` | `opcoes ausente`, `opcoes não-array` | `+ "TypeError: Cannot read properties of undefined (reading 'map') at PerguntaDaVima (…:65:28)"` |

A mutação da raiz foi **refeita de forma independente na revisão**: **18 failed | 9 passed**, contra
**27 passed** com a guarda em pé.

**Dois predicados foram ELIMINADOS por não terem rede.** A primeira versão trazia
`if (data === null || typeof data !== "object") return false;`. Medindo: o `typeof` era **mutante
equivalente** (acesso a propriedade em primitivo devolve `undefined`, não estoura) e o `data === null`
era coberto em silêncio pelo `.catch()` da promise. Em vez de documentar e desativar, a **necessidade
foi eliminada**: o acesso é por `p?.`, então a cadeia reprova `null`/`0`/`""` no primeiro predicado.
Zero mutante equivalente na versão final.

**Falsa confiança que a mutação denunciou.** Os dois casos de `opcoes` passavam **VERDES** sob a
mutação `data ?? null`: o `.map` em `undefined` estourava no render, o React desmontava a árvore, e
`toBeEmptyDOMElement()` **aprovava a tela hospedeira caindo**. Foi acrescentado
`expect(errosDoReact).toEqual([])` (spy em `console.error`) a todos os casos inválidos — DOM vazio
**por guarda**, não por queda. Isso levou a mutação da raiz de 15 para **18** mortes.

## Verde

```
Test Files  1 passed (1)
     Tests  27 passed (27)
```

`tsc --noEmit` e `eslint --max-warnings 0` exit 0. Nenhum outro teste mocka `/dna/pendente` (grep: só
o próprio arquivo). **Nada em `e2e/`** — a fronteira com o #164 é limpa.

## Achados FORA do escopo — viram issue nova, não commit escondido aqui

A classe `?? null` sobre payload de API, varrida em `apps/web/src` (66 ocorrências de `?? null`/
`|| null`; filtradas as que caem sobre resposta):

| Local | Padrão | Consequência |
|---|---|---|
| `dna/NucleoPage.tsx:46` | `data ?? []` de `/dna/faltantes` | **Pior que o #161**: `{}` truthy passa, `perguntas.length === 0` é `undefined === 0` → falso, e `perguntas[i].key` **estoura no render** → tela branca. Irmão direto, mesma feature |
| `pagar/ComprovantePage.tsx:103` | `data.find(...) ?? null` | não-array → `TypeError` absorvido pelo `.catch` — degrada em silêncio |
| `funis/FunnelBuilderPage.tsx:227-228` | `data.nodes ?? []` / `data.edges ?? []` | não-array truthy chega inteiro ao reactflow |
| `funis/FunnelAutomation.tsx:37` | `data.config ?? {}` | idem, sem checagem de forma |
| `financeiro/ContasSaldosPage.tsx:124` | `cps.data[0] ?? null` | índice em não-array |
| `lib/api.ts:48` | `data.access_token ?? null` | token truthy não-string vira sessão |

**O padrão certo já existe no repo e só não foi propagado:** `crm/ClientTimeline.tsx:47-52` usa
`Array.isArray(data?.entries)` **com o comentário explicando exatamente esta classe**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
