### PR TITLE
fix(infra): ENTRYPOINT sem CMD derrubava o Caddy em loop com exit code 0

### DIFF
--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -1,0 +1,82 @@
+# Imagem do Caddy — o gate que faltava, e o motivo dele existir.
+#
+# Em 2026-08-21 a produção ficou fora do ar com o container do Caddy em `Restarting (0)`: o
+# Dockerfile declarava ENTRYPOINT e não declarava CMD, e declarar ENTRYPOINT **zera** o CMD
+# herdado da imagem base. O entrypoint chegava no `exec "$@"` sem argumento, terminava com
+# SUCESSO, e o `restart: always` reiniciava para sempre.
+#
+# Cinco cenários de configuração tinham sido validados antes do merge — e nenhum pegou, porque
+# **todos passavam um comando explícito** (`sh -c ...`) e portanto forneciam o `"$@"` que faltava
+# no caminho real. O compose roda a imagem SEM argumentos. Testar que a config adapta não é
+# testar que o container SOBE.
+#
+# Roda só quando a imagem ou o Caddyfile mudam: `xcaddy` recompila o Caddy e custa ~2 min, que
+# não faz sentido pagar em PR de frontend. Fora deste recorte, o gate de texto em
+# `apps/api/tests/test_caddyfile_blocos_opcionais.py` continua valendo em toda mudança.
+name: Imagem do Caddy
+
+on:
+  pull_request:
+    paths:
+      - "infra/caddy/**"
+      - "infra/Caddyfile"
+      - ".github/workflows/caddy-image.yml"
+  push:
+    branches: [main]
+    paths:
+      - "infra/caddy/**"
+      - "infra/Caddyfile"
+      - ".github/workflows/caddy-image.yml"
+
+jobs:
+  arranque:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build da imagem (com o plugin de DNS)
+        run: docker build -t e1p-caddy:ci infra/caddy
+
+      # A asserção CENTRAL: sem argumento nenhum, do jeito que o compose roda.
+      - name: O container SOBE sem argumentos (o defeito de 2026-08-21)
+        run: |
+          set -uo pipefail
+          cid=$(docker run -d -e DOMAIN=app.exemplo.com e1p-caddy:ci)
+          sleep 8
+          estado=$(docker inspect "$cid" --format '{{.State.Status}}')
+          codigo=$(docker inspect "$cid" --format '{{.State.ExitCode}}')
+          echo "--- log do container ---"
+          docker logs "$cid" 2>&1 | tail -15
+          docker rm -f "$cid" >/dev/null
+          echo "estado=$estado exit=$codigo"
+          if [ "$estado" != "running" ]; then
+            echo "::error::O container do Caddy NAO ficou de pe sem argumentos (estado=$estado, exit=$codigo). Se o exit for 0, o Dockerfile provavelmente perdeu o CMD: declarar ENTRYPOINT zera o CMD da imagem base, o entrypoint recebe zero argumentos e o container termina 'com sucesso' em loop."
+            exit 1
+          fi
+
+      # Controle positivo da guarda do entrypoint: sem comando, ele tem de FALHAR, nunca sair com 0.
+      - name: Entrypoint sem comando falha alto
+        run: |
+          if docker run --rm --entrypoint /usr/local/bin/entrypoint.sh -e DOMAIN=x e1p-caddy:ci; then
+            echo "::error::O entrypoint saiu com 0 sem receber comando. Sucesso silencioso aqui vira loop de restart que nao se anuncia em lugar nenhum."
+            exit 1
+          fi
+          echo "ok: o entrypoint recusou ficar sem comando"
+
+      # A config continua adaptando nos dois modos — o que o PR #170 entregou.
+      - name: A config adapta com e sem o bloco wildcard
+        run: |
+          set -euo pipefail
+          echo "--- sem token: wildcard fora, dominio unico de pe ---"
+          docker run --rm -i -e DOMAIN=app.exemplo.com e1p-caddy:ci \
+            sh -c 'cat > /etc/caddy/Caddyfile; caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | tail -1' < infra/Caddyfile
+          # Token DESCARTAVEL gerado na hora. Placeholder literal aqui e indistinguivel de um
+          # segredo de verdade -- o `secret-scan` acusou, e estava certo. `openssl rand -hex 20`
+          # da 40 chars [a-f0-9], que e o formato que o plugin da Cloudflare valida, e nao usa
+          # pipe: `tr ... | head -c 40` mata o `tr` com SIGPIPE (141) e o `pipefail` deste passo
+          # derrubaria a corrida.
+          token_falso=$(openssl rand -hex 20)
+          echo "--- com token + ROOT_DOMAIN: wildcard entra ---"
+          docker run --rm -i -e DOMAIN=app.exemplo.com -e ROOT_DOMAIN=exemplo.com \
+            -e CLOUDFLARE_API_TOKEN="$token_falso" e1p-caddy:ci \
+            sh -c 'cat > /etc/caddy/Caddyfile; test -f /etc/caddy/conf.d/wildcard.caddy || { echo "wildcard NAO entrou"; exit 1; }; caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | tail -1' < infra/Caddyfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3231,10 +3231,42 @@ segue normal)"* — uma degradação graciosa que **não existia**. Derrubou a p
     de `apps/api` não pode viver só no `pytest` da imagem — ou ele se pula, ou ele quebra a
     coleta.**
 
