### PR TITLE
test(web): guarda o default que impede o card fantasma do Gancho [#164]

### DIFF
--- a/apps/web/e2e/gancho-fantasma-360.spec.ts
+++ b/apps/web/e2e/gancho-fantasma-360.spec.ts
@@ -12,14 +12,22 @@ import { semearSessao } from "./support/sessao";
  * **nada guardava essa linha**: medido no #164, removê-la deixava `agenda-evento-360` inteiro verde
  * (12 passed, `--repeat-each=3`), com as réguas de 360px medindo 101px de tela que não existe.
  *
- * ⚠️ **QUAL MUTAÇÃO ESTE ARQUIVO MATA, E SOB QUAL CONDIÇÃO.** Ele mata "apagar
- * `"/dna/pendente": null` do `PADROES`" — mas isso vale **enquanto a guarda do componente for
- * frouxa** (`data ?? null`). Medido nesta branch, com a guarda frouxa: a mutação mata os DOIS
- * testes abaixo. Com a guarda apertada do #161 aplicada (o componente passa a exigir a FORMA de
- * `DnaPergunta` e rejeita `[]`), essa mesma mutação vira **mutante equivalente** — o `[]` deixa de
- * virar card e não há empurrão para medir. O que sobra guardado depois do #161, e não é pouco, é a
- * outra metade: que a fixture PADRÃO não monte card nenhum, qualquer que seja o caminho — um
- * default trocado por payload de forma válida continua morrendo aqui.
+ * ⚠️ **QUAL MUTAÇÃO ESTE ARQUIVO MATA — e qual ele DEIXOU de matar quando o #161 entrou.**
+ *
+ * | mutação no `PADROES` | antes do #161 | HOJE (guarda apertada em `main`) |
+ * |---|---|---|
+ * | apagar `"/dna/pendente": null` | mata os 2 | **SOBREVIVE — mutante equivalente** |
+ * | trocar por payload de FORMA VÁLIDA | mata os 2 | **mata os 2** |
+ *
+ * Ambas as linhas foram MEDIDAS: a primeira contra a branch do #164 com a guarda ainda frouxa, e as
+ * duas de novo em 2026-08-21 contra o `main` que já contém o #161 (PR #176). O `[]` deixou de virar
+ * card porque `ehPergunta` o rejeita, então não há mais empurrão de 101px para medir por esse
+ * caminho — e exigir morte de mutante equivalente só produziria teste que fixa literal sem
+ * consequência.
+ *
+ * O que este arquivo guarda HOJE, e não é pouco: **a fixture PADRÃO não monta card do Gancho,
+ * qualquer que seja o caminho**. O mock deixou de ser a única linha de defesa (o componente virou a
+ * primeira), mas continua sendo o que faz as réguas de 360px medirem a tela que a produção produz.
  *
  * ⚠️ **UMA rota, não as seis.** O alvo é UMA linha de UM arquivo compartilhado, e as seis telas
  * chamam o MESMO endpoint (`/dna/pendente`, casado por prefixo de caminho, não por rota). Não
@@ -78,7 +86,7 @@ test("a fixture padrão não monta o card do Gancho na /agenda", async ({ page }
   await abrirAgenda(page);
   await expect(
     cardDoGancho(page),
-    "o default `/dna/pendente: null` de support/api.ts caiu: `[]` voltou a virar card e as réguas de 360px passaram a medir 101px de tela que a produção não produz (#164)",
+    "a fixture padrão passou a montar o card do Gancho na /agenda. O default `/dna/pendente: null` de `support/api.ts` caiu, ou foi trocado por um payload de forma válida — e as réguas de 360px destas seis telas voltaram a medir ~101px de tela que a produção não produz (#164). NÃO é mais o `[]`: desde o #161 o próprio componente o rejeita.",
   ).toHaveCount(0);
 });
 

