### PR TITLE
feat(ci): o job de mutacao passa a falar — noite verde deixa de ser silenciosa

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -63,6 +63,21 @@ jobs:
     # que escapou do `timeoutMS` do Stryker, não para apertar a medição.
     timeout-minutes: 120
 
+    # ── PERMISSOES, NO NIVEL DO JOB ─────────────────────────────────────────────────────────────
+    # O default deste repositorio da ao GITHUB_TOKEN apenas `contents/metadata/packages: read` — o
+    # proprio log de execucao imprime isso no grupo "GITHUB_TOKEN Permissions". Os dois passos de
+    # relatorio abaixo precisam de mais:
+    #
+    #   actions: read  -> baixar o `mutation-report` da corrida ANTERIOR (a tendencia depende dele)
+    #   issues: write  -> abrir/comentar o aviso quando o score cai
+    #
+    # Declarar o bloco inteiro e obrigatorio: assim que `permissions:` existe, o que nao esta
+    # listado passa a ser `none` — por isso `contents: read` aparece aqui, mesmo sendo default.
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+
     # ── FUSO, NO NIVEL DO JOB (issue #169) ──────────────────────────────────────────────────────
     # O runner do GitHub roda em UTC. Este job abortou nas suas DUAS unicas execucoes (19 e
     # 20/08/2026), sempre no dry run do Stryker, e sempre com a mesma notícia:
@@ -138,6 +153,54 @@ jobs:
       - name: Teste de mutação (Stryker)
         run: pnpm mutation
 
