### PR TITLE
chore(web): thresholds.break de null para 80, com o baseline que o produziu [#169]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,9 +313,27 @@ depender (issue #121).
   "o teste DEDICADO prende a lógica" e "algum teste de componente passou por ali de raspão" — e
   vale 5,5x em tempo (74s → 13,5s no ciclo base). O erro que isso introduz tem direção conhecida:
   a régua pode pedir teste **a mais**, nunca a menos.
-- **Não há limiar de reprovação** (`thresholds.break: null`). Limiar antes da primeira medição é
-  número sem evidência. Observável primeiro, bloqueante depois — mesmo caminho de
-  `secret-scan`/`sast-semgrep`/`frontend`.
+- **O limiar de reprovação é 80** (`thresholds.break: 80`, desde 2026-08-21). Nasceu `null` de
+  propósito — limiar antes da primeira medição é número sem evidência — e virou número quando
+  houve medição, mesmo caminho de `secret-scan`/`sast-semgrep`/`frontend`: observável primeiro,
+  bloqueante depois. Ele compara com o **score GLOBAL** (a linha "All files", que inclui os
+  mutantes sem cobertura), nunca com o de um arquivo: `app/navigation.ts` mede 55,65% e **não**
+  derruba o job sozinho. A aritmética dos 80 está comentada no `stryker.config.mjs`; o resumo é
+  que 1 ponto ≈ 17,8 mutantes e a folga de ~3,5 pt absorve um módulo novo entrando pelo escopo
+  descoberto sem que nenhum teste existente tenha piorado.
+
+**Baseline no CI — 83,52%** (2026-08-21, run `32478357936`, `main` em `e422278`, runner de 2 vCPU,
+**12min56s**). 1.779 mutantes em **27 módulos**: 1.479 mortos, 1 timeout, 269 sobreviventes, 23 sem
+cobertura, 0 erros. É desta corrida que saiu o limiar acima, e é a **primeira que o job noturno
+completou**: as três anteriores (19, 20 e 21/08) abortavam no dry run por fuso — o runner do GitHub
+roda em UTC e o `env: { TZ }` do `vitest.config.ts` não pega no pool `threads` que o Stryker força
+(issue #169; conserto no `env:` do job em `.github/workflows/mutation.yml` + guarda fail-closed em
+`src/test-setup.ts`).
+
+↳ O 27º módulo é **`features/busca/resultado.ts`** (18 mutantes, 72,22%, 5 sobreviventes), que
+entrou pelo escopo descoberto depois de 18/08 e por isso **não está na tabela abaixo** — é
+exatamente a contrapartida avisada acima. A tabela que segue continua sendo a medição local de
+2026-08-18 (12 vCPU, 26 módulos), preservada pelo par antes/depois da triagem da issue #121.
 
 **Baseline MEDIDO** (2026-08-18, Node 24, 12 vCPU, `--concurrency` default; ~21 min em quatro
 lotes para os 1.605 mutantes; **os 25 módulos de então foram medidos, nenhum ficou de fora** — o

--- a/apps/web/stryker.config.mjs
+++ b/apps/web/stryker.config.mjs
@@ -119,13 +119,43 @@ export default {
   jsonReporter: { fileName: "reports/mutation/mutation.json" },
   clearTextReporter: { allowColor: false, maxTestsToLog: 0 },
 
-  // ⚠️ SEM `break`. O gate nasce OBSERVÁVEL, igual a `secret-scan`, `sast-semgrep` e
-  // `frontend` no ci.yml — e aqui há um motivo a mais: limiar escrito antes da primeira
-  // medição é número sem evidência (Artigo IV da Constitution, "No Invention"). O baseline
-  // medido está no CLAUDE.md §5.3; a promoção a bloqueante vem depois de um período de
-  // observação, e é uma edição de uma linha aqui (`break: <n>`).
-  // `high`/`low` só colorem o relatório — não reprovam nada.
-  thresholds: { high: 80, low: 60, break: null },
+  // ── LIMIAR BLOQUEANTE — 80, e a aritmética que o produziu ────────────────────────────────
+  // Este campo nasceu `null` de propósito: limiar escrito antes da primeira medição é número
+  // sem evidência (Artigo IV da Constitution, "No Invention"). Agora HÁ medição.
+  //
+  // **Baseline: 83,52%**, da primeira corrida que o job noturno completou —
+  // `Mutation (noturno)` run 32478357936, 21/08/2026, `main` em e422278, 12min56s no runner de
+  // 2 vCPU. 1.779 mutantes: 1.479 mortos, 1 timeout, 269 sobreviventes, 23 sem cobertura,
+  // 0 erros. As três execuções anteriores (19, 20 e 21/08) nunca chegaram a medir — abortavam
+  // no dry run por fuso, ver issue #169 e o `env: TZ` do `.github/workflows/mutation.yml`.
+  //
+  // ⚠️ O `break` compara com o `mutationScore` GLOBAL — a linha "All files", que inclui os
+  // mutantes sem cobertura. São os 83,52, e NÃO os 84,62 de `mutationScoreBasedOnCoveredCode`
+  // ("covered" na tabela). Lido na fonte, não inferido: `determineExitCode()` em
+  // `dist/src/reporters/mutation-test-report-helper.js` faz
+  // `metrics.systemUnderTestMetrics.metrics.mutationScore < break`. Comparação ESTRITA: um
+  // empate exato no limiar passa.
+  //
+  // Consequência que evita susto na triagem: nenhum arquivo reprova sozinho. `app/navigation.ts`
+  // mede 55,65% e responde por 51 dos 269 sobreviventes — continua sendo o pior da árvore e
+  // continua NÃO derrubando o job. O que este número protege é o total.
+  //
+  // **Por que 80 e não 83.** 1 ponto de score = ~17,8 mutantes. Um limiar colado no baseline
+  // reprovaria a primeira noite em que qualquer coisa se mexesse, inclusive coisas que não são
+  // queda de qualidade: (a) `mutate` é DESCOBERTO, não escrito à mão — todo `.ts` que ganhar um
+  // irmão `.test.ts` entra sozinho, e um módulo novo com teste mediano puxa o total para baixo
+  // sem que nenhum teste existente tenha piorado; (b) o timeout conta como morto, então um
+  // mutante que hoje estoura o `timeoutMS` pode sobreviver numa noite de runner mais folgado
+  // (é 1 mutante, ~0,06 pt — pequeno, mas não é zero). 80 dá ~3,5 pt = ~63 mutantes de folga:
+  // absorve um módulo novo inteiro e ainda pega qualquer desmonte real da suíte.
+  //
+  // **E por que exatamente 80, o mesmo valor de `high`.** Vira uma regra só em vez de duas:
+  // o job reprova exatamente quando o relatório deixa de ser verde. Não há restrição do Stryker
+  // ligando os dois — o `customValidation()` do `options-validator.js` só exige `high >= low`,
+  // `break` é independente. A coincidência é escolha de legibilidade, não imposição.
+  //
+  // `high`/`low` seguem só colorindo o relatório — quem reprova é `break`.
+  thresholds: { high: 80, low: 60, break: 80 },
 
   // O timeout do Stryker é `tempo-do-teste-original * fator + offset`. Os testes de lógica
   // pura rodam em milissegundos, então o fator multiplica quase nada e um mutante que cai em


### PR DESCRIPTION
## O que muda

`apps/web/stryker.config.mjs`: `thresholds.break` de `null` para **80**. Mais a §5.3 do `CLAUDE.md`, que afirmava "não há limiar de reprovação" e passaria a mentir.

## O baseline que produziu o número

Run [`32478357936`](https://github.com/educacaocriativa/escritorio-1-pessoa/actions/runs/32478357936) (21/08/2026, `main` em `e422278`, `workflow_dispatch`): **83,52%** em **12min56s** no runner de 2 vCPU. 1.779 mutantes em 27 módulos — 1.479 mortos, 1 timeout, 269 sobreviventes, 23 sem cobertura, 0 erros.

É a **primeira corrida que o job noturno completou**. As três anteriores (19, 20 e 21/08) abortavam no dry run por fuso; o conserto (#172) só entrou depois da última delas. Antes desta corrida não havia número nenhum para virar limiar.

## Contra o quê o `break` compara

O `mutationScore` **global** — a linha "All files", que inclui os mutantes sem cobertura: os **83,52**, e não os 84,62 de `mutationScoreBasedOnCoveredCode` ("covered" na tabela). Lido na fonte, não inferido: `determineExitCode()` em `dist/src/reporters/mutation-test-report-helper.js`. Comparação estrita (`<`), então empate exato passa.

Consequência que evita susto na triagem: **nenhum arquivo reprova sozinho.** `app/navigation.ts` mede 55,65% e responde por 51 dos 269 sobreviventes — segue sendo o pior da árvore e segue não derrubando o job.

## Por que 80 e não 83

1 ponto de score ≈ 17,8 mutantes. Um limiar colado no baseline reprovaria na primeira noite em que qualquer coisa se mexesse, inclusive o que não é queda de qualidade:

- `mutate` é **descoberto**, não escrito à mão — todo `.ts` que ganhar irmão `.test.ts` entra sozinho, e um módulo novo com teste mediano puxa o total para baixo sem que nenhum teste existente tenha piorado. Isso **já aconteceu**: `features/busca/resultado.ts` (18 mutantes, 72,22%) é o 27º módulo e entrou assim depois de 18/08.
- Timeout conta como morto, então 1 mutante pode trocar de lado num runner mais folgado (~0,06 pt — pequeno, não zero).

80 dá ~3,5 pt = ~63 mutantes de folga: absorve um módulo novo inteiro e ainda pega qualquer desmonte real da suíte.

**80 é também o valor de `high`**, de propósito: vira uma regra só em vez de duas — o job reprova exatamente quando o relatório deixa de ser verde. Não há restrição do Stryker ligando os dois; o `customValidation()` do `options-validator.js` só exige `high >= low`.

## Verificação

Nas duas direções, com Stryker de verdade:

| Comando | Score | Exit | Mensagem |
|---|---:|---:|---|
| `stryker run --mutate src/features/crm/origem.ts` | 100,00 | 0 | `is greater than or equal to break threshold 80` |
| `stryker run --mutate src/app/navigation.ts` | 55,65 | **1** | `under breaking threshold 80, setting exit code to 1` |

`pnpm lint` e `pnpm typecheck` limpos.

## Ressalva honesta

É **uma** medição. O limiar tem folga justamente porque uma corrida não é um período de observação — se as próximas noites mostrarem variação maior que os ~3,5 pt previstos, o número certo é este aqui, não o baseline.

Contexto: #169 (consertada pelo #172; esta PR usa o número que ela destravou)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
