### PR TITLE
fix: o worker nao recebia a composicao da API — 336 BankError/24h em producao

### DIFF
--- a/apps/api/app/composicao.py
+++ b/apps/api/app/composicao.py
@@ -1,0 +1,189 @@
+"""A composição do aplicativo: onde os módulos são LIGADOS uns aos outros.
+
+**Por que este módulo existe, e por que ele não é `main.py`.** Toda esta fiação morava no corpo de
+`app/main.py`, que é importado pela API — e **só por ela**. `app/worker.py` roda `python -m
+app.worker` e nunca importa `app.main`, então no processo do worker nenhum probe era registrado.
+Efeito medido em produção (AWS, 2026-08-21): **336 `BankError` em 24h**, com o briefing da Vima
+falhando para os tenants afetados, silencioso do ponto de vista do dono.
+
+**O defeito NÃO era a guarda fail-closed — ela é a parte certa.** Era a fiação existir só na
+composição da API. Um `main.py` que compõe é correto num processo e é uma armadilha em dois.
+
+⚠️ **A fiação e as guardas rodam no IMPORT deste módulo**, exatamente como rodavam no import de
+`main.py`. Quem compõe, importa: `main.py` e `worker.py` fazem `from app import composicao`. Não
+transforme isto numa função que alguém precisa lembrar de chamar — foi um esquecimento desses que
+produziu o defeito.
+
+⚠️ **Ao acrescentar fiação nova, acrescente AQUI.** Pôr no `main.py` devolve o bug para o worker,
+e o gate `test_worker_recebe_a_composicao.py` reprova — ele importa o worker num interpretador
+LIMPO (sem `app.main` carregado) e exige os três probes registrados.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.modules.bank import payout as bank_payout
+from app.modules.bank import reconciliation as bank_reconciliation
+from app.modules.bank import service as bank_service
+from app.modules.funnels.automation import register as register_funnel_automation
+from app.modules.notifications.service import register as register_notifications
+from app.modules.payables import service as payables_service
+from app.modules.payables.service import probe_pagamento_duplicado
+from app.modules.receivables import service as receivables_service
+from app.modules.wallet import service as wallet_service
+
+# Liga os assinantes do barramento de eventos (ex.: WhatsApp ao mover card no CRM;
+# auto-enroll no funil de vendas padrão ao criar lead).
+register_notifications()
+register_funnel_automation()
+
+
+# ── A composição da guarda de contagem dupla (Story 8.17 AC6) ────────────────────────────────
+#
+# ⚠️ **Este é o ÚNICO lugar onde `bank` e `payables` se encontram nesta direção — e é de propósito.**
+# O gate estrutural da Story 8.9 (`tests/test_money_planes.py`) proíbe `bank` de importar
+# `payables`; `bank` declara o `Protocol` e o registrador, `payables` implementa, e a fiação é feita
+# **aqui**, na composição. Direção final: `main → bank`, `main → payables`, `payables → bank`.
+# O gate fica verde **porque a dependência sumiu**, não porque foi escondida. Ver
+# `bank/service.py`, bloco "A porta de saída da guarda de contagem dupla".
+def liga_a_guarda_de_contagem_dupla() -> None:
+    bank_service.register_duplicata_probe(probe_pagamento_duplicado)
+
+
+def verifica_fiacao_da_guarda() -> None:
+    """**FAIL-CLOSED NO BOOT: a aplicação não sobe sem o probe registrado** (ratificação §C-5.2).
+
+    *"Um erro de fiação é condição de startup, não de request."* A alternativa — deixar o request
+    seguir sem validar — seria a guarda **desligada em produção sem ninguém saber**, e a
+    consequência é o pior modo de falha da onda (o pagamento contado duas vezes, com a divergência
+    dobrada parecendo um achado real). A outra alternativa, o 500 no request, descobriria o
+    problema no pior lugar imaginável: uma ação legítima do dono lançando uma tarifa de R$ 2,90.
+
+    Precedente do próprio projeto: a guarda de boot contra `JWT_SECRET` fraco em produção
+    (`CLAUDE.md` §6.1). A checagem de request-time **fica** como segunda guarda
+    (`bank/service._probe_duplicata`), inalcançável se esta funcionar.
+
+    ⚠️ **Não transforme isto num `warning`.** O teste que amarra o comportamento é
+    `test_bank_contagem_dupla.py::test_app_nao_sobe_sem_o_probe_de_contagem_dupla`, e há um teste
+    ESTRUTURAL provando que esta função é chamada no nível do módulo — apagar a chamada abaixo
+    reprova, porque um fail-closed que ninguém invoca é um comentário.
+    """
+    if not bank_service.duplicata_probe_registrado():
+        raise RuntimeError(
+            "A guarda de contagem dupla não foi ligada: `bank.service.register_duplicata_probe` "
+            "não recebeu implementação. A aplicação NÃO sobe sem ela — sem essa consulta, um "
+            "pagamento lançado à mão e também baixado em Contas a Pagar derrubaria o saldo duas "
+            "vezes, em silêncio. Verifique `liga_a_guarda_de_contagem_dupla` em app/composicao.py."
+        )
+
+
+liga_a_guarda_de_contagem_dupla()
+verifica_fiacao_da_guarda()
+
+
+# ── A composição dos termos da pré-condição do gate (Story 8.16 AC7/AC8) ─────────────────────
+#
+# ⚠️ **Mesmo motivo e mesma forma da guarda acima.** A conferência (`bank/reconciliation.py`)
+# precisa CONTAR obrigações de negócio para poder anotar *"N lançamentos deste período não informam
+# de qual conta saíram"* — e o gate estrutural da Story 8.9 proíbe `bank` de importar os módulos de
+# negócio. `bank` declara o `Protocol` e o registrador; os módulos de negócio implementam as
+# contagens; a fiação é feita **aqui**. Direção final: `main → bank`, `main → negócio`,
+# `negócio → bank`.
+#
+# **Esta função é a ÚNICA que soma P1 com P2**, e a soma é deliberada: os dois termos fecham na
+# MESMA onda (a 2) e pedem a MESMA ação do dono, então uma frase só os cobre. **P3 continua
+# separado** porque fecha na Onda 2b — outro prazo, outra frase. **P4 não é contado**: desde a
+# Onda 3 a população é vazia por construção — `request_payout` recusa sem conta principal (409) e
+# `bank/payout.py` escreve a perna bancária na mesma transação —, e alcançá-la exigiria cruzar o
+# plano da plataforma com o plano do banco, que é a mistura que produziu o bug de origem.
+# ⚠️ A frase anterior aqui era *"o payout ainda não move dinheiro de conta real"*, e ela descrevia o
+# `request_payout` de ANTES da Onda 3: ficou falsa no merge dela. A vacuidade de P4 vale **só a
+# partir do deploy** — quem decide isso é `bank.reconciliation.PRIMEIRO_CICLO_MEDIVEL`.
+def probe_termos_do_gate(
+    db: Session, *, start: date, end: date
+) -> bank_reconciliation.TermosDoGate:
+    p1_qtd, p1_valor = payables_service.contar_saidas_sem_conta_informada(db, start=start, end=end)
+    p2_qtd, p2_valor = receivables_service.contar_entradas_sem_conta_informada(
+        db, start=start, end=end
+    )
+    p3_qtd, p3_valor = receivables_service.contar_rendimentos_sem_perna_bancaria(
+        db, start=start, end=end
+    )
+    return bank_reconciliation.TermosDoGate(
+        lancamentos_sem_conta_informada=p1_qtd + p2_qtd,
+        valor_sem_conta_informada_cents=p1_valor + p2_valor,
+        rendimentos_sem_perna_bancaria=p3_qtd,
+        valor_rendimentos_sem_perna_cents=p3_valor,
+    )
+
+
+def liga_os_termos_do_gate() -> None:
+    bank_reconciliation.register_termos_do_gate_probe(probe_termos_do_gate)
+
+
+def verifica_fiacao_dos_termos_do_gate() -> None:
+    """**FAIL-CLOSED NO BOOT** — a aplicação não sobe sem a contagem dos termos ligada.
+
+    Pelo mesmo princípio da guarda de contagem dupla (*"um erro de fiação é condição de startup, não
+    de request"*) e por um motivo próprio, mais caro: sem a contagem, as notas do bloco 4 **somem em
+    silêncio** e a conferência passa a dizer, por omissão, *"nenhum termo pendente"*. Zero por
+    ausência de medição não é zero — e ler a divergência sob essa premissa falsa é exatamente o erro
+    que custou uma decisão de produto neste épico (a divergência medindo a própria incompletude do
+    sistema, e pedindo a construção da onda mais cara).
+    """
+    if not bank_reconciliation.termos_do_gate_probe_registrado():
+        raise RuntimeError(
+            "A contagem dos termos da pré-condição do gate não foi ligada: "
+            "`bank.reconciliation.register_termos_do_gate_probe` não recebeu implementação. A "
+            "aplicação NÃO sobe sem ela — sem essa contagem, a conferência devolveria um relatório "
+            "sem as notas do bloco 4 e o gate pareceria pronto para ser lido quando não está. "
+            "Verifique `liga_os_termos_do_gate` em app/composicao.py."
+        )
+
+
+liga_os_termos_do_gate()
+verifica_fiacao_dos_termos_do_gate()
+
+
+# ── A composição do ponto de contato entre os PLANOS de dinheiro (Epic 8, Onda 3) ─────────────
+#
+# ⚠️ **Terceira aplicação do mesmo padrão, e a primeira que atravessa a fronteira dos planos**
+# (design-mãe §1.2: o payout é o único write que a cruza). As duas irmãs acima ligam `bank` a
+# módulos de negócio; esta liga a Carteira ao banco — a direção em que o Epic 8 nasceu de um bug.
+#
+# Aqui a declaração é do lado da CARTEIRA (`wallet/service.RegistradorDePayout`) e a implementação
+# do lado do BANCO (`bank/payout.registra_payout`). Direção final: `main → wallet`, `main → bank`,
+# e **nada** entre os dois. Os dois gates (`test_wallet_nao_importa_bank`,
+# `test_bank_nao_referencia_transaction`) continuam apertados **e sem allowlist** — a dependência
+# não existe, em vez de existir com permissão.
+def liga_o_registrador_de_payout() -> None:
+    wallet_service.register_payout_registrar(bank_payout.registra_payout)
+
+
+def verifica_fiacao_do_payout() -> None:
+    """**FAIL-CLOSED NO BOOT: a aplicação não sobe sem o registrador de payout.**
+
+    *"Um erro de fiação é condição de startup, não de request."* Sem esta guarda o modo de falha é
+    silencioso e caro: o saque voltaria a ser troca de status sem perna bancária, o termo **P4** da
+    pré-condição do gate reabriria, e `|divergencia_cents|` — a métrica que decide se as Ondas 4
+    (import OFX) e 5 (matcher) valem o custo — voltaria a medir a própria incompletude do sistema
+    sem que ninguém percebesse.
+
+    ⚠️ **Não transforme isto num `warning`.** O par de testes que amarra o comportamento é
+    `test_payout_registrar.py::test_app_nao_sobe_sem_o_registrador_de_payout` **e** o teste
+    ESTRUTURAL que prova que esta função é chamada no nível do módulo — apagar a chamada abaixo
+    reprova, porque um fail-closed que ninguém invoca é um comentário.
+    """
+    if not wallet_service.payout_registrar_registrado():
+        raise RuntimeError(
+            "O registrador de payout não foi ligado: `wallet.service.register_payout_registrar` "
+            "não recebeu implementação. A aplicação NÃO sobe sem ele — sem essa ligação o saque da "
+            "Carteira volta a não escrever movimento bancário nenhum, reabrindo o termo P4 do gate "
+            "do Epic 8 em silêncio. Verifique `liga_o_registrador_de_payout` em app/composicao.py."
+        )
+
+
+liga_o_registrador_de_payout()
+verifica_fiacao_do_payout()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,21 +1,11 @@
 import logging
-from datetime import date
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy.orm import Session
 
+from app import composicao  # noqa: F401 — a fiacao e as guardas fail-closed rodam no import
 from app.config import settings
 from app.modules import ALL_ROUTERS
-from app.modules.bank import payout as bank_payout
-from app.modules.bank import reconciliation as bank_reconciliation
-from app.modules.bank import service as bank_service
-from app.modules.funnels.automation import register as register_funnel_automation
-from app.modules.notifications.service import register as register_notifications
-from app.modules.payables import service as payables_service
-from app.modules.payables.service import probe_pagamento_duplicado
-from app.modules.receivables import service as receivables_service
-from app.modules.wallet import service as wallet_service
 
 
 class PublicLeadsCORSMiddleware:
@@ -91,159 +81,6 @@ app.add_middleware(PublicLeadsCORSMiddleware)
 for router in ALL_ROUTERS:
     app.include_router(router)
 
-# Liga os assinantes do barramento de eventos (ex.: WhatsApp ao mover card no CRM;
-# auto-enroll no funil de vendas padrão ao criar lead).
-register_notifications()
-register_funnel_automation()
-
-
-# ── A composição da guarda de contagem dupla (Story 8.17 AC6) ────────────────────────────────
-#
-# ⚠️ **Este é o ÚNICO lugar onde `bank` e `payables` se encontram nesta direção — e é de propósito.**
-# O gate estrutural da Story 8.9 (`tests/test_money_planes.py`) proíbe `bank` de importar
-# `payables`; `bank` declara o `Protocol` e o registrador, `payables` implementa, e a fiação é feita
-# **aqui**, na composição. Direção final: `main → bank`, `main → payables`, `payables → bank`.
-# O gate fica verde **porque a dependência sumiu**, não porque foi escondida. Ver
-# `bank/service.py`, bloco "A porta de saída da guarda de contagem dupla".
-def liga_a_guarda_de_contagem_dupla() -> None:
-    bank_service.register_duplicata_probe(probe_pagamento_duplicado)
-
-
-def verifica_fiacao_da_guarda() -> None:
-    """**FAIL-CLOSED NO BOOT: a aplicação não sobe sem o probe registrado** (ratificação §C-5.2).
-
-    *"Um erro de fiação é condição de startup, não de request."* A alternativa — deixar o request
-    seguir sem validar — seria a guarda **desligada em produção sem ninguém saber**, e a
-    consequência é o pior modo de falha da onda (o pagamento contado duas vezes, com a divergência
-    dobrada parecendo um achado real). A outra alternativa, o 500 no request, descobriria o
-    problema no pior lugar imaginável: uma ação legítima do dono lançando uma tarifa de R$ 2,90.
-
-    Precedente do próprio projeto: a guarda de boot contra `JWT_SECRET` fraco em produção
-    (`CLAUDE.md` §6.1). A checagem de request-time **fica** como segunda guarda
-    (`bank/service._probe_duplicata`), inalcançável se esta funcionar.
-
-    ⚠️ **Não transforme isto num `warning`.** O teste que amarra o comportamento é
-    `test_bank_contagem_dupla.py::test_app_nao_sobe_sem_o_probe_de_contagem_dupla`, e há um teste
-    ESTRUTURAL provando que esta função é chamada no nível do módulo — apagar a chamada abaixo
-    reprova, porque um fail-closed que ninguém invoca é um comentário.
-    """
-    if not bank_service.duplicata_probe_registrado():
-        raise RuntimeError(
-            "A guarda de contagem dupla não foi ligada: `bank.service.register_duplicata_probe` "
-            "não recebeu implementação. A aplicação NÃO sobe sem ela — sem essa consulta, um "
-            "pagamento lançado à mão e também baixado em Contas a Pagar derrubaria o saldo duas "
-            "vezes, em silêncio. Verifique `liga_a_guarda_de_contagem_dupla` em app/main.py."
-        )
-
-
-liga_a_guarda_de_contagem_dupla()
-verifica_fiacao_da_guarda()
-
-
-# ── A composição dos termos da pré-condição do gate (Story 8.16 AC7/AC8) ─────────────────────
-#
-# ⚠️ **Mesmo motivo e mesma forma da guarda acima.** A conferência (`bank/reconciliation.py`)
-# precisa CONTAR obrigações de negócio para poder anotar *"N lançamentos deste período não informam
-# de qual conta saíram"* — e o gate estrutural da Story 8.9 proíbe `bank` de importar os módulos de
-# negócio. `bank` declara o `Protocol` e o registrador; os módulos de negócio implementam as
-# contagens; a fiação é feita **aqui**. Direção final: `main → bank`, `main → negócio`,
-# `negócio → bank`.
-#
-# **Esta função é a ÚNICA que soma P1 com P2**, e a soma é deliberada: os dois termos fecham na
-# MESMA onda (a 2) e pedem a MESMA ação do dono, então uma frase só os cobre. **P3 continua
-# separado** porque fecha na Onda 2b — outro prazo, outra frase. **P4 não é contado**: desde a
-# Onda 3 a população é vazia por construção — `request_payout` recusa sem conta principal (409) e
-# `bank/payout.py` escreve a perna bancária na mesma transação —, e alcançá-la exigiria cruzar o
-# plano da plataforma com o plano do banco, que é a mistura que produziu o bug de origem.
-# ⚠️ A frase anterior aqui era *"o payout ainda não move dinheiro de conta real"*, e ela descrevia o
-# `request_payout` de ANTES da Onda 3: ficou falsa no merge dela. A vacuidade de P4 vale **só a
-# partir do deploy** — quem decide isso é `bank.reconciliation.PRIMEIRO_CICLO_MEDIVEL`.
-def probe_termos_do_gate(
-    db: Session, *, start: date, end: date
-) -> bank_reconciliation.TermosDoGate:
-    p1_qtd, p1_valor = payables_service.contar_saidas_sem_conta_informada(db, start=start, end=end)
-    p2_qtd, p2_valor = receivables_service.contar_entradas_sem_conta_informada(
-        db, start=start, end=end
-    )
-    p3_qtd, p3_valor = receivables_service.contar_rendimentos_sem_perna_bancaria(
-        db, start=start, end=end
-    )
-    return bank_reconciliation.TermosDoGate(
-        lancamentos_sem_conta_informada=p1_qtd + p2_qtd,
-        valor_sem_conta_informada_cents=p1_valor + p2_valor,
-        rendimentos_sem_perna_bancaria=p3_qtd,
-        valor_rendimentos_sem_perna_cents=p3_valor,
-    )
-
-
-def liga_os_termos_do_gate() -> None:
-    bank_reconciliation.register_termos_do_gate_probe(probe_termos_do_gate)
-
-
-def verifica_fiacao_dos_termos_do_gate() -> None:
-    """**FAIL-CLOSED NO BOOT** — a aplicação não sobe sem a contagem dos termos ligada.
-
-    Pelo mesmo princípio da guarda de contagem dupla (*"um erro de fiação é condição de startup, não
-    de request"*) e por um motivo próprio, mais caro: sem a contagem, as notas do bloco 4 **somem em
-    silêncio** e a conferência passa a dizer, por omissão, *"nenhum termo pendente"*. Zero por
-    ausência de medição não é zero — e ler a divergência sob essa premissa falsa é exatamente o erro
-    que custou uma decisão de produto neste épico (a divergência medindo a própria incompletude do
-    sistema, e pedindo a construção da onda mais cara).
-    """
-    if not bank_reconciliation.termos_do_gate_probe_registrado():
-        raise RuntimeError(
-            "A contagem dos termos da pré-condição do gate não foi ligada: "
-            "`bank.reconciliation.register_termos_do_gate_probe` não recebeu implementação. A "
-            "aplicação NÃO sobe sem ela — sem essa contagem, a conferência devolveria um relatório "
-            "sem as notas do bloco 4 e o gate pareceria pronto para ser lido quando não está. "
-            "Verifique `liga_os_termos_do_gate` em app/main.py."
-        )
-
-
-liga_os_termos_do_gate()
-verifica_fiacao_dos_termos_do_gate()
-
-
-# ── A composição do ponto de contato entre os PLANOS de dinheiro (Epic 8, Onda 3) ─────────────
-#
-# ⚠️ **Terceira aplicação do mesmo padrão, e a primeira que atravessa a fronteira dos planos**
-# (design-mãe §1.2: o payout é o único write que a cruza). As duas irmãs acima ligam `bank` a
-# módulos de negócio; esta liga a Carteira ao banco — a direção em que o Epic 8 nasceu de um bug.
-#
-# Aqui a declaração é do lado da CARTEIRA (`wallet/service.RegistradorDePayout`) e a implementação
-# do lado do BANCO (`bank/payout.registra_payout`). Direção final: `main → wallet`, `main → bank`,
-# e **nada** entre os dois. Os dois gates (`test_wallet_nao_importa_bank`,
-# `test_bank_nao_referencia_transaction`) continuam apertados **e sem allowlist** — a dependência
-# não existe, em vez de existir com permissão.
-def liga_o_registrador_de_payout() -> None:
-    wallet_service.register_payout_registrar(bank_payout.registra_payout)
-
-
-def verifica_fiacao_do_payout() -> None:
-    """**FAIL-CLOSED NO BOOT: a aplicação não sobe sem o registrador de payout.**
-
-    *"Um erro de fiação é condição de startup, não de request."* Sem esta guarda o modo de falha é
-    silencioso e caro: o saque voltaria a ser troca de status sem perna bancária, o termo **P4** da
-    pré-condição do gate reabriria, e `|divergencia_cents|` — a métrica que decide se as Ondas 4
-    (import OFX) e 5 (matcher) valem o custo — voltaria a medir a própria incompletude do sistema
-    sem que ninguém percebesse.
-
-    ⚠️ **Não transforme isto num `warning`.** O par de testes que amarra o comportamento é
-    `test_payout_registrar.py::test_app_nao_sobe_sem_o_registrador_de_payout` **e** o teste
-    ESTRUTURAL que prova que esta função é chamada no nível do módulo — apagar a chamada abaixo
-    reprova, porque um fail-closed que ninguém invoca é um comentário.
-    """
-    if not wallet_service.payout_registrar_registrado():
-        raise RuntimeError(
-            "O registrador de payout não foi ligado: `wallet.service.register_payout_registrar` "
-            "não recebeu implementação. A aplicação NÃO sobe sem ele — sem essa ligação o saque da "
-            "Carteira volta a não escrever movimento bancário nenhum, reabrindo o termo P4 do gate "
-            "do Epic 8 em silêncio. Verifique `liga_o_registrador_de_payout` em app/main.py."
-        )
-
-
-liga_o_registrador_de_payout()
-verifica_fiacao_do_payout()
 
 
 @app.get("/health", tags=["infra"])

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -28,6 +28,7 @@ from datetime import UTC, datetime
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app import composicao  # noqa: F401 — MESMA fiacao da API; sem ela o gate levanta BankError
 from app.config import settings
 from app.db.session import SessionLocal, tenant_session
 from app.modules.auth.models import Tenant

--- a/apps/api/tests/test_bank_contagem_dupla.py
+++ b/apps/api/tests/test_bank_contagem_dupla.py
@@ -36,7 +36,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import main as app_main
+from app import composicao
 from app.modules.bank import service as bank_service
 from app.modules.bank.models import KIND_CHECKING, OPERATION_NATURES, BankTransaction
 from app.modules.bank.schemas import BankTransactionCreate
@@ -327,7 +327,7 @@ def test_app_nao_sobe_sem_o_probe_de_contagem_dupla(monkeypatch):
     """
     monkeypatch.setattr(bank_service, "_duplicata_probe", None)
     with pytest.raises(RuntimeError, match="guarda de contagem dupla"):
-        app_main.verifica_fiacao_da_guarda()
+        composicao.verifica_fiacao_da_guarda()
 
 
 def test_a_guarda_de_boot_e_chamada_no_nivel_do_modulo():
@@ -337,7 +337,7 @@ def test_a_guarda_de_boot_e_chamada_no_nivel_do_modulo():
     Nenhum teste de comportamento pegaria isso — a app continuaria subindo, e a guarda de boot
     viraria uma função morta que ninguém percebe.
     """
-    fonte = (pathlib.Path(app_main.__file__)).read_text(encoding="utf-8")
+    fonte = (pathlib.Path(composicao.__file__)).read_text(encoding="utf-8")
     tree = ast.parse(fonte)
     chamadas = {
         node.value.func.id

--- a/apps/api/tests/test_payout_registrar.py
+++ b/apps/api/tests/test_payout_registrar.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app import main as app_main
+from app import composicao
 from app.modules.bank import payout as bank_payout
 from app.modules.bank.models import SOURCE_PAYOUT, STATUS_MATCHED, BankTransaction
 from app.modules.wallet import service as wallet_service
@@ -229,7 +229,7 @@ def test_app_nao_sobe_sem_o_registrador_de_payout(monkeypatch):
     """
     monkeypatch.setattr(wallet_service, "_payout_registrar", None)
     with pytest.raises(RuntimeError, match="registrador de payout"):
-        app_main.verifica_fiacao_do_payout()
+        composicao.verifica_fiacao_do_payout()
 
 
 def test_a_verificacao_do_payout_e_chamada_no_nivel_do_modulo():
@@ -239,7 +239,7 @@ def test_a_verificacao_do_payout_e_chamada_no_nivel_do_modulo():
     Nenhum teste de comportamento pegaria — a app continuaria subindo e a guarda viraria função
     morta. Mesmo par de `test_a_guarda_de_boot_e_chamada_no_nivel_do_modulo`.
     """
-    fonte = pathlib.Path(app_main.__file__).read_text(encoding="utf-8")
+    fonte = pathlib.Path(composicao.__file__).read_text(encoding="utf-8")
     tree = ast.parse(fonte)
     chamadas = {
         node.value.func.id

--- a/apps/api/tests/test_worker_recebe_a_composicao.py
+++ b/apps/api/tests/test_worker_recebe_a_composicao.py
@@ -1,0 +1,83 @@
+"""O worker recebe a MESMA composição da API — e este teste é o consumidor mecânico disso.
+
+**O defeito que ele existe para impedir, medido em produção (AWS, 2026-08-21): 336 `BankError`
+em 24h.** `app/main.py` compunha a aplicação no import, e o worker roda `python -m app.worker`,
+que nunca importa `app.main`. Nesse processo nenhum probe era registrado, e
+`bank/reconciliation.py` levantava `BankError` — **o briefing da Vima falhava, em silêncio do
+ponto de vista do dono**. O fail-closed estava CERTO; errada era a fiação existir num processo só.
+
+⚠️ **O teste roda num interpretador NOVO, e isso não é preciosismo — é a diferença entre provar e
+não provar nada.** Dentro do pytest, `app.main` já foi importado pela `conftest` (o `TestClient`),
+então os probes estariam registrados de qualquer jeito e a asserção passaria **verde sobre o bug**.
+É a família do "teste que passa e não prova nada" que o Epic 8 documenta oito vezes.
+
+A guarda de não-vacuidade é explícita: o subprocesso assere que `app.main` **não** está em
+`sys.modules`. Se um dia o worker passar a importar a API por outro caminho, este teste falha e
+avisa — em vez de virar decoração.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+_API_DIR = pathlib.Path(__file__).resolve().parents[1]
+
+_SONDA = """
+import sys
+import app.worker  # noqa: F401
+
+assert "app.main" not in sys.modules, (
+    "o worker importou a API — este teste deixaria de provar qualquer coisa"
+)
+
+from app.modules.bank import reconciliation, service
+from app.modules.wallet import service as wallet
+
+faltando = [
+    nome
+    for nome, ok in (
+        ("termos_do_gate", reconciliation.termos_do_gate_probe_registrado()),
+        ("contagem_dupla", service.duplicata_probe_registrado()),
+        ("payout", wallet.payout_registrar_registrado()),
+    )
+    if not ok
+]
+assert not faltando, f"o worker subiu sem a fiacao: {faltando}"
+print("COMPOSICAO_OK")
+"""
+
+
+def test_o_worker_sozinho_ja_tem_toda_a_fiacao():
+    r = subprocess.run(
+        [sys.executable, "-c", _SONDA],
+        cwd=_API_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert r.returncode == 0, f"stdout={r.stdout}\nstderr={r.stderr}"
+    assert "COMPOSICAO_OK" in r.stdout
+
+
+def test_a_sonda_roda_mesmo_um_interpretador_limpo():
+    """Controle positivo DA SONDA: sem a fiação, ela precisa REPROVAR.
+
+    Sem isto, uma sonda que deixasse de exercitar o worker (import renomeado, `cwd` errado)
+    passaria verde para sempre. Aqui o membro é um processo que importa só os módulos do banco,
+    **sem** o worker — e nele os probes têm de estar ausentes.
+    """
+    sem_worker = (
+        "from app.modules.bank import reconciliation\n"
+        "assert not reconciliation.termos_do_gate_probe_registrado()\n"
+        "print('SEM_FIACAO_OK')\n"
+    )
+    r = subprocess.run(
+        [sys.executable, "-c", sem_worker],
+        cwd=_API_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert r.returncode == 0, f"stdout={r.stdout}\nstderr={r.stderr}"
+    assert "SEM_FIACAO_OK" in r.stdout


### PR DESCRIPTION
## O defeito, medido em produção

**336 `BankError` em 24h na AWS** (medido em 2026-08-21). O **briefing da Vima falha** para os tenants afetados — silencioso do ponto de vista do dono.

`app/main.py` compunha a aplicação **no import**: registrava os probes e rodava as guardas fail-closed. Mas `app/worker.py` roda `python -m app.worker` e **nunca importa `app.main`** — então naquele processo nenhum probe existia, e `bank/reconciliation.py` levantava `BankError`.

⚠️ **O fail-closed está CERTO e não foi afrouxado.** Sem a contagem, as notas do bloco 4 somem em silêncio e a conferência passa a dizer *"nenhum termo pendente"* por omissão — o erro que já custou uma decisão de produto neste épico. O defeito era a fiação existir só na composição da API.

## O achado: não era uma fiação, eram cinco

`main.py` compunha **cinco** coisas; o worker não recebia nenhuma:

| Fiação | Efeito no worker |
|---|---|
| `liga_os_termos_do_gate` | 🔴 **os 336 erros/24h** |
| `liga_a_guarda_de_contagem_dupla` | inócuo hoje (worker não chama `create_transaction`) |
| `liga_o_registrador_de_payout` | inócuo hoje (worker não dispara saque) |
| `register_notifications()` | assinante do barramento |
| `register_funnel_automation()` | assinante do barramento |

**Mover só a quebrada recriaria o defeito que estamos consertando** — uma lista que é a garantia, com a garantia incompleta. Verifiquei que as quatro inócuas são de fato inócuas hoje: os módulos que o worker alcança praticamente não emitem eventos.

## O que mudou

- **`app/composicao.py`** (novo) — o lugar único. A fiação e as guardas rodam **no import**, exatamente como rodavam em `main.py`. Todas as docstrings vieram junto, inteiras: elas carregam as razões, e resumi-las seria perder o motivo.
- `main.py` e `worker.py` fazem `from app import composicao`.

## O gate que impede a volta

`test_worker_recebe_a_composicao.py` sobe o worker num **interpretador limpo** (subprocesso) e exige os três probes registrados.

⚠️ **O subprocesso não é preciosismo — é a diferença entre provar e não provar nada.** Dentro do pytest a `conftest` já importou `app.main` (via `TestClient`), então os probes estariam registrados de qualquer jeito e a asserção passaria **verde sobre o bug**. É a família do "teste que passa e não prova nada" que o Epic 8 documenta oito vezes.

Guarda de não-vacuidade explícita: o subprocesso assere que `app.main` **não** está em `sys.modules`. Mais um controle positivo da própria sonda (um processo sem o worker, onde os probes têm de estar **ausentes**).

**Provado por mutação:** removida a linha do `worker.py`, o gate reprova nomeando o que faltou. Restaurado por cópia de arquivo, nunca `git checkout`.

## Os dois testes estruturais seguiram a fiação

`test_bank_contagem_dupla` e `test_payout_registrar` liam `app/main.py` para provar que as guardas são chamadas no nível do módulo (*"um fail-closed que ninguém invoca é um comentário"*). Passaram a ler `composicao.py`. **Apagá-los mataria a garantia** — a correção óbvia e errada.

## Testes

- Suíte: **2259 passed**. As 8 falhas da primeira execução eram **Docker fora do ar** (`NpipeHTTPConnection`), todas em `*_rls.py`.
- `pytest -m rls_e2e` com Docker de pé: **66 passed, 0 falhas** — conferido de verdade, não por inferência.
- `ruff` limpo.

## Escopo

Sem migration, sem mudança de contrato HTTP, sem afrouxar guarda. Move fiação e acrescenta o gate que faltava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)