### PR TITLE
fix(crm): 'Trocar venc.' mostrava a data velha depois de um reagendamento do backend [#155]

### DIFF
--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -510,6 +510,168 @@ describe("ClientDetailPage — trocar vencimento (issue #145)", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
+// 6b. O vencimento que o `load()` traz e o campo que não o vê (issue #155)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+
+describe("ClientDetailPage — 'Trocar venc.' depois de um reagendamento do backend (issue #155)", () => {
+  /** Uma SEGUNDA cobrança aberta: é o reagendamento DELA que dispara o `load()` da ficha. */
+  const OUTRA = {
+    ...COBRANCA_BASE,
+    id: "c-outra",
+    description: "Retainer mensal",
+    amount_cents: 60000,
+    status: "open",
+  };
+
+  /** O `<input type="date">` de uma linha — `null` quando o campo está FECHADO. */
+  function campoDeData(descricao: string): HTMLInputElement | null {
+    return linhaDaCobranca(descricao).querySelector('input[type="date"]');
+  }
+
+  /**
+   * O valor do campo, ou um sentinela legível quando ele nem está aberto.
+   *
+   * `getByDisplayValue` esconderia o valor real na mensagem de erro, e um `!` cru faria o conserto
+   * por `key` — que remonta a linha e fecha o campo junto — falhar com "Cannot read properties of
+   * null" em vez de dizer o que aconteceu. Medido: é exatamente assim que ele falha.
+   */
+  function valorDoCampo(descricao: string): string {
+    return campoDeData(descricao)?.value ?? "<campo fechado pela remontagem da linha>";
+  }
+
+  /**
+   * Reagenda a `Retainer mensal` enquanto o "servidor" muda TAMBÉM o vencimento da `Consultoria`
+   * — o reagendamento vindo de fora (outra aba, rotina do backend) do enunciado. A linha da
+   * `Consultoria` nunca desmonta no meio: `key={c.id}` não depende do vencimento.
+   */
+  async function reagendarAOutraComAConsultoriaMudandoPorFora() {
+    const user = userEvent.setup();
+    ficha.charges = [ABERTA, OUTRA];
+    vi.mocked(api.post).mockImplementation(() => {
+      ficha.charges = [
+        { ...ABERTA, due_date: "2026-11-05", competence_date: "2026-11-05" },
+        { ...OUTRA, due_date: "2026-10-31", competence_date: "2026-10-31" },
+      ];
+      return Promise.resolve({ data: {} } as never);
+    });
+    renderFicha();
+    await screen.findByRole("heading", { name: "Joana Ré" });
+
+    const outra = linhaDaCobranca("Retainer mensal");
+    await user.click(within(outra).getByRole("button", { name: "Trocar venc." }));
+    fireEvent.change(within(outra).getByDisplayValue("2026-09-16"), {
+      target: { value: "2026-10-31" },
+    });
+    await user.click(within(outra).getByRole("button", { name: "OK" }));
+
+    // A recarga JÁ chegou à linha da `Consultoria` — o texto dela mostra 05/11. Sem esta espera,
+    // "campo com data velha" poderia ser apenas o `load()` que ainda não voltou, e o teste
+    // mediria a corrida em vez do estado preso.
+    expect(await screen.findByText(/vence 05\/11\/2026/)).toBeInTheDocument();
+    return user;
+  }
+
+  it("o campo abre com o vencimento que o backend mandou, não com o da montagem", async () => {
+    const user = await reagendarAOutraComAConsultoriaMudandoPorFora();
+
+    await user.click(
+      within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "Trocar venc." }),
+    );
+
+    expect(valorDoCampo("Consultoria")).toBe("2026-11-05");
+  });
+
+  it("confirmar sem reparar NÃO reenvia o vencimento velho", async () => {
+    // A metade que custa dinheiro: o campo errado só é visível para quem olhar, mas o `OK` manda.
+    const user = await reagendarAOutraComAConsultoriaMudandoPorFora();
+
+    await user.click(
+      within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "Trocar venc." }),
+    );
+    await user.click(within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "OK" }));
+
+    expect(vi.mocked(api.post).mock.calls.map(([u, b]) => [String(u), b])).toEqual([
+      ["/receivables/charges/c-outra/reschedule", { due_date: "2026-10-31" }],
+      ["/receivables/charges/c-aberta/reschedule", { due_date: "2026-11-05" }],
+    ]);
+  });
+
+  it("uma recarga no meio da digitação NÃO apaga o que o dono já escreveu", async () => {
+    // Este é o teste que decide ENTRE os dois consertos possíveis do enunciado. Pôr o vencimento
+    // na `key` da linha (`key={`${c.id}:${c.due_date}`}`) também faz o campo reabrir com a data
+    // certa — remontando a linha inteira. O preço é este: a remontagem joga fora o rascunho, e
+    // quem estava digitando quando a recarga chegou perde a data pela metade. Derivar o valor do
+    // prop custa zero remontagens, então é este o conserto.
+    const user = userEvent.setup();
+    ficha.charges = [ABERTA, OUTRA];
+    vi.mocked(api.post).mockImplementation(() => {
+      // O reagendamento da OUTRA muda, de quebra, o vencimento da Consultoria lá no servidor.
+      ficha.charges = [
+        { ...ABERTA, due_date: "2026-11-05", competence_date: "2026-11-05" },
+        { ...OUTRA, due_date: "2026-10-31", competence_date: "2026-10-31" },
+      ];
+      return Promise.resolve({ data: {} } as never);
+    });
+    renderFicha();
+    await screen.findByRole("heading", { name: "Joana Ré" });
+
+    // O dono abre o campo da Consultoria e digita ANTES de qualquer recarga.
+    await user.click(
+      within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "Trocar venc." }),
+    );
+    fireEvent.change(campoDeData("Consultoria") as HTMLInputElement, {
+      target: { value: "2026-12-24" },
+    });
+
+    // ...e só então a recarga chega, disparada pelo reagendamento da outra cobrança.
+    const outra = linhaDaCobranca("Retainer mensal");
+    await user.click(within(outra).getByRole("button", { name: "Trocar venc." }));
+    fireEvent.change(within(outra).getByDisplayValue("2026-09-16"), {
+      target: { value: "2026-10-31" },
+    });
+    await user.click(within(outra).getByRole("button", { name: "OK" }));
+    expect(await screen.findByText(/vence 05\/11\/2026/)).toBeInTheDocument();
+
+    // O que o dono digitou continua lá, e é ele que o `OK` manda — não o do servidor.
+    expect(valorDoCampo("Consultoria")).toBe("2026-12-24");
+    await user.click(within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "OK" }));
+    expect(vi.mocked(api.post).mock.calls.at(-1)).toEqual([
+      "/receivables/charges/c-aberta/reschedule",
+      { due_date: "2026-12-24" },
+    ]);
+  });
+  it("depois do OK o rascunho MORRE: o campo volta a seguir o servidor", async () => {
+    // Quem grava o vencimento é o servidor, e ele pode gravar um dia DIFERENTE do pedido (dia
+    // útil, normalização, uma alteração concorrente que chegou primeiro). Se o rascunho
+    // sobrevivesse ao `OK`, o campo seguiria mostrando o que o dono DIGITOU em vez do que ficou
+    // gravado — e o `OK` seguinte reenviaria isso. É a mesma falha da issue, um passo depois.
+    const user = userEvent.setup();
+    ficha.charges = [ABERTA];
+    vi.mocked(api.post).mockImplementation(() => {
+      ficha.charges = [{ ...ABERTA, due_date: "2026-11-05", competence_date: "2026-11-05" }];
+      return Promise.resolve({ data: {} } as never);
+    });
+    renderFicha();
+    await screen.findByRole("heading", { name: "Joana Ré" });
+
+    await user.click(
+      within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "Trocar venc." }),
+    );
+    fireEvent.change(campoDeData("Consultoria") as HTMLInputElement, {
+      target: { value: "2026-12-24" },
+    });
+    await user.click(within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "OK" }));
+    expect(await screen.findByText(/vence 05\/11\/2026/)).toBeInTheDocument();
+
+    await user.click(
+      within(linhaDaCobranca("Consultoria")).getByRole("button", { name: "Trocar venc." }),
+    );
+
+    expect(valorDoCampo("Consultoria")).toBe("2026-11-05");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
 // 7. "Recebi direto na conta" — a MESMA porta da `CobrancasPage`, e o dia é o do TENANT (#136)
 // ══════════════════════════════════════════════════════════════════════════════════════════════
 