+      # ── A TENDENCIA: baixar a medicao ANTERIOR ────────────────────────────────────────────────
+      # O `mutation.json` guarda mutantes, nao historico. Para dizer "caiu 1,4 desde ontem" e
+      # preciso o relatorio da corrida passada, e o unico lugar onde ele existe e o artefato dela.
+      #
+      # Procura a corrida COMPLETA mais recente que nao seja esta — deliberadamente sem filtrar por
+      # `--status success`: uma corrida reprovada pelo `thresholds.break` mediu, e o numero dela e
+      # justamente o que se quer comparar. Ignorar as reprovadas compararia hoje com a ultima noite
+      # BOA e reportaria a queda inteira de novo, toda noite, ate alguem consertar.
+      #
+      # `continue-on-error` e a parte importante: sem relatorio anterior o resumo ainda sai, so que
+      # sem delta. Tendencia indisponivel nao pode derrubar a medicao.
+      - name: Relatório da corrida anterior (para a tendência)
+        if: always()
+        continue-on-error: true
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for id in $(gh run list --workflow=mutation.yml --status=completed --limit=8 \
+                        --json databaseId --jq '.[].databaseId'); do
+            [ "$id" = "$GITHUB_RUN_ID" ] && continue
+            if gh run download "$id" -n mutation-report -D anterior 2>/dev/null; then
+              echo "RUN_ANTERIOR=$id" >> "$GITHUB_ENV"
+              echo "Comparando com a corrida $id."
+              exit 0
+            fi
+          done
+          echo "Nenhuma corrida anterior com relatório — o resumo sai sem delta."
+
+      # ── O RESUMO NA PAGINA DA CORRIDA ─────────────────────────────────────────────────────────
+      # `$GITHUB_STEP_SUMMARY` renderiza markdown na propria pagina do run. E o conserto do que
+      # tornava a noite verde SILENCIOSA: antes disto o score so existia dentro do log e de um
+      # artefato de 990 KB, entao ninguem via 83,52 virar 81,2 — a primeira noticia seria o build
+      # quebrando no dia em que cruzasse o `break`.
+      - name: Resumo do score na página da corrida
+        id: resumo
+        if: always()
+        working-directory: .
+        run: |
+          node scripts/resumo-mutacao.mjs \
+            apps/web/reports/mutation/mutation.json \
+            anterior/mutation.json >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${RUN_ANTERIOR:-}" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "_Comparado com a corrida [\`$RUN_ANTERIOR\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ANTERIOR})._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          cat "$GITHUB_STEP_SUMMARY"
+
       # `if: always()` — o relatório é o PRODUTO deste job, não um anexo de falha. É o oposto do
       # `playwright-report` do ci.yml (`if: failure()`), e de propósito: lá o artefato serve para
       # explicar um vermelho; aqui ele é a razão de o job existir. Numa corrida interrompida, o
@@ -150,3 +213,54 @@ jobs:
           # 30 dias, contra os 7 do playwright-report: este roda uma vez por dia, e comparar o
           # score de hoje com o de três semanas atrás é justamente o uso que justifica guardá-lo.
           retention-days: 30
+
+      # ── O AVISO — a unica parte que CHEGA ATE ALGUEM ──────────────────────────────────────────
+      # O resumo acima resolve "onde eu vejo o numero", nao "como eu fico sabendo". Corrida verde
+      # nao notifica ninguem: o GitHub so manda e-mail de `schedule` quando o job FALHA. Sem este
+      # passo, uma queda de 83,5 para 80,4 ao longo de semanas seria invisivel ate cruzar o
+      # `break`, e a primeira noticia seria a reprovacao — tarde demais para ser tendencia.
+      #
+      # Abrir/comentar uma issue e o unico canal de PUSH disponivel para um job que passou. A outra
+      # opcao seria reprovar o job na queda, e ela foi rejeitada: misturaria "a suite piorou um
+      # pouco" com "a suite esta abaixo do minimo", que sao decisoes diferentes e ja tem donos
+      # diferentes (este aviso e o `thresholds.break`).
+      #
+      # A condicao vem do script (`alerta`), que so diz `true` numa QUEDA de >= 1,0 ponto contra a
+      # corrida anterior — evento, nao estado. O porque de nao ser estado esta no cabecalho do
+      # `scripts/resumo-mutacao.mjs`.
+      #
+      # `continue-on-error`: falha ao abrir issue nao pode reprovar uma medicao que deu certo.
+      - name: Avisar quando o score cair
+        if: always() && steps.resumo.outputs.alerta == 'true'
+        continue-on-error: true
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SCORE: ${{ steps.resumo.outputs.score }}
+          DELTA: ${{ steps.resumo.outputs.delta }}
+        run: |
+          set -euo pipefail
+          CORRIDA="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          CORPO="O mutation score caiu **${DELTA} ponto(s)**, para **${SCORE}%**.
+
+          O resumo da corrida — incluindo **quais módulos pioraram** e se algum módulo novo entrou pelo escopo descoberto — está na página do run: ${CORRIDA}
+
+          Queda não é reprovação: o \`thresholds.break\` segue sendo o piso, e o job passou. Isto é o aviso de TENDÊNCIA, que existe porque noite verde não notifica ninguém.
+
+          Antes de procurar teste que piorou, descarte a causa mais comum: **módulo novo no escopo**. O \`stryker.config.mjs\` descobre todo \`.ts\` com teste irmão, então um módulo recém-testado entra sozinho e derruba o total sem que nenhum teste existente tenha regredido — o resumo do run diz se foi isso."
+
+          # A label serve de chave de deduplicacao: um aviso aberto recebe COMENTARIO, nao uma
+          # segunda issue. Sem isto, uma queda em tres noites seguidas viraria tres issues.
+          gh label create mutacao-tendencia --color FBCA04 \
+            --description "Aviso automático de queda no mutation score" 2>/dev/null || true
+
+          ABERTA=$(gh issue list --label mutacao-tendencia --state open \
+                     --json number --jq '.[0].number // empty')
+
+          if [ -n "$ABERTA" ]; then
+            gh issue comment "$ABERTA" --body "$CORPO"
+            echo "Comentado na issue #$ABERTA."
+          else
+            gh issue create --label mutacao-tendencia \
+              --title "Mutation score caiu ${DELTA} ponto(s), para ${SCORE}%"               --body "$CORPO"
+          fi

--- a/scripts/resumo-mutacao.mjs
+++ b/scripts/resumo-mutacao.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// O job de mutação PASSA A FALAR — noite verde deixa de ser silenciosa.
+//
+// ── O PROBLEMA ───────────────────────────────────────────────────────────────────────────────────
+// O `mutation.yml` só notifica quando FALHA: é assim que o GitHub Actions trata `schedule`. Com o
+// `thresholds.break: 80` ligado (PR #189), isso significa que o score só vira notícia no dia em que
+// cruza 80 — e a queda que levou até lá aconteceu em silêncio, uma noite de cada vez. O número
+// existia apenas dentro do log e do artefato: para ver os 83,52 da primeira medição era preciso
+// baixar 990 KB de JSON.
+//
+// Uma tendência que só fica visível depois de virar falha não é tendência, é surpresa. Este script
+// põe o número na PÁGINA da corrida e compara com a noite anterior.
+//
+// ── COMO RODAR ───────────────────────────────────────────────────────────────────────────────────
+//   node scripts/resumo-mutacao.mjs <atual.json> [anterior.json]
+//
+// Escreve markdown no stdout (o workflow redireciona para `$GITHUB_STEP_SUMMARY`) e, quando
+// `GITHUB_OUTPUT` existe, publica `score`, `delta` e `alerta` para os passos seguintes.
+//
+// ── A REGRA DE ALERTA: EVENTO, NÃO ESTADO ────────────────────────────────────────────────────────
+// Alerta só quando o score CAI >= 1,0 ponto contra a corrida anterior bem-sucedida.
+//
+// Foi considerado, e rejeitado, alertar por ESTADO ("margem até o break menor que 1 ponto").
+// Estado repete: uma vez que o score se acomode em 80,4, TODA noite dispararia o mesmo aviso — e
+// aviso que chega toda noite é aviso que se aprende a ignorar, o mesmo raciocínio que tirou a
+// mutação das PRs, escrito no cabeçalho do `mutation.yml`. Queda é EVENTO: acontece uma vez, e
+// depois dela o novo patamar vira a régua da comparação seguinte. Não repete sozinha.
+//
+// O caso "score baixo demais" já tem dono e não precisa de segundo mecanismo: o `thresholds.break`
+// reprova o job, e job reprovado o GitHub notifica sozinho.
+//
+// ── FÓRMULA DO SCORE ─────────────────────────────────────────────────────────────────────────────
+// (Killed + Timeout) / (Killed + Timeout + Survived + NoCoverage). `Ignored` fica FORA do
+// denominador. Conferida contra a corrida 32478357936, que o Stryker reportou como 83,52:
+// (1479 + 1) / 1772 = 83,52. Não é reimplementação por gosto — o `mutation.json` guarda mutantes,
+// não o score, então somar é o único caminho a partir do artefato.
+
+import { readFileSync, appendFileSync } from "node:fs";
+
+const LIMIAR_DE_QUEDA = 1.0;
+
+// Os mutadores que trocam COMPORTAMENTO, separados dos que trocam texto. A triagem da issue #191
+// mostrou por que a distinção importa: 138 dos 269 sobreviventes da primeira corrida eram
+// `StringLiteral`, e ordenar por contagem bruta apontava `app/navigation.ts` (51 sobreviventes,
+// ZERO operador — é uma tabela declarativa, não exporta função nenhuma) como a pior dívida da
+// árvore, quando o alvo de maior valor era uma única `ConditionalExpression` em `projecao.ts`.
+// Um resumo que só mostrasse o total repetiria esse engano toda noite.
+const OPERADORES = new Set([
+  "ArithmeticOperator",
+  "ConditionalExpression",
+  "LogicalOperator",
+  "EqualityOperator",
+  "UpdateOperator",
+  "MethodExpression",
+  "OptionalChaining",
+  "Regex",
+]);
+
+/** Lê um relatório; devolve `null` se não existir ou não for JSON válido. */
+export function lerRelatorio(caminho) {
+  try {
+    return JSON.parse(readFileSync(caminho, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function score(c) {
+  const den = c.Killed + c.Timeout + c.Survived + c.NoCoverage;
+  return den === 0 ? null : ((c.Killed + c.Timeout) * 100) / den;
+}
+
+export function medir(relatorio) {
+  const porModulo = new Map();
+  const total = { Killed: 0, Timeout: 0, Survived: 0, NoCoverage: 0, Ignored: 0 };
+
+  for (const [caminho, arquivo] of Object.entries(relatorio.files ?? {})) {
+    const m = { Killed: 0, Timeout: 0, Survived: 0, NoCoverage: 0, texto: 0, operadores: 0 };
+    for (const mutante of arquivo.mutants ?? []) {
+      if (mutante.status in total) total[mutante.status] += 1;
+      if (mutante.status in m) m[mutante.status] += 1;
+      if (mutante.status !== "Survived") continue;
+      if (mutante.mutatorName === "StringLiteral") m.texto += 1;
+      else if (OPERADORES.has(mutante.mutatorName)) m.operadores += 1;
+    }
+    porModulo.set(caminho, { ...m, score: score(m) });
+  }
+
+  return { score: score(total), total, porModulo };
+}
+
+const n2 = (v) => (v === null || v === undefined ? "—" : v.toFixed(2));
+
+export function montarResumo(atual, anterior, limiarBreak) {
+  const linhas = [];
+  const delta = anterior && anterior.score !== null ? atual.score - anterior.score : null;
+  const seta = delta === null ? "" : delta > 0.005 ? " ⬆️" : delta < -0.005 ? " ⬇️" : " ▪️";
+
+  linhas.push(`## Mutation score: **${n2(atual.score)}%**${seta}`, "");
+
+  if (delta === null) {
+    linhas.push("_Sem corrida anterior para comparar — esta vira a régua da próxima._");
+  } else {
+    const sinal = delta >= 0 ? "+" : "";
+    linhas.push(
+      `Corrida anterior: ${n2(anterior.score)}% · **${sinal}${delta.toFixed(2)} ponto(s)**`,
+    );
+  }
+
+  if (typeof limiarBreak === "number") {
+    linhas.push(
+      "",
+      `Limiar de reprovação: **${limiarBreak}** · margem de **${(atual.score - limiarBreak).toFixed(2)} ponto(s)**.`,
+    );
+  }
+
+  const t = atual.total;
+  linhas.push(
+    "",
+    "| Mortos | Timeout | Sobreviventes | Sem cobertura | Ignorados |",
+    "|---:|---:|---:|---:|---:|",
+    `| ${t.Killed} | ${t.Timeout} | ${t.Survived} | ${t.NoCoverage} | ${t.Ignored} |`,
+  );
+
+  if (anterior) {
+    // Quem PIOROU — a pergunta que o número global não responde. Sem isto, "caiu 1,4" manda
+    // alguém baixar dois artefatos e fazer o diff à mão, que é exatamente o custo que este
+    // script existe para tirar.
+    const piores = [];
+    for (const [caminho, a] of atual.porModulo) {
+      const b = anterior.porModulo.get(caminho);
+      if (!b || a.score === null || b.score === null) continue;
+      if (a.score < b.score - 0.005) piores.push({ caminho, de: b.score, para: a.score });
+    }
+    piores.sort((x, y) => x.para - x.de - (y.para - y.de));
+    if (piores.length) {
+      linhas.push(
+        "",
+        "### Módulos que pioraram",
+        "",
+        "| Módulo | Antes | Agora |",
+        "|---|---:|---:|",
+      );
+      for (const p of piores) {
+        linhas.push(`| \`${p.caminho}\` | ${n2(p.de)} | **${n2(p.para)}** |`);
+      }
+    }
+
+    const novos = [...atual.porModulo.keys()].filter((c) => !anterior.porModulo.has(c));
+    if (novos.length) {
+      // O escopo é DESCOBERTO (`stryker.config.mjs`): todo `.ts` com teste irmão entra sozinho.
+      // É o suspeito nº 1 de uma queda que não veio de teste piorando — e a §5.3 do CLAUDE.md
+      // avisa que a tabela de baseline não acompanha.
+      linhas.push(
+        "",
+        `> ⚠️ **${novos.length} módulo(s) novo(s) no escopo** desde a corrida anterior: ` +
+          novos.map((c) => `\`${c}\``).join(", ") +
+          ". Módulo novo com teste mediano derruba o total sem que nenhum teste existente tenha piorado.",
+      );
+    }
+  }
+
+  // Ordenado por OPERADORES, não por total de sobreviventes: é a ordem de triagem da issue #191.
+  const ordenado = [...atual.porModulo.entries()]
+    .filter(([, m]) => m.Survived > 0)
+    .sort((a, b) => b[1].operadores - a[1].operadores || b[1].Survived - a[1].Survived);
+
+  if (ordenado.length) {
+    linhas.push(
+      "",
+      "<details><summary>Sobreviventes por módulo (ordenado por operadores — ver #191)</summary>",
+      "",
+      "| Módulo | Score | Sobrev. | `StringLiteral` | Operadores |",
+      "|---|---:|---:|---:|---:|",
+    );
+    for (const [caminho, m] of ordenado) {
+      linhas.push(
+        `| \`${caminho}\` | ${n2(m.score)} | ${m.Survived} | ${m.texto} | ${m.operadores} |`,
+      );
+    }
+    linhas.push("", "</details>");
+  }
+
+  return { texto: linhas.join("\n"), delta };
+}
+
+export function principal(argv) {
+  const relAtual = lerRelatorio(argv[0]);
+  if (!relAtual) {
+    // Corrida abortada (o dry run do Stryker morrendo, por exemplo) não produz relatório. Isso
+    // NÃO é erro deste script: o job já falhou por conta própria e o GitHub já notificou.
+    process.stdout.write(
+      "## Mutation score: sem relatório\n\nA corrida não produziu `mutation.json` — abortou antes de medir. O vermelho do job é a notícia; o motivo está no log da etapa do Stryker.\n",
+    );
+    return { alerta: false, score: null, delta: null };
+  }
+
+  const atual = medir(relAtual);
+  const relAnterior = argv[1] ? lerRelatorio(argv[1]) : null;
+  const anterior = relAnterior ? medir(relAnterior) : null;
+
+  const { texto, delta } = montarResumo(atual, anterior, relAtual.thresholds?.break);
+  process.stdout.write(texto + "\n");
+
+  const alerta = delta !== null && delta <= -LIMIAR_DE_QUEDA;
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `score=${n2(atual.score)}\ndelta=${delta === null ? "" : delta.toFixed(2)}\nalerta=${alerta}\n`,
+    );
+  }
+
+  return { alerta, score: atual.score, delta };
+}
+
+// `import.meta.main` existe do Node 24 em diante — o mesmo Node do job. O fallback cobre quem
+// rodar numa versão anterior na mão.
+if (import.meta.main ?? process.argv[1]?.endsWith("resumo-mutacao.mjs")) {
+  principal(process.argv.slice(2));
+}


