### PR TITLE
fix(web): a porta do dia rolava de lado em 360px, e ninguém media [#178]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,8 +499,8 @@ arquivar um centro de custo num celular de 360px**. O `<a>` do bloco "botão" va
 **página pública** (`PageBlocks.tsx` é o mesmo componente), onde ele é a única conversão que existe:
 rótulo longo sem espaço media **626px** de largura.
 
-**Cobertura: 29 das 47 rotas não-públicas de `App.tsx`** — **43 no `ProtectedLayout`** (com shell:
-sidebar + topbar) **+ 4 no `ProtectedBareLayout`** (sem shell). **18 de fora**, e as duas caixas
+**Cobertura: 30 das 47 rotas não-públicas de `App.tsx`** — **43 no `ProtectedLayout`** (com shell:
+sidebar + topbar) **+ 4 no `ProtectedBareLayout`** (sem shell). **17 de fora**, e as duas caixas
 falham por motivos diferentes:
 
 **14 do `ProtectedLayout`.** `/`, `/config`, `/crm`, `/financeiro/conferencia` **quebram com o mock
@@ -511,15 +511,34 @@ renderizam **em branco** (`pageerror` real: `reading 'some'`/`'trim'`/`'filter'`
 `/juridico/novo`, `/juridico/:id` (as duas últimas exigem `?skill=`) e `/admin` (exige
 `is_platform_admin`) pedem fixture ou sessão própria. `*` (ComingSoon) não tem controle.
 
-**4 do `ProtectedBareLayout`, e estas são a categoria INTEIRA:** `/vima`, `/dna/nucleo`,
-`/compartilhar`, `/comprovante/:id`. **Nenhuma está no catálogo** — não por triagem, por omissão do
-denominador. E não são periferia: os comentários do próprio `App.tsx` dizem que `/vima` e
-`/dna/nucleo` são **"desenhados para 360px"**, e `/comprovante/:id` é **tela de dinheiro** que já
+**3 do `ProtectedBareLayout`** (eram as 4 da categoria INTEIRA até o #178): `/dna/nucleo`,
+`/compartilhar`, `/comprovante/:id`. **Nenhuma das três está no catálogo** — não por triagem, por
+omissão do denominador. E não são periferia: o comentário do próprio `App.tsx` diz que
+`/dna/nucleo` é **"desenhado para 360px"**, e `/comprovante/:id` é **tela de dinheiro** que já
 carrega dívida de medição registrada no §5.1 (*"Segue de pé a dívida da `ComprovantePage` … aquela
 tela não está entre as medidas"*) — o `ALTURA_DA_BARRA` do `baixa.ts` tem seis mutantes
 sobreviventes justamente porque o número é medida do DOM e ninguém mede aquela tela. **Não foram
 medidas nesta issue de propósito** (o pedido era o número honesto, não mais cobertura): se
 alguma tiver defeito, vira issue própria com o número medido.
+
+⚠️ **`/vima` saiu dessa lista no #178, e o que ela tinha escondido era defeito de verdade.** É a
+PORTA DO DIA (`EntradaDoDia` manda a raiz autenticada para lá enquanto o briefing de hoje não foi
+lido — a primeira tela do dono no aparelho de 360px, de manhã) e era a **única das seis telas que
+montam `GanchoDaVima`** sem régua nenhuma. Uma entrada em `e2e/support/rotas.ts` com o payload de
+pior caso na forma real do `BriefingOut` reprovou **na primeira medição**: `documentElement
+.scrollWidth` **649px** numa viewport de 360. Causa: `linhas[].texto` e a narração repetem nomes
+**digitados pelo dono** (fornecedor, título do prazo, nome da conversa — `vima/absences.py`), e um
+token sem espaço não tem onde quebrar; sem shell **não há `main.overflow-x-hidden`** para recortar,
+então o que não cabe vaza e a página inteira rola. Conserto: `break-words` nos dois lugares —
+medidos **um a um**, a narração sozinha vale **649px** e a lista sozinha **525px**.
+
+⚠️ **Nesta rota as duas réguas NÃO são independentes, e a razão é estrutural.** Sem shell não há
+ancestral que recorte: o que estoura empurra o documento, e `medirControles` **absolve** todo
+controle quando a página rola (`deslizador = "document"`). Logo, hoje, quem tem dente aqui é a
+régua do #135; a do #144 só acusa se alguém introduzir um recorte. Medido no #178: `overflow-hidden`
+no contêner + «Ir para o painel» em largura fixa de 600px → `alcance-360` acusa **272px além da
+borda** e `rotas-360` continua devolvendo **360**. É exatamente por isso que a entrada vale nas
+DUAS listas: a segunda é a guarda do dia em que essa tela ganhar um cartão com recorte.
 
 ⚠️ **COMO RECONTAR — a régua que impede o próximo erro deste parágrafo, que já aconteceu DUAS
 vezes seguidas.** Conte `<Route path=` nas **DUAS** caixas de layout (`ProtectedLayout` **e**

--- a/apps/web/e2e/alcance-360.spec.ts
+++ b/apps/web/e2e/alcance-360.spec.ts
@@ -41,11 +41,14 @@ import { semearSessao } from "./support/sessao";
  *      deslizador que rola e exige que ela NÃO o acuse. Sem o primeiro ninguém sabe se ela
  *      enxerga; sem o segundo ninguém sabe se ela sabe parar.
  *
- * Cobertura: as 29 rotas de `support/rotas.ts` (as mesmas que `rotas-360.spec.ts` mede), de 47
- * não-públicas. As 18 que ficaram de fora estão listadas no CLAUDE.md §5.4, uma a uma, com o
- * motivo — inclusive as 4 do `ProtectedBareLayout`, que são a categoria inteira das telas SEM
- * shell e não têm nenhuma medida aqui. Antes de mexer nesse número, leia o "COMO RECONTAR" da
- * §5.4: contar só uma das duas caixas de layout já errou o denominador duas vezes.
+ * Cobertura: as 30 rotas de `support/rotas.ts` (as mesmas que `rotas-360.spec.ts` mede), de 47
+ * não-públicas. As 17 que ficaram de fora estão listadas no CLAUDE.md §5.4, uma a uma, com o
+ * motivo — inclusive as 3 do `ProtectedBareLayout` que seguem sem medida (`/dna/nucleo`,
+ * `/compartilhar`, `/comprovante/:id`). A quarta, `/vima`, entrou no catálogo pelo #178: é a
+ * PORTA DO DIA (`EntradaDoDia` manda a raiz autenticada para lá enquanto o briefing de hoje não
+ * foi lido) e era a única das seis telas que montam `GanchoDaVima` sem régua nenhuma. Antes de
+ * mexer nesse número, leia o "COMO RECONTAR" da §5.4: contar só uma das duas caixas de layout
+ * já errou o denominador duas vezes.
  */
 
 for (const { rota, marca, mocks } of CASOS) {

--- a/apps/web/e2e/support/rotas.ts
+++ b/apps/web/e2e/support/rotas.ts
@@ -126,6 +126,42 @@ const DIAGNOSTICO = {
   narrative_source: "template",
 };
 
+/**
+ * `/vima/briefing` devolve OBJETO (`BriefingOut`, `apps/api/app/modules/vima/schemas.py`). Com o
+ * `[]` default de `mockarApi` a tela nunca sai de "Preparando seu resumo…" — mediria 360 por
+ * não ter briefing nenhum, e a `marca` "Seu dia" (que só existe no estado CARREGADO) é
+ * exatamente o que reprova esse verde.
+ *
+ * Pior caso plausível na forma real: `linhas[].texto` é o `title` da ausência, montado com nome
+ * DIGITADO pelo dono — fornecedor, título do prazo, nome da conversa (`vima/absences.py`) — e a
+ * narração repete esses nomes. Um token sem espaço ali é o que mais empurra numa tela cuja caixa
+ * é `max-w-prose` e que não recorta nada: `/vima` mora no `ProtectedBareLayout`, sem o
+ * `main.overflow-x-hidden` que segura as telas com shell.
+ *
+ * `kind` preenchido na PRIMEIRA linha PENDENTE não é enfeite: é o que faz `BriefingPage` montar
+ * `GanchoDaVima` (`BriefingPage.tsx:177`) — o caminho que dá nome a esta issue. O card em si
+ * segue de fora pelo default `"/dna/pendente": null` de `support/api.ts`, como nas outras cinco.
+ *
+ * `read_at: null` é o estado em que o dono ABRE a porta do dia; o POST de leitura que ele dispara
+ * cai no mesmo prefixo e recebe o mesmo objeto.
+ */
+const BRIEFING = {
+  id: "b1",
+  reference_date: "2026-08-21",
+  texto: `Bom dia. A conta ${LONGO} venceu ontem, e ${LONGO} escreveu e ainda espera resposta.`,
+  por_ia: true,
+  vazio: false,
+  excedente: 4,
+  linhas: [
+    { secao: "PENDENTE", module: "financeiro", texto: `${LONGO} — R$ 12.345,67 venceu em 19/08`, kind: "financeiro.conta.vencendo" },
+    { secao: "PENDENTE", module: "comercial", texto: `${LONGO} escreveu e ainda não foi respondido`, kind: "comercial.contato.esperando_resposta" },
+    { secao: "ACONTECEU", module: "comercial", texto: `${LONGO} virou cliente`, kind: "" },
+    { secao: "NÚMEROS", module: "financeiro", texto: `${LONGO}: R$ 123.456,78 recebidos no mês`, kind: "" },
+  ],
+  read_at: null,
+  created_at: "2026-08-21T08:00:00Z",
+};
+
 export interface Caso {
   rota: string;
   /** Texto que PRECISA estar visível antes de medir. Sem ele, 360 significaria "tela em branco". */
@@ -167,4 +203,10 @@ export const CASOS: Caso[] = [
   { rota: "/busca", marca: "Busca" }, // vazio
   { rota: "/pagar", marca: "Despesas" }, // vazio
   { rota: "/conversas", marca: "Conversas" }, // vazio
+  // A PORTA DO DIA (#178). `EntradaDoDia` manda a raiz autenticada para cá enquanto o briefing de
+  // hoje não foi lido: é a PRIMEIRA tela que o dono vê no aparelho de 360px, e era a única das
+  // seis que montam `GanchoDaVima` sem régua nenhuma. Mora no `ProtectedBareLayout` — sem shell,
+  // logo sem o `main.overflow-x-hidden`: aqui o que não cabe faz a PÁGINA rolar em vez de ficar
+  // recortado, e é a régua do #135 que o pega primeiro.
+  { rota: "/vima", marca: "Seu dia", mocks: { "/vima/briefing": BRIEFING } },
 ];

--- a/apps/web/src/features/vima/BriefingPage.tsx
+++ b/apps/web/src/features/vima/BriefingPage.tsx
@@ -88,8 +88,17 @@ export default function BriefingPage() {
         <span className="text-xs text-neutral-400">{formatTime(briefing.created_at, fuso)}</span>
       </header>
 
-      {/* A narração. Tipografia grande porque é o que se lê, não o que se consulta. */}
-      <p className="mt-3 whitespace-pre-line text-lg leading-relaxed text-neutral-800 sm:text-xl">
+      {/*
+        A narração. Tipografia grande porque é o que se lê, não o que se consulta.
+
+        `break-words` não é enfeite (#178): este texto repete nomes DIGITADOS pelo dono —
+        fornecedor, título do prazo, nome da conversa (`vima/absences.py` monta o `title` da
+        ausência com eles) — e um token sem espaço não tem onde quebrar. Medido em 360×740 com a
+        fixture de pior caso: sem a classe, a PÁGINA INTEIRA rola até **649px**. E aqui não há
+        `main.overflow-x-hidden` para recortar nada: `/vima` mora no `ProtectedBareLayout`
+        (sem shell), então o que não cabe vaza para fora da tela em vez de ficar preso.
+      */}
+      <p className="mt-3 whitespace-pre-line break-words text-lg leading-relaxed text-neutral-800 sm:text-xl">
         {briefing.texto}
       </p>
 
@@ -161,9 +170,11 @@ function Secoes({ linhas, excedente }: { linhas: BriefingLinha[]; excedente: num
             {linhas
               .filter((l) => l.secao === secao)
               .map((l, i) => (
+                // `break-words` pela mesma razão do parágrafo da narração, e medida à parte:
+                // só estas linhas, sem a classe, já levam a página a **525px** em 360 (#178).
                 <li
                   key={`${secao}-${i}`}
-                  className="rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-700"
+                  className="break-words rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-700"
                 >
                   {l.texto}
                 </li>


### PR DESCRIPTION
## Resumo

`/vima` era a **única das seis telas que montam `GanchoDaVima`** sem régua de 360px nenhuma —
`grep -rn 'goto("/vima' e2e/` → **0**, `grep -c 'rota: "/vima"' e2e/support/rotas.ts` → **0**.

E é a **porta do dia**: `EntradaDoDia` manda a raiz autenticada para lá enquanto o briefing de hoje
não foi lido, então é a primeira tela que o dono vê no aparelho de 360px, de manhã.

Fecha #178.

## O alcance, confirmado — a issue dizia 30 rotas; são 29

```
grep -c '^  { rota: "' e2e/support/rotas.ts   →  30   (29 antes deste PR)
grep -c '<Route path=' src/app/App.tsx        →  50
grep -cE '^\s*path="' src/app/App.tsx         →   1   → 51 − 4 públicas = 47
```

Cobertura passa de **29/47** para **30/47**; "18 de fora" vira **17**. `alcance-360.spec.ts:44` e o
CLAUDE.md §5.4 diziam 29 — os dois atualizados.

| rota | `goto` em `e2e/` | em `CASOS` | régua de 360px? |
|---|---|---|---|
| `/agenda` | 2 | 0 | sim (`agenda-evento-360`, `ficha-agenda-360`) |
| `/cobrancas` | 0 | 1 | sim |
| `/crm` | 11 | 0 | sim (`crm-360`) |
| `/orcamentos` | 0 | 1 | sim |
| `/pagar` | 11 | 1 | sim |
| **`/vima`** | **0** | **0** | **nenhuma** |

## A régua reprovou na PRIMEIRA medição — e o defeito é real

```
Error: a rota /vima estourou a viewport de 360px
expect(received).toBe(expected)
Expected: 360
Received: 649
```

`linhas[].texto` é o `title` da ausência, montado com nome **digitado pelo dono** (fornecedor, título
do prazo, nome da conversa — `vima/absences.py`), e a narração repete esses nomes. Token sem espaço
não tem onde quebrar.

E aqui **não há `main.overflow-x-hidden`**: `/vima` mora no `ProtectedBareLayout`, sem shell. O que
não cabe **vaza** em vez de ficar recortado.

Conserto: `break-words` na narração e nas linhas — medidos **um a um**, a narração sozinha vale
**649px** e a lista sozinha **525px**. São carga, não uma classe só.

## Prova por mutação

| Mutação | Régua que morreu | Mensagem real |
|---|---|---|
| payload `/vima/briefing` → `[]` | `rotas-360` (a **marca**) | `getByText('Seu dia').first()` … `element(s) not found` |
| sem `break-words` na narração | `rotas-360` | `Expected: 360 / Received: 649` |
| sem `break-words` nas linhas | `rotas-360` | `Expected: 360 / Received: 525` |
| `overflow-hidden` + «Ir para o painel» em `w-[600px]` | `alcance-360` | `parcialmente fora x 16 → 616 (272px além da borda)` |

A primeira linha é a que importa: com `[]` a tela renderiza **em branco** e mediria 360 por não ter
desenhado nada — a armadilha que a issue nomeia, morta pela `marca`.

## ⚠️ Mutante que não dá para matar com uma linha só, e por quê

Nesta rota as duas réguas **não são independentes**. Sem shell não há ancestral que recorte, e
`medirControles` **absolve** todo controle quando a página rola (`deslizador = "document"`). Qualquer
estouro morre antes em `rotas-360`; `alcance-360` só acusa se **existir** recorte — por isso a
mutação dela precisa introduzir o `overflow-hidden`.

Documentado no §5.4, não perseguido. E é o que justifica a entrada valer nas **duas** listas: a
segunda é a guarda do dia em que essa tela ganhar um cartão com recorte.

## Gates

```
pnpm lint       → exit 0
pnpm typecheck  → exit 0
E2E_PORT=… pnpm e2e e2e/rotas-360.spec.ts    → 31 passed (2.2m)
E2E_PORT=… pnpm e2e e2e/alcance-360.spec.ts  → 32 passed (4.4m)
pnpm test       → 853/855
```

Os 2 vermelhos (`PlatformUsers`, `BuscaGlobal`) passam sozinhos em 49,95s com a máquina a 100% de
CPU — classe do #162; nenhum toca `vima`.

## Fora de escopo (vira issue)

- `rotas-360.spec.ts` ainda diz **"as 18 asserções acima"** (duas vezes); são 30.
- `/dna/nucleo`, `/compartilhar`, `/comprovante/:id` seguem sem régua — **mesma forma sem shell** que
  fez `/vima` quebrar na primeira medição. A suspeita de que quebrem também é forte.

Fecha #178.
