### PR TITLE
fix(web): o card de titulo longo transborda os 360px em 5 telas, e a borda passa a ser medida [#182]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -613,6 +613,70 @@ rodando. Se havia, o resultado é **descartado** — não é "flake", não é "b
 numa investigação, num comentário de PR ou numa Completion Note.
 
 
+### 5.6 A régua da BORDA DO CARD (`e2e/card-largo-360.spec.ts`, issue #182, 2026-08-21)
+
+**A terceira pergunta sobre a mesma tela, e as duas primeiras são cegas para ela — cada uma por um
+motivo diferente.** Com título de pior caso (74 chars sem espaço), em 360×740:
+
+| | #135 (`rotas-360`) | #58/#144 (`alcance-360`) | **#182 (`card-largo-360`)** |
+|---|---|---|---|
+| O que mede | `scrollWidth` do documento | `boundingBox` de CONTROLE vs. a borda alcançável | **borda direita do que foi DESENHADO** (`x + width`, ou `x + scrollWidth` quando o elemento não recorta a si mesmo) |
+| Por que é cega para o #182 | `main` é `overflow-x-hidden`: o card é recortado, não empurra o documento — **360 nas cinco rotas** | a CAIXA do `<button w-full>` mede 312px e cabe; o que vaza é a TINTA, e `getBoundingClientRect` não vê tinta | — |
+
+**As cinco rotas medidas, e o que cada uma devolvia antes do conserto** (`textoForaDaTela`, escopo
+`main`; `documentElement.scrollWidth` = **360** em todas as cinco):
+
+| Rota | Sobra além da borda | Controle levado junto |
+|---|---|---|
+| `/funis` | **+316px** (nome do funil, e a linha "N componentes" junto) | — |
+| `/juridico` (documentos) | **+213,5px** | lixeira `absolute right-3` em **x 583,5 → 597,5, INTEIRAMENTE FORA** |
+| `/juridico` (skills) | **+187,5px** (rótulo e tipo de saída) | card de skill parcialmente fora (24 → 563,5) |
+| `/sites` | **+264px** (título da página) | — |
+| `/produtos` | **+264px** (nome) e **+315,8px** (etiqueta "Inativo" empurrada para x=624) | — |
+| `/financeiro/investimentos` | **+264px** (nome da conta e rótulo do índice) | — |
+
+**Os dois mecanismos, e o conserto de cada um:**
+
+1. **Trilha de grade `auto`.** `grid gap-2 sm:grid-cols-2` sem contagem de colunas no breakpoint
+   base tem UMA coluna implícita de tamanho `auto`, e trilha `auto` cresce com o min-content. Só
+   `/juridico` estava assim, e é a única em que a CAIXA do card crescia — levando junto o que está
+   `absolute` dentro dela. Conserto: `grid-cols-1`, que o Tailwind escreve `repeat(1, minmax(0,
+   1fr))`; é o `minmax(0, …)` que segura.
+2. **Item de flex com `min-width: auto`.** Ele não encolhe abaixo do próprio min-content, e o
+   min-content de uma palavra sem espaço é a palavra inteira. Conserto: **`min-w-0` no item de
+   flex + `break-words` no bloco de texto, nessa ordem** — `break-words` sozinho quebra a palavra
+   DENTRO da caixa, e a caixa é que estava larga demais (é o mesmo "não muda o número" já medido
+   no §5.4). Onde o texto é bloco dentro de bloco (`/sites`), `break-words` sozinho basta.
+
+- ⚠️ **A `marca` desta régua é o TÍTULO DO CARD, nunca o da página.** As cinco rotas estavam
+  catalogadas em `support/rotas.ts` como `// vazio`: a régua visitava, não havia card nenhum, e
+  "nada fora da borda" era o resultado — verde por não ter desenhado nada. É por isso que o defeito
+  atravessou o #135, o #144 e o #160. Cada caso do spec tem um teste irmão que reprova com payload
+  `[]` (a marca do card some, a da página fica), e `/funis` e `/juridico` saíram do estado vazio no
+  catálogo TAMBÉM, com `marca: LONGO`. **Prova por mutação:** esvaziar `FUNIS_LONGOS` deixa as
+  **três** réguas vermelhas na marca ("element(s) not found"), nunca verdes.
+- ⚠️ **`produtos-vender-360` já usava um nome de 74 chars, e mesmo assim não via** — ele aponta
+  `textoForaDaTela` para dentro do modal de venda (`'[data-testid="modal-vender-produto"]'`), e o
+  card da lista nunca esteve no escopo. Fixture de pior caso não mede nada sozinha: quem mede é o
+  escopo.
+- ⚠️ **Escopo `main`, de propósito.** `textoForaDaTela` mede contra a borda do ancestral que
+  RECORTA, e um deslizador horizontal legítimo (a DRE de 12 meses, o Kanban) tem conteúdo fora dessa
+  borda por construção. Nenhuma das cinco rotas daqui tem deslizador.
+- **O controle positivo** planta um `<p white-space: nowrap>` no `main`, prova pelo número que a
+  CAIXA cabe (`right <= 360`) e que a página não rola (360) — o disfarce exato da classe — e exige
+  que a régua veja a tinta. Mutação "régua cega" (`sobra > 0.5` → `sobra > 1e9`): morre.
+- **Mutante equivalente, medido e dispensado:** `break-words` na descrição da skill não muda número
+  nenhum, porque `line-clamp-3` já é `overflow: hidden` e ela RECORTA em vez de vazar. Não entrou —
+  mudança que nenhuma régua vê é peso morto (§5.4).
+
+**Achado fora do escopo, não consertado:** em `/marketing`, `textoForaDaTela` acusa **+808,4px** num
+`div` dentro do `CarouselThumb`. Não é defeito do produto: o thumb desenha a arte em 1080px e a
+encolhe com `transform: scale()` dentro de um `overflow: hidden` (`CarouselSlideView.tsx:182-185`), e
+`scrollWidth` é medido ANTES do `transform`. É um falso positivo da régua na mesma família da
+exceção `.react-flow` do §5.4, e por isso `/marketing` **não** entrou no catálogo do
+`card-largo-360`. O card de `/marketing` em si está correto (`truncate` + `min-w-0` + `grid-cols-2`)
+— medido, zero sobra.
+
 ## 6. Estado atual / roadmap
 - [x] Fundação do monorepo, docs, agentes de QA, CI local.
 - [x] Core do backend: tenancy (RLS) + anonimizador + camada de IA + auditoria.

--- a/apps/web/e2e/card-largo-360.spec.ts
+++ b/apps/web/e2e/card-largo-360.spec.ts
@@ -1,0 +1,247 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { controlesInalcancaveis, medirPagina, textoForaDaTela } from "./support/medidas";
+import { FUNIS_LONGOS, JURIDICO_DOCS, JURIDICO_SKILLS, LONGO } from "./support/rotas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O CARD QUE TRANSBORDA A BORDA de 360px (#182) — a terceira pergunta sobre a mesma tela.
+ *
+ * `rotas-360.spec.ts` pergunta se a página rola de lado (#135) e `alcance-360.spec.ts` se todo
+ * CONTROLE é alcançável (#58/#144). Medido nesta issue, em 360×740, com título de pior caso: as
+ * duas são cegas para o defeito daqui, e por motivos diferentes.
+ *
+ *   - **`scrollWidth` não vê.** `main` é `overflow-x-hidden` (`AppShell.tsx:64`), então o card
+ *     largo é RECORTADO em vez de empurrar o documento: `document.documentElement.scrollWidth`
+ *     devolveu **360** nas CINCO rotas medidas aqui, com o card até 316px fora da tela.
+ *   - **`controlesInalcancaveis` também não vê, em 4 das 5.** O card é um `<button w-full>`: a
+ *     CAIXA dele mede 312px e cabe. O que vaza é a TINTA — um `<p>` dentro de um item de flex com
+ *     `min-width: auto`, que não encolhe, com uma palavra sem espaço que não quebra. A régua de
+ *     alcance mede `getBoundingClientRect` de controle, e `getBoundingClientRect` não vê tinta.
+ *     Em `/juridico` ela via, e só ali: lá a GRADE não tinha `grid-cols-1`, a trilha `auto` crescia
+ *     junto com o conteúdo, e a lixeira `absolute right-3` ia com ela para x=583,5 — inteiramente
+ *     fora. As outras quatro grades têm `grid-cols-1` (que o Tailwind escreve `minmax(0, 1fr)`) e
+ *     por isso seguravam a caixa enquanto deixavam a tinta sair.
+ *
+ * A pergunta que falta, e que esta régua faz, é a do §5.1: **a BORDA DIREITA do que foi desenhado
+ * (`x + width`, ou `x + scrollWidth` quando o elemento não recorta a si mesmo) passa da borda que
+ * o dono alcança?** É `textoForaDaTela` de `support/medidas.ts` — a mesma régua que o
+ * `produtos-vender-360` já usa DENTRO do modal de venda, e que nunca tinha sido apontada para a
+ * LISTA de nenhuma destas telas. Daí `/produtos` ter atravessado com um nome de 74 chars já na
+ * fixture: o nome estava lá, o card estava desenhado, e a medição olhava só para o modal.
+ *
+ * ⚠️ O escopo é `main` de propósito. `textoForaDaTela` mede contra a borda do ancestral que
+ * RECORTA, e um deslizador horizontal legítimo (a DRE de 12 meses, o Kanban) tem conteúdo fora
+ * dessa borda por construção. Nenhuma das cinco rotas daqui tem deslizador — medido: com o
+ * conserto aplicado, as cinco devolvem lista vazia.
+ *
+ * ## Por que spec próprio, e não mais entradas no catálogo de `support/rotas.ts`
+ *
+ * A `marca` do catálogo é o título da PÁGINA ("Funis de Vendas", "Produtos"). Ele aparece com a
+ * lista vazia — que é o estado em que estas cinco rotas estavam catalogadas (`// vazio`) e a razão
+ * de o defeito ter atravessado #135, #144 e #160 sem ninguém ver. Um card só é medível quando a
+ * `marca` é o PRÓPRIO CARD: aqui toda rota declara um texto que só o card produz, e o teste
+ * «reprova sem card» abaixo prova, com payload `[]`, que essa marca de fato reprova.
+ *
+ * As duas rotas de que a issue trata (`/funis` e `/juridico`) saíram do estado vazio no catálogo
+ * TAMBÉM, porque é lá que mora a cegueira que a issue descreve — e as fixtures delas são
+ * importadas daqui para não existirem em duas cópias. As outras três continuam `// vazio` lá: o
+ * catálogo é percorrido pelas outras duas réguas e mudar o que ELAS medem em rotas fora desta
+ * issue é decisão de outra issue, não efeito colateral desta.
+ */
+
+const PAGINAS_LONGAS = [
+  {
+    id: "s1",
+    title: LONGO,
+    model: "captura",
+    status: "published",
+    public_slug: LONGO,
+    created_at: "2026-01-01T10:00:00Z",
+  },
+];
+
+const PRODUTOS_LONGOS = [
+  {
+    id: "p1",
+    tenant_id: "t1",
+    name: LONGO,
+    kind: "membership",
+    price_cents: 299700,
+    description: LONGO,
+    active: false,
+    stock: 42,
+    checkout_url: `https://exemplo.com.br/${LONGO}`,
+    students: 128,
+    created_at: "2026-01-01T10:00:00Z",
+  },
+];
+
+const INVESTIMENTOS_LONGOS = [
+  {
+    id: "i1",
+    name: LONGO,
+    kind: LONGO,
+    index_rate_label: LONGO,
+    principal_cents: 123456789,
+    accrued_yield_cents: 98765,
+    opened_at: "2026-01-01",
+    created_at: "2026-01-01T10:00:00Z",
+    bank_account_id: null,
+    bank_account_name: null,
+  },
+];
+
+interface CasoDeCard {
+  rota: string;
+  /** Título da PÁGINA — o que a tela mostra mesmo sem dado. Só serve para provar que ela abriu. */
+  marcaDaPagina: string;
+  /** Texto que SÓ o CARD produz. É ele que impede esta régua de medir uma lista vazia. */
+  marcaDoCard: string;
+  mocks: Record<string, unknown>;
+  /** O mesmo mapa com as listas apagadas — usado pelo teste «reprova sem card». */
+  semDado: Record<string, unknown>;
+}
+
+const CARDS: CasoDeCard[] = [
+  {
+    rota: "/funis",
+    marcaDaPagina: "Funis de Vendas",
+    marcaDoCard: LONGO,
+    mocks: { "/funnels": FUNIS_LONGOS },
+    semDado: { "/funnels": [] },
+  },
+  {
+    rota: "/juridico",
+    marcaDaPagina: "Assistente Jurídico",
+    marcaDoCard: LONGO,
+    mocks: { "/juridico/documents": JURIDICO_DOCS, "/juridico/skills": JURIDICO_SKILLS },
+    semDado: { "/juridico/documents": [], "/juridico/skills": [] },
+  },
+  {
+    rota: "/sites",
+    marcaDaPagina: "Sites & Páginas",
+    marcaDoCard: LONGO,
+    mocks: { "/pages": PAGINAS_LONGAS },
+    semDado: { "/pages": [] },
+  },
+  {
+    rota: "/produtos",
+    marcaDaPagina: "Produtos",
+    marcaDoCard: LONGO,
+    // As três chaves explícitas: `/products` sozinha casaria `/products/coupons` e
+    // `/products/enrollments` (o mock resolve pelo prefixo mais longo — ver `support/api.ts`).
+    mocks: { "/products": PRODUTOS_LONGOS, "/products/coupons": [], "/products/enrollments": [] },
+    semDado: { "/products": [], "/products/coupons": [], "/products/enrollments": [] },
+  },
+  {
+    rota: "/financeiro/investimentos",
+    marcaDaPagina: "Investimentos",
+    marcaDoCard: LONGO,
+    mocks: { "/investments": INVESTIMENTOS_LONGOS, "/bank/accounts": [] },
+    semDado: { "/investments": [], "/bank/accounts": [] },
+  },
+];
+
+for (const { rota, marcaDoCard, mocks } of CARDS) {
+  test(`${rota} não deixa o card passar da borda de 360px`, async ({ page }) => {
+    await semearSessao(page);
+    await mockarApi(page, mocks);
+    await page.goto(rota);
+
+    // O CARD tem de existir antes de ser medido — ver o «reprova sem card» abaixo.
+    await expect(page.getByText(marcaDoCard).first()).toBeVisible();
+
+    // Documenta o disfarce da classe, e não é enfeite: se um dia isto deixar de ser 360, o defeito
+    // passou a ser o do #135 e tem outro dono. As linhas abaixo continuariam vermelhas de qualquer
+    // jeito — mas por outro motivo, e quem for ler o vermelho precisa saber qual.
+    expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+
+    const cortes = await textoForaDaTela(page, "main");
+    expect(
+      cortes,
+      `a rota ${rota} desenhou card além da borda de 360px:\n` +
+        cortes.map((c) => `  +${c.forcaFora}px ${c.descricao} «${c.texto}»`).join("\n"),
+    ).toEqual([]);
+
+    // A metade do #144 que ESTA classe também produz quando a grade não segura a trilha: a caixa
+    // do card cresce e leva junto o que está `absolute` dentro dela — em `/juridico` a lixeira.
+    const fora = await controlesInalcancaveis(page);
+    expect(
+      fora,
+      `a rota ${rota} levou controle junto com o card:\n` +
+        fora
+          .map(
+            (c) =>
+              `  ${c.inteiramenteFora ? "INTEIRAMENTE FORA" : "parcialmente fora"} ` +
+              `x ${c.esquerda} → ${c.direita} (${c.foraPor}px além da borda) — ${c.descricao}`,
+          )
+          .join("\n"),
+    ).toEqual([]);
+  });
+}
+
+/**
+ * REPROVA SEM CARD — o que impede as cinco asserções acima de medirem uma lista vazia.
+ *
+ * É a falha exata que deixou esta issue passar: as cinco rotas estavam no catálogo como `// vazio`,
+ * a régua visitava, não havia card nenhum, e "nada fora da borda" era o resultado. Aqui o payload é
+ * `[]` de propósito: a marca do CARD tem de sumir, e a da PÁGINA tem de continuar — sem a segunda
+ * metade, uma tela que não abriu (mock podre, erro de boot) daria o mesmo verde.
+ */
+for (const { rota, marcaDaPagina, marcaDoCard, semDado } of CARDS) {
+  test(`${rota}: a marca do card reprova quando a lista vem vazia`, async ({ page }) => {
+    await semearSessao(page);
+    await mockarApi(page, semDado);
+    await page.goto(rota);
+
+    await expect(page.getByText(marcaDaPagina).first()).toBeVisible();
+    await expect(page.getByText(marcaDoCard)).toHaveCount(0);
+  });
+}
+
+/**
+ * CONTROLE POSITIVO — a régua VÊ tinta que sai da borda sem a caixa sair junto.
+ *
+ * Planta o defeito na sua forma nua dentro do `main` recortado: um bloco de largura normal com uma
+ * palavra sem espaço e `white-space: nowrap`. A CAIXA continua cabendo (a asserção abaixo prova o
+ * número), a página continua medindo 360 — e é exatamente aí que as outras duas réguas ficam
+ * verdes. Se um dia este teste devolver lista vazia, as cinco asserções acima pararam de
+ * significar qualquer coisa, mesmo continuando verdes.
+ */
+test("a régua enxerga tinta fora da borda com a caixa dentro dela", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/funnels": [] });
+  await page.goto("/funis");
+  await expect(page.getByText("Funis de Vendas").first()).toBeVisible();
+
+  expect(await textoForaDaTela(page, "main")).toEqual([]);
+
+  // A isca é marcada por CLASSE, e não por `data-isca`: `textoForaDaTela` descreve o elemento por
+  // tag + classe e trunca o TEXTO em 60 chars, então procurar a palavra de 74 no texto devolvido
+  // nunca casaria — a régua estaria certa e a asserção, errada.
+  await page.evaluate((palavra) => {
+    const isca = document.createElement("p");
+    isca.className = "isca-182";
+    isca.style.cssText = "white-space:nowrap";
+    isca.textContent = palavra;
+    document.querySelector("main")!.appendChild(isca);
+  }, LONGO);
+
+  const { caixa, larguraDaPagina } = await page.evaluate(() => {
+    const el = document.querySelector(".isca-182")!;
+    return {
+      caixa: +el.getBoundingClientRect().right.toFixed(1),
+      larguraDaPagina: document.documentElement.scrollWidth,
+    };
+  });
+  // O disfarce: a caixa cabe e a página não rola. As duas réguas antigas ficariam verdes aqui.
+  expect(caixa).toBeLessThanOrEqual(360);
+  expect(larguraDaPagina).toBe(360);
+
+  const cortes = await textoForaDaTela(page, "main");
+  expect(
+    cortes.map((c) => c.descricao),
+    "a régua ficou CEGA para a classe do #182: tinta além da borda com a caixa dentro dela",
+  ).toContain("p.isca-182");
+});

--- a/apps/web/e2e/support/rotas.ts
+++ b/apps/web/e2e/support/rotas.ts
@@ -68,6 +68,22 @@ const CARROSSEL = {
   created_at: "2026-01-01T10:00:00Z",
 };
 
+/** As LISTAS de `/funis` e `/juridico` (#182). Ficam aqui porque o catálogo é quem as usa; são
+ * importadas por `card-largo-360.spec.ts`, que mede a BORDA do card, para não haver duas cópias. */
+export const FUNIS_LONGOS = [
+  { id: "f1", name: LONGO, node_count: 7, created_at: "2026-01-01T10:00:00Z" },
+];
+
+export const JURIDICO_DOCS = [
+  { id: "d1", skill: "peticao", category: "core", title: LONGO, client_id: null,
+    client_name: LONGO, status: "ready", created_at: "2026-01-01T10:00:00Z" },
+];
+
+export const JURIDICO_SKILLS = [
+  { skill: "peticao", label: LONGO, category: "core", description: `${LONGO} ${LONGO}`,
+    output_type: LONGO },
+];
+
 const CATALOGO_FUNIL = [{
   category: "gatilhos", label: "Gatilhos", color: "#123456",
   items: [{ key: "lead", label: LONGO, description: LONGO, shape: "node", action: "" }],
@@ -149,8 +165,11 @@ export const CASOS: Caso[] = [
   { rota: "/contratos", marca: "Contratos" }, // vazio
   { rota: "/marketing", marca: "Carrosséis" }, // vazio
   { rota: "/marketing/m1", marca: "Pré-visualização (Instagram 4:5) — baixe em PNG", mocks: { "/marketing/carousels/templates": [], "/marketing/carousels": CARROSSEL } },
-  { rota: "/juridico", marca: "Assistente Jurídico" }, // vazio
-  { rota: "/funis", marca: "Funis de Vendas" }, // vazio
+  // #182: as duas saíram do estado vazio. A `marca` é o TÍTULO DO CARD, não o da página: com o
+  // título da página elas passavam sem card nenhum, e foi assim que o card de 316px fora da tela
+  // atravessou o #135, o #144 e o #160. A borda do card é medida em `card-largo-360.spec.ts`.
+  { rota: "/juridico", marca: LONGO, mocks: { "/juridico/documents": JURIDICO_DOCS, "/juridico/skills": JURIDICO_SKILLS } },
+  { rota: "/funis", marca: LONGO, mocks: { "/funnels": FUNIS_LONGOS } },
   { rota: "/funis/f1", marca: "Automação", mocks: { "/funnels/components": CATALOGO_FUNIL, "/funnels/f1": FUNIL, "/crm/clients": [] } },
   // A partir daqui, rotas acrescentadas pelo #144. `/funis/novo` é a outra metade da issue: mesmo
   // componente do `/funis/:id`, estado inicial diferente — e o cabeçalho que não cabia era o

--- a/apps/web/src/features/financeiro/InvestimentosPage.tsx
+++ b/apps/web/src/features/financeiro/InvestimentosPage.tsx
@@ -114,9 +114,14 @@ export default function InvestimentosPage() {
           return (
             <div key={a.id} className="rounded-2xl bg-white p-5 shadow-sm">
               <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h2 className="font-semibold text-neutral-800">{a.name}</h2>
-                  <p className="text-xs text-neutral-500">
+                {/* ⚠️ `min-w-0` + `break-words` (#182): `flex-wrap` resolve a QUEBRA DE LINHA entre
+                    o bloco e o botão, mas não faz o bloco encolher — item de flex nasce com
+                    `min-width: auto` e o min-content de um nome de conta sem espaço é o nome
+                    inteiro. Medido em 360×740: nome e rótulo de índice saíam 264px além da borda,
+                    com `documentElement.scrollWidth` em 360. */}
+                <div className="min-w-0">
+                  <h2 className="break-words font-semibold text-neutral-800">{a.name}</h2>
+                  <p className="break-words text-xs text-neutral-500">
                     {[a.kind, a.index_rate_label].filter(Boolean).join(" · ") || "Aplicação"}
                   </p>
                 </div>

--- a/apps/web/src/features/funis/FunisPage.tsx
+++ b/apps/web/src/features/funis/FunisPage.tsx
@@ -60,12 +60,20 @@ export default function FunisPage() {
                 onClick={() => navigate(`/funis/${f.id}`)}
                 className="group flex w-full items-center rounded-2xl bg-white p-5 pr-14 text-left shadow-sm transition hover:shadow-md"
               >
-                <div className="flex items-center gap-3">
+                {/* ⚠️ `min-w-0` nos DOIS níveis, e `break-words` só depois (#182). Item de flex
+                    nasce com `min-width: auto`: ele NÃO encolhe abaixo do próprio min-content, e o
+                    min-content de um nome sem espaço é o nome inteiro. Medido em 360×740 com um
+                    título de 74 chars: a caixa do `<button w-full>` continuava em 312px (cabe), e
+                    a tinta ia para x=676 — **316px além da borda** — enquanto
+                    `documentElement.scrollWidth` seguia em 360, porque `main` é `overflow-x-hidden`
+                    e recorta. `break-words` sozinho não muda número nenhum aqui: ele quebra a
+                    palavra DENTRO da caixa, e a caixa é que estava larga demais (§5.4). */}
+                <div className="flex min-w-0 items-center gap-3">
                   <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary-50 text-primary-600">
                     <Workflow size={18} />
                   </span>
-                  <div>
-                    <p className="font-semibold text-neutral-800">{f.name}</p>
+                  <div className="min-w-0">
+                    <p className="break-words font-semibold text-neutral-800">{f.name}</p>
                     <p className="text-xs text-neutral-400">{f.node_count} componentes</p>
                   </div>
                 </div>

--- a/apps/web/src/features/juridico/JuridicoPage.tsx
+++ b/apps/web/src/features/juridico/JuridicoPage.tsx
@@ -51,7 +51,14 @@ export default function JuridicoPage() {
       {docs.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-sm font-semibold text-neutral-700">Documentos recentes</h2>
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {/* ⚠️ `grid-cols-1` não é redundante com o `sm:grid-cols-2` (#182). Sem uma contagem de
+              colunas no breakpoint base, a grade tem UMA coluna implícita de tamanho `auto`, e
+              trilha `auto` cresce com o min-content do conteúdo — um título sem espaço a levava a
+              585,5px numa tela de 360. `grid-cols-1` é `repeat(1, minmax(0, 1fr))` no Tailwind, e é
+              o `minmax(0, …)` que segura a trilha. Medido: a lixeira `absolute right-3` ia junto,
+              para x=583,5 → 597,5 — **inteiramente fora**, sem jeito de excluir um documento no
+              celular — e `documentElement.scrollWidth` continuava dizendo 360. */}
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {docs.slice(0, 6).map((d) => (
               // ⚠️ A lixeira é IRMÃ do card, nunca filha (#160) — ver o comentário longo em
               // `funis/FunisPage.tsx`. Resumo: com os dois alvos aninhados, 10px de deslocamento
@@ -66,7 +73,10 @@ export default function JuridicoPage() {
                   <FileText className="mt-0.5 shrink-0 text-primary-600" size={18} />
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-neutral-700">{d.title}</p>
-                    <p className="text-xs text-neutral-400">
+                    {/* O título acima é `truncate` (recorta com reticências); esta linha não pode
+                        ser, porque o nome do cliente precisa ser lido inteiro. `break-words`
+                        (#182): sem ele o `client_name` sem espaço saía 213,5px além da borda. */}
+                    <p className="break-words text-xs text-neutral-400">
                       {categoryLabel(d.category)}
                       {d.client_name ? ` · ${d.client_name}` : ""}
                       {d.status === "failed" ? " · falhou" : ""}
@@ -95,18 +105,26 @@ export default function JuridicoPage() {
               <Icon className="text-primary-600" size={18} />
               <h2 className="text-sm font-semibold text-neutral-700">{categoryLabel(cat)}</h2>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {/* `grid-cols-1` pelo mesmo motivo da grade de documentos acima (#182): sem ele o card
+                de skill ia a 563,5px de largura numa tela de 360. */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {byCategory.get(cat)!.map((s) => (
                 <button
                   key={s.skill}
                   onClick={() => navigate(`/juridico/novo?skill=${s.skill}`)}
                   className="flex h-full flex-col rounded-2xl bg-white p-4 text-left shadow-sm transition hover:shadow-md hover:ring-1 hover:ring-primary-300"
                 >
-                  <p className="text-sm font-semibold text-neutral-800">{s.label}</p>
+                  {/* `break-words` no rótulo e no tipo de saída (#182): os dois vêm do catálogo de
+                      skills e nenhum tem largura garantida — medido, saíam 187,5px além da borda.
+                      A DESCRIÇÃO fica de fora de propósito: `line-clamp-3` já é `overflow: hidden`,
+                      então ela RECORTA em vez de vazar. Mutante equivalente, medido: tirar
+                      `break-words` só dela não muda número nenhum, e mudança que nenhuma régua vê é
+                      peso morto (§5.4). */}
+                  <p className="break-words text-sm font-semibold text-neutral-800">{s.label}</p>
                   <p className="mt-1 line-clamp-3 flex-1 text-xs text-neutral-500">
                     {s.description}
                   </p>
-                  <p className="mt-3 text-[11px] font-medium uppercase tracking-wide text-primary-600">
+                  <p className="mt-3 break-words text-[11px] font-medium uppercase tracking-wide text-primary-600">
                     {s.output_type}
                   </p>
                 </button>

--- a/apps/web/src/features/produtos/ProdutosPage.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.tsx
@@ -88,8 +88,14 @@ export default function ProdutosPage() {
             products.map((p) => (
               <div key={p.id} className="rounded-2xl bg-white p-5 shadow-sm">
                 <div className="mb-2 flex items-start justify-between">
-                  <div>
-                    <p className="font-semibold text-neutral-800">{p.name}</p>
+                  {/* ⚠️ `min-w-0` + `break-words` (#182), e a ordem importa: item de flex nasce com
+                      `min-width: auto` e não encolhe abaixo do min-content, que num nome sem espaço
+                      é o nome inteiro. Medido com o mesmo nome de 74 chars que a fixture do
+                      `produtos-vender-360` já usava: a tinta ia 264px além da borda e a etiqueta
+                      "Inativo" era empurrada para x=624 → 675,8 — 315,8px fora. O spec antigo não
+                      via porque media `textoForaDaTela` DENTRO do modal de venda, nunca no card. */}
+                  <div className="min-w-0">
+                    <p className="break-words font-semibold text-neutral-800">{p.name}</p>
                     <p className="text-xs text-neutral-400">{kindLabel(p.kind)}</p>
                   </div>
                   {!p.active && (

--- a/apps/web/src/features/sites/SitesPage.tsx
+++ b/apps/web/src/features/sites/SitesPage.tsx
@@ -67,7 +67,11 @@ export default function SitesPage() {
                   {p.status === "published" ? "Publicada" : "Rascunho"}
                 </span>
               </div>
-              <p className="font-semibold text-neutral-800">{p.title}</p>
+              {/* `break-words` (#182): o título da página é livre e sem espaço não quebrava — a
+                  tinta saía 264px além da borda de 360px, com `scrollWidth` em 360 (o `main` é
+                  `overflow-x-hidden` e recorta). A caixa do card já é segurada pelo `grid-cols-1`
+                  da grade acima, então aqui basta deixar a palavra quebrar. */}
+              <p className="break-words font-semibold text-neutral-800">{p.title}</p>
               <p className="text-xs text-neutral-400">{MODELS.find(([m]) => m === p.model)?.[1] ?? p.model}</p>
               <div className="mt-3 flex items-center justify-between">
                 {p.status === "published" && p.public_slug ? (


### PR DESCRIPTION
## O que estava quebrado

Com título de pior caso (74 chars sem espaço), o card de `/funis`, `/juridico`, `/sites`, `/produtos`
e `/financeiro/investimentos` desenhava até **316px além da borda de 360px** — e
`document.documentElement.scrollWidth` seguia em **360** nas cinco, porque `main` é
`overflow-x-hidden` e **recorta** em vez de deixar rolar.

Em `/juridico` a caixa do card crescia junto e levava a **lixeira** para `x 583,5 → 597,5`,
**inteiramente fora**: não havia como excluir um documento num celular.

Fecha #182.

## O alcance — a issue mediu 2 rotas; são 5

Das 29 entradas de `e2e/support/rotas.ts`, **21 estavam `// vazio`**. Classifiquei por estrutura e
medi as 7 que têm card dirigido por título de dado:

| Rota `// vazio` | Estrutura | Sobra além da borda |
|---|---|---|
| `/funis` | grade de card | **+316px** |
| `/juridico` | 2 grades de card | **+213,5px** e **+187,5px** + lixeira fora |
| `/sites` | grade de card | **+264px** |
| `/produtos` | grade de card | **+264px** e **+315,8px** |
| `/financeiro/investimentos` | `<ul>` de card | **+264px** |
| `/marketing` | grade de card | **0** — card correto (`truncate` + `min-w-0` + `grid-cols-2`) |
| `/conversas` | `<ul>` de botão | **0** |

As 14 restantes não foram medidas, e digo por quê em vez de afirmar que estão certas: 7 são
`<table>` dentro de `overflow-x-auto` (classe do deslizador, outro dono e outra régua), 4 são listas
de bloco sem card de título, 3 são construtores sem lista.

**Achado que explica por que `/produtos` durou tanto:** `produtos-vender-360.spec.ts` **já** usa um
nome de 74 chars sem espaço na fixture — mas aponta `textoForaDaTela` para
`'[data-testid="modal-vender-produto"]'`. O card da lista nunca esteve no escopo. **Fixture de pior
caso não mede nada sozinha.**

## Por que escapou — e são DOIS mecanismos, não um

| Mecanismo | Rotas | Conserto |
|---|---|---|
| **trilha de grade `auto`** — a *caixa* cresce: `grid gap-2 sm:grid-cols-2` sem contagem no breakpoint base tem coluna implícita `auto`, que cresce com o min-content e leva a lixeira `absolute right-3` junto (caixa ia a 585,5px) | `/juridico` | `grid-cols-1` → `minmax(0, 1fr)` |
| **item de flex com `min-width: auto`** — a caixa do `<button w-full>` continuava em 312px e cabia; o que vazava era a **tinta** | as outras 4 | `min-w-0` **+** `break-words`, nessa ordem |

`break-words` sozinho não muda número nenhum — o mesmo achado já registrado no §5.4.

## O vermelho de antes

```
x /funis     → +316px  p.font-semibold.text-neutral-800 «Relatorio…»
x /juridico  → +213.5px p.truncate.text-sm.font-medium «Relatorio…»
               +187.5px p.text-sm.font-semibold + line-clamp-3 + uppercase
x /sites     → +264px  p.font-semibold.text-neutral-800
x /produtos  → +264px  p.font-semibold  ·  +315.8px span.rounded-pill «Inativo»
x /financeiro/investimentos → +264px h2.font-semibold  ·  +264px p.text-xs
5 failed / 6 passed (4.2m)
```

E a régua de alcance, com `/juridico` fora do estado vazio:

```
x /juridico não deixa controle fora do alcance do dedo em 360px
  INTEIRAMENTE FORA  x 583.5 → 597.5 (237.5px além da borda) — button.absolute.right-3.top-3 (a lixeira)
ok /juridico não faz o documento rolar de lado em 360px   ← scrollWidth = 360, VERDE
```

Aquelas duas linhas juntas **são a issue inteira**: a lixeira inteiramente fora, e a régua de largura
aprovando.

## A régua nova

`e2e/card-largo-360.spec.ts` pergunta pela **borda direita do que foi desenhado** (`x + width`, ou
`x + scrollWidth` quando o elemento não recorta a si mesmo), não pelo `scrollWidth` da página. A
`marca` de cada caso é o **título do card**, nunca o da página.

As fixtures de `/funis` e `/juridico` são **importadas** de `rotas.ts`, não duplicadas — o cabeçalho
daquele arquivo proíbe duas cópias e está certo.

**O que mudou nas duas réguas antigas** por essas rotas saírem do vazio:

- `rotas-360`: continuam em 360 antes **e** depois do conserto. Nenhuma régua de largura enxergou
  este defeito, exatamente como a issue diz.
- `alcance-360`: `/juridico` ficou **vermelha** ao sair do vazio (3 controles, um inteiramente fora)
  e voltou a verde com o conserto. `/funis` ficou verde nos dois estados — e é por isso que a régua
  nova precisou existir.
- Nenhuma falha de outra classe apareceu.

## Prova por mutação — 9 mutações

Cada conserto revertido isoladamente, por cópia de arquivo:

| Mutação | Régua que morreu | Mensagem |
|---|---|---|
| `FunisPage`: tira os dois `min-w-0` | `card-largo /funis` | `+316px p.break-words.font-semibold` — note o `break-words` ainda lá **e inútil** |
| `JuridicoPage`: tira `grid-cols-1` (documentos) | `alcance-360` **e** `card-largo` | `INTEIRAMENTE FORA x 583.5 → 597.5 (237.5px)` / `+213.5px` |
| `JuridicoPage`: tira `grid-cols-1` (skills) | `alcance-360` **e** `card-largo` | `parcialmente fora x 24 → 563.5 (203.5px)` / `+187.5px ×3` |
| `JuridicoPage`: tira os `break-words` | `card-largo` | `+128px`, `+187px`, `+176px` |
| `SitesPage`: tira `break-words` | `card-largo /sites` | `+264px` |
| `ProdutosPage`: tira `min-w-0` | `card-largo /produtos` | `+264px`, `+264px`, `+315.8px «Inativo»` |
| `InvestimentosPage`: tira `min-w-0` | `card-largo /financeiro/investimentos` | `+264px h2`, `+264px p` |
| `medidas.ts`: `sobra > 0.5` → `sobra > 1e9` (régua cega) | controle positivo | `Expected "p.isca-182" / Received []` |
| `rotas.ts`: `FUNIS_LONGOS = []` (fixture vazia) | **as três** réguas | `expect(locator).toBeVisible() failed / element(s) not found` |

A última é a prova de que a fixture não é vazia: com `[]` a marca reprova nas três, nunca dá verde.

**Mutante equivalente, documentado e dispensado:** `break-words` na descrição da skill não muda número
nenhum — `line-clamp-3` já é `overflow: hidden`, então ela **recorta** em vez de vazar. A classe saiu
do conserto: mudança que nenhuma régua vê é peso morto.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 74 arquivos / 855 testes
E2E_PORT=… pnpm e2e rotas-360 card-largo-360 --timeout=120000  → 41 passed (2.1m)
E2E_PORT=… pnpm e2e alcance-360 --timeout=120000               → 31 passed (1.2m)
E2E_PORT=… pnpm e2e produtos-vender-360 aninhamento-clicavel-360 shell-360 → 22 passed (1.9m)
```

A última corrida é regressão nas telas cujo markup mudou — não foi pedida, mas mexi nelas.

## Fora de escopo (vira issue)

- **`/marketing` acusa +808,4px num `div` do `CarouselThumb`** e é **falso positivo da régua**: o
  thumb desenha a arte em 1080px e a encolhe com `transform: scale()` dentro de `overflow: hidden`, e
  `scrollWidth` é medido **antes** do transform. Mesma família da exceção `.react-flow` do §5.4. Não
  entrou no catálogo do spec novo porque exigiria exceção nova, e exceção sem número medido é como
  régua vira enfeite. O card de `/marketing` em si está certo (medido: zero sobra).
- **`/sites`, `/produtos`, `/financeiro/investimentos` não tiveram a entrada do catálogo alterada**,
  apesar de terem o defeito: mudar a `marca` delas mudaria o que as **outras duas** réguas medem em
  rotas fora desta issue. As fixtures moram no spec novo.

Fecha #182.