--- a/apps/web/e2e/gancho-fantasma-360.spec.ts
+++ b/apps/web/e2e/gancho-fantasma-360.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O GUARDA do default `"/dna/pendente": null` de `support/api.ts` (#164).
+ *
+ * `mockarApi` responde `[]` para toda rota não mapeada. `[]` é **verdadeiro** em JS, e
+ * `GanchoDaVima` faz `setPergunta(data ?? null)` — a guarda `if (!pergunta) return null` não pega,
+ * e SEIS telas (`agenda`, `cobrancas`, `crm`, `orcamentos`, `pagar`, `vima`) ganham um card que a
+ * produção nunca monta. O PR #159 neutralizou o gatilho com uma linha no `PADROES`, e até aqui
+ * **nada guardava essa linha**: medido no #164, removê-la deixava `agenda-evento-360` inteiro verde
+ * (12 passed, `--repeat-each=3`), com as réguas de 360px medindo 101px de tela que não existe.
+ *
+ * ⚠️ **QUAL MUTAÇÃO ESTE ARQUIVO MATA, E SOB QUAL CONDIÇÃO.** Ele mata "apagar
+ * `"/dna/pendente": null` do `PADROES`" — mas isso vale **enquanto a guarda do componente for
+ * frouxa** (`data ?? null`). Medido nesta branch, com a guarda frouxa: a mutação mata os DOIS
+ * testes abaixo. Com a guarda apertada do #161 aplicada (o componente passa a exigir a FORMA de
+ * `DnaPergunta` e rejeita `[]`), essa mesma mutação vira **mutante equivalente** — o `[]` deixa de
+ * virar card e não há empurrão para medir. O que sobra guardado depois do #161, e não é pouco, é a
+ * outra metade: que a fixture PADRÃO não monte card nenhum, qualquer que seja o caminho — um
+ * default trocado por payload de forma válida continua morrendo aqui.
+ *
+ * ⚠️ **UMA rota, não as seis.** O alvo é UMA linha de UM arquivo compartilhado, e as seis telas
+ * chamam o MESMO endpoint (`/dna/pendente`, casado por prefixo de caminho, não por rota). Não
+ * existe mutação que seis asserções matem e uma não — seriam seis mortes do mesmo mutante, a
+ * ~1s/spec com `workers: 1`. O que acrescenta poder de morte aqui não é a segunda rota: é o
+ * CONTROLE POSITIVO abaixo. Sem ele, `toHaveCount(0)` não distingue "o card não existe" de "o
+ * seletor não vê card nenhum" — a armadilha do #123, e a família do `toContain("flex-wrap")`.
+ *
+ * A rota escolhida é a `/agenda` porque é onde o empurrão foi MEDIDO (#159: `main` 781→681) e onde
+ * o card é o PRIMEIRO filho da página (`AgendaPage.tsx:93`), logo o empurrão é lido direto na
+ * ordenada do cabeçalho, sem intermediário.
+ */
+
+/**
+ * O único marcador comum ao card FANTASMA e ao card de verdade.
+ *
+ * Com `[]`, `pergunta.texto` e `pergunta.formato` são `undefined`: não há enunciado nem opções, e
+ * sobram só o subtítulo da classe e este botão. Um seletor pelo enunciado veria o card real e NÃO
+ * veria o fantasma — mediria a metade errada.
+ */
+const cardDoGancho = (page: Page) => page.getByRole("button", { name: "Responder depois" });
+
+/** Ordenada do cabeçalho da Agenda — o primeiro elemento DEPOIS do gancho. */
+async function topoDoCabecalho(page: Page): Promise<number> {
+  const caixa = await page.getByRole("button", { name: "Hoje" }).boundingBox();
+  expect(caixa).not.toBeNull();
+  return caixa!.y;
+}
+
+async function abrirAgenda(page: Page, respostas: Record<string, unknown> = {}): Promise<void> {
+  await mockarApi(page, respostas);
+  await page.goto("/agenda");
+  // A tela TEM de existir antes de ser medida: uma /agenda que não renderizou também devolve
+  // "nenhum card" e passaria verde por não ter desenhado nada.
+  await expect(page.getByRole("button", { name: "Hoje" })).toBeVisible();
+}
+
+/** Forma real de `DnaPergunta` (`packages/shared-types`), como o servidor devolve. */
+const PERGUNTA = {
+  key: "ritmo.card_parado_dias",
+  classe: "calibracao",
+  eixo: "ritmo",
+  texto: "A partir de quantos dias parado um card te incomoda?",
+  formato: "escolha",
+  opcoes: [
+    { rotulo: "5 dias", valor: 5 },
+    { rotulo: "10 dias", valor: 10 },
+  ],
+};
+
+test.beforeEach(async ({ page }) => {
+  await semearSessao(page);
+});
+
+test("a fixture padrão não monta o card do Gancho na /agenda", async ({ page }) => {
+  await abrirAgenda(page);
+  await expect(
+    cardDoGancho(page),
+    "o default `/dna/pendente: null` de support/api.ts caiu: `[]` voltou a virar card e as réguas de 360px passaram a medir 101px de tela que a produção não produz (#164)",
+  ).toHaveCount(0);
+});
+
+test("controle positivo: a régua enxerga o card do Gancho, e ele empurra a tela", async ({
+  page,
+}) => {
+  // Sem card: a linha de base. Se esta asserção cair, o número de baixo não significa nada.
+  await abrirAgenda(page);
+  await expect(cardDoGancho(page)).toHaveCount(0);
+  const semCard = await topoDoCabecalho(page);
+
+  // Com card: a MESMA tela, com o endpoint devolvendo o que a produção devolve quando há pergunta
+  // do dia. `unrouteAll` porque `mockarApi` registra um `page.route` novo a cada chamada.
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await abrirAgenda(page, { "/dna/pendente": PERGUNTA });
+  await expect(cardDoGancho(page)).toBeVisible();
+  const comCard = await topoDoCabecalho(page);
+
+  // Medido nesta rota em 20/08/2026: **269px** — este é o card CHEIO (enunciado + duas opções),
+  // maior que o fantasma. O fantasma do `[]` não tem enunciado nem opções e empurra os **101px**
+  // que o #159 mediu. A exigência aqui é só que o empurrão EXISTA e seja da ordem de grandeza dos
+  // dois: prender o número exato transformaria qualquer ajuste de padding do card num vermelho que
+  // não é defeito, e o piso de 50px já é intransponível para "o card não apareceu".
+  expect(comCard - semCard).toBeGreaterThan(50);
+});


### PR DESCRIPTION
## Resumo

`e2e/support/api.ts` responde `[]` para toda rota não mapeada. O PR #159 neutralizou o card fantasma
do Gancho com uma linha — `PADROES = { "/dna/pendente": null }` — e **nada guardava essa linha**.
Este PR escreve o guarda.

Fecha #164. É o último da leva das issues #151–#169.

## O alcance, confirmado

```
grep -rn "dna/pendente\|fantasma\|PADROES" e2e/ --include=*.spec.ts
e2e/agenda-evento-360.spec.ts:55:  // fantasma do `GanchoDaVima` (+101px: ...
```

**1 comentário, 0 `expect`.** E, medido antes do guarda existir:

```
# removido o "/dna/pendente": null do PADROES, tsc --noEmit limpo
E2E_PORT=5359 npx playwright test agenda-evento-360 --repeat-each=3
  12 passed (53.1s)
```

Tirar a linha por engano devolvia os **101px** às seis telas sem nenhum gate acusar. Enquanto o card
existia, todas as medições de 360px de `/agenda`, `/cobrancas`, `/crm`, `/orcamentos`, `/pagar` e
`/vima` **mediam 101px de tela que a produção não produz**.

## ⚠️ O que este PR mede MUDOU no meio do caminho, e isso está escrito no spec

O #161 (PR #176) entrou em `main` e apertou a guarda do componente. As duas mutações foram medidas
**de novo em 2026-08-21, contra o `main` real** — não contra a branch de ontem:

| mutação no `PADROES` | antes do #161 | HOJE (guarda apertada em `main`) |
|---|---|---|
| apagar `"/dna/pendente": null` | mata os 2 | **SOBREVIVE — mutante equivalente** |
| trocar por payload de **forma válida** | mata os 2 | **mata os 2** |

O `[]` deixou de virar card porque `ehPergunta` o rejeita. **Exigir morte do mutante equivalente só
produziria teste que fixa literal sem consequência** — está documentado e não perseguido.

O que o arquivo guarda hoje, e não é pouco: **a fixture padrão não monta card do Gancho, qualquer que
seja o caminho.** O mock deixou de ser a única linha de defesa; continua sendo o que faz as réguas de
360px medirem a tela que a produção produz.

**Por isso o segundo commit.** A mensagem da asserção culpava o `[]`, e isso passou a estar **errado**
— quem caísse nela seria mandado investigar o mock quando a causa agora é outra. Reescrita para
nomear as duas causas possíveis e dizer explicitamente que o `[]` não é mais uma delas. Confirmada
rodando a mutação e lendo a mensagem real:

```
Error: a fixture padrão passou a montar o card do Gancho na /agenda. O default
`/dna/pendente: null` de `support/api.ts` caiu, ou foi trocado por um payload de forma válida —
e as réguas de 360px destas seis telas voltaram a medir ~101px de tela que a produção não produz
(#164). NÃO é mais o `[]`: desde o #161 o próprio componente o rejeita.
```

Cabeçalho e mensagem, nada de lógica: as duas asserções e o controle positivo seguem idênticos.

## Prova por mutação — as duas, com `tsc --noEmit` limpo

| Mutação | Resultado | Mensagem real |
|---|---|---|
| **M1** apagar o default (guarda frouxa) | **2 failed** | `expect(locator).toHaveCount(expected) failed` · `Locator: getByRole('button', { name: 'Responder depois' })` · `Expected: 0` · `Received: 1` |
| **M1** apagar o default (guarda apertada, hoje) | **2 passed — sobrevive** | equivalente: `[]` não vira card |
| **M2** default → payload de forma válida (hoje) | **2 failed** | `Expected: 0` · `Received: 1`, com a mensagem nova |
| **M3** `setPergunta(data ? null : null)` no componente | só o **controle positivo** morre | `toBeVisible() failed` · `element(s) not found` |

**M3 é o que mede que o controle positivo não é enfeite.** Sem ele, o `toHaveCount(0)` do teste 1
sobreviveria a um seletor cego — a armadilha do #123 e a família do `toContain("flex-wrap")`.

## Decisão: UMA rota, não as seis — e a razão

O alvo é **uma linha de um arquivo compartilhado**, e as seis telas batem no **mesmo endpoint**
(`/dna/pendente`, casado por prefixo de caminho, não por rota). Não existe mutação que seis asserções
matem e uma não: seriam seis mortes do mesmo mutante, a ~1s/spec com `workers: 1`. O que acrescenta
poder de morte não é a segunda rota — **é o controle positivo**, e isso está medido em M3.

`/agenda` porque é onde o empurrão foi medido (#159: `main` 781→681) e onde o card é o **primeiro
filho** da página (`AgendaPage.tsx:93`), então o empurrão se lê direto na ordenada do cabeçalho.

**Empurrão medido agora, em 360×740: 269px** para o card cheio (enunciado + 2 opções) — maior que os
**101px** do fantasma, que não tem enunciado nem opções. O comentário do spec traz os dois números; o
piso da asserção é 50px, para não prender padding.

Seletor: `getByRole("button", { name: "Responder depois" })` — o **único marcador comum** ao card
fantasma e ao real. Um seletor pelo enunciado veria o card real e **não** veria o fantasma.

## Fora de escopo, já registrado

`/vima` é a única das seis telas sem régua e2e nenhuma (`goto("/vima"` → **0**; em `CASOS` → **0**),
e é a **porta do dia**: `EntradaDoDia` manda a raiz autenticada para lá quando o briefing não foi
lido. Virou a issue **#178**, com os números medidos dentro. Não implementada aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