--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -338,29 +338,48 @@ describe("ClientDetailPage — a montagem (issue #145)", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
-// 2. O resumo financeiro — TRÊS somas com recortes DIFERENTES sobre a MESMA lista
+// 2. O resumo financeiro — QUATRO somas com recortes DIFERENTES sobre a MESMA lista
+//
+// ⚠️ **Eram TRÊS até a issue #154, e as três não cobriam a lista.** `ChargeStatus` tem quatro
+// valores (`open` | `scheduled` | `paid` | `canceled`) e os três recortes originais só alcançavam
+// três deles: a cobrança `scheduled` sumia da ficha inteira. O quarto cartão é o espelho do que a
+// `CobrancasPage` já fazia desde a Story 8.15 — mesmo rótulo, mesma semântica, mesmo sumiço no
+// zero. Ver a nota em `CobrancasPage.tsx`.
+//
+// ⚠️ **O teste que "congelava" o defeito só congelava os TRÊS números, não a AUSÊNCIA do quarto.**
+// Medido na issue #154: com o cartão novo em pé, as três asserções antigas continuavam VERDES —
+// o defeito estava preso pelo NOME do teste, não pelas asserções dele. É por isso que o bloco
+// abaixo afirma o cartão que EXISTE e o que NÃO existe, nunca só as somas.
 // ══════════════════════════════════════════════════════════════════════════════════════════════
 
-describe("ClientDetailPage — as três somas do resumo (issue #145)", () => {
+describe("ClientDetailPage — as quatro somas do resumo (issues #145, #154)", () => {
   it("'a vencer' EXCLUI a vencida; 'Vencido' é só ela; 'Recebido' é só o que foi pago", async () => {
-    // Os três recortes andam sobre a mesma lista de seis cobranças e têm de dar TRÊS números
+    // Os quatro recortes andam sobre a mesma lista de seis cobranças e têm de dar QUATRO números
     // diferentes. Por isso as fixtures têm valores distintos: se `openSum` passasse a somar
     // também a vencida (`!c.is_overdue` → `true`) daria R$ 1.500,00, e a linha abaixo morre.
     renderFicha();
     await screen.findByRole("heading", { name: "Joana Ré" });
 
     // Aberta (R$ 1.000,00) — sem a vencida, sem a agendada, sem a cancelada.
+    // ⚠️ O valor EXATO é o que mata a mutação que joga a agendada neste cartão: R$ 1.300,00.
     expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
     // Só a vencida (R$ 500,00). O recorte aqui é `is_overdue`, e NÃO `status === "open"`.
     expect(valorDoCartao("Vencido")).toBe("R$ 500,00");
     // As duas pagas (R$ 200,00 + R$ 700,00), pelas DUAS rotas: a de banco e a do trilho.
+    // Somar a agendada aqui daria R$ 1.200,00 — o outro cartão errado possível.
     expect(valorDoCartao("Recebido")).toBe("R$ 900,00");
+    // [#154] E a agendada (R$ 300,00) tem o SEU: quatro números, quatro recortes.
+    expect(valorDoCartao("Agendado para entrar")).toBe("R$ 300,00");
   });
 
-  it("a cobrança AGENDADA e a CANCELADA não entram em soma nenhuma", async () => {
-    // O caso que expõe o recorte `status === "open"` do `openSum`: `scheduled` e `canceled` não
-    // são "a vencer", não são "vencido" e não são "recebido". Trocar o recorte por
-    // `status !== "paid"` somaria R$ 700,00 aqui e a primeira linha morre.
+  it("[#154] a AGENDADA tem cartão PRÓPRIO; a CANCELADA continua fora de TUDO", async () => {
+    // O caso que expõe os recortes por status: `scheduled` não é "a vencer" (exige `status ===
+    // "open"`), não é "vencido" e não é "recebido" — e por não caber em nenhum dos três é que ela
+    // precisou de cartão próprio, exatamente como na `CobrancasPage`.
+    //
+    // `canceled` é DIFERENTE e continua fora dos quatro: não é dinheiro que vai entrar. Este teste
+    // é o que impede o conserto de #154 de arrastar a cancelada junto — os R$ 400,00 dela não
+    // aparecem em cartão nenhum, e o cartão novo lê R$ 300,00, nunca R$ 700,00.
     ficha.charges = [ABERTA, AGENDADA, CANCELADA];
     renderFicha();
     await screen.findByRole("heading", { name: "Joana Ré" });
@@ -368,6 +387,25 @@ describe("ClientDetailPage — as três somas do resumo (issue #145)", () => {
     expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
     expect(valorDoCartao("Vencido")).toBe("R$ 0,00");
     expect(valorDoCartao("Recebido")).toBe("R$ 0,00");
+    expect(valorDoCartao("Agendado para entrar")).toBe("R$ 300,00");
+
+    // A cancelada (R$ 400,00) não é o valor de NENHUM dos quatro cartões. Um `queryByText` solto
+    // não serviria: o valor também vive na linha da cobrança, e o teste passaria por acidente.
+    const cartoes = ["A receber (a vencer)", "Vencido", "Recebido", "Agendado para entrar"];
+    expect(cartoes.map(valorDoCartao)).not.toContain("R$ 400,00");
+  });
+
+  it("[#154] o cartão 'Agendado para entrar' SOME quando é zero (espelho da CobrancasPage)", async () => {
+    // Mesma disciplina anti-ruído da 8.14/8.15: na ficha do dono que nunca recebeu com data
+    // futura, um cartão eternamente zerado é peso de ERP. Sem o `scheduledSum > 0`, o rótulo
+    // apareceria aqui com R$ 0,00.
+    ficha.charges = [ABERTA, PAGA_TRILHO, CANCELADA];
+    renderFicha();
+    await screen.findByRole("heading", { name: "Joana Ré" });
+
+    // Os três de sempre continuam em pé — o sumiço é SÓ do quarto.
+    expect(valorDoCartao("A receber (a vencer)")).toBe("R$ 1.000,00");
+    expect(screen.queryByText("Agendado para entrar")).toBeNull();
   });
 });
 

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -281,7 +281,20 @@ function ChargeRow({
   onReceberForaDoTrilho: (c: Charge) => void;
 }) {
   const fuso = useFuso();
-  const [due, setDue] = useState(c.due_date);
+  /**
+   * O que o dono DIGITOU no campo de vencimento — `null` enquanto ele não digitou nada (#155).
+   *
+   * ⚠️ **O valor exibido é DERIVADO do prop, não uma cópia dele.** `useState(c.due_date)` lê o
+   * argumento só na MONTAGEM, e esta linha não desmonta quando o vencimento muda: `key={c.id}`
+   * não depende dele. Um `load()` que trouxesse a cobrança reagendada por fora (outra aba, rotina
+   * do backend) deixava o "Trocar venc." pré-preenchido com a data VELHA — e o `OK` a reenviava.
+   *
+   * A alternativa era pôr o vencimento na `key` da linha, remontando-a a cada mudança. Custa
+   * caro: uma recarga no meio da digitação apagaria o que o dono acabou de escrever. Com o
+   * rascunho, o prop manda enquanto ninguém digitou e o dono manda depois que digitou.
+   */
+  const [rascunho, setRascunho] = useState<string | null>(null);
+  const due = rascunho ?? c.due_date;
   const [showDate, setShowDate] = useState(false);
   return (
     <li className="flex flex-wrap items-center justify-between gap-2 py-3">
@@ -316,8 +329,8 @@ function ChargeRow({
             {c.is_overdue && <span className="rounded-pill bg-red-50 px-2 py-0.5 text-xs text-danger">Vencida</span>}
             {showDate ? (
               <span className="flex items-center gap-1">
-                <input type="date" value={due} onChange={(e) => setDue(e.target.value)} className="rounded-lg border border-neutral-200 px-2 py-1 text-xs outline-none" />
-                <button onClick={() => { onReschedule(c.id, due); setShowDate(false); }} className="text-xs font-medium text-primary-600">OK</button>
+                <input type="date" value={due} onChange={(e) => setRascunho(e.target.value)} className="rounded-lg border border-neutral-200 px-2 py-1 text-xs outline-none" />
+                <button onClick={() => { onReschedule(c.id, due); setRascunho(null); setShowDate(false); }} className="text-xs font-medium text-primary-600">OK</button>
               </span>
             ) : (
               <button onClick={() => setShowDate(true)} className="text-xs font-medium text-neutral-500 hover:text-primary-600">Trocar venc.</button>

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -66,6 +66,15 @@ export default function ClientDetailPage() {
   const openSum = charges.filter((c) => c.status === "open" && !c.is_overdue).reduce((a, c) => a + c.amount_cents, 0);
   const overdueSum = charges.filter((c) => c.is_overdue).reduce((a, c) => a + c.amount_cents, 0);
   const paidSum = charges.filter((c) => c.status === "paid").reduce((a, c) => a + c.amount_cents, 0);
+  // [issue #154] A QUARTA soma, e ela existe porque as três de cima **não cobrem a lista**.
+  // `ChargeStatus` tem quatro valores (`open` | `scheduled` | `paid` | `canceled`) e os recortes
+  // acima só alcançam três deles: uma cobrança `scheduled` não é "a vencer" (o recorte exige
+  // `status === "open"`), não é "Vencido" (`is_overdue` nasce `false` fora de `open`) e não é
+  // "Recebido" (o dinheiro ainda não caiu). Sem este cartão ela **some da ficha** — o mesmo modo
+  // de falha que a `CobrancasPage` eliminou na Story 8.15 e que o `scheduled_cents` do backend
+  // (`receivables/service.py`) já calcula para a tela irmã.
+  // `canceled` ficar fora de tudo é DIFERENTE e está certo: não é dinheiro que vai entrar.
+  const scheduledSum = charges.filter((c) => c.status === "scheduled").reduce((a, c) => a + c.amount_cents, 0);
 
   async function protest(cid: string) {
     await api.post(`/receivables/charges/${cid}/protest`);
@@ -111,6 +120,14 @@ export default function ClientDetailPage() {
         <Stat label="A receber (a vencer)" value={brl(openSum)} tone="text-neutral-700" />
         <Stat label="Vencido" value={brl(overdueSum)} tone="text-danger" />
         <Stat label="Recebido" value={brl(paidSum)} tone="text-accent-700" />
+        {/* [issue #154] Espelho EXATO do quarto cartão da `CobrancasPage` (Story 8.15): mesmo
+            rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
+            Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
+            ação de dinheiro, e uma terceira convenção para o mesmo estado seria a assimetria que
+            esta issue existe para fechar. */}
+        {scheduledSum > 0 && (
+          <Stat label="Agendado para entrar" value={brl(scheduledSum)} tone="text-amber-700" />
+        )}
       </div>
 
       {/* Histórico — primeiro bloco de propósito: é a história que dá sentido às seções


### PR DESCRIPTION
## Resumo

`ChargeRow` guardava o vencimento em `useState(c.due_date)`. `useState` só lê o argumento na
**montagem**, e a linha é montada com `key={c.id}` — que não muda quando o vencimento muda. Um
`load()` que trouxesse `due_date` novo (reagendado noutra aba, ou alterado pelo backend) **não**
atualizava o campo: o "Trocar venc." reabria com a data velha, e confirmar sem reparar **reenviava o
valor antigo**.

Fecha #155. Empilhado sobre o #171 (issue #154), já mergeado — este PR mostra só o que é dele.

## A issue pedia MEDIR primeiro, e reproduziu

O achado foi *raciocinado do código* durante o PR #152, nunca medido. Os testes vieram antes do
conserto, contra a produção intacta:

```
× o campo abre com o vencimento que o backend mandou, não com o da montagem
  → expected '2026-09-16' to be '2026-11-05'
× confirmar sem reparar NÃO reenvia o vencimento velho
  →   "due_date": "2026-11-05"   (esperado)
    + "due_date": "2026-09-16"   (recebido)
Tests  2 failed | 32 passed (34)
```

Cenário: duas cobranças abertas; o dono reagenda a segunda; o `load()` traz a **primeira** com
`due_date` novo (reagendamento vindo de fora); a linha **não** desmonta; e o "Trocar venc." dela abre
com `2026-09-16`. O texto da linha já mostrava `vence 05/11/2026` na mesma tela — o teste espera por
isso antes de medir, para não confundir **estado preso** com **corrida de `load()`**.

## O que muda

O valor exibido passa a ser **derivado do prop**, não uma cópia dele:

```tsx
const [rascunho, setRascunho] = useState<string | null>(null);
const due = rascunho ?? c.due_date;
```

O prop manda enquanto ninguém digitou; o dono manda depois que digitou; e o `OK` mata o rascunho
(`setRascunho(null)`), devolvendo o campo ao servidor.

## Por que NÃO o `key={`${c.id}:${c.due_date}`}` que a issue sugeria — medido, não preferido

A `key` também faz o campo reabrir com a data certa. Mas ela **remonta a linha inteira**, e isso é
uma mutação com morte própria neste PR:

```
× uma recarga no meio da digitação NÃO apaga o que o dono já escreveu
  → expected '<campo fechado pela remontagem da linha>' to be '2026-12-24'
```

Perde o que o dono digitou **e fecha o campo debaixo do dedo** — o `showDate` volta a `false`, então
o campo *some*, não só o valor. Derivar do prop custa **zero** remontagens. O `if (!due) return`
continua funcionando porque `??` preserva a string vazia.

## Prova por mutação — 4 mutantes, 4 mortos (`tsc --noEmit` limpo em todos)

| Mutação na produção | Teste que morreu | Mensagem real |
|---|---|---|
| Reverter para `useState(c.due_date)` | `o campo abre com o vencimento que o backend mandou` | `expected '2026-09-16' to be '2026-11-05'` |
| idem | `confirmar sem reparar NÃO reenvia o vencimento velho` | `"due_date": "2026-11-05"` esperado vs `"2026-09-16"` recebido |
| Trocar pelo conserto alternativo (`key` com o vencimento) | `uma recarga no meio da digitação NÃO apaga o que o dono já escreveu` | `expected '<campo fechado pela remontagem da linha>' to be '2026-12-24'` |
| Remover `setRascunho(null)` do OK | `depois do OK o rascunho MORRE` | `expected '2026-12-24' to be '2026-11-05'` |

**O quarto mutante sobreviveu na primeira rodada.** Ganhou teste em vez de virar "equivalente
documentado", porque é a mesma falha um passo depois: servidor grava dia diferente do pedido → o
campo seguiria mostrando o digitado. Nenhum mutante equivalente restou.

A mutação da raiz foi **refeita de forma independente na revisão**, e de novo **depois** que o #171
entrou em `main`: `tsc` exit 0, **2 failed | 35 passed (37)**, mesmas mensagens.

## Alcance: a classe `useState(prop)` sem ressincronização — 92 varridos, **1 outro caso vivo**

Dos 92 `useState` não-triviais de `apps/web/src`, só **15** nascem de uma prop (os demais partem de
constante de módulo, `useParams`, `localStorage` ou lazy init).

| Local | Veredito |
|---|---|
| `crm/ClientDetailPage.tsx:284` `ChargeRow` | **DEFEITO** — é esta issue |
| `financeiro/PeriodPicker.tsx:24-25` ← `value` | **mesma família, FORA DE ESCOPO** → issue #180 |
| `pagar/PagarPage.tsx:665-674` `NewBillModal` ← `inicial` | não — **já consertado com `key={duplicando?.id ?? "nova"}`**, com docstring. É o precedente do conserto por `key` neste repo |
| `crm/EditClientModal`, `cobrancas/EditChargeModal`, `pagar/EditBillModal`+`AttachModal`, `funis/FunnelBuilderPage` (2), `vima/PreferenciasSection` | não — montagem **condicional** (`{editing && …}`), rascunho deliberado que morre ao fechar |
| `pagar/EscolhaDaBaixa.tsx:119`, `financeiro/ChartAccountSelect.tsx:25` | não — a prop é constante em todo call site |
| `contratos/ContractBuilderPage`, `orcamentos/QuoteBuilderPage`, `funis/FunnelBuilderPage:188`, `marketing/CarrosselBuilderPage` ← `useParams` | não — todos ressincronizam por `useEffect([isNew, id])` → `hydrate()` |

O `PeriodPicker` **não foi consertado aqui** — virou issue própria, com o número medido dentro.

## Verde

```
Test Files  1 passed (1)
     Tests  37 passed (37)
```

`tsc --noEmit` exit 0 · `eslint` exit 0 nos dois arquivos.

## Reconciliação com o #171, conferida por conteúdo

Os dois PRs tocam o mesmo arquivo e o mesmo teste. O merge foi automático, mas **ausência de marcador
de conflito não é prova**: conferido que o cartão do #154 aparece **uma** vez (`scheduledSum`:
declaração + guarda + rótulo), que o rascunho do #155 está intacto, que **nenhum `it` duplicou**, e
que o total bate em 37 (33 do #154 + 4 novos). Também rodado antes do merge, na worktree combinada
com os 9 branches da leva: **855 vitest + 158 e2e** verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