### PR DESCRIPTION
## O problema

O `mutation.yml` só notifica quando **falha** — é assim que o GitHub trata `schedule`. Com o `thresholds.break: 80` ligado (#189), o score só vira notícia no dia em que cruza 80, e a queda que levou até lá acontece em silêncio, uma noite de cada vez. O número existia apenas dentro do log e de um artefato de 990 KB.

Tendência que só fica visível depois de virar falha não é tendência, é surpresa.

## Três peças

**1. `scripts/resumo-mutacao.mjs`** escreve o score na página da corrida (`$GITHUB_STEP_SUMMARY`): número, delta, margem até o `break`, contagem por status e tabela por módulo.

A tabela sai ordenada por **operadores**, não por total de sobreviventes — a ordem defendida na #191. Ordenar por contagem bruta aponta `app/navigation.ts` (51 sobreviventes, **zero** operador — é tabela declarativa, não exporta função nenhuma) como pior dívida da árvore, quando o alvo de maior valor é uma única `ConditionalExpression` em `projecao.ts`. Um resumo que mostrasse só o total repetiria esse engano toda noite.

**2. A tendência** baixa o `mutation-report` da corrida anterior e diz **quais módulos pioraram**, mais um aviso quando módulo novo entra pelo escopo descoberto — o suspeito nº 1 de uma queda que não veio de teste piorando.

Deliberadamente **sem** `--status success` na busca: uma corrida reprovada pelo `break` mediu, e o número dela é o que se quer comparar. Filtrar só as boas compararia hoje com a última noite BOA e reportaria a queda inteira de novo, toda noite, até alguém consertar.

**3. O aviso** abre (ou comenta) uma issue quando o score cai. É o único canal de *push* que existe para um job que passou.

## A regra de alerta: evento, não estado

Dispara só em **queda de ≥ 1,0 ponto** contra a corrida anterior.

Alertar por estado ("margem menor que 1 ponto até o `break`") foi considerado e rejeitado: **estado repete.** Uma vez que o score se acomode em 80,4, toda noite dispararia o mesmo aviso — e aviso que chega toda noite é aviso que se aprende a ignorar, exatamente o raciocínio que tirou a mutação das PRs, escrito no cabeçalho deste workflow. Queda é evento: acontece uma vez, e depois dela o novo patamar vira a régua da comparação seguinte.

"Score baixo demais" já tem dono e não precisa de segundo mecanismo: o `break` reprova, e job reprovado o GitHub notifica sozinho. Reprovar também na queda misturaria "a suíte piorou um pouco" com "a suíte está abaixo do mínimo" — decisões diferentes, donos diferentes.

## Permissões

O default do repo dá só `contents/metadata/packages: read`. O bloco `permissions:` no nível do job acrescenta `actions: read` (baixar o artefato anterior) e `issues: write` (o aviso). `contents: read` está listado porque, uma vez que `permissions:` existe, o que não aparece vira `none`.

## Verificação

**Rodado de verdade nesta branch** antes do merge, que é o uso do `workflow_dispatch` documentado no próprio arquivo — [corrida `32508528834`](https://github.com/educacaocriativa/escritorio-1-pessoa/actions/runs/32508528834), sucesso. Os três passos novos executaram; o aviso foi corretamente **pulado** (sem queda). O resumo publicado:

```
## Mutation score: **83.52%** ▪️
Corrida anterior: 83.52% · **+0.00 ponto(s)**
Limiar de reprovação: **80** · margem de **3.52 ponto(s)**.
```

E o log da tendência: `Comparando com a corrida 32478357936.`

**Fórmula do score** conferida contra a corrida que o Stryker reportou como 83,52: `(1479 + 1) / 1772`. O `mutation.json` guarda mutantes, não score — somar é o único caminho a partir do artefato.

**Script contra o artefato real:** reproduz 83,52, os 1479/1/269/23/7 por status e a contagem operador-vs-string dos 22 módulos com sobreviventes.

**Bordas:** anterior sintético com −1,83 → `alerta=true` + tabela de piores + detecção de módulo novo; −0,85 → `false`; 0,00 → `false`; relatório ausente → mensagem em vez de exceção, exit 0.

**Passo de aviso** executado com um `gh` postiço: cria quando não há issue aberta, comenta na existente quando há. Consultas conferidas contra o repo real (`--status=completed` aceito, `.[0].number // empty` devolve vazio limpo).

## O que NÃO está provado

A **criação da issue em produção**. A corrida de teste não teve queda, então esse caminho tem só o teste com `gh` postiço. A primeira queda real de ≥ 1 ponto é que vai exercitá-lo — e os dois passos são `continue-on-error`, então se ele falhar não derruba a medição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)