-- **Dívida:** a validação de verdade (build da imagem + `caddy validate` nos cinco cenários) é
-  **manual, com Docker, e não roda no CI** — o que roda é o gate de TEXTO. Um job que buildasse a
-  imagem por PR pagaria ~2 min de `xcaddy` em toda mudança do repo; a troca não foi feita, e fica
-  registrada em vez de escondida.
+~~**Dívida:** a validação de verdade não roda no CI.~~ **FECHADA no dia seguinte, e o preço foi a
+produção fora do ar** — ver logo abaixo. Hoje existe `.github/workflows/caddy-image.yml`, com
+filtro de caminho: buildar a imagem custa ~2 min de `xcaddy` e só se paga quando `infra/caddy/**`
+ou `infra/Caddyfile` mudam.
+
+#### O container que sobe, sai com 0, e reinicia para sempre (2026-08-21)
+
+**Declarar `ENTRYPOINT` num Dockerfile ZERA o `CMD` herdado da imagem base.** Medido com
+`docker inspect`: `caddy:2-alpine` tem `CMD=["caddy","run",…]`, e a imagem do PR #170 ficou com
+**`CMD=null`**. O entrypoint rodava, imprimia as duas linhas de diagnóstico, chegava no
+`exec "$@"` **sem argumento nenhum**, e o script terminava. Exit **0**. O `restart: always`
+reiniciava, e o ciclo não aparecia como falha em lugar nenhum — `docker ps` dizia
+`Restarting (0)` e a porta 443 recusava conexão.
+
+- ⚠️ **Os cinco cenários validados no #170 NÃO pegavam isto, e o motivo é a lição.** Todos eles
+  rodavam a imagem passando um comando explícito (`sh -c 'cat > …; caddy validate …'`) — e o
+  comando explícito **fornecia o `"$@"` que faltava**. O compose roda a imagem **sem argumentos**,
+  e esse era o único caminho nunca exercitado. **Testar que a config adapta não é testar que o
+  container SOBE**: é a família do `toContain("flex-wrap")` do §5.1, agora em Docker.
+- ⚠️ **E o comentário do Dockerfile afirmava o contrário, sem código atrás** (*"esse CMD chega ao
+  script como `$@`"*) — a classe de defeito nº 1 do Epic 8, o documento que afirma sobre a camada
+  de baixo e desliga quem viria conferir. Hoje o Dockerfile declara `CMD` explicitamente, com o
+  aviso ao lado.
+- [x] **Duas camadas, porque uma só volta a falhar em silêncio:** o `CMD` explícito **e** uma guarda
+  no entrypoint que **recusa (exit 1)** quando `$#` é zero, dizendo o que fazer. Sair com 0 é o
+  pior desfecho possível aqui — transforma erro de build em loop que ninguém vê.
+- [x] **`caddy-image.yml` roda o container do jeito que o compose roda** (`docker run -d`, sem
+  argumento) e reprova se ele não ficar `running`; mais o controle positivo da guarda e os dois
+  modos de config. **Provado localmente antes de subir:** a imagem antiga sai com `exit=0`, a nova
+  fica `running`.
+- [x] **Gate de texto** no mesmo arquivo do #170: Dockerfile que declara `ENTRYPOINT` **precisa**
+  declarar `CMD`. Barato, roda em toda mudança, e morre sob mutação (tirar o `CMD` deixa vermelho).
+- **Restauração do incidente:** `command:` no `docker-compose.override.yml` da instância — a
+  imagem estava boa, faltava só o comando, então `up -d` **sem `--build`** devolveu o site em
+  segundos. ⚠️ **Esse `command:` precisa SAIR do override** depois deste PR chegar em produção;
+  enquanto estiver lá ele mascara uma eventual reincidência.
 - **Dívida:** o `docker-compose.override.yml` da AWS pode perder o bloco `caddy:` depois que isto
   for deployado — mas só **depois**, e conferindo que o wildcard segue desligado lá
   (`CLOUDFLARE_API_TOKEN` vazio de propósito). Enquanto o override existir, ele vence: monta o

--- a/apps/api/tests/test_caddyfile_blocos_opcionais.py
+++ b/apps/api/tests/test_caddyfile_blocos_opcionais.py
@@ -101,3 +101,46 @@ def test_o_bloco_opcional_existe_e_nao_esta_vazio(nome: str):
     `test_todo_bloco_opcional_e_ativado_pelo_entrypoint` verde por vacuidade."""
     conteudo = (OPCIONAIS / nome).read_text(encoding="utf-8")
     assert "{" in conteudo, f"{nome} não tem bloco de site nenhum"
+
+
+# --- ENTRYPOINT sem CMD: o container que sai com 0 e reinicia para sempre (2026-08-21) ---
+#
+# Declarar `ENTRYPOINT` num Dockerfile **ZERA** o CMD herdado da imagem base. Medido:
+# `caddy:2-alpine` tem CMD=["caddy","run",...] e a nossa imagem ficou com CMD=null. O entrypoint
+# entao chegava no `exec "$@"` sem argumento, terminava com SUCESSO, e o `restart: always`
+# reiniciava em loop — produção fora do ar com **exit code 0** em toda tentativa.
+#
+# Os cinco cenários validados no PR #170 não pegaram isto porque **todos passavam um comando
+# explícito** (`sh -c ...`) e portanto forneciam o `"$@"` que faltava no caminho real: o compose
+# roda a imagem SEM argumentos. Testar o mecanismo não é testar o efeito.
+
+DOCKERFILE_CADDY = (INFRA or pathlib.Path(".")) / "caddy" / "Dockerfile"
+
+
+def test_dockerfile_que_declara_entrypoint_declara_cmd_tambem():
+    linhas = [
+        linha.strip()
+        for linha in DOCKERFILE_CADDY.read_text(encoding="utf-8").splitlines()
+        if not linha.lstrip().startswith("#")
+    ]
+    tem_entrypoint = any(linha.startswith("ENTRYPOINT") for linha in linhas)
+    tem_cmd = any(linha.startswith("CMD") for linha in linhas)
+    assert not tem_entrypoint or tem_cmd, (
+        "o Dockerfile declara ENTRYPOINT e NÃO declara CMD. O ENTRYPOINT zera o CMD da imagem "
+        "base, então o entrypoint recebe zero argumentos, sai com 0 e o container reinicia em "
+        "loop servindo NADA — sem nunca aparecer como falha."
+    )
+
+
+def test_o_entrypoint_recusa_ficar_sem_comando():
+    """Segunda camada: se o CMD sumir de novo, o container FALHA em vez de sair com 0.
+
+    Sucesso silencioso é o que torna este defeito invisível — `docker ps` mostra "Restarting"
+    e o exit code diz 0, então nada no sinal aponta para o arranque.
+    """
+    script = (INFRA or pathlib.Path(".")) / "caddy" / "entrypoint.sh"
+    texto = script.read_text(encoding="utf-8")
+    assert '"$#" -eq 0' in texto and "exit 1" in texto, (
+        "o entrypoint precisa recusar (exit != 0) quando não recebe comando; sair com 0 "
+        "transforma um erro de build num loop de restart que não se anuncia."
+    )

--- a/infra/caddy/Dockerfile
+++ b/infra/caddy/Dockerfile
@@ -22,7 +22,17 @@ COPY optional/ /etc/caddy/optional/
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# A imagem oficial tem ENTRYPOINT null e o CMD completo (`caddy run --config ... --adapter
-# caddyfile`). Pondo o entrypoint aqui, esse CMD chega ao script como "$@" e e repassado com
-# `exec` — nada da imagem base precisa ser reescrito.
+# O entrypoint monta os blocos opcionais e repassa o comando com `exec "$@"`. O comando vem do
+# CMD declarado LOGO ABAIXO -- nao do CMD da imagem base, que o ENTRYPOINT zera (ver o aviso).
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# ⚠️ O CMD PRECISA estar aqui, e nao herdado. Declarar ENTRYPOINT num Dockerfile **ZERA** o CMD
+# da imagem base -- `docker inspect` mostrou `CMD=null` nesta imagem contra
+# `CMD=["caddy","run",...]` na `caddy:2-alpine`. Sem ele o entrypoint chega no `exec "$@"` sem
+# argumento nenhum, o script termina com sucesso, e o `restart: always` reinicia em loop: o
+# container "saudavel" que nunca serve nada. Derrubou a producao em 2026-08-21, com exit code 0.
+#
+# O comentario anterior aqui dizia que "o CMD da imagem oficial chega ao script como $@" -- era
+# FALSO, e nenhum dos cinco cenarios validados o pegava, porque todos passavam um comando
+# explicito (`sh -c ...`) e portanto forneciam o $@ que faltava no caminho real.
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/infra/caddy/entrypoint.sh
+++ b/infra/caddy/entrypoint.sh
@@ -38,6 +38,15 @@ else
 	echo "caddy/entrypoint: monitor DESLIGADO (MONITORING_ENABLED != true)"
 fi
 
-# O CMD da imagem oficial (`caddy run --config /etc/caddy/Caddyfile --adapter caddyfile`)
-# chega aqui como "$@" — repassar em vez de reescrever evita divergir da imagem base.
+# Sem comando nao ha o que executar, e SAIR COM 0 aqui e o pior desfecho possivel: o container
+# termina "com sucesso", o `restart: always` o reinicia, e o loop nao aparece como falha em lugar
+# nenhum -- foi assim que a producao ficou fora do ar em 2026-08-21 com exit code 0.
+# Isto acontece quando o Dockerfile declara ENTRYPOINT e NAO declara CMD (o ENTRYPOINT zera o CMD
+# herdado da imagem base). Falhar alto e o unico desfecho honesto.
+if [ "$#" -eq 0 ]; then
+	echo "caddy/entrypoint: ERRO - nenhum comando recebido. O Dockerfile precisa declarar CMD" >&2
+	echo "caddy/entrypoint: (declarar ENTRYPOINT zera o CMD da imagem base -- ele nao e herdado)" >&2
+	exit 1
+fi
+
 exec "$@"


### PR DESCRIPTION
## O incidente

Depois do deploy do #170, o Caddy entrou em `Restarting (0)` e a porta 443 passou a recusar conexão. **Produção fora do ar**, e o sinal era enganoso: exit code **0**, o container "terminando com sucesso".

```
$ docker inspect <imagem do #170>  →  ENTRYPOINT=["/usr/local/bin/entrypoint.sh"]  CMD=null
$ docker inspect caddy:2-alpine    →  ENTRYPOINT=null                              CMD=["caddy","run",…]
```

**Declarar `ENTRYPOINT` num Dockerfile ZERA o `CMD` herdado da imagem base.** O entrypoint rodava, imprimia as duas linhas de diagnóstico, chegava no `exec "$@"` **sem argumento nenhum** e o script terminava. `restart: always` reiniciava, para sempre.

## Por que os cinco cenários do #170 não pegaram — e é esta a lição

Todos eles rodavam a imagem assim:

```
docker run --rm -i … e1p-caddy sh -c 'cat > /etc/caddy/Caddyfile; caddy validate …'
                                 ^^^^^^^^ o comando explícito FORNECIA o "$@" que faltava
```

O compose roda a imagem **sem argumentos**, e esse era o único caminho nunca exercitado. **Testar que a config adapta não é testar que o container SOBE** — a família do `toContain("flex-wrap")` do §5.1, agora em Docker.

E o comentário do próprio Dockerfile afirmava o contrário (*"esse CMD chega ao script como `$@`"*), **sem código atrás**: a classe de defeito nº 1 do Epic 8, o documento que afirma sobre a camada de baixo e desliga quem viria conferir.

## O que muda

**Duas camadas, porque uma só volta a falhar em silêncio.**

- **`CMD` explícito** no `infra/caddy/Dockerfile`, com o aviso ao lado.
- **Guarda no entrypoint**: `$#` igual a zero → `exit 1` com a mensagem do que fazer. Sair com 0 aqui transforma erro de build em loop que não se anuncia em lugar nenhum.

**E o gate que faltava, agora rodando o container de verdade** — `.github/workflows/caddy-image.yml`:

| Passo | Afirma |
|---|---|
| `docker run -d` **sem argumentos** | o container fica `running` (é o defeito, direto) |
| entrypoint chamado sem comando | falha com exit ≠ 0 (controle positivo da guarda) |
| config sem token / com token | wildcard fora / dentro, `Valid configuration` nos dois |

Com **filtro de caminho**: os ~2 min de `xcaddy` só se pagam quando `infra/caddy/**` ou `infra/Caddyfile` mudam. Em PR de frontend, não roda.

**Gate de texto** no arquivo do #170: Dockerfile que declara `ENTRYPOINT` precisa declarar `CMD`. Barato, roda sempre, e **morre sob mutação** (removi o `CMD` → vermelho; restaurei por cópia → verde).

## Medido, não suposto

| Verificação | Resultado |
|---|---|
| Imagem do #170, sem argumentos | **`exit=0`**, nenhum servidor — o defeito reproduzido |
| Imagem corrigida, sem argumentos | **`running`** |
| Entrypoint sem comando | **`exit=1`** + mensagem apontando o `CMD` ausente |
| Config wildcard ON (token + `ROOT_DOMAIN`) | `wildcard.caddy` em `conf.d` + `Valid configuration` |
| `pytest` do gate · `ruff` | 7 passed · `All checks passed!` |

Os dois passos do workflow foram **ensaiados localmente** com Docker antes de subir.

## Ação operacional depois do merge

A restauração do incidente foi um `command:` no `docker-compose.override.yml` **da instância** — a imagem estava boa, faltava só o comando, então `up -d` sem `--build` devolveu o site em segundos.

⚠️ **Esse `command:` precisa SAIR do override** depois deste PR chegar em produção. Enquanto estiver lá, ele mascara uma eventual reincidência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
