### PR TITLE
fix(financeiro): abrir 'Personalizado' aplicava o intervalo da MONTAGEM, nao o em vigor [#180]

### DIFF
--- a/apps/web/src/features/financeiro/PeriodPicker.test.tsx
+++ b/apps/web/src/features/financeiro/PeriodPicker.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import PeriodPicker from "./PeriodPicker";
+import { resolvePeriod, type PeriodRange } from "./periodRange";
+
+/**
+ * Espelha os QUATRO call sites reais (`DrePage`, `LucratividadePage`, `ConferenciaPage`,
+ * `ContasSaldosPage`): todos guardam o período num `useState(() => resolvePeriod("this_year"))`
+ * e passam o par `value`/`onChange` direto. Nenhum deles mexe no período por fora do picker,
+ * então o `value` que o componente recebe é SEMPRE o eco da sua própria última mudança.
+ * `em-vigor` é o período que o pai está de fato usando para consultar o backend.
+ */
+function Pai({ inicial }: { inicial: PeriodRange }) {
+  const [range, setRange] = useState<PeriodRange>(inicial);
+  return (
+    <>
+      <PeriodPicker value={range} onChange={setRange} />
+      <output data-testid="em-vigor">{`${range.start}..${range.end}`}</output>
+    </>
+  );
+}
+
+const seletor = () => screen.getByLabelText("Período");
+const inicio = () => screen.getByLabelText("Início do período personalizado");
+const fim = () => screen.getByLabelText("Fim do período personalizado");
+
+describe("PeriodPicker", () => {
+  beforeEach(() => {
+    // Instante congelado: sem ele, "Este mês"/"Este ano" mudam de valor conforme o calendário
+    // da máquina e o teste vira um oráculo diferente a cada mês. 21/08/2026, 15:00Z — a suíte
+    // roda em America/Sao_Paulo e `resolvePeriod` lê o relógio em UTC, então o mês é agosto.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-21T15:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reabrir 'Personalizado' mostra o intervalo EM VIGOR, não o da montagem", () => {
+    render(<Pai inicial={resolvePeriod("this_year")} />);
+
+    fireEvent.change(seletor(), { target: { value: "this_month" } });
+    fireEvent.change(seletor(), { target: { value: "custom" } });
+
+    expect(inicio()).toHaveValue("2026-08-01");
+    expect(fim()).toHaveValue("2026-08-31");
+  });
+
+  it("abrir 'Personalizado' NÃO troca o período em vigor por baixo do dono", () => {
+    // O lado do dinheiro do mesmo defeito: o pai refaz a consulta ao backend a cada troca de
+    // `period` (`useCallback([period, …])`), então um intervalo velho aplicado aqui não é só um
+    // campo mal preenchido — é a DRE inteira voltando para o ano quando o dono pediu o mês.
+    render(<Pai inicial={resolvePeriod("this_year")} />);
+
+    fireEvent.change(seletor(), { target: { value: "this_month" } });
+    expect(screen.getByTestId("em-vigor")).toHaveTextContent("2026-08-01..2026-08-31");
+
+    fireEvent.change(seletor(), { target: { value: "custom" } });
+    expect(screen.getByTestId("em-vigor")).toHaveTextContent("2026-08-01..2026-08-31");
+  });
+
+  it("digitar no campo personalizado não fecha o campo debaixo do dedo", () => {
+    // Mata o conserto alternativo — pôr o intervalo na `key` do componente. Como cada tecla já
+    // chama `onChange`, uma `key` derivada do `value` remontaria o picker a CADA dígito: o
+    // `shortcut` voltaria a "Este ano", os dois campos de data sumiriam da tela e o foco iria
+    // junto. O precedente por `key` do repo (`NewBillModal`, `pagar/PagarPage.tsx`) é legítimo
+    // lá porque aquilo é um MODAL, que nasce e morre por abertura; este aqui fica montado.
+    render(<Pai inicial={resolvePeriod("this_year")} />);
+    fireEvent.change(seletor(), { target: { value: "custom" } });
+
+    inicio().focus();
+    fireEvent.change(inicio(), { target: { value: "2026-03-01" } });
+
+    expect(screen.queryByLabelText("Início do período personalizado")).not.toBeNull();
+    expect(inicio()).toHaveValue("2026-03-01");
+    expect(document.activeElement).toBe(inicio());
+  });
+
+  it("abrir 'Personalizado' não dispara consulta nova — o pai depende da IDENTIDADE do objeto", () => {
+    // `DrePage`/`LucratividadePage` fecham o `load` num `useCallback([period, …])`. Um `onChange`
+    // com os MESMOS valores mas objeto novo passa pela igualdade referencial do React e refaz a
+    // consulta à toa. Abrir o campo para ajustar não é ainda um pedido de período novo.
+    const onChange = vi.fn();
+    render(<PeriodPicker value={resolvePeriod("this_year")} onChange={onChange} />);
+
+    fireEvent.change(seletor(), { target: { value: "custom" } });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(inicio()).toHaveValue("2026-01-01");
+  });
+
+  it("o que o dono digita vira o período em vigor, campo a campo", () => {
+    render(<Pai inicial={resolvePeriod("this_year")} />);
+    fireEvent.change(seletor(), { target: { value: "custom" } });
+
+    fireEvent.change(inicio(), { target: { value: "2026-03-01" } });
+    expect(screen.getByTestId("em-vigor")).toHaveTextContent("2026-03-01..2026-12-31");
+
+    fireEvent.change(fim(), { target: { value: "2026-06-30" } });
+    expect(screen.getByTestId("em-vigor")).toHaveTextContent("2026-03-01..2026-06-30");
+  });
+});

--- a/apps/web/src/features/financeiro/PeriodPicker.tsx
+++ b/apps/web/src/features/financeiro/PeriodPicker.tsx
@@ -20,16 +20,44 @@ export default function PeriodPicker({
   value: PeriodRange;
   onChange: (range: PeriodRange) => void;
 }) {
+  /**
+   * ⚠️ O rótulo do select nasce FIXO em "Este ano" — ele não olha o `value` recebido. Hoje isso
+   * não mente porque os QUATRO call sites montam com `resolvePeriod("this_year")` (verificado
+   * em 21/08/2026: DrePage:32, LucratividadePage:17, ConferenciaPage:53, ContasSaldosPage:531),
+   * e nenhum deles mexe no período por fora deste componente. Um call site novo que monte com
+   * outro período faria o rótulo mentir já no primeiro quadro — se isso acontecer, o conserto é
+   * receber o atalho como prop, não adivinhar o atalho a partir do intervalo.
+   */
   const [shortcut, setShortcut] = useState<PeriodShortcut>("this_year");
-  const [customStart, setCustomStart] = useState(value.start);
-  const [customEnd, setCustomEnd] = useState(value.end);
+
+  /**
+   * Os dois campos de "Personalizado" são DERIVADOS do prop — não há cópia local deles (#180).
+   *
+   * ⚠️ Eram `useState(value.start)`/`useState(value.end)`. `useState` lê o argumento só na
+   * MONTAGEM, e este componente NÃO desmonta: ele fica na barra da DRE/Lucratividade/Conferência/
+   * Contas & Saldos a tela inteira. Trocar para "Este mês" e depois abrir "Personalizado" aplicava
+   * de volta o intervalo da MONTAGEM ("Este ano") — e como o pai refaz a consulta ao backend a
+   * cada `period` novo, a tela voltava para o ano quando o dono tinha pedido o mês.
+   *
+   * Aqui não existe rascunho a preservar (o padrão `rascunho ?? prop` do #155): cada tecla já
+   * chama `onChange`, então o prop É o que o dono acabou de digitar. Ler direto dele deixa o
+   * componente sem estado nenhum que possa envelhecer.
+   *
+   * A alternativa era pôr o intervalo na `key` do picker, remontando-o a cada mudança. Custa
+   * caro justamente porque cada tecla muda o intervalo: o `shortcut` voltaria a "Este ano", os
+   * campos de data sumiriam da tela e o foco iria junto — o campo fecharia debaixo do dedo. O
+   * precedente de conserto por `key` deste repo (`NewBillModal`, `pagar/PagarPage.tsx`) é
+   * legítimo lá porque aquilo é um MODAL, que nasce e morre por abertura; este não é.
+   */
+  const customStart = value.start;
+  const customEnd = value.end;
 
   function selectShortcut(next: PeriodShortcut) {
     setShortcut(next);
-    if (next === "custom") {
-      onChange({ start: customStart, end: customEnd });
-      return;
-    }
+    // "Personalizado" não aplica intervalo nenhum: só abre os campos já preenchidos com o
+    // período EM VIGOR, para o dono ajustá-lo. Chamar `onChange` aqui com os mesmos valores
+    // dispararia uma consulta redundante ao backend — o pai depende da IDENTIDADE do objeto.
+    if (next === "custom") return;
     onChange(resolvePeriod(next));
   }
 
@@ -52,10 +80,7 @@ export default function PeriodPicker({
           <input
             type="date"
             value={customStart}
-            onChange={(e) => {
-              setCustomStart(e.target.value);
-              onChange({ start: e.target.value, end: customEnd });
-            }}
+            onChange={(e) => onChange({ start: e.target.value, end: customEnd })}
             aria-label="Início do período personalizado"
             className="rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
           />
@@ -63,10 +88,7 @@ export default function PeriodPicker({
           <input
             type="date"
             value={customEnd}
-            onChange={(e) => {
-              setCustomEnd(e.target.value);
-              onChange({ start: customStart, end: e.target.value });
-            }}
+            onChange={(e) => onChange({ start: customStart, end: e.target.value })}
             aria-label="Fim do período personalizado"
             className="rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400"
           />


### PR DESCRIPTION
## O defeito, medido

`PeriodPicker` guardava o intervalo personalizado em `useState(value.start)` / `useState(value.end)`.
`useState` lê o argumento só na **montagem**, e este componente **não desmonta**: fica na barra da
DRE / Lucratividade / Conferência / Contas & Saldos a tela inteira.

Trocar para "Este mês" e depois abrir "Personalizado" reaplicava o intervalo da montagem
("Este ano"). Fecha #180.

**E não é só um campo mal preenchido:** os quatro pais fecham o `load` num `useCallback([period, …])`,
então o intervalo velho **refaz a consulta ao backend** e devolve a tela inteira para o ano quando o
dono tinha pedido o mês.

Medido antes de consertar, com produção intacta:

```
❯ src/features/financeiro/PeriodPicker.test.tsx (4 tests | 2 failed)
  × reabrir 'Personalizado' mostra o intervalo EM VIGOR, não o da montagem
    → expect(element).toHaveValue(2026-08-01)
       Expected: 2026-08-01
       Received: 2026-01-01
  × abrir 'Personalizado' NÃO troca o período em vigor por baixo do dono
    → Expected: 2026-08-01..2026-08-31
       Received: 2026-01-01..2026-12-31
```

## O alcance — a varredura do #155 refeita, e confirmada

784 ocorrências de `useState`; 142 com inicializador não-trivial; filtrando lazy-init e constantes de
módulo, os sítios que nascem de **prop**:

| Sítio ← prop | Veredito |
|---|---|
| `crm/ClientDetailPage.tsx:304` `ChargeRow` ← `c.due_date` | já é `rascunho ?? c.due_date` (#155 / PR #187) |
| **`financeiro/PeriodPicker.tsx:24-25` ← `value`** | **era o único vivo — consertado aqui** |
| `pagar/PagarPage.tsx:665-674` `NewBillModal` ← `inicial` | resolvido por `key={duplicando?.id ?? "nova"}` — é **modal** |
| `cobrancas`, `crm`, `pagar`, `funis` (montagem condicional) | rascunho que morre ao fechar |
| `pagar/EscolhaDaBaixa.tsx:119`, `financeiro/ChartAccountSelect.tsx:25` | conferidos call site a call site: prop constante |
| `vima/PreferenciasSection.tsx:21-22` | monta só depois de `prefs != null`; o `prefs` novo é eco do próprio save |
| `contratos`, `funis`, `orcamentos`, `marketing` ← `useParams` | ressincronizam via `useEffect([isNew,id]) → hydrate()` |

**`PeriodPicker` era o único caso vivo.** A tabela da issue estava correta.

## O conserto, e por que este

Os dois campos passam a ser **derivados do prop** — o componente fica **sem estado nenhum** que possa
envelhecer. Aqui não há rascunho a preservar como no #155: cada tecla já chama `onChange`, então o
prop *é* o que o dono acabou de digitar. Um `rascunho` local reintroduziria o mesmo defeito pela porta
dos fundos.

Segundo movimento: `selectShortcut("custom")` deixou de chamar `onChange`. Abrir o campo para ajustar
não é ainda um pedido de período novo.

**A `key` foi medida e rejeitada** (precedente do `NewBillModal`, legítimo lá porque é modal):

```
× digitar no campo personalizado não fecha o campo debaixo do dedo
  → expected null not to be null
× o que o dono digita vira o período em vigor
  → Unable to find a label with the text of: Fim do período personalizado
```

Ela **conserta** o defeito da issue — só cobra o preço de fechar os dois campos de data a cada tecla.
Sem os testes 3 e 4 a escolha pareceria empate.

## Prova por mutação — 5 mutações, 5 mortas

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| volta a `useState(value.start/end)` (o defeito) | 3 testes | `Expected: 2026-08-01 / Received: 2026-01-01` · `expected "spy" to not be called at all, but actually been called 1 times` |
| o conserto por `key` | 2 testes | `expected null not to be null` · `Unable to find a label…` |
| campo Início ignora `e.target.value` | 2 testes | `Expected: 2026-03-01 / Received: 2026-01-01` |
| campo Fim ignora `e.target.value` | 1 teste | `Expected: 2026-03-01..2026-06-30` |
| `if (next === "custom")` volta a chamar `onChange` | 1 teste | `expected "spy" to not be called at all, but actually been called 1 times` |

A última merece nota: com o conserto derivado, essa chamada tem os **mesmos valores** — seria mutante
equivalente se a régua só olhasse texto na tela. Não é equivalente pelo que o repo faz com ele (o pai
compara **identidade** de objeto), então a asserção de spy a mata em vez de dispensá-la.

Primeira mutação refeita de forma independente na revisão, com o mesmo resultado.

## Fora de escopo, medido e não commitado

`shortcut` nasce fixo em `"this_year"` sem olhar o `value` recebido. **Não é defeito vivo:** os quatro
call sites montam com `resolvePeriod("this_year")` (`DrePage:32`, `LucratividadePage:17`,
`ConferenciaPage:53`, `ContasSaldosPage:531`) e nenhum mexe no período por fora do picker. Virou aviso
escrito na linha, com a data, os 4 call sites nomeados e o conserto certo apontado — não virou código,
e não virou issue: não há sintoma para relatar hoje.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → Test Files 75 passed (75) · Tests 860 passed (860)
E2E_PORT=… pnpm e2e (3 specs que montam PeriodPicker) → 66 passed, 1 failed (7.6m)
```

O vermelho é `alcance-360.spec.ts:52 › /financeiro` — **passa isolado** (`1 passed`, 24,1s), e
`/financeiro` → `FinanceiroPage` **não monta `PeriodPicker`**. Contenção, a classe do #162.

Fecha #180.
