### PR TITLE
fix(web): guarda payload de API por forma em 6 sites — o pior deixava a tela BRANCA [#179]

### DIFF
--- a/apps/web/src/features/auth/LoginPage.test.tsx
+++ b/apps/web/src/features/auth/LoginPage.test.tsx
@@ -115,3 +115,42 @@ describe("LoginPage / LoginForm (Story 7.4 — portão de entrada)", () => {
     expect(loginMock).not.toHaveBeenCalled();
   });
 });
+
+// ── `dev_reset_token` fora de forma (issue #179) ──────────────────────────────
+//
+// Sétimo site da classe, FORA da lista da issue: `devToken` é renderizado direto em
+// `<code>{devToken}</code>`. Com `?? null`, um objeto *truthy* passava e o React estoura com
+// "Objects are not valid as a React child" — tela branca no LOGIN, a única tela de onde ninguém
+// consegue sair navegando.
+describe("ForgotForm — dev_reset_token só é exibido se tiver FORMA de token", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  async function pedirRedefinicao() {
+    render(<LoginPage />);
+    await userEvent.click(screen.getByRole("button", { name: /esqueci minha senha/i }));
+    await userEvent.type(screen.getByLabelText(/e-mail/i), "joao@e1p.com");
+    await userEvent.click(screen.getByRole("button", { name: /enviar/i }));
+  }
+
+  it.each([
+    ["objeto", { toString: "x" }],
+    ["número", 12345],
+    ["booleano", true],
+    ["array", ["tok"]],
+  ])("dev_reset_token %s não é renderizado e não derruba o login", async (_rotulo, valor) => {
+    postMock.mockResolvedValue({ data: { message: "ok", dev_reset_token: valor } });
+    await pedirRedefinicao();
+
+    await waitFor(() => expect(screen.queryByRole("code")).not.toBeInTheDocument());
+    expect(screen.queryByText(/token:/i)).not.toBeInTheDocument();
+  });
+
+  it("token string de verdade continua aparecendo", async () => {
+    postMock.mockResolvedValue({ data: { message: "ok", dev_reset_token: "tok-123" } });
+    await pedirRedefinicao();
+
+    await waitFor(() => expect(screen.getByText("tok-123")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -90,7 +90,11 @@ function ForgotForm({ onBack, onHaveToken }: { onBack: () => void; onHaveToken: 
         { email },
       );
       setSent(true);
-      setDevToken(data.dev_reset_token ?? null);
+      // Guarda por FORMA, e não `?? null` (issue #179 — sétimo site, fora da lista da issue):
+      // `devToken` é renderizado direto em `<code>{devToken}</code>`. Um objeto *truthy* passava
+      // pelo `??` e o React estoura com "Objects are not valid as a React child" — tela branca no
+      // LOGIN, a única tela de onde ninguém consegue sair navegando.
+      setDevToken(typeof data?.dev_reset_token === "string" ? data.dev_reset_token : null);
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/features/dna/GanchoDaVima.tsx
+++ b/apps/web/src/features/dna/GanchoDaVima.tsx
@@ -29,6 +29,11 @@ const FORMATOS = ["escolha", "escolha_multipla", "texto"] as const;
  *   render não cai no `.catch()` da promise, então derrubaria a tela hospedeira, quebrando o
  *   "falha em silêncio, sempre" que este componente promete.
  *
+ * **Exportada porque a classe não mora neste componente** (issue #179): `NucleoPage` renderiza
+ * uma LISTA das mesmas perguntas pelo mesmo `PerguntaDaVima`, e lá o payload fora de forma não
+ * dava card fantasma, dava TELA BRANCA. Um predicado só, no arquivo que o documenta, em vez de
+ * uma segunda convenção parecida a dois diretórios de distância.
+ *
  * `eixo` fica de fora de propósito: é obrigatório no contrato, mas nenhum pixel depende dele.
  * Validá-lo só se sustentaria num teste tautológico, e predicado sem consequência é dívida.
  *
@@ -37,7 +42,7 @@ const FORMATOS = ["escolha", "escolha_multipla", "texto"] as const;
  * separada seria um predicado que nenhum teste consegue matar — o `.catch()` da promise a
  * cobriria em silêncio — e predicado sem rede é dívida, não proteção.
  */
-function ehPergunta(data: unknown): data is DnaPergunta {
+export function ehPergunta(data: unknown): data is DnaPergunta {
   const p = data as Record<string, unknown> | null | undefined;
   return (
     typeof p?.key === "string" &&

--- a/apps/web/src/features/dna/NucleoPage.test.tsx
+++ b/apps/web/src/features/dna/NucleoPage.test.tsx
@@ -135,3 +135,45 @@ describe("NucleoPage", () => {
     expect(apiMock.post).not.toHaveBeenCalledWith("/dna/nucleo/abandon", {});
   });
 });
+
+// ── Payload fora de forma (issue #179) ───────────────────────────────────────
+//
+// Irmão direto do #161: lá `data ?? null` deixava passar truthy inesperado e rendia card
+// FANTASMA; aqui `data ?? []` deixava passar e rendia **TELA BRANCA**. `{}` é truthy, então
+// `!perguntas` não pega; `perguntas.length === 0` é `undefined === 0` → falso; e `perguntas[i].key`
+// estoura DENTRO do render — que não cai no `.catch()` da promise.
+describe("NucleoPage — payload fora de forma não deixa a tela branca", () => {
+  // `0` e `""` são falsy e já caíam no ramo antigo; `[]`/`{}`/array de forma errada são os que
+  // passavam. Todos são exercitados pelo mesmo contrato: degrada como núcleo vazio.
+  it.each([
+    ["objeto vazio", {}],
+    ["objeto de erro serializado", { detail: "boom" }],
+    ["string", "ok"],
+    ["número", 7],
+    ["booleano", true],
+    ["array de forma errada", [{ foo: 1 }]],
+    ["array com item sem opcoes", [{ key: "a", texto: "t", classe: "retrato", formato: "escolha" }]],
+    ["null", null],
+    ["zero", 0],
+    ["string vazia", ""],
+  ])("%s → sai como núcleo vazio, sem estourar", async (_rotulo, payload) => {
+    apiMock.get.mockResolvedValue({ data: payload });
+    montar();
+
+    await waitFor(() => expect(navegar).toHaveBeenCalledWith("/", { replace: true }));
+    // Nada foi exibido, então não houve abertura — o mesmo contrato do núcleo vazio.
+    expect(apiMock.post).not.toHaveBeenCalled();
+  });
+
+  it("item malformado no meio da lista é DESCARTADO, os válidos continuam", async () => {
+    // Filtrar, e não rejeitar a lista inteira: uma pergunta nova com contrato quebrado no servidor
+    // não pode apagar as outras cinco. E o denominador que a telemetria grava passa a ser o que a
+    // pessoa REALMENTE viu — que é o que o comentário de `avisar("open")` já prometia.
+    apiMock.get.mockResolvedValue({ data: [PERGUNTAS[0], { foo: 1 }, PERGUNTAS[1]] });
+    montar();
+
+    await waitFor(() => expect(screen.getByText("O que você vende?")).toBeInTheDocument());
+    expect(screen.getByText("1 de 2")).toBeInTheDocument();
+    expect(apiMock.post).toHaveBeenCalledWith("/dna/nucleo/open", { exibidas: 2 });
+  });
+});

--- a/apps/web/src/features/dna/NucleoPage.tsx
+++ b/apps/web/src/features/dna/NucleoPage.tsx
@@ -2,6 +2,7 @@ import type { DnaPergunta } from "@e1p/shared-types";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../../lib/api";
+import { ehPergunta } from "./GanchoDaVima";
 import PerguntaDaVima from "./PerguntaDaVima";
 
 /** Marca de "o núcleo já foi decidido NESTE aparelho". Espelha `CHAVE_ENTRADA` do briefing. */
@@ -43,7 +44,21 @@ export default function NucleoPage() {
     api
       .get<DnaPergunta[]>("/dna/faltantes", { params: { gancho: "nucleo" } })
       .then(({ data }) => {
-        const lista = data ?? [];
+        // `Array.isArray` + forma item a item, e não `data ?? []` (issue #179): `{}` é *truthy*,
+        // então passava, `!perguntas` (abaixo) não pegava, `perguntas.length === 0` virava
+        // `undefined === 0` → falso, e `perguntas[i].key` estourava DENTRO do render — que não cai
+        // no `.catch()` desta promise. Isso era **tela branca**, o irmão pior do card fantasma do
+        // #161.
+        //
+        // `Array.isArray` sozinho NÃO bastaria: um array bem formado de itens fora de contrato
+        // passa por ele e estoura mais adiante, em `pergunta.opcoes.map` dentro de
+        // `PerguntaDaVima`. Por isso o filtro é `ehPergunta`, o mesmo predicado do #161 — ele
+        // valida exatamente o que o caminho de render consome.
+        //
+        // **Filtra, não rejeita a lista inteira:** uma pergunta nova com contrato quebrado no
+        // servidor não pode apagar as outras cinco. E o denominador da telemetria passa a ser o
+        // que a pessoa REALMENTE viu — que é o que `avisar("open")` já prometia logo abaixo.
+        const lista = Array.isArray(data) ? data.filter(ehPergunta) : [];
         if (!vivo) return;
         setPerguntas(lista);
         // `open` só DEPOIS do sucesso e só quando havia o que ver: é isso que faz "ausência de

--- a/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
@@ -1261,3 +1261,43 @@ describe("#136 — o dia desta tela é o do TENANT, e é UM só", () => {
     expect(botao).toBeEnabled();
   });
 });
+
+// ── Payload fora de forma nos checkpoints (issue #179) ────────────────────────
+describe("checkpoints fora de formato não viram saldo declarado", () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+    fusoDoTenant = "America/Sao_Paulo";
+  });
+
+  it("payload STRING não vira checkpoint — indexar string devolve CARACTERE", async () => {
+    // O que mata a volta para `cps.data[0] ?? null`: em `"abcdef"`, `[0]` é `"a"` — *truthy*.
+    // O cartão passava a exibir a linha de saldo declarado montada sobre um caractere, com
+    // `formatDateBR(undefined)` e `formatBRL(undefined)` no meio.
+    mockApi([conta({ id: "a", name: "Itaú PJ" })], "abcdef" as never);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Itaú PJ")).toBeInTheDocument());
+    expect(screen.getByText("Nenhum saldo declarado ainda")).toBeInTheDocument();
+    expect(screen.queryByText(/Saldo declarado em/)).not.toBeInTheDocument();
+  });
+
+  it("payload OBJETO indexável não vira checkpoint", async () => {
+    mockApi([conta({ id: "a", name: "Itaú PJ" })], {
+      0: { id: "cp", reference_date: "2026-08-01", balance_cents: 999 },
+    } as never);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Itaú PJ")).toBeInTheDocument());
+    expect(screen.getByText("Nenhum saldo declarado ainda")).toBeInTheDocument();
+  });
+
+  it("lista de verdade continua produzindo o saldo declarado", async () => {
+    // O contra-teste: a guarda não pode ter fechado o caminho feliz.
+    mockApi([conta({ id: "a", name: "Itaú PJ" })], [
+      { id: "cp", bank_account_id: "a", reference_date: "2026-08-01", balance_cents: 123456 },
+    ] as never);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Saldo declarado em/)).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -121,7 +121,10 @@ export default function ContasSaldosPage() {
               `/bank/accounts/${a.id}/checkpoints`,
               { params: { limit: 1 } },
             );
-            return [a.id, cps.data[0] ?? null] as const;
+            // `Array.isArray`, e não `cps.data[0] ?? null` (issue #179): indexar um payload fora
+            // do formato devolve lixo *truthy* (numa string, `[0]` é o primeiro CARACTERE), que
+            // vira o `checkpoint` do cartão e chega a `formatDateBR`/`formatBRL`.
+            return [a.id, Array.isArray(cps.data) ? (cps.data[0] ?? null) : null] as const;
           } catch {
             // Falha em UM cartão não derruba a lista inteira: a tela mostra "—" naquele campo.
             return [a.id, null] as const;

--- a/apps/web/src/features/funis/FunnelAutomation.tsx
+++ b/apps/web/src/features/funis/FunnelAutomation.tsx
@@ -34,6 +34,13 @@ export function AutomationFields({
   data: NodeLike;
   onChange: (patch: ConfigPatch) => void;
 }) {
+  // Issue #179 mapeou este `?? {}` como irmão do `?? null` sobre payload de API, mas ele é FALSO
+  // POSITIVO e fica como está — de propósito. Todo consumo de `cfg` abaixo é `cfg.X ?? padrão`
+  // sobre chaves que nenhum protótipo embutido define, e `cfg` nunca é espalhado nem iterado:
+  // com `config` valendo string, número ou array, TODA leitura dá `undefined` e a tela renderiza
+  // igualzinho a `{}`. Uma guarda de forma aqui seria um predicado que nenhum teste consegue
+  // matar — e "predicado sem rede é dívida, não proteção" (`GanchoDaVima`, #161). A proteção
+  // real deste caminho mora na origem, em `FunnelBuilderPage` (`Array.isArray(data?.nodes)`).
   const cfg = data.config ?? {};
   const key = data.key;
   const action = data.action ?? "";

--- a/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
@@ -163,3 +163,59 @@ describe("nó de WhatsApp — template (Meta) × texto livre (Evolution)", () =>
     expect(screen.getByRole("button", { name: "Salvar no nó" })).toBeDisabled();
   });
 });
+
+// ── Payload fora de forma em `GET /funnels/{id}` (issue #179) ─────────────────
+//
+// `setNodes`/`setEdges` são setters de estado do React alimentados direto pelo payload. O antigo
+// `data.nodes ?? []` só barrava `null`/`undefined`: qualquer *truthy* fora de formato chegava
+// inteiro ao reactflow, que faz `.map` nele — e `.map` de não-array ESTOURA no render, que não
+// cai no `.catch()` da promise. É a mesma armadilha que o `ClientTimeline` documenta.
+describe("funil com nodes/edges fora de formato não derruba o builder", () => {
+  function renderEdit() {
+    return render(
+      <MemoryRouter initialEntries={["/funis/f-1"]}>
+        <Routes>
+          <Route path="/funis/:id" element={<FunnelBuilderPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  function mockFunnel(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/funnels/components") return Promise.resolve({ data: catalog } as never);
+      if (url === "/settings/profile") return Promise.resolve({ data: profile(null) } as never);
+      if (url === "/funnels/f-1") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["objeto no lugar da lista", { name: "F", nodes: { a: 1 }, edges: { b: 2 } }],
+    ["string no lugar da lista", { name: "F", nodes: "n", edges: "e" }],
+    ["número no lugar da lista", { name: "F", nodes: 3, edges: 4 }],
+    ["payload inteiro fora de formato", "não é json"],
+  ])("%s → o builder monta vazio em vez de estourar", async (_rotulo, payload) => {
+    mockFunnel(payload);
+    renderEdit();
+
+    // O catálogo é a prova de que o render CHEGOU AO FIM: ele fica depois do canvas na árvore.
+    await waitFor(() => expect(screen.getByText("Novo Lead")).toBeInTheDocument());
+  });
+
+  it("nodes/edges de verdade continuam chegando ao canvas", async () => {
+    // Contra-teste: a guarda não pode ter fechado o caminho feliz.
+    mockFunnel({
+      name: "Funil real",
+      nodes: [{ id: "n1", position: { x: 0, y: 0 }, data: { key: "novo_lead", label: "Novo Lead" } }],
+      edges: [],
+    });
+    renderEdit();
+
+    await waitFor(() => expect(screen.getByDisplayValue("Funil real")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -224,8 +224,12 @@ function Builder() {
     if (!isNew && id) {
       api.get(`/funnels/${id}`).then(({ data }) => {
         setName(data.name);
-        setNodes(data.nodes ?? []);
-        setEdges(data.edges ?? []);
+        // `Array.isArray`, e não `?? []` (issue #179): um valor *truthy* fora do formato passa
+        // pelo `??` e chega inteiro ao reactflow, que faz `.map` nele. Pior, `setNodes`/`setEdges`
+        // são setters de estado do React: se o valor for FUNÇÃO, o React a trata como updater e a
+        // EXECUTA — a armadilha que o `ClientTimeline` documenta.
+        setNodes(Array.isArray(data?.nodes) ? data.nodes : []);
+        setEdges(Array.isArray(data?.edges) ? data.edges : []);
       });
     }
   }, [isNew, id, setNodes, setEdges]);

--- a/apps/web/src/features/pagar/ComprovantePage.test.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.test.tsx
@@ -598,3 +598,44 @@ describe("ComprovantePage — a escolha da baixa (Story 8.13)", () => {
     expect(pagina.className).toContain("pb-52");
   });
 });
+
+// ── Payload fora de forma na bandeja de comprovantes (issue #179) ─────────────
+describe("bandeja fora de formato não identifica comprovante nenhum", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fusoDoTenant = "America/Sao_Paulo";
+  });
+
+  it("payload que RESPONDE a `.find` mas não é lista não vira comprovante", async () => {
+    // A asserção que mata a volta para `data.find(...) ?? null`: com um objeto que tem `.find`,
+    // o código antigo aceitava o retorno como se fosse um `ReceiptInfo` da bandeja e escrevia o
+    // nome dele no cabeçalho. `Array.isArray` reprova por FORMA — "não é lista, não tem
+    // comprovante" — em vez de confiar em quem responde ao método certo.
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/receipts") {
+        return Promise.resolve({
+          data: { find: () => ({ id: "r-1", filename: "forjado.pdf", size: 4096 }) },
+        } as never);
+      }
+      if (url.startsWith("/payables/receipts/candidates")) return Promise.resolve({ data: [] } as never);
+      if (url === "/bank/accounts") return Promise.resolve({ data: [CONTA] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Comprovante recebido")).toBeInTheDocument());
+    expect(screen.queryByText("forjado.pdf")).not.toBeInTheDocument();
+  });
+
+  it("bandeja não-array degrada para o rótulo genérico, sem derrubar a tela", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/receipts") return Promise.resolve({ data: { detail: "erro" } } as never);
+      if (url.startsWith("/payables/receipts/candidates")) return Promise.resolve({ data: [] } as never);
+      if (url === "/bank/accounts") return Promise.resolve({ data: [CONTA] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Comprovante recebido")).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -100,7 +100,11 @@ export default function ComprovantePage() {
       .get<ReceiptInfo[]>("/payables/receipts")
       .then(({ data }) => {
         if (cancelled) return;
-        setReceipt(data.find((r) => r.id === id) ?? null);
+        // `Array.isArray`, e não `data.find(...) ?? null` (issue #179): com `data` fora do
+        // formato, `.find` não existe e o `TypeError` cai no `.catch()` abaixo — que está escrito
+        // para "sem o nome do arquivo a tela opera igual", então o erro sumiria em silêncio e o
+        // comprovante ficaria sem identificação sem ninguém saber por quê.
+        setReceipt(Array.isArray(data) ? (data.find((r) => r.id === id) ?? null) : null);
       })
       .catch(() => {
         /* o nome do arquivo é contexto, não função — sem ele a tela opera igual */

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `lib/api` cria os clientes axios no import; mockar a fábrica mantém o módulo importável sem
+// rede e devolve o mesmo objeto em `api`/`publicApi` (o que basta: só `api.post` é exercido).
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+vi.mock("axios", () => {
+  const instancia = {
+    post: postMock,
+    get: vi.fn(),
+    interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+  };
+  return { default: { create: () => instancia, isAxiosError: () => false }, AxiosError: class {} };
+});
+
+const { refreshSession } = await import("./api");
+
+beforeEach(() => {
+  postMock.mockReset();
+});
+
+/**
+ * `refreshSession` guarda a SESSÃO — por isso a checagem é de FORMA, não de veracidade (#179).
+ *
+ * O retorno vai direto para o `localStorage` e daí para o header `Authorization`. Com o antigo
+ * `data.access_token ?? null`, qualquer *truthy* passava: um objeto de erro serializado viraria
+ * `Bearer [object Object]` e o backend responderia 401 opaco a cada request seguinte — em vez do
+ * `null` que significa "não renovou", que é o caso que o interceptor sabe tratar (logout limpo).
+ */
+describe("refreshSession — token só é token se tiver FORMA de token", () => {
+  it("devolve a string quando o servidor renova de verdade", async () => {
+    postMock.mockResolvedValue({ data: { access_token: "tok-novo" } });
+    await expect(refreshSession()).resolves.toBe("tok-novo");
+  });
+
+  it.each([
+    ["objeto", { erro: "boom" }],
+    ["número", 12345],
+    ["booleano", true],
+    ["array", ["tok"]],
+    ["string vazia", ""],
+    ["ausente", undefined],
+  ])("payload com access_token %s NÃO vira sessão", async (_rotulo, valor) => {
+    postMock.mockResolvedValue({ data: { access_token: valor } });
+    await expect(refreshSession()).resolves.toBeNull();
+  });
+
+  it("payload inteiro fora de formato não vira sessão nem estoura", async () => {
+    postMock.mockResolvedValue({ data: "não é json" });
+    await expect(refreshSession()).resolves.toBeNull();
+  });
+
+  it("falha de rede continua sendo `null`, nunca exceção", async () => {
+    postMock.mockRejectedValue(new Error("offline"));
+    await expect(refreshSession()).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -45,7 +45,13 @@ export const publicApi = axios.create({
 export async function refreshSession(): Promise<string | null> {
   try {
     const { data } = await api.post<{ access_token: string }>("/auth/refresh");
-    return data.access_token ?? null;
+    // Guarda por FORMA, nunca por veracidade (issue #179): isto é SESSÃO. `data.access_token ??
+    // null` aceitava qualquer *truthy* — um objeto de erro serializado, um número — e ele iria
+    // parar no header `Authorization` como `[object Object]`, trocando "sessão não renovada"
+    // (que o interceptor sabe tratar) por um 401 opaco a cada request seguinte.
+    return typeof data?.access_token === "string" && data.access_token !== ""
+      ? data.access_token
+      : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Resumo

Propaga a `ClientTimeline`/`GanchoDaVima` a checagem por **forma** sobre payload de resposta de API.
`?? null` / `?? []` só barra `null`/`undefined`: qualquer *truthy* fora de formato passa e vira
render. Fecha #179.

## O alcance, medido — 7 sites, não 6

A contagem de 66 da issue não reproduz:

| Varredura em `apps/web/src` | Contagem |
|---|---|
| `?? null` / `\|\| null`, todos os arquivos | 55 |
| idem, excluindo testes | **53** |
| incluindo `?? []`, `?? {}`, `\|\| []`, `\|\| {}`, excl. testes | **67** |
| destes, sobre **payload de resposta de API** | **7** |

O sétimo, que o `grep` da issue estruturalmente não podia ver:

- **`auth/LoginPage.tsx:93`** — `setDevToken(data.dev_reset_token ?? null)`, renderizado direto em
  `<code>{devToken}</code>`. Objeto *truthy* passa e o React estoura com *"Objects are not valid as a
  React child"* — **tela branca no login**, a única tela de onde ninguém sai navegando.

## Um falso positivo da lista da issue, revertido de propósito

**`funis/FunnelAutomation.tsx:37`** não é defeito. Todo consumo de `cfg` é `cfg.X ?? padrão` sobre
chaves que nenhum protótipo embutido define, e `cfg` nunca é espalhado nem iterado: com `config`
valendo string, número ou array, **toda** leitura dá `undefined` e a tela renderiza igual a `{}`.

A guarda chegou a ser escrita e é **mutante equivalente por construção**. Foi revertida e a razão
ficou no código, seguindo a doutrina que o próprio `GanchoDaVima` escreve: *"predicado sem rede é
dívida, não proteção"*. A proteção real desse caminho mora na origem, em `FunnelBuilderPage`.

## O pior site, e o que ele ensinou

`dna/NucleoPage.tsx:46` com `{}`: `!perguntas` não pega, `perguntas.length === 0` vira
`undefined === 0`, e `perguntas[i].key` estoura **dentro do render**. Medido contra o código não
corrigido:

```
TypeError: Cannot read properties of undefined (reading 'key')
❯ NucleoPage src/features/dna/NucleoPage.tsx:113:27
    113|         key={perguntas[i].key}
```

E um **segundo** modo de falha que a issue não mapeou:

```
TypeError: Cannot read properties of undefined (reading 'map')
❯ PerguntaDaVima src/features/dna/PerguntaDaVima.tsx:65:28
```

Por isso `Array.isArray` **sozinho não bastava** — um array bem formado de itens fora de contrato
passa por ele e estoura adiante. O filtro reusa `ehPergunta` do #161, agora exportado: um predicado
só, não uma terceira convenção.

## Prova por mutação — 7 mutações, 7 mortas

| Mutação (volta ao original) | Testes mortos | Mensagem real |
|---|---|---|
| `NucleoPage` → `data ?? []` | **10 de 19** | `TypeError: Cannot read properties of undefined (reading 'key')` |
| `NucleoPage` → `Array.isArray(data) ? data : []` | **3 de 19** | `TypeError: …(reading 'map')` + `Unable to find an element with the text: 1 de 2` |
| `ComprovantePage` → `data.find(...) ?? null` | 1 | `expected document not to contain element, found <p` |
| `FunnelBuilderPage` → `data?.nodes ?? []` | **3 de 9** | `TypeError: nodes.find is not a function` |
| `ContasSaldosPage` → `cps.data[0] ?? null` | 2 | `TypeError: …(reading 'slice')` |
| `lib/api` → `data.access_token ?? null` | **5 de 9** | `expected { erro: 'boom' } to be null` · `expected 12345 to be null` |
| `LoginPage` → `data.dev_reset_token ?? null` | 3 | `expected document not to contain element, found <code />` |

A segunda linha é a que mais importa: prova que a guarda de tipo **sem** a de forma deixaria o defeito
de pé.

**Mutante equivalente dispensado:** `FunnelAutomation:37`, com a razão gravada no código.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → Test Files 75 passed (75) · Tests 890 passed (890)
E2E_PORT=… pnpm e2e contas-modais-360 gancho-fantasma-360 → 5 passed (40.9s)
```

Um flake foi **investigado em vez de ignorado**: trocando `ContasSaldosPage.tsx` pela versão de
`origin/main` por cópia de arquivo, o padrão de falha variou entre corridas (3 → 1 → 0)
**independentemente da versão**. É contenção de CPU, não o diff.

## Fora de escopo (vira issue) — e é maior que esta

**67 sites `setX(data)` / `setX(res.data)`** — payload cru direto no setter, **sem operador nenhum**.
Classe estritamente maior e mais perigosa que a desta issue (`FunnelBuilderPage:216 setCatalog(data)`
→ `catalog.map` no render; `ContasSaldosPage:113 setAccounts(res.data)` → `accounts.map`). Tocá-los
aqui viraria um diff irrevisável.

Fecha #179.
