### PR TITLE
fix(web): os 3 alvos de centros de custo vao a 44px, e a rota ganha a terceira regua [#181]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,32 @@ alcançabilidade, e não há régua verde para ela nesta rota. Medido também qu
 do nome **não muda o número** (o `span` é item de flex com `min-width: auto`, então nunca chega a
 quebrar) — mudança que nenhuma régua vê é peso morto, e por isso ela não entrou.
 
+**A TERCEIRA régua de `/financeiro/centros-custo` (#181, 2026-08-21) — e o que ela ensina sobre as
+duas anteriores.** A mesma tela já tinha passado em duas réguas e continuava com **3 alvos abaixo
+do mínimo tocável de 44px**, medidos com `alvosPequenos` no documento inteiro em 360×740:
+
+| Elemento | Antes | Depois |
+|---|---|---|
+| `input[type=checkbox]` «Mostrar arquivados» (área do `<label>`) | 13×13 (rótulo de **20px**) | rótulo de **44px** |
+| `button` «Editar» do cartão | 49,6 × **16** | 57,6 × **44** |
+| `button` «Arquivar» do cartão | 64,3 × **16** | 72,3 × **44** |
+
+Os dois botões são **exatamente os que o #144/PR #156 tornou alcançáveis**: alcançáveis, e de 16px.
+É a lição cara desta rota — **verde em `alcance-360` e em `centros-custo-360` não diz nada sobre
+tamanho de alvo**, porque as três perguntam coisas diferentes (o dedo CHEGA? a TINTA cabe? o alvo
+tem TAMANHO de dedo?). Consertado com o precedente de `ContasSaldosPage.tsx`: `min-h-[44px]` nas
+duas ações e na **linha inteira** do rótulo do checkbox — nunca engordando o `<input>`, que
+viraria um quadrado do tamanho de um botão. Travado por `apps/web/e2e/toque-360.spec.ts`, com
+varredura de `alvosPequenos` no documento inteiro (não só nos três alvos conhecidos).
+
+- **Dívida:** o modal de cadastro/edição desta rota tem **2** alvos abaixo de 44 — o `<input>` do
+  `Field` (**38px**, a dívida GERAL do componente compartilhado, já registrada na Onda 2) e o
+  `<select>` de tipo (**39px**). Fora do escopo do #181, que mede a superfície da PÁGINA.
+- **Dívida:** a varredura filtra `input` por construção — `alvosPequenos` mede o ELEMENTO, e a
+  caixinha do checkbox tem 20×20 por convenção do repo. O custo, medido: tirar o `h-5 w-5` do
+  `<input>` (volta a 13×13) e o `px-1` dos botões são **mutantes equivalentes** — sobrevivem à
+  régua, porque o que ela exige é ÁREA de toque, não quadrado desenhado.
+
 
 ### 5.5 As suítes pesadas não se sobrepõem (issue #162, 2026-08-20)
 

--- a/apps/web/e2e/toque-360.spec.ts
+++ b/apps/web/e2e/toque-360.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { mockarApi } from "./support/api";
-import { medirPagina } from "./support/medidas";
+import { alvosPequenos, medirPagina } from "./support/medidas";
+import { LONGO } from "./support/rotas";
 import { semearSessao } from "./support/sessao";
 
 const CONTA = {
@@ -195,4 +196,126 @@ test("a aba 'A sua empresa' abre recolhida, não com 22 telas de rolagem", async
   expect(caixa!.x).toBeGreaterThanOrEqual(0);
   expect(caixa!.x + caixa!.width).toBeLessThanOrEqual(360);
   expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+// ── `/financeiro/centros-custo` ────────────────────────────────────────────────────
+// A TERCEIRA régua desta rota (#181), e as outras duas já passavam nela quando esta foi escrita.
+//
+// ⚠️ Três perguntas DIFERENTES sobre a mesma tela, e verde nas duas primeiras não diz nada sobre a
+// terceira — foi exatamente assim que este defeito sobreviveu a dois PRs:
+//
+//   - `alcance-360` (#144/PR #156): o dedo CHEGA ao controle? Ali «Editar» e «Arquivar» começavam
+//     em x=637 e x=699 numa tela de 360px — INTEIRAMENTE fora. O `flex-wrap` os trouxe de volta.
+//   - `centros-custo-360` (#157/PR #174): a TINTA cabe? 14 elementos de texto terminavam além da
+//     borda do cartão, com a página inteira ainda dizendo `scrollWidth === 360`.
+//   - esta: o alvo tem TAMANHO de dedo? Os dois botões que o #156 tornou alcançáveis ficaram
+//     alcançáveis **e de 16px de altura**, e o «Mostrar arquivados» era um checkbox de **13×13**
+//     — a forma LITERAL do defeito do PR #56, onde um controle pequeno demais fez uma conta real
+//     ser marcada como paga sem o dono conseguir ver.
+//
+// Medido em 21/08/2026, ANTES do conserto, com `alvosPequenos` no documento inteiro:
+//   input                                  13   × 13
+//   button «Editar»                        49,6 × 16
+//   button «Arquivar»                      64,3 × 16
+//
+// A fixture é a MESMA de `centros-custo-360` e de `support/rotas.ts` (nome de 74 chars sem
+// espaço) de propósito: 44px de altura muda o REFLOW do cartão, e medir com nome curto seria
+// medir uma tela que o #157 já provou não existir.
+const CENTRO = {
+  id: "cc1",
+  tenant_id: "t1",
+  name: LONGO,
+  kind: "operacional",
+  archived_at: null,
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+const RELATORIO_CENTROS = {
+  start: "2026-08-01",
+  end: "2026-08-31",
+  buckets: [
+    {
+      cost_center_id: "cc1",
+      name: LONGO,
+      kind: "operacional",
+      receita_cents: 123456789,
+      resultado_cents: -98765432,
+      lancamentos: 42,
+    },
+    {
+      cost_center_id: null,
+      name: "Não atribuído",
+      kind: null,
+      receita_cents: 0,
+      resultado_cents: -1234567,
+      lancamentos: 3,
+    },
+  ],
+  notes: [],
+};
+
+test("as ações do centro de custo são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/cost-centers": [CENTRO],
+    // `by-cost-center` devolve OBJETO. Com o `[]` default de `mockarApi` a tela quebra no primeiro
+    // campo e o que sobra é uma página em branco — que não tem controle nenhum e passaria.
+    "/financial-intelligence/by-cost-center": RELATORIO_CENTROS,
+  });
+  await page.goto("/financeiro/centros-custo");
+  // A `marca`: sem ela, "zero alvos pequenos" significaria "não desenhou nada".
+  await expect(page.getByTestId("lista-centros")).toBeVisible();
+
+  // As duas ações do cartão — as MESMAS que o #156 trouxe para dentro da tela, e «Arquivar» é
+  // destrutiva. Mesma forma do bloco de `/financeiro/contas` acima, inclusive a mensagem por
+  // rótulo: um vermelho sem nome não diz qual dos dois encolheu.
+  for (const rotulo of ["Editar", "Arquivar"]) {
+    const alvo = page.getByRole("button", { name: rotulo }).last();
+    const caixa = await alvo.boundingBox();
+    expect(caixa, rotulo).not.toBeNull();
+    expect(caixa!.height, rotulo).toBeGreaterThanOrEqual(44);
+  }
+
+  // O alvo do checkbox é a LINHA INTEIRA do rótulo, não a caixinha — mesma convenção do
+  // «Mostrar arquivadas» de `/financeiro/contas` (`ContasSaldosPage.tsx:208`). Engordar o
+  // `<input>` para 44×44 daria um quadrado desenhado do tamanho de um botão; o que o dedo precisa
+  // é de ÁREA, e o `<label>` já alterna o estado em qualquer ponto dela.
+  const caixaCheckbox = await page.getByText("Mostrar arquivados").boundingBox();
+  expect(caixaCheckbox, "Mostrar arquivados").not.toBeNull();
+  expect(caixaCheckbox!.height, "Mostrar arquivados").toBeGreaterThanOrEqual(44);
+
+  // O «Novo centro de custo» vem do `usePrimaryAction` e é desenhado pelo CABEÇALHO DO SHELL —
+  // outro botão, outra classe, fora do `<main>`. É o mesmo cuidado que o bloco de
+  // `/financeiro/contas` tem com o «Transferir entre contas» do cabeçalho: lá a medição final o
+  // pegou em 34px depois de as ações do cartão irem para 44.
+  const cabecalho = await page
+    .getByRole("button", { name: "Novo centro de custo" })
+    .boundingBox();
+  expect(cabecalho, "Novo centro de custo").not.toBeNull();
+  expect(cabecalho!.height, "Novo centro de custo").toBeGreaterThanOrEqual(44);
+
+  // E a varredura, que é o que impede este arquivo de medir SÓ os três alvos que a issue já
+  // conhecia. Documento inteiro de propósito: um ícone, um chip, um `summary` ou um controle de
+  // filtro acrescentado depois entra na conta sem ninguém precisar lembrar de escrever a linha.
+  //
+  // ⚠️ **O `<input>` fica de fora, e o motivo é que `alvosPequenos` mede o ELEMENTO, não a área
+  // que o dedo acerta.** A caixinha do checkbox tem 20×20 DEPOIS do conserto, e continuará tendo:
+  // quem cumpre os 44px é o `<label>` que a envolve — medido oito linhas acima, e a mesma
+  // convenção de `ContasSaldosPage.tsx:208`. Exigir 44 do quadrado desenhado acusaria toda tela
+  // que segue o padrão do repo e daria um botão onde deveria haver um checkbox.
+  //
+  // O que este filtro CUSTA, dito por extenso em vez de escondido: um campo de TEXTO de 38px
+  // acrescentado a esta página passaria por aqui. É a dívida geral do `Field`, já registrada no
+  // CLAUDE.md e no `modal-conta-360.spec.ts` (o componente é compartilhado por todos os modais do
+  // app), e não é assunto que este PR declare consertar. O modal de cadastro/edição desta rota
+  // também fica fora — ele não está aberto — e tem exatamente esses dois: o `<input>` do `Field`
+  // (38px) e o `<select>` de tipo (39px).
+  const pequenos = (await alvosPequenos(page)).filter((a) => !a.descricao.startsWith("input"));
+  expect(pequenos, "alvos abaixo de 44px").toEqual([]);
+
+  // O que as outras duas réguas já garantiam continua garantido DEPOIS de os alvos crescerem:
+  // 44px de altura mexe no reflow do cartão, e era o reflow que o #156 e o #157 consertaram.
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+  await expect(page.getByTestId("comparativo-centros")).toBeVisible();
 });

--- a/apps/web/src/features/financeiro/CentrosCustoPage.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.tsx
@@ -78,9 +78,15 @@ export default function CentrosCustoPage() {
             usa não é obrigado — lançamentos sem centro aparecem como "Não atribuído".
           </p>
         </div>
-        <label className="flex items-center gap-2 text-sm text-neutral-600">
+        {/* O alvo é a LINHA INTEIRA do rótulo, não a caixinha: o `<input>` nasce com **13×13px**
+            e engordá-lo para 44×44 desenharia um quadrado do tamanho de um botão. O `<label>` já
+            alterna o estado em qualquer ponto da sua área — mesma convenção do «Mostrar
+            arquivadas» de `ContasSaldosPage.tsx`. O `h-5 w-5` é só para a caixinha parar de ser um
+            ponto; quem cumpre os 44px é o `min-h-[44px]` da linha. */}
+        <label className="flex min-h-[44px] items-center gap-3 text-sm text-neutral-600">
           <input
             type="checkbox"
+            className="h-5 w-5 shrink-0"
             checked={includeArchived}
             onChange={(e) => setIncludeArchived(e.target.checked)}
           />
@@ -140,16 +146,21 @@ export default function CentrosCustoPage() {
                 </span>
                 {!c.archived_at && (
                   <span className="flex items-center gap-3">
+                    {/* `min-h-[44px]` nas DUAS ações. O #156 as trouxe para dentro da tela e
+                        parou aí: alcançáveis, e de **16px** de altura. «Arquivar» é destrutiva e
+                        pede confirmação, mas errar o alvo dela não é de graça — é a classe do PR
+                        #56. A fonte não cresce, só a área: o cartão fica mais alto e rolar na
+                        vertical é nativo e gratuito. Medido em #181. */}
                     <button
                       onClick={() => setEditing(c)}
-                      className="inline-flex items-center gap-1 text-xs font-medium text-neutral-500 hover:text-primary-600"
+                      className="inline-flex min-h-[44px] items-center gap-1 px-1 text-xs font-medium text-neutral-500 hover:text-primary-600"
                     >
                       <Pencil size={14} />
                       Editar
                     </button>
                     <button
                       onClick={() => archive(c.id)}
-                      className="inline-flex items-center gap-1 text-xs font-medium text-neutral-500 hover:text-danger"
+                      className="inline-flex min-h-[44px] items-center gap-1 px-1 text-xs font-medium text-neutral-500 hover:text-danger"
                     >
                       <Archive size={14} />
                       Arquivar


### PR DESCRIPTION
## Resumo

A régua de **alvo tocável de 44px** (a classe do PR #56) estava vermelha em
`/financeiro/centros-custo`, e **nenhum spec desta rota fazia essa pergunta**. Este PR mede, conserta,
e deixa a terceira régua no lugar. Fecha #181.

## O alcance, medido — 3, e nenhum quarto na página

Medi com `alvosPequenos` no **documento inteiro** (não só nos três da issue), em 360×740:

```
input                                        13   × 13
button.inline-flex… «Editar»                 49,6 × 16
button.inline-flex… «Arquivar»               64,3 × 16
```

Bate exatamente com a issue. Medi também o que ela **não** listava:

- **«Novo centro de custo» do cabeçalho** — vem do `usePrimaryAction`, é outro botão com outra classe,
  desenhado **fora do `<main>`**. Já cumpria 44px; ficou assertivo no spec assim mesmo, pelo mesmo
  cuidado que o gabarito tem com o «Transferir entre contas».
- **Lista com centro arquivado presente** — sem alvo novo (as ações não são renderizadas para
  arquivados).
- **Modal de cadastro/edição** — 2 alvos abaixo de 44. Fora do escopo, ver o rodapé.

## Por que esta rota passou em duas réguas e falhava na terceira

- **#144 (PR #156)** fechou **controle inalcançável** — «Editar» e «Arquivar» estavam *inteiramente*
  fora da tela.
- **#157 (PR #174)** fechou **texto cortado** — 14 lugares, com reflow em cartões.

Os dois botões de 16px são **exatamente os que o #156 tornou alcançáveis**. Alcançáveis, e de 16px. E
o checkbox de 13×13 é a forma literal do defeito do PR #56 — conta marcada como paga sem o dono ver.

Três réguas, três perguntas diferentes sobre a mesma tela.

## O vermelho de antes, com os três números

O spec morre no primeiro rótulo:

```
Error: Editar
expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 44
Received:    16
```

Para vê-los de uma vez, uma corrida com as asserções por rótulo neutralizadas (arquivo restaurado por
cópia logo depois):

```
Error: alvos abaixo de 44px
- Array []
+ Array [
+   Object { "altura": 13, "descricao": "input",                 "largura": 13   },
+   Object { "altura": 16, "descricao": "button…«Editar»",       "largura": 49.6 },
+   Object { "altura": 16, "descricao": "button…«Arquivar»",     "largura": 64.3 },
+ ]
```

Depois do conserto: «Editar» **57,6×44**, «Arquivar» **72,3×44**, rótulo do checkbox **151,9×44**.

## O conserto segue o precedente, não inventa

O alvo do checkbox é a **linha inteira do rótulo**, não a caixinha: engordar o `<input>` para 44×44
desenharia um quadrado do tamanho de um botão. O `<label>` já alterna o estado em qualquer ponto da
sua área — **mesma convenção do «Mostrar arquivadas» de `ContasSaldosPage.tsx`**. O `h-5 w-5` é só
para a caixinha parar de ser um ponto; quem cumpre os 44px é o `min-h-[44px]` da linha.

Nos dois botões, a fonte não cresce — só a área. O cartão fica mais alto, e rolar na vertical é nativo
e gratuito.

## Prova por mutação

| Mutação | Teste que morreu | Mensagem |
|---|---|---|
| «Editar» sem `min-h-[44px]` | `toque-360 › as ações do centro de custo…` | `Error: Editar` · `>= 44`, **recebido 16** |
| «Arquivar» sem `min-h-[44px]` | idem | `Error: Arquivar` · `>= 44`, **recebido 16** |
| `<label>` do checkbox sem `min-h-[44px]` | idem | `Error: Mostrar arquivados` · `>= 44`, **recebido 20** |
| checkbox de volta ao markup original | idem | `Error: Mostrar arquivados` · `>= 44`, **recebido 20** |

Todas compilam (`tsc --noEmit` limpo em cada estado). A primeira foi **refeita de forma independente
na revisão**, com `tsc` verificado e o mesmo `Received: 16`.

**Mutantes equivalentes, documentados e dispensados** (rodados, sobrevivem — `1 passed`): remover
`h-5 w-5` do `<input>` e remover `px-1` dos botões. A régua exige **área de toque** (o `<label>`,
44px), não o quadrado desenhado; e as larguras já eram ≥44 sem o `px-1`.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → Test Files 74 passed (74) · Tests 855 passed (855)
E2E_PORT=… pnpm e2e toque-360 centros-custo-360 rotas-360 alcance-360 → 71 passed (7.9m)
```

**As duas réguas antigas desta rota, nominalmente verdes na mesma corrida:**

```
ok 32-38  centros-custo-360.spec.ts   (as 7, incluindo as duas iscas plantadas)
ok  3     alcance-360.spec.ts:52  › /financeiro/centros-custo
ok 41     rotas-360.spec.ts:35    › /financeiro/centros-custo
ok 69     toque-360.spec.ts:44    › as ações da conta (a rota irmã, intocada)
ok 71     toque-360.spec.ts:257   › as ações do centro de custo
```

## Dívida registrada, não escondida

- **`Field` do modal (38px) e `<select>` de tipo (39px).** O `Field` é compartilhado por **todos** os
  modais do app, e `modal-conta-360.spec.ts` já registra por extenso a decisão de não engordá-lo
  ("mudaria telas que este PR declara não tocar"). O `<select>` é local, mas consertá-lo sozinho
  deixaria o modal meio-consertado.
- **`<input>` filtrado da varredura** — `alvosPequenos` mede o **elemento**, e a caixinha tem 20×20
  por convenção do repo. O custo (um campo de **texto** de 38px passaria pelo filtro) está escrito no
  spec, não silenciado.

Fecha #181. Referências: #157 (PR #174), #144 (PR #156), #56.
