### PR TITLE
fix: alvo unico em serie para as suites pesadas + a regra escrita [#162]

### DIFF
--- a/.claude/agents/regression-tester.md
+++ b/.claude/agents/regression-tester.md
@@ -10,8 +10,15 @@ não quebrou nada que já funcionava.
 
 ## Processo
 1. Identifique o que mudou (git diff contra o último commit / branch base).
-2. Rode a suíte completa: `bash scripts/check.sh` (lint + type-check + testes backend pytest + testes web vitest).
-3. Para áreas tocadas, rode também os testes e2e relevantes (playwright) se existirem.
+2. Rode a suíte completa pelo **alvo único**: `bash scripts/gates.sh` — ele encadeia, **em série**,
+   `scripts/check.sh` (lint + type-check + pytest backend + vitest web) → `pytest -m rls_e2e`
+   (Postgres real, Docker) → `pnpm e2e` (régua de 360px). Para uma checagem rápida sem as pesadas,
+   `bash scripts/check.sh` sozinho.
+3. ⚠️ **NUNCA rode duas suítes pesadas ao mesmo tempo** (`pytest -q`, `pytest -m rls_e2e`,
+   `pnpm e2e`, mutação). Sob concorrência elas se contaminam e a falha sai como `AssertionError` /
+   `locator not found` — **indistinguível de regressão real**. Uma falha obtida com outra suíte
+   rodando **não conta como sinal**: descarte-a e refaça em série antes de reportar qualquer coisa.
+   Ver `CLAUDE.md` §5.5.
 4. **Foco especial em fronteiras de tenant (RLS) e na camada de IA/anonimizador** — regressões aqui são críticas.
 5. Se algum teste falhar, reporte exatamente:
    - qual teste, qual asserção, o output do erro;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,10 @@ scripts/           Utilitários (check, seed, etc.)
 ## 5. Fluxo de qualidade (Req. 3 — obrigatório a cada mudança)
 Ao criar/alterar qualquer funcionalidade:
 1. Escreva/atualize testes (`apps/api/tests`, `apps/web` vitest, e2e playwright).
-2. Rode `bash scripts/check.sh` (lint + types + testes) — deve passar.
+2. Rode `bash scripts/check.sh` (lint + types + testes) — deve passar. Antes de fechar a tarefa,
+   rode o alvo único **`bash scripts/gates.sh`**, que encadeia as três suítes pesadas **em série**
+   (`check.sh` → `pytest -m rls_e2e` → `pnpm e2e`). **Nunca rode duas delas ao mesmo tempo:** sob
+   concorrência elas se contaminam e a falha fica indistinguível de regressão real — §5.5.
 3. Rode os agentes de QA conforme a tarefa:
    - **regression-tester** — garante que o novo não quebrou o antigo.
    - **bug-hunter** — caça bugs/edge cases no código novo.
@@ -103,7 +106,10 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   vermelhos com `getByTestId` "não encontrado" para um `data-testid` escrito no arquivo — e o modo
   de falha oposto (**verde** contra código alheio) seria indistinguível de aprovação. Agora
   `reuseExistingServer` é **`false` sempre**: porta ocupada vira erro alto em vez de medição falsa.
-  Para rodar duas worktrees ao mesmo tempo: `E2E_PORT=5373 pnpm --filter @e1p/web e2e`.
+  Para rodar duas worktrees ao mesmo tempo: `E2E_PORT=5373 pnpm --filter @e1p/web e2e`. ⚠️ **A
+  porta própria resolve a colisão de PORTA, não a de MÁQUINA** (#162): duas suítes pesadas rodando
+  de fato ao mesmo tempo se contaminam e devolvem `locator not found` indistinguível de regressão
+  real — ver §5.5.
 - ⚠️ **O controle positivo é parte do teste, não cortesia — e ele MUDA com o título** (#130).
   Modal de título **digitado pelo dono**: remover `min-w-0 break-words` do `Modal.tsx` tem de deixar
   o spec **vermelho**, restaurar (por CÓPIA do arquivo, nunca `git checkout`) tem de devolver o
@@ -523,6 +529,70 @@ lugares — o nome do centro sobra **215,5px** e a tabela "Resultado por centro 
 alcançabilidade, e não há régua verde para ela nesta rota. Medido também que `break-words` no rótulo
 do nome **não muda o número** (o `span` é item de flex com `min-width: auto`, então nunca chega a
 quebrar) — mudança que nenhuma régua vê é peso morto, e por isso ela não entrou.
+
+
+### 5.5 As suítes pesadas não se sobrepõem (issue #162, 2026-08-20)
+
+**`pytest -q`, `pytest -m rls_e2e` e `pnpm e2e` NÃO rodam ao mesmo tempo — e uma falha obtida sob
+concorrência NÃO conta como sinal.** Nem como sinal de que há bug, nem como sinal de que não há.
+Ela não é evidência de nada: é para ser jogada fora e refeita em série.
+
+**O mecanismo, e por que ele custa caro.** O sintoma honesto seria "timeout por carga". Não é o que
+aparece. As três suítes disputam CPU, disco e Docker; o que sai na tela é `AssertionError` no
+backend e `locator not found` no Playwright — exatamente o que uma regressão de VERDADE diria. Não
+há nada na mensagem que separe "seu diff quebrou isto" de "a máquina estava cheia". Quem roda as
+três em paralelo para economizar relógio tem dois destinos, e os dois são caros: investigar um bug
+que não existe, ou — pior — catalogar como "aquele flake" uma quebra que era real.
+
+O **único** sinal secundário é o **tempo**, e ninguém o lê no meio de uma investigação: quando o
+teste está vermelho, a atenção vai para a asserção, não para o rodapé com a duração. Números
+**citados da issue #162** (medidos lá, não remedidos aqui): sob concorrência a `pytest -q` foi de
+**21min para 48min** e o Playwright de **1,9min para 9,2min**. Observado em **duas sessões
+independentes** durante o #146 (PR #158) — `test_financial_intelligence_profitability_rls.py`
+(FAILED sob concorrência, `3 passed in 28.32s` isolado), `agenda-evento-360.spec.ts` ×2 (FAILED,
+`4 passed (43.2s)` isolado) e `test_ai_usage_rls.py` (FAILED, `1 passed in 6.55s` isolado). O
+terceiro veio de uma **reconferência separada**, com o diff já verificado: a classe reincide e não
+depende de qual branch está na árvore.
+
+**Não é classe nova — é a mesma, um nível acima.** O #147 (PR #148) já a fechou **dentro** do
+Playwright pondo `workers: 1` como padrão: *"o paralelo inventa falhas"* — 14 vermelhos espalhados
+por specs sem relação contra os 2 que a mesma mutação produz serialmente (ver o cabeçalho de
+`apps/web/playwright.config.ts`). O `mutation.yml` fecha a mesma coisa com `concurrency:` (*"a
+segunda mediria contenção de CPU, não qualidade de teste — e é assim que timeout vira falso
+positivo"*). E o `apps/web/vitest.config.ts` já carrega a terceira instância: `testTimeout: 15000`
+existe porque `PlatformUsers.test.tsx` e `ContractBuilderPage.test.tsx` estouravam os 5000ms
+default *"só sob a suíte completa em paralelo — isolados, ambos passam"*. Três lugares, a mesma
+física. O que faltava era a proteção **ENTRE** as suítes.
+
+- **O alvo único é `bash scripts/gates.sh`** (issue #162). Encadeia as três **em série**, na ordem
+  do `ci.yml` (mais barata primeiro): `scripts/check.sh` → `pytest -m rls_e2e` → `pnpm e2e`. Falha
+  rápido (`set -euo pipefail`): etapa vermelha aborta o encadeamento e as caras nem começam.
+  **Imprime o tempo de cada etapa** — é a forma de pôr na tela o sinal fraco que ninguém lê.
+- **Preflight que não se pula:** sem `pnpm` ou sem Docker respondendo, o script reprova ANTES da
+  etapa 1, em vez de descobrir isso 20 minutos depois. E a etapa de RLS carrega a **mesma guarda
+  anti-skip-silencioso do `ci.yml`** (lê o `--junitxml` e exige ≥ 1 teste REALMENTE executado):
+  `rls_e2e` que se pula sozinho fica verde sem ter exercido RLS nenhuma.
+- ⚠️ **`gates.sh` não é um lock.** Ele torna o modo certo o mais fácil; não impede que alguém abra
+  outro terminal — ou outra worktree do mesmo repo — e rode `pnpm e2e` por cima. A contenção
+  continua sendo responsabilidade de quem digita. O lock de arquivo foi considerado e **não** foi
+  feito (issue #162, opção 2).
+- **Em worktrees paralelas:** `E2E_PORT=5373 bash scripts/gates.sh`. A 5273 colide entre checkouts
+  do próprio e1p (#123, §5.1); com `reuseExistingServer: false`, porta ocupada vira erro alto em
+  vez de medição do branch alheio.
+- **O teste de mutação (`pnpm --filter @e1p/web mutation`, ~21min) é a QUARTA suíte pesada** e
+  **não** entra no `gates.sh`: é diagnóstico periódico da qualidade da suíte, não portaria de
+  mudança (§5.3, e o cabeçalho de `mutation.yml`). Se você o rodar à mão, ele conta para esta regra
+  igual às outras três — não o sobreponha a elas.
+- ⚠️ **Quem for cronometrar as suítes não está exercitando fuso.** `TZ=UTC` **não troca o fuso no
+  Windows**: a variável chega ao Python, mas o fuso local não muda (`apps/api/tests/test_search_deep.py`
+  documenta). Por isso `gates.sh` **não mexe em `TZ`** — um `TZ=...` na frente destas suítes daria a
+  impressão de estar exercitando fuso sem exercitar nada. A régua do fuso é a do §5.2 (mock do fuso
+  do **tenant**), nunca a variável de ambiente da máquina.
+
+**O que fazer quando a falha aparece.** Antes de abrir o editor: pergunte se havia outra suíte
+rodando. Se havia, o resultado é **descartado** — não é "flake", não é "bug", não é nada. Rode
+`bash scripts/gates.sh` com a máquina só para você e leia o que sair de lá. Só esse resultado entra
+numa investigação, num comentário de PR ou numa Completion Note.
 
 
 ## 6. Estado atual / roadmap

--- a/README.md
+++ b/README.md
@@ -34,5 +34,10 @@ docker compose --env-file .env -f infra/docker-compose.yml up --build
 ## Qualidade (obrigatório a cada mudança)
 ```bash
 bash scripts/check.sh           # lint + types + testes (backend e web)
+bash scripts/gates.sh           # as 3 suítes PESADAS, em série (check.sh → rls_e2e → playwright)
 ```
+⚠️ **Nunca rode duas suítes pesadas ao mesmo tempo.** Sob concorrência elas se contaminam e a falha
+sai como `AssertionError`/`locator not found` — indistinguível de regressão real, e por isso não
+conta como sinal. Use o `gates.sh`, que as encadeia (ver `CLAUDE.md` §5.5).
+
 Mais os agentes de QA em `.claude/agents/` (ver `CLAUDE.md` §5).

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -18,6 +18,12 @@ import { defineConfig, devices } from "@playwright/test";
  * código alheio — é indistinguível de aprovação, e por isso `reuseExistingServer` é `false`
  * sempre: porta ocupada passa a ser erro alto ("port is already used") em vez de medição falsa.
  * Para rodar duas worktrees ao mesmo tempo: `E2E_PORT=5373 pnpm e2e`.
+ *
+ * ⚠️ **Mas a porta própria só resolve a colisão de PORTA, não a de MÁQUINA** (#162). Duas suítes
+ * pesadas rodando de fato ao mesmo tempo — dois Playwright, ou um Playwright e um `pytest -m
+ * rls_e2e` — se contaminam por CPU/disco/Docker, e o que sai é `locator not found`, indistinguível
+ * de regressão real. Falha obtida assim NÃO conta como sinal: descarte e refaça em série, pelo
+ * alvo único `bash scripts/gates.sh`. Ver CLAUDE.md §5.5.
  */
 const PORTA = Number(process.env.E2E_PORT ?? 5273);
 

--- a/docs/CHECKLIST-COMPROVANTE-MOBILE.md
+++ b/docs/CHECKLIST-COMPROVANTE-MOBILE.md
@@ -18,6 +18,11 @@ como o papel não-superusuário `e1p_app` contra um Postgres real, exercitando d
 cd apps/api && pytest -m rls_e2e -k receipts
 ```
 
+⚠️ **Com a máquina só para você.** Se houver outra suíte pesada rodando (`pytest -q`, `pnpm e2e`,
+mutação), a contaminação devolve `AssertionError` indistinguível de regressão real e o resultado
+não conta como sinal — ver `CLAUDE.md` §5.5. Para rodar tudo em série de uma vez:
+`bash scripts/gates.sh`.
+
 Se precisar validar à mão de qualquer forma (ex.: investigando uma regressão), o roteiro
 equivalente por HTTP é: dois tenants via `/auth/register`, conta a pagar em A, comprovante em B,
 `POST /payables/receipts/{id}/link` com token de B e `bill_id` de A → esperado `404`.

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# O ALVO ÚNICO das suítes pesadas — encadeia EM SÉRIE o que não pode se sobrepor (issue #162).
+#
+# ── POR QUE UM ALVO ÚNICO, E NÃO TRÊS COMANDOS SOLTOS ────────────────────────────────────────────
+# `pytest -q`, `pytest -m rls_e2e` (Docker) e `pnpm e2e` rodando AO MESMO TEMPO inventam falhas:
+# testes que passam isolados ficam vermelhos, e as mensagens são `AssertionError` e
+# `locator not found` — exatamente o que uma regressão de VERDADE diria. Quem economiza relógio
+# rodando as três em paralelo investiga um bug que não existe, ou pior: cataloga como "aquele
+# flake" uma quebra que era real. Observado em duas sessões independentes durante o #146 (PR #158).
+#
+# O único sinal secundário é o TEMPO — e ninguém o lê no meio de uma investigação. Números CITADOS
+# da issue #162 (medidos lá, NÃO remedidos aqui): sob concorrência a `pytest -q` foi de 21min para
+# 48min, e o Playwright de 1,9min para 9,2min. Por isso este script IMPRIME o tempo de cada etapa:
+# o sinal fraco passa a ficar escrito na tela em vez de depender de alguém lembrar dele.
+#
+# É a MESMA classe que o #147 (PR #148) já fechou DENTRO do Playwright com `workers: 1` por padrão
+# — "o paralelo inventa falhas", ver o cabeçalho de `apps/web/playwright.config.ts` — e a mesma que
+# o `mutation.yml` já fecha com `concurrency:` ("duas corridas simultâneas disputariam os mesmos
+# vCPU e a segunda mediria contenção de CPU, não qualidade de teste"). O que faltava era a mesma
+# proteção ENTRE as suítes. Este arquivo é ela.
+#
+# ⚠️ ESTE SCRIPT NÃO É UM LOCK. Ele torna o modo certo o mais fácil; não impede que alguém abra
+# outro terminal e rode `pnpm e2e` por cima — nem que outra worktree do mesmo repo faça isso. A
+# regra escrita, com o mecanismo da falha, está no CLAUDE.md §5.5.
+#
+# ── A ORDEM NÃO É ARBITRÁRIA ─────────────────────────────────────────────────────────────────────
+# É a mesma do `.github/workflows/ci.yml`, do mais barato para o mais caro: lint + suíte limpa (sem
+# Docker) → RLS no Postgres real (Docker) → régua de 360px (sobe um Vite numa porta). Falha rápido:
+# a etapa barata reprova primeiro e as caras nem começam.
+#
+# O teste de MUTAÇÃO (`pnpm --filter @e1p/web mutation`, ~21min) NÃO entra aqui de propósito: é
+# diagnóstico periódico da qualidade da suíte, não portaria de mudança — a mesma razão pela qual
+# ele mora num workflow noturno e não no `ci.yml` (ver o cabeçalho de `mutation.yml`). Se você o
+# rodar à mão, ele conta como quarta suíte pesada: não o sobreponha a estas três.
+#
+# ── FUSO: ESTE SCRIPT NÃO MEXE EM `TZ`, DE PROPÓSITO ─────────────────────────────────────────────
+# `TZ=UTC` NÃO troca o fuso no Windows: a variável chega ao Python, mas o fuso local não muda
+# (verificado; `apps/api/tests/test_search_deep.py` documenta). Um `TZ=...` na frente destas suítes
+# daria a impressão de estar exercitando fuso sem exercitar nada. A régua do fuso é a do CLAUDE.md
+# §5.2 (mock do fuso do TENANT), nunca a variável de ambiente da máquina.
+#
+# ── USO ──────────────────────────────────────────────────────────────────────────────────────────
+#   bash scripts/gates.sh                 # as três, em série
+#   E2E_PORT=5373 bash scripts/gates.sh   # em OUTRA worktree (a 5273 colide entre checkouts, #123)
+#
+# ⚠️ Dívida HERDADA da etapa 1, já registrada no CLAUDE.md: `scripts/check.sh` resolve `ruff`/
+# `python` do PATH (que pode não ser o do venv) e mascara falha do frontend com `|| true` no
+# vitest. Enquanto isso não for corrigido, a etapa 1 pode ficar verde com o vitest vermelho. Este
+# script não conserta nem piora essa dívida — mas não a esconde de quem lê.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# O junit da etapa 2 mora em `.pytest_cache/`, que o .gitignore já ignora — nada de artefato solto
+# na árvore, e nada de caminho POSIX de `mktemp` chegando a um Python de Windows.
+RLS_XML_REL=".pytest_cache/gates-rls-results.xml"
+RLS_XML="apps/api/$RLS_XML_REL"
+
+ETAPAS_TOTAL=3
+etapa=0
+inicio_total=$SECONDS
+
+anuncia() {
+  etapa=$((etapa + 1))
+  echo ""
+  echo "=============================================================================="
+  echo "> Etapa $etapa/$ETAPAS_TOTAL — $1"
+  echo "=============================================================================="
+}
+
+# Cronometra e IMPRIME, inclusive quando a etapa falha: o tempo é o único sinal secundário de
+# contaminação (ver cabeçalho), e ele só serve se estiver na tela.
+cronometra() {
+  local rotulo="$1"; shift
+  local inicio=$SECONDS rc=0
+  "$@" || rc=$?
+  echo "[tempo] $rotulo: $((SECONDS - inicio))s (exit $rc)"
+  return "$rc"
+}
+
+echo "=============================================================================="
+echo "  gates.sh — as três suítes pesadas, UMA DE CADA VEZ (issue #162)"
+echo ""
+echo "  AVISO: não rode nenhuma suíte em outro terminal enquanto isto roda. Sob"
+echo "  concorrência elas se contaminam e a falha fica INDISTINGUÍVEL de regressão"
+echo "  real (AssertionError / locator not found). Ver CLAUDE.md §5.5."
+echo "=============================================================================="
+
+# ── Preflight ────────────────────────────────────────────────────────────────────────────────────
+# Só o que as etapas TARDIAS exigem. Descobrir na etapa 3 que falta `pnpm`, depois de 20 minutos de
+# etapa 1, é exatamente o desperdício que "falha rápido" existe para evitar.
+faltando=()
+command -v pnpm >/dev/null 2>&1 || faltando+=("pnpm (etapa 3)")
+docker info >/dev/null 2>&1 || faltando+=("Docker respondendo (etapa 2)")
+if [ "${#faltando[@]}" -gt 0 ]; then
+  echo ""
+  echo "FALHOU no preflight — falta:"
+  for f in "${faltando[@]}"; do echo "    - $f"; done
+  echo ""
+  echo "  PULAR uma destas etapas é ficar verde sem ter exercido o que ela protege. Sem Docker,"
+  echo "  os arquivos rls_e2e viram SKIPPED na coleta e o pytest devolve 5 — verde sem RLS"
+  echo "  nenhuma exercida. Resolva e rode de novo; este script não se pula sozinho."
+  exit 1
+fi
+
+# ── Etapa 1 — lint + types + suíte limpa (sem Docker) ────────────────────────────────────────────
+anuncia "lint + types + suíte limpa  (scripts/check.sh)"
+cronometra "check.sh" bash scripts/check.sh
+
+# ── Etapa 2 — isolamento cross-tenant no Postgres real ───────────────────────────────────────────
+# Filtra por PROPRIEDADE (o marker), NÃO por arquivo nomeado — mesma escolha do job
+# `cross-tenant-rls` do ci.yml, para que um arquivo `test_*_rls.py` novo entre sozinho.
+etapa_rls() {
+  local rc=0
+  mkdir -p "apps/api/.pytest_cache"
+  ( cd apps/api && python -m pytest -q -m rls_e2e --junitxml="$RLS_XML_REL" ) || rc=$?
+  # rc: 0=passaram · 1=algum FALHOU · 5=nenhum rodou/coletado · outros=erro de coleta/uso.
+  # Falha real (rc != 0 e != 5) derruba já aqui; rc=0 e rc=5 seguem para a guarda anti-skip.
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then return "$rc"; fi
+  # Guarda anti-skip-silencioso — a MESMA do ci.yml (Story 7.1): o exit code do pytest sozinho não
+  # basta, porque cada arquivo rls_e2e abre com `importorskip("testcontainers.postgres")`. Exigimos
+  # que >= 1 teste tenha REALMENTE executado (coletado E não-skipped). O one-liner abaixo é o
+  # MESMO do ci.yml, de propósito: uma convenção só, e quem mudar uma metade acha a outra por grep.
+  python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse(sys.argv[1]).getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"rls_e2e: coletados={t} executados={ex} skipped={k}"); ok=ex>=1; ok or print("ERRO: nenhum teste rls_e2e executou (todos SKIPPED ou zero coletados). RLS real nao foi exercida — falhando em vez de passar em silencio."); sys.exit(0 if ok else 1)' "$RLS_XML"
+}
+anuncia "isolamento cross-tenant no Postgres real  (pytest -m rls_e2e)"
+cronometra "pytest -m rls_e2e" etapa_rls
+
+# ── Etapa 3 — régua de layout em 360px ───────────────────────────────────────────────────────────
+# `E2E_PORT` passa adiante sozinho (é lido pelo playwright.config.ts). Em worktree paralela, use
+# uma porta própria: `reuseExistingServer` é `false`, então porta ocupada vira erro alto — o que é
+# o comportamento certo, e não o disfarce de medir o branch alheio (#123).
+anuncia "régua de layout em 360px  (Playwright, workers: 1 por padrão — #147)"
+cronometra "pnpm e2e" pnpm --filter @e1p/web e2e
+
+echo ""
+echo "=============================================================================="
+echo "OK — as $ETAPAS_TOTAL suítes pesadas passaram, em série. Total: $((SECONDS - inicio_total))s"
+echo "=============================================================================="


### PR DESCRIPTION
## Resumo

`pytest -q`, `pytest -m rls_e2e` (Docker) e `pnpm e2e` rodando **ao mesmo tempo** inventam falhas:
testes que passam isolados ficam vermelhos, e as mensagens são `AssertionError` e `locator not found`
— exatamente o que uma regressão de verdade diria. Este PR faz o modo certo ser o mais fácil (um alvo
único, em série) e escreve a regra com o mecanismo.

Fecha #162.

## O que custa caro

O sintoma honesto seria "timeout por carga". Não é o que aparece. Quem economiza relógio rodando as
três em paralelo vai investigar um bug que não existe — ou, pior, catalogar como *"aquele flake"* uma
quebra que era real.

O único sinal secundário é o **tempo**, e ninguém o lê no meio de uma investigação. Números **citados
da issue** (medidos lá, **não** remedidos aqui — havia 9 agentes trabalhando nesta máquina enquanto
este PR era escrito, e cronometrar sob essa condição não mediria nada): `pytest -q` de **21min para
48min**; Playwright de **1,9min para 9,2min**.

## Alcance medido

**Suítes pesadas: 4** — a issue lista 3; a quarta é a mutação.

| Suíte | Onde estava documentada |
|---|---|
| `pytest -q -m "not rls_e2e"` | `scripts/check.sh`, job `test-in-prod-image` |
| `pytest -m rls_e2e` (testcontainers) | job `cross-tenant-rls`, cabeçalho de 18 `tests/*_rls.py` |
| `pnpm e2e` | `playwright.config.ts`, job `frontend`, CLAUDE.md §5.1 |
| `pnpm mutation` (Stryker, ~21min) | `mutation.yml`, CLAUDE.md §5.3 |

**Lugares que mandam rodar as suítes: 9 afirmações vivas + 98 arquivos de registro histórico + 18
cabeçalhos de teste.** Corrigidos **6**:

- `README.md` — a seção "Qualidade" só conhecia `check.sh`
- `CLAUDE.md` §5 passo 2 — idem
- `.claude/agents/regression-tester.md` — mandava rodar `check.sh` **e** "os e2e relevantes", sem
  dizer que não podem se sobrepor
- `docs/CHECKLIST-COMPROVANTE-MOBILE.md` — checklist operacional com `pytest -m rls_e2e -k receipts`
- ⚠️ **duas afirmações vivas que diziam o CONTRÁRIO da regra nova**, e que a issue não lista:
  `playwright.config.ts:20` e CLAUDE.md §5.1 mandavam, literalmente, *"para rodar duas worktrees ao
  mesmo tempo: `E2E_PORT=5373 pnpm e2e`"*. A porta própria resolve a colisão de **porta**, não a de
  **máquina** — ficaria uma receita publicada para produzir exatamente esta contaminação. As duas
  foram **qualificadas, não removidas**: a receita segue necessária contra o #123.

Deixados sem tocar, com razão escrita: **98 arquivos** de `docs/stories`, `docs/plans`,
`docs/superpowers`, `docs/prd` — registro histórico datado, e **nenhum contradiz** a regra (dão
comando de execução, não mandam paralelizar), então não geram errata; **18 cabeçalhos**
`tests/*_rls.py` — dizem *onde* o teste roda, não contradizem; **`ci.yml`** — cada job roda em runner
próprio, não há contaminação entre eles, e `mutation.yml` já resolve o caso análogo com `concurrency:`.

## O que muda

**`scripts/gates.sh`** — o alvo único. Não é convenção nova: não há `Makefile` no repo, o
`package.json` raiz não define alvo de gates, e a convenção existente é `bash scripts/<nome>.sh`.

- **`scripts/check.sh` é a etapa 1**, reusado, não reescrito nem duplicado.
- **A ordem veio do `ci.yml`**, não foi inventada: `check.sh` → `rls_e2e` → `e2e`, do mais barato ao
  mais caro. Falha rápido.
- **A guarda anti-skip-silencioso do `ci.yml`** (lê `--junitxml`, exige ≥1 teste realmente executado)
  entrou **verbatim**, com comentário apontando a origem — uma convenção só, e quem mudar uma metade
  acha a outra por grep.
- **Preflight** só do que as etapas tardias exigem (`pnpm`, Docker respondendo): descobrir na etapa 3
  que falta `pnpm`, depois de 20min de etapa 1, é o desperdício que "falha rápido" existe para evitar.
- **Cronometra e imprime cada etapa**, inclusive quando falha — o sinal fraco passa a ficar escrito na
  tela em vez de depender de alguém lembrar dele.

**CLAUDE.md § 5.5** — a regra escrita com o mecanismo: falha sob concorrência **não conta como sinal**.

**A opção 2 da issue (lock de arquivo) NÃO foi implementada**, e o alvo único não é insuficiente sem
ela. Está escrito dentro do script e na §5.5 que `gates.sh` **não é um lock** e não impede outro
terminal.

⚠️ **O script não mexe em `TZ`, de propósito**, e diz por quê: `TZ=UTC` não troca o fuso no Windows —
a variável chega ao Python mas o fuso local não muda (`test_search_deep.py` documenta). Um `TZ=` na
frente destas suítes daria a impressão de estar exercitando fuso sem exercitar nada.

## Prova: o alvo único falha ALTO, não em silêncio

Não há mutação de produção clássica aqui. A prova é quebrar o alvo e mostrar o vermelho.

**A — etapa 1 quebrada de verdade** (`ruff` ausente do PATH), script real, sem modificação:

```
> Etapa 1/3 — lint + types + suíte limpa  (scripts/check.sh)
scripts/check.sh: line 14: ruff: command not found
[tempo] check.sh: 5s (exit 127)
=========== EXIT CODE DO GATES.SH: 127 ===========
```

Etapas 2 e 3 **nunca foram anunciadas**; o exit propagou.

**B — apontado para uma suíte inexistente** (marker `rls_e2e` → `suite_que_nao_existe`):

```
2259 deselected in 21.20s
rls_e2e: coletados=0 executados=0 skipped=0
ERRO: nenhum teste rls_e2e executou (todos SKIPPED ou zero coletados). RLS real
nao foi exercida - falhando em vez de passar em silencio.
[tempo] pytest -m rls_e2e: 41s (exit 1)
```

O pytest sozinho devolveria **5** ("nada rodou"); a guarda transforma isso em **exit 1 com mensagem
explícita**. **Nenhuma suíte pesada foi rodada** — a prova B só fez coleta, 2259 deselecionados, zero
executados.

**Refeito de forma independente na revisão**, com uma cópia do script cujo estágio 1 foi forçado a
falhar: etapas 2 e 3 não anunciadas, `EXIT 1`, árvore limpa depois.

## Prova por parse

**Nenhum YAML/TOML/JSON foi alterado** — as extensões tocadas são `md`, `sh`, `ts`. O único arquivo
com frontmatter YAML (`regression-tester.md`) teve o frontmatter desserializado antes e depois e
comparado: **`IGUAIS: True`** (reconferido na revisão com `yaml.safe_load`).

Seções do CLAUDE.md, antes vs. depois: **uma linha adicionada** (`### 5.5`), zero removidas, zero
renumeradas — 5.1 a 5.4 intactas, `## 6` intacta.

`eslint playwright.config.ts` exit 0 · `bash -n scripts/gates.sh` OK · **0 CRLF** (o `.gitattributes`
exige LF em `*.sh`) · varredura de NBSP/ZWSP/BOM/U+FFFD nos 6 arquivos: **0**.

## Uma dívida herdada, registrada e não consertada

`scripts/check.sh` mascara falha do frontend com `|| true` no vitest (já registrada no CLAUDE.md).
Como o `gates.sh` usa o `check.sh` como etapa 1, **a etapa 1 pode ficar verde com o vitest vermelho**.
Não é a classe desta issue e o arquivo é compartilhado com outras branches vivas — mas está escrito no
cabeçalho do `gates.sh` para não ficar escondido de quem lê.

## Achado extra

`apps/web/vitest.config.ts:20` já carrega a **terceira** instância desta classe na casa:
`testTimeout: 15000` existe porque dois testes estouravam os 5000ms *"só sob a suíte completa em
paralelo — isolados, ambos passam"*. Três lugares, a mesma física — citado na §5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
