### PR TITLE
fix(infra): a guarda de checkout limpo abortava 100% dos deploys na AWS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py --junitxml=infra-gates.xml
           rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=9; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 9 executados: 5 do Caddyfile + 4 da guarda do deploy.sh). Eles dependem de infra/, bash e git alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=11; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 11 executados: 7 do Caddyfile + 4 da guarda do deploy.sh). Eles dependem de infra/, bash e git alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS."); sys.exit(0 if ok else 1)'
 
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
       #
       # A guarda abaixo reprova o SKIP, mesma lógica do `rls_e2e` logo abaixo: um gate que se pula
       # sozinho fica verde sem proteger nada, e o silêncio é indistinguível de aprovação.
-      - name: Gate do Caddyfile (bloco opcional fora do arquivo base)
+      - name: Gates de infra/ (Caddyfile e a guarda do deploy.sh)
         run: |
           set -uo pipefail
           cd apps/api
-          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py --junitxml=caddy-gate.xml
+          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py --junitxml=infra-gates.xml
           rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("caddy-gate.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"caddy-gate: coletados={t} executados={ex} skipped={k}"); ok=ex>=1; ok or print("::error::O gate do Caddyfile foi PULADO (infra/ nao alcancavel a partir do teste). Ele existe para reprovar bloco que exige config externa no arquivo base; pulado, nao protege nada (issue #151)."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=9; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 9 executados: 5 do Caddyfile + 4 da guarda do deploy.sh). Eles dependem de infra/, bash e git alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS."); sys.exit(0 if ok else 1)'
 
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem
@@ -108,7 +108,7 @@ jobs:
           # rc: 0=passaram · 1=algum FALHOU · 5=nenhum rodou/coletado · outros=erro de coleta/uso.
           # Falha real (rc != 0 e != 5) derruba já aqui; rc=5 e rc=0 seguem p/ a guarda de execução.
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("rls-results.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"rls_e2e: coletados={t} executados={ex} skipped={k}"); ok=ex>=1; ok or print("::error::Nenhum teste rls_e2e executou (todos SKIPPED ou zero coletados). RLS real nao foi exercido — falhando o CI em vez de passar em silencio (Story 7.1)."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("rls-results.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"rls_e2e: coletados={t} executados={ex} skipped={k}"); ok=ex>=9; ok or print("::error::Nenhum teste rls_e2e executou (todos SKIPPED ou zero coletados). RLS real nao foi exercido — falhando o CI em vez de passar em silencio (Story 7.1)."); sys.exit(0 if ok else 1)'
 
   # Story 6.2 / AC1: secret scan com gitleaks (OSS, MIT — custo zero, Regra de Ouro nº 4).
   # Usamos o CLI gitleaks via container pinado por DIGEST (supply-chain), NÃO a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3103,10 +3103,54 @@ de existir quando ninguém escolhe.
 > config do webhook da Evolution em memória (§WhatsApp): **estado em memória divergindo do estado
 > em disco**, três vezes no mesmo repositório.
 
+#### A guarda de "checkout limpo" abortava 100% dos deploys na AWS (2026-08-21)
+
+**`git status --porcelain` lista arquivo NÃO RASTREADO como `?? caminho`**, e a instância da AWS
+carrega três de propósito — `DEPLOY-AWS.md`, `docker-compose.override.yml`, `Caddyfile.single` —
+justamente para o `git pull` nunca conflitar. A guarda do passo 2 era
+`[[ -z "$(git status --porcelain)" ]] || morre`, então **um `?? DEPLOY-AWS.md` sozinho já
+derrubava**: o script morria antes de fazer qualquer coisa, em toda execução, naquele host.
+
+- ⚠️ **A ironia é o que ensina: o MESMO script conhecia os três arquivos.** O comentário do passo
+  1 os cita **por nome** para explicar por que a lista de compose vem do label em vez de ser
+  cravada. A guarda do passo 2, doze linhas abaixo, não recebeu a mesma informação. **Saber de um
+  fato num ponto do arquivo não o propaga para o resto dele** — e nada no #167 protestou, porque
+  o script nunca tinha sido rodado no host que ele existe para servir.
+- [x] **`--untracked-files=no`, e isso NÃO é afrouxar.** O risco que a guarda existe para pegar
+  continua pego: arquivo **versionado** modificado ou em stage — o caso *"editei em produção para
+  testar e esqueci"* —, que faria o `git pull --ff-only` do passo seguinte falhar no meio do
+  deploy. O que ela parou de recusar é o desvio que a máquina carrega **por desenho**.
+- [x] **O teste EXTRAI a linha do `deploy.sh` e a EXECUTA** num repo git descartável
+  (`test_deploy_guarda_checkout_limpo.py`) — não é uma cópia da linha escrita no teste, que
+  passaria a concordar consigo mesma no dia em que alguém editasse o script. **Provado por
+  mutação:** com a guarda de volta ao `--porcelain` puro, morre exatamente o caso do não
+  rastreado e os três controles seguem verdes.
+  - Os controles positivos são **três**, e cada um mata uma guarda degenerada diferente:
+    versionado modificado **aborta**, mudança em **stage** aborta (o `--untracked-files=no` não
+    pode cegar a guarda para o índice), e checkout limpo **passa** — sem este último, uma guarda
+    que recusasse tudo passaria nos dois primeiros.
+- ⚠️ **`bash` nesta máquina de dev é o do WSL, e ele traz um git PRÓPRIO** (`PWD=/mnt/c/...`).
+  Com `core.autocrlf` diferente do git do Windows que cria o repo de teste, os dois discordam
+  sobre um arquivo escrito com LF: um vê limpo, o outro vê ` M`. O repo de teste nascia **sujo** e
+  os dois casos de "aceita" falhavam por um motivo que não tinha nada a ver com a guarda — 20
+  minutos de investigação até o `PWD` no log denunciar. O fixture fixa `core.autocrlf=false` **no
+  repo** (não por `-c`), que é o que faz os dois gits lerem a mesma coisa.
+- **O gate roda no job `cross-tenant-rls`, junto com o do Caddyfile**, no mesmo passo e sob a
+  mesma guarda anti-vacuidade — agora `executados >= 9` (5 + 4) em vez de `>= 1`, que aceitaria
+  **um dos dois** pulado em silêncio. Os dois dependem de `infra/` alcançável e se auto-pulam
+  dentro da imagem da API; um gate que se pula sozinho fica verde sem proteger nada.
+
+> **A regra que fica:** um script de operação só está verificado depois de rodar **no host que
+> ele existe para servir**. `--dry-run` na máquina de dev prova que ele RECUSA o ambiente errado
+> (o que é uma garantia real, e ela funcionou); não prova que ele aceita o certo.
+
 - **Dívida:** nada no repo REPROVA um deploy que ignore o override — a garantia é o script, e quem
-  rodar compose à mão continua exposto. O conserto de verdade é a **issue #151**: enquanto o
-  `infra/Caddyfile` tiver o bloco wildcard incondicional, aquela instância depende de um arquivo
-  local para subir.
+  rodar compose à mão continua exposto. ⚠️ **Mas a issue #151 está FECHADA** (PRs #170 e #193, em
+  produção desde 21/08): o `infra/Caddyfile` não tem mais o bloco wildcard incondicional, então
+  esquecer o override deixou de derrubar o site. O override segue valendo pelo `Caddyfile.single`.
+- **Dívida:** o `deploy.sh` **nunca completou uma execução de verdade** — o `--dry-run` da AWS
+  parava na guarda, e o primeiro caminho feliz ainda não aconteceu. Os passos 3 em diante (gate de
+  CI, backup, `up -d`, prova do bundle) seguem exercitados só por leitura.
 - **Dívida:** o `CLOUDFLARE_API_TOKEN` segue vazio na AWS. Correto hoje (sem wildcard, sem DNS-01);
   vira problema no dia em que subdomínio por tenant entrar em uso.
 

--- a/apps/api/tests/test_deploy_guarda_checkout_limpo.py
+++ b/apps/api/tests/test_deploy_guarda_checkout_limpo.py
@@ -1,0 +1,119 @@
+"""A guarda de "checkout limpo" do deploy.sh recusa o que deve e ACEITA o que a máquina carrega.
+
+⚠️ Este teste EXECUTA a linha que está no `deploy.sh`, extraída dele em tempo de teste — não uma
+cópia dela escrita aqui. Uma cópia passaria a concordar consigo mesma no dia em que alguém
+editasse o script, que é exatamente a família de teste que este repositório documenta como
+"passa e não prova nada" (§5.1). Se a linha mudar, é a linha nova que roda.
+
+O defeito que ele fecha: `git status --porcelain` lista arquivo NÃO RASTREADO como `?? caminho`,
+e a instância da AWS carrega três de propósito (`DEPLOY-AWS.md`, `docker-compose.override.yml`,
+`Caddyfile.single`) para o `git pull` nunca conflitar. A guarda original abortava em 100% das
+execuções naquele host — medido no primeiro `--dry-run` real, depois do merge do #167.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+def _acha_infra() -> pathlib.Path | None:
+    """Sobe procurando o `infra/` — o mesmo motivo do gate do Caddyfile.
+
+    A suíte também roda DENTRO da imagem da API, onde só `apps/api` foi copiado. Resolver a raiz
+    por índice fixo (`parents[3]`) estoura `IndexError` na COLETA e derruba o job inteiro por um
+    teste que nem era sobre a API.
+    """
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "infra"
+        if (candidato / "scripts" / "deploy.sh").is_file():
+            return candidato
+    return None
+
+
+INFRA = _acha_infra()
+
+pytestmark = pytest.mark.skipif(
+    INFRA is None or shutil.which("bash") is None or shutil.which("git") is None,
+    reason=(
+        "precisa de infra/, bash e git — o job cross-tenant-rls tem os três, "
+        "e lá o SKIP é reprovado pela guarda anti-vacuidade"
+    ),
+)
+
+
+def _linha_da_guarda() -> str:
+    """A linha do `deploy.sh` que decide se o checkout está limpo."""
+    assert INFRA is not None
+    fonte = (INFRA / "scripts" / "deploy.sh").read_text(encoding="utf-8")
+    linhas = [
+        linha.strip()
+        for linha in fonte.splitlines()
+        if "git status --porcelain" in linha and not linha.lstrip().startswith("#")
+    ]
+    assert len(linhas) == 1, f"esperava UMA linha de guarda, achei {len(linhas)}: {linhas}"
+    return linhas[0]
+
+
+def _repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Um repositório com um commit e um arquivo versionado."""
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-q", ".")
+    git("config", "user.email", "teste@e1p")
+    git("config", "user.name", "teste")
+    # ⚠️ NÃO é supérfluo. `bash` nesta máquina de dev é o do WSL, que traz um git PRÓPRIO com
+    # `core.autocrlf` diferente do git do Windows que cria o repo aqui — e os dois discordam
+    # sobre um arquivo escrito com LF: o git do Windows vê limpo, o do WSL vê ` M`. O repo de
+    # teste nasceria SUJO e os dois casos de "aceita" falhariam por um motivo que não tem nada a
+    # ver com a guarda. Fixar no repo (e não por `-c`) é o que faz os dois lerem a mesma coisa.
+    git("config", "core.autocrlf", "false")
+    (tmp_path / "versionado.txt").write_text("original\n", encoding="utf-8")
+    git("add", "versionado.txt")
+    git("commit", "-q", "-m", "base")
+    return tmp_path
+
+
+def _guarda_aceita(repo: pathlib.Path) -> bool:
+    """Roda a guarda REAL nesse repo. True = deploy seguiria; False = abortaria."""
+    script = f'morre() {{ echo "ABORTADO: $*" >&2; exit 1; }}\nRAIZ="."\n{_linha_da_guarda()}\n'
+    r = subprocess.run(["bash", "-c", script], cwd=repo, capture_output=True, text=True)
+    return r.returncode == 0
+
+
+def test_arquivo_nao_rastreado_NAO_impede_o_deploy(tmp_path):
+    """O caso que abortava a AWS em toda execução — um `?? DEPLOY-AWS.md` sozinho bastava."""
+    repo = _repo(tmp_path)
+    (repo / "DEPLOY-AWS.md").write_text("runbook local, nao versionado\n", encoding="utf-8")
+    assert _guarda_aceita(repo), (
+        "a guarda recusou um checkout cujo único desvio é arquivo NÃO RASTREADO. A instância da "
+        "AWS carrega três de propósito (DEPLOY-AWS.md, docker-compose.override.yml, "
+        "Caddyfile.single) para o `git pull` nunca conflitar: assim o deploy.sh não roda ali."
+    )
+
+
+def test_arquivo_VERSIONADO_modificado_ABORTA(tmp_path):
+    """Controle positivo — sem ele, a guarda poderia aceitar tudo e o teste acima passaria igual."""
+    repo = _repo(tmp_path)
+    (repo / "versionado.txt").write_text("editado direto no servidor\n", encoding="utf-8")
+    assert not _guarda_aceita(repo), (
+        "a guarda aceitou um arquivo versionado modificado. É o caso 'editei em produção para "
+        "testar e esqueci': o `git pull --ff-only` do passo seguinte falharia no meio do deploy."
+    )
+
+
+def test_mudanca_em_STAGE_tambem_ABORTA(tmp_path):
+    """`--untracked-files=no` não pode cegar a guarda para o que já foi adicionado ao índice."""
+    repo = _repo(tmp_path)
+    (repo / "versionado.txt").write_text("editado e adicionado\n", encoding="utf-8")
+    subprocess.run(["git", "add", "versionado.txt"], cwd=repo, check=True, capture_output=True)
+    assert not _guarda_aceita(repo), "mudança em stage passou pela guarda"
+
+
+def test_checkout_limpo_passa(tmp_path):
+    """Sem este, os dois 'ABORTA' acima passariam com uma guarda que recusa tudo."""
+    assert _guarda_aceita(_repo(tmp_path))

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -105,7 +105,17 @@ bundle_servido() {
 }
 
 # --- 2. O checkout esta limpo? ------------------------------------------------
-[[ -z "$(git status --porcelain)" ]] || morre "ha mudancas nao commitadas em $RAIZ - resolva antes de deployar"
+# --untracked-files=no NAO e frouxidao: e o que torna a guarda APLICAVEL neste parque. A AWS
+# carrega arquivos NAO RASTREADOS de proposito -- `DEPLOY-AWS.md`, `docker-compose.override.yml`,
+# `Caddyfile.single` -- justamente para o `git pull` nunca conflitar (o passo 1 acima os cita por
+# nome). `git status --porcelain` lista nao rastreado como `?? caminho`, entao a versao anterior
+# ABORTAVA em 100% das execucoes naquele host: um `?? DEPLOY-AWS.md` sozinho ja derrubava.
+# Medido em 2026-08-21, no primeiro `--dry-run` real depois do merge do #167.
+#
+# O risco que a guarda existe para pegar continua pego: arquivo VERSIONADO modificado ou em
+# stage -- o caso "editei em producao para testar e esqueci" --, porque o `git pull --ff-only`
+# do passo seguinte falharia no meio do deploy, ou pior, o build subiria com a edicao solta.
+[[ -z "$(git status --porcelain --untracked-files=no)" ]] || morre "ha mudancas nao commitadas em arquivo versionado de $RAIZ - resolva antes de deployar"
 
 git fetch origin --quiet
 SHA_ANTES="$(git rev-parse HEAD)"


### PR DESCRIPTION
## O que o primeiro `--dry-run` real achou

O `deploy.sh` foi mergeado no #167 e **nunca tinha rodado no host que ele existe para servir**. Rodado agora:

```
=== Ambiente ===
  OK   perfil aws (PRODUCAO) - https://e1p.criativaeduca.com.br
  OK   compose: -f docker-compose.prod.yml -f docker-compose.override.yml   ← isto funcionou
ABORTADO: ha mudancas nao commitadas em /opt/e1p - resolva antes de deployar
```

A detecção pelo label funcionou — inclusive derivando os **dois** `-f`, que é a correção que o #167 existe para trazer. O que não funcionou foi a guarda seguinte:

```bash
[[ -z "$(git status --porcelain)" ]] || morre "ha mudancas nao commitadas"
```

`--porcelain` **lista arquivo não rastreado** como `?? caminho`, e a AWS carrega três de propósito (`DEPLOY-AWS.md`, `docker-compose.override.yml`, `Caddyfile.single`) justamente para o `git pull` nunca conflitar. **Um `?? DEPLOY-AWS.md` sozinho já derruba** — medido num repo descartável antes de tocar no script.

### A ironia é o que ensina

O **mesmo script** conhecia os três arquivos: o comentário do passo 1 os cita **por nome** para explicar por que a lista de compose vem do label em vez de ser cravada. A guarda do passo 2, doze linhas abaixo, não recebeu a mesma informação. Saber de um fato num ponto do arquivo não o propaga para o resto dele.

## O conserto

`--untracked-files=no`, **e isso não é afrouxar**. O risco que a guarda existe para pegar continua pego:

| Estado do checkout | Antes | Agora |
|---|---|---|
| Arquivo **não rastreado** (o desenho da AWS) | aborta ❌ | passa ✅ |
| Arquivo **versionado modificado** | aborta | **aborta** ✅ |
| Mudança em **stage** | aborta | **aborta** ✅ |
| Limpo | passa | passa |

*"Editei em produção para testar e esqueci"* continua sendo recusado — e é ele que faria o `git pull --ff-only` do passo seguinte falhar no meio do deploy.

## O teste executa a linha REAL

`test_deploy_guarda_checkout_limpo.py` **extrai a linha do `deploy.sh`** e a roda num repo git descartável. Uma cópia da linha escrita dentro do teste passaria a concordar consigo mesma no dia em que alguém editasse o script — a família "passa e não prova nada" que o §5.1 documenta.

**Provado por mutação:** com o `--porcelain` puro de volta, morre **exatamente** o caso do não rastreado (`1 failed, 3 passed`); restaurado por cópia do arquivo, 4 verdes.

Os controles positivos são três, e cada um mata uma guarda degenerada diferente: versionado modificado aborta, **stage** aborta (o `--untracked-files=no` não pode cegar a guarda para o índice), e limpo passa — sem este último, uma guarda que recusasse tudo passaria nos dois primeiros.

## CI

Entrou no **mesmo passo** do gate do Caddyfile — os dois dependem de `infra/` alcançável e se auto-pulam dentro da imagem da API. A guarda anti-vacuidade subiu de `executados >= 1` para **`>= 9`** (5 + 4): com `>= 1`, **um dos dois** gates podia estar pulado em silêncio e o passo ficaria verde.

## Uma armadilha do ambiente, registrada no fixture

`bash` na máquina de dev é o do **WSL**, com git próprio. Com `core.autocrlf` diferente do git do Windows que cria o repo de teste, os dois discordam sobre um arquivo escrito com LF — um vê limpo, o outro vê ` M`. O repo de teste nascia **sujo** e os dois casos de "aceita" falhavam por motivo alheio à guarda; o `PWD=/mnt/c/...` no log foi o que denunciou. O fixture fixa `core.autocrlf=false` **no repo**, com a razão escrita ao lado.

## O que continua aberto

O `deploy.sh` **ainda não completou uma execução de verdade**. O `--dry-run` parava aqui; os passos 3 em diante (gate de CI, backup, `up -d`, prova do bundle) seguem exercitados só por leitura. Está escrito como dívida no CLAUDE.md em vez de passar por verificado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
