### PR TITLE
fix(web): o chip da agenda sai de dentro do botao do dia, e o escorregao de 12px para de abrir o modal errado [#183]

### DIFF
--- a/apps/web/e2e/agenda-chip-aninhamento-360.spec.ts
+++ b/apps/web/e2e/agenda-chip-aninhamento-360.spec.ts
@@ -1,0 +1,279 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { agendaEvent as evento } from "./support/fixtures";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * A régua do ANINHAMENTO CLICÁVEL da AGENDA (#183) — a irmã do #160, com outro limiar.
+ *
+ * O chip do compromisso morava DENTRO do `<button>` da célula do dia (`AgendaPage.tsx`), e os dois
+ * abrem modais DIFERENTES: chip → detalhe do evento · célula → "Novo evento". Com dois alvos
+ * clicáveis aninhados, o navegador emite o `click` no ANCESTRAL COMUM de `mousedown` e `mouseup` —
+ * então um escorregão de poucos pixels entre apertar e soltar troca a ação, sem erro nenhum: o
+ * hit-target do Playwright está satisfeito, porque o `mousedown` acertou o chip.
+ *
+ * ## Por que este arquivo existe separado de `aninhamento-clicavel-360.spec.ts`
+ *
+ * Outro limiar, outra geometria, outra prova. Lá o alvo interno é um ícone de canto de 16px e o
+ * limiar medido é **10px**; aqui o chip é CONTEÚDO NO FLUXO da célula, mede 31,3×20,5 dentro de uma
+ * célula de 44,3×92, e a meia-altura de **10,25px** é tudo o que separa os dois regimes. Os helpers
+ * abaixo são CÓPIA, não import: a duplicação é barata perto de acoplar duas réguas que medem
+ * gestos diferentes em telas diferentes.
+ *
+ * ## O limiar, medido em 21/08/2026 contra `origin/main` (viewport 360×740)
+ *
+ * Chip 31,3×20,5 em (119,6 · 602,8); célula 44,3×92 em (113,6 · 553,0). Duas varreduras, porque a
+ * DIREÇÃO do escorregão importa e o desenho novo a muda:
+ *
+ * | deslocamento | → centro da célula (para CIMA em `main`) | → para BAIXO |
+ * |---|---|---|
+ * | 8px | chip · detalhe 1 · "Novo evento" 0 | chip · detalhe 1 · "Novo evento" 0 |
+ * | 10px | chip · detalhe 1 · "Novo evento" 0 | chip · detalhe 1 · "Novo evento" 0 |
+ * | 11px | chip · detalhe 1 · "Novo evento" 0 | **célula · detalhe 0 · "Novo evento" 1** |
+ * | **12px** | **célula · detalhe 0 · "Novo evento" 1** | célula · detalhe 0 · "Novo evento" 1 |
+ * | 14 / 16 / 20px | célula · detalhe 0 · "Novo evento" 1 | célula · detalhe 0 · "Novo evento" 1 |
+ *
+ * A coluna da esquerda REPRODUZ exatamente a tabela da issue: 12px é o limiar quando o escorregão
+ * aponta para o centro da célula. A da direita mostra que, para baixo, bastam 11px.
+ *
+ * ⚠️ **E é por isso que o GESTO desta régua escorrega para BAIXO, não "na direção do centro da
+ * célula".** Desaninhar sobe o chip de `y=602,8` para `y=588,0` (o `<button>` centralizava o
+ * conteúdo verticalmente; a `<div>` o alinha no topo), e o centro do chip passa a ficar a **0,75px**
+ * do centro da célula — a direção "para o centro" vira degenerada e 12px param de sair do chip.
+ * Régua com gesto degenerado no código CORRIGIDO mede coisas diferentes nas duas versões e deixa de
+ * ser comparável. Para baixo o gesto é o mesmo nas duas, com a mesma folga de 1,75px além da borda
+ * do chip, e é também o escorregão que o dedo faz de verdade: a página rolando enquanto ele desce.
+ *
+ * ⚠️ **Esta régua mede o GESTO, não o CSS nem o markup.** `expect(html).toContain("<div")` seria a
+ * família do `toContain("flex-wrap")` que o CLAUDE.md §5.1 proíbe: passaria com a tela quebrada.
+ * A pergunta é a do dedo do dono: *o toque no chip, escorregando 12px, abriu o modal errado?*
+ *
+ * ⚠️ **Os DOIS controles positivos não são enfeite.** Sem (a) — o gesto emitiu exatamente 1
+ * `click` — um gesto que não clica em nada passaria em toda asserção negativa, verde por não ter
+ * medido (o modo de falha do #123). Sem (b) — nenhum `click` saiu do chip — um escorregão que não
+ * SAI do chip também passa: o `click` volta para o chip, o detalhe abre, e "o 'Novo evento' não
+ * abriu" continua verdadeiro com o aninhamento de pé. Foi assim que a primeira versão da régua do
+ * #175 ficou 14/15 verde contra o código aninhado. Os dois estão medidos na tabela de mutação da PR.
+ */
+
+/** O limiar da issue, e o número medido de novo aqui: 12px entre `mousedown` e `mouseup`. */
+const DESLOCAMENTO_PX = 12;
+
+const EVENTO_ID = "ev-chip";
+const CHIP = `chip-evento-${EVENTO_ID}`;
+/** A célula do dia 18/08/2026 — o relógio abaixo congela a grade nesse mês. */
+const CELULA = "celula-dia-2026-08-18";
+
+/**
+ * Pior caso PLAUSÍVEL (§5.1), não `lorem ipsum`: `title` aceita 255 chars (`agenda/schemas.py`) e o
+ * que o dono digita num compromisso comprido é isto — sem espaço, sem hífen, sem barra. É também o
+ * título que produziu o nome acessível engolido no snapshot do CI do #149.
+ */
+const TITULO =
+  "AlinhamentoFinalDoCasamentoDaJulianaComTodosOsFornecedoresBuffetFotografiaEDecoracao2026";
+
+type JanelaComGravador = Window & { __cliques?: string[] };
+
+/**
+ * Grava, com `capture` no `document`, QUAL elemento o navegador escolheu como alvo de cada `click`.
+ * É a leitura direta do mecanismo — o ancestral comum — e não uma inferência a partir do sintoma.
+ */
+async function armarGravadorDeCliques(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const janela = window as Window & { __cliques?: string[] };
+    janela.__cliques = [];
+    document.addEventListener(
+      "click",
+      (ev) => {
+        const alvo = ev.target as Element | null;
+        const marca = alvo?.closest("[data-testid]")?.getAttribute("data-testid") ?? "";
+        janela.__cliques?.push(`${alvo ? alvo.tagName.toLowerCase() : "?"}[${marca}]`);
+      },
+      true,
+    );
+  });
+}
+
+async function lerCliques(page: Page): Promise<string[]> {
+  return page.evaluate(() => (window as JanelaComGravador).__cliques ?? []);
+}
+
+/**
+ * O GESTO: `mousedown` no centro do chip, `mouseup` `DESLOCAMENTO_PX` abaixo — ainda DENTRO da
+ * célula. O "dentro da célula" é exigência, não detalhe: se o `mouseup` saísse dela, o ancestral
+ * comum mudaria e a régua passaria a medir outra coisa.
+ */
+async function toqueQueEscorrega(page: Page, chip: Locator, celula: Locator): Promise<void> {
+  const doChip = await chip.boundingBox();
+  const daCelula = await celula.boundingBox();
+  expect(doChip, "o chip precisa estar na tela — sem caixa não há gesto").not.toBeNull();
+  expect(daCelula, "a célula precisa estar na tela — sem caixa não há alvo externo").not.toBeNull();
+
+  const x = doChip!.x + doChip!.width / 2;
+  const y0 = doChip!.y + doChip!.height / 2;
+  const y1 = y0 + DESLOCAMENTO_PX;
+  expect(
+    y1,
+    "o mouseup caiu FORA da célula — a régua mediria outro ancestral comum, não o aninhamento",
+  ).toBeLessThan(daCelula!.y + daCelula!.height);
+
+  await page.mouse.move(x, y0);
+  await page.mouse.down();
+  await page.mouse.move(x, y1);
+  await page.mouse.up();
+}
+
+test.beforeEach(async ({ page }) => {
+  // Relógio congelado em 18/08/2026 (fuso do tenant): a grade abre no mês CORRENTE, e sem isto o
+  // compromisso simplesmente não estaria na tela.
+  await page.clock.setFixedTime(new Date("2026-08-18T12:00:00Z"));
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/agenda/events": [
+      evento({
+        id: EVENTO_ID,
+        title: TITULO,
+        starts_at: "2026-08-18T13:00:00Z",
+        ends_at: "2026-08-18T14:00:00Z",
+      }),
+    ],
+  });
+  await page.goto("/agenda");
+
+  // A `marca` (§5.1): medir uma /agenda que renderizou em branco passa em qualquer régua negativa.
+  await expect(page.getByRole("button", { name: "Hoje" })).toBeVisible();
+  await expect(page.getByTestId(CELULA)).toBeVisible();
+  await expect(page.getByTestId(CHIP)).toBeVisible();
+
+  const caixa = (await page.getByTestId(CHIP).boundingBox())!;
+
+  // ⚠️ **A guarda de ALCANCE, e ela é a lição do #159.** O card fantasma do `GanchoDaVima` empurrava
+  // a tela 101px e punha o chip a 7,8px da dobra de 740px; um chip fora da viewport não pode ser
+  // tocado, e o gesto abaixo bateria no `<html>` — verde por não ter medido nada. `toBeVisible()`
+  // não acusa isso: o elemento está lá, com caixa e tudo, só que fora da tela.
+  expect(caixa.x, "o chip escapou pela ESQUERDA da viewport de 360px").toBeGreaterThanOrEqual(0);
+  expect(
+    caixa.x + caixa.width,
+    "o chip escapou pela DIREITA da viewport de 360px",
+  ).toBeLessThanOrEqual(360);
+  expect(caixa.y, "o chip escapou pelo TOPO da viewport de 740px").toBeGreaterThanOrEqual(0);
+  expect(
+    caixa.y + caixa.height,
+    "o chip caiu ABAIXO da dobra de 740px — o gesto bateria no <html> e a régua não mediria nada",
+  ).toBeLessThanOrEqual(740);
+
+  // E a meia-altura do chip TEM de ser menor que o deslocamento, senão o escorregão de 12px cai
+  // dentro dele e a régua vira um medidor de padding.
+  expect(
+    caixa.height / 2,
+    `o chip ficou alto demais: o escorregão de ${DESLOCAMENTO_PX}px para baixo não sairia dele`,
+  ).toBeLessThan(DESLOCAMENTO_PX);
+});
+
+test(`o toque no chip que escorrega ${DESLOCAMENTO_PX}px NÃO abre o "Novo evento"`, async ({
+  page,
+}) => {
+  await armarGravadorDeCliques(page);
+
+  await toqueQueEscorrega(page, page.getByTestId(CHIP), page.getByTestId(CELULA));
+
+  // Controle positivo (a) do INSTRUMENTO, antes de qualquer asserção negativa: o gesto TEM de ter
+  // produzido um `click`. Zero cliques passaria em tudo que vem abaixo sem medir nada (#123).
+  await expect
+    .poll(async () => (await lerCliques(page)).length, {
+      message: "o gesto não emitiu click nenhum — a régua não mediu nada",
+    })
+    .toBe(1);
+
+  // Controle positivo (b): o escorregão tem de ter SAÍDO do chip. Sem esta linha, "o 'Novo evento'
+  // não abriu" não distingue "o aninhamento foi desfeito" de "o gesto nunca chegou a escorregar" —
+  // e a segunda é verde com o defeito de pé.
+  const cliques = await lerCliques(page);
+  expect(
+    cliques.filter((c) => c.includes(CHIP)),
+    `o deslocamento de ${DESLOCAMENTO_PX}px não saiu do chip — a régua não mediu o aninhamento`,
+  ).toEqual([]);
+
+  // A AFIRMAÇÃO da issue: o modal ERRADO não abriu.
+  await expect(
+    page.getByRole("heading", { name: "Novo evento" }),
+    `o escorregão de ${DESLOCAMENTO_PX}px abriu o "Novo evento": o chip voltou a ser filho do <button> da célula e o click caiu no ancestral comum (#183)`,
+  ).toHaveCount(0);
+});
+
+test("o toque certeiro no chip abre o DETALHE, e não o 'Novo evento'", async ({ page }) => {
+  await page.getByTestId(CHIP).click();
+
+  await expect(page.getByTestId("modal-evento")).toBeVisible();
+  // A metade que falta: com os dois handlers disparando, os DOIS modais ficam de pé e a linha de
+  // cima passa verde.
+  await expect(page.getByRole("heading", { name: "Novo evento" })).toHaveCount(0);
+});
+
+test("a célula continua abrindo o 'Novo evento' — pelo espaço vazio e pelo dia sem compromisso", async ({
+  page,
+}) => {
+  // Abaixo do chip, na MESMA célula que tem compromisso: é o pedaço da célula que o dono toca para
+  // marcar mais uma coisa naquele dia, e desaninhar não pode custá-lo.
+  await page.getByTestId(CELULA).click({ position: { x: 22, y: 84 } });
+  await expect(page.getByRole("heading", { name: "Novo evento" })).toBeVisible();
+  await page.getByRole("button", { name: /fechar/i }).first().click();
+  await expect(page.getByRole("heading", { name: "Novo evento" })).toHaveCount(0);
+
+  // E um dia sem nenhum compromisso, onde a célula é a única coisa clicável.
+  await page.getByTestId("celula-dia-2026-08-20").click();
+  await expect(page.getByRole("heading", { name: "Novo evento" })).toBeVisible();
+});
+
+test("o nome acessível da célula não engole mais o compromisso", async ({ page }) => {
+  // Aninhado, o snapshot do CI do #149 anunciava dia e compromisso como UM controle só:
+  // `button "18 10:00 AlinhamentoFinalDoCasamentoDaJuliana…"`. A âncora `^...$` é o que prova que o
+  // título não está mais lá dentro — uma asserção só de "contém 18" passaria com o defeito de pé.
+  await expect(page.getByTestId(CELULA)).toHaveAccessibleName(/^Novo evento em 18 de agosto$/);
+
+  // E o compromisso passa a ser um controle PRÓPRIO, com nome próprio — antes era uma `<div>` muda.
+  await expect(page.getByTestId(CHIP)).toHaveRole("button");
+  await expect(page.getByTestId(CHIP)).toHaveAccessibleName(new RegExp(TITULO));
+});
+
+test("os dois alvos são alcançáveis pelo TECLADO, um depois do outro", async ({ page }) => {
+  // A metade que a desaninhagem não pode custar. Antes o chip era `<div onClick>`: invisível para o
+  // teclado. Trocar um defeito de mouse por um de teclado seria trocar de defeito.
+  await page.getByTestId(CELULA).focus();
+  await expect(page.getByTestId(CELULA)).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId(CHIP)).toBeFocused();
+
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("modal-evento")).toBeVisible();
+});
+
+test("a grade do mês continua inteira em 360px depois da remontagem", async ({ page }) => {
+  // O custo que a issue avisou: desaninhar chips que são CONTEÚDO NO FLUXO significa remontar a
+  // célula, e a grade tem de 35 a 42 delas numa tela de 360. Medido antes e depois: 42 células de
+  // 44,3×92, nas mesmas 7 colunas, `scrollWidth` 360 nos dois casos.
+  const celulas = page.locator('[data-testid^="celula-dia-"]');
+  const total = await celulas.count();
+  expect(total).toBeGreaterThanOrEqual(35);
+  expect(total).toBeLessThanOrEqual(42);
+
+  const caixas = [];
+  for (let i = 0; i < total; i++) caixas.push((await celulas.nth(i).boundingBox())!);
+
+  const larguras = new Set(caixas.map((c) => c.width.toFixed(1)));
+  expect(larguras.size, "as células deixaram de ter a mesma largura").toBe(1);
+
+  const colunas = new Set(caixas.map((c) => c.x.toFixed(1)));
+  expect(colunas.size, "a grade deixou de ter 7 colunas alinhadas").toBe(7);
+
+  for (const c of caixas) {
+    expect(c.x, "uma célula escapou pela ESQUERDA da viewport de 360px").toBeGreaterThanOrEqual(0);
+    expect(
+      c.x + c.width,
+      "uma célula escapou pela DIREITA da viewport de 360px",
+    ).toBeLessThanOrEqual(360);
+  }
+
+  const larguraDaPagina = await page.evaluate(() => document.documentElement.scrollWidth);
+  expect(larguraDaPagina, "a /agenda passou a rolar de lado em 360px").toBe(360);
+});

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -205,47 +205,67 @@ function MonthGrid({
           const inMonth = d.getMonth() === anchor.getMonth();
           const dayEvents = eventsOfDay(events, d);
           return (
-            <button
+            // ⚠️ **O chip é IRMÃO da célula, nunca filho (#183).** Ele morava DENTRO do `<button>` do
+            // dia, e os dois abrem modais DIFERENTES (chip → detalhe · célula → "Novo evento").
+            // Com dois alvos clicáveis aninhados o navegador emite o `click` no ANCESTRAL COMUM de
+            // `mousedown` e `mouseup`: medido em 21/08/2026, chip de 31,3×20,5 numa célula de
+            // 44,3×92, **12px de deslocamento** já bastam para o toque no chip virar "Novo evento"
+            // — 8/10/11px ainda caem no chip, 12/14/16/20px caem na célula. O limiar é a meia-altura
+            // do chip (10,25px), e por isso ele é 12 aqui e 10 nas listas do #160.
+            //
+            // ⚠️ O `data-testid` + `stopPropagation` do #149 CONTORNARAM o sintoma sem desfazer o
+            // aninhamento: o alvo nunca foi ambíguo (`count() === 1`, medido), ambíguo era o PONTO.
+            // `stopPropagation` só age quando o `click` nasce no chip — escorregando, ele nasce na
+            // célula, e não há o que parar.
+            //
+            // ⚠️ **A correção é o PARENTESCO, não a tag.** O ancestral comum passa a ser esta `<div>`
+            // sem handler, então o escorregão não faz NADA. A célula vira uma camada `absolute
+            // inset-0` ATRÁS do conteúdo, e o conteúdo é `pointer-events-none` com os chips
+            // reabilitados — assim a geometria da grade (42 células de 44,3×92 em 360px) fica
+            // idêntica à de antes, medido antes e depois. Trocar o `<button>` de fora por
+            // `<div role="button">` NÃO resolveria: o `click` continuaria caindo nele.
+            //
+            // ⚠️ E o NOME ACESSÍVEL deixa de engolir o compromisso. Aninhado, o snapshot do CI do
+            // #149 anunciava dia e evento como um controle só: `button "18 10:00 Alinhamento…"`.
+            // Medido em `e2e/agenda-chip-aninhamento-360.spec.ts`.
+            <div
               key={d.toISOString()}
-              onClick={() => onDayClick(d)}
-              className={`min-h-[92px] border-b border-r border-neutral-50 p-1.5 text-left align-top hover:bg-neutral-50 ${
+              className={`relative min-h-[92px] border-b border-r border-neutral-50 ${
                 inMonth ? "" : "bg-neutral-50/50 text-neutral-300"
               }`}
             >
-              <span
-                className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs ${
-                  sameDay(d, today) ? "bg-primary-500 font-bold text-white" : "text-neutral-500"
-                }`}
-              >
-                {d.getDate()}
-              </span>
-              <div className="mt-1 space-y-0.5">
-                {dayEvents.slice(0, 3).map((e) => (
-                  <div
-                    key={e.id}
-                    // ⚠️ O chip mora DENTRO do `<button>` da célula do dia, e os dois abrem modais
-                    // DIFERENTES (chip → detalhe · célula → "Novo evento"). Mirar o chip por TEXTO
-                    // não basta: o alvo certo é preciso, mas o `click` do Playwright é por PONTO, e
-                    // um deslocamento vertical de ~10px entre o `mousedown` e o `mouseup` faz o
-                    // navegador emitir o `click` no ANCESTRAL COMUM — a célula — abrindo o modal
-                    // errado sem erro de hit-target (#149). O `testId` torna o alvo inequívoco e o
-                    // spec passa a exigir que o modal ERRADO não tenha aberto.
-                    data-testid={`chip-evento-${e.id}`}
-                    onClick={(ev) => {
-                      ev.stopPropagation();
-                      onEventClick(e);
-                    }}
-                    className={`cursor-pointer truncate rounded px-1 py-0.5 text-[11px] hover:opacity-80 ${eventColor(e, hoje)}`}
-                  >
-                    {!e.all_day && <span className="tabular-nums">{hhmm(e.starts_at, fuso)} </span>}
-                    {chipLabel(e)}
-                  </div>
-                ))}
-                {dayEvents.length > 3 && (
-                  <div className="text-[10px] text-neutral-400">+{dayEvents.length - 3} mais</div>
-                )}
+              <button
+                data-testid={`celula-dia-${localYmd(d)}`}
+                aria-label={`Novo evento em ${d.toLocaleDateString("pt-BR", { day: "2-digit", month: "long" })}`}
+                onClick={() => onDayClick(d)}
+                className="absolute inset-0 h-full w-full hover:bg-neutral-50"
+              />
+              <div className="pointer-events-none relative p-1.5 text-left">
+                <span
+                  className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs ${
+                    sameDay(d, today) ? "bg-primary-500 font-bold text-white" : "text-neutral-500"
+                  }`}
+                >
+                  {d.getDate()}
+                </span>
+                <div className="mt-1 space-y-0.5">
+                  {dayEvents.slice(0, 3).map((e) => (
+                    <button
+                      key={e.id}
+                      data-testid={`chip-evento-${e.id}`}
+                      onClick={() => onEventClick(e)}
+                      className={`pointer-events-auto block w-full truncate rounded px-1 py-0.5 text-left text-[11px] hover:opacity-80 ${eventColor(e, hoje)}`}
+                    >
+                      {!e.all_day && <span className="tabular-nums">{hhmm(e.starts_at, fuso)} </span>}
+                      {chipLabel(e)}
+                    </button>
+                  ))}
+                  {dayEvents.length > 3 && (
+                    <div className="text-[10px] text-neutral-400">+{dayEvents.length - 3} mais</div>
+                  )}
+                </div>
               </div>
-            </button>
+            </div>
           );
         })}
       </div>


### PR DESCRIPTION
## O que era

O chip do evento morava **dentro** do `<button>` da célula do dia, e os dois abrem modais
**diferentes**: chip → detalhe do evento, célula → "Novo evento". Quando dois alvos clicáveis são
aninhados, o navegador emite o `click` no **ancestral comum** de `mousedown` e `mouseup`.

O #149 (PR #159) **contornou** com `data-testid` e `stopPropagation` — não removeu o aninhamento. O
#160 (PR #175) desaninhou as três telas de lista e deixou esta de fora de propósito. Este PR
desaninha de verdade. Fecha #183.

## O limiar, medido — 12px, confirmado

Viewport 360×740, relógio congelado em 18/08/2026. Chip **31,3×20,5** em (119,6 · 602,8); célula
**44,3×92** em (113,6 · 553,0). Meia-altura do chip = **10,25px**. Alvo do `click` lido com um
gravador `capture` no `document` — o mecanismo direto, não o sintoma:

| deslocamento | alvo do `click` | detalhe (certo) | "Novo evento" (errado) |
|---|---|---|---|
| 8px | `span[chip-evento-…]` | 1 | 0 |
| 10 / 11px | `div[chip-evento-…]` | 1 | 0 |
| **12px** | **`button[]` (a célula)** | **0** | **1** |
| 14 / 16 / 20px | `button[]` (a célula) | 0 | 1 |

**Bateu a tabela da issue linha a linha.** O #149 mediu 10px nas listas; aqui são 12, e é a
meia-altura do chip que separa os dois regimes.

## ⚠️ A direção do gesto mudou, e isso é decisão medida

A régua escorrega **para baixo**, não "para o centro da célula". Razão: desaninhar sobe o chip de
`y = 602,8` para `588,0` (o `<button>` centralizava o conteúdo; a `<div>` alinha no topo), e o centro
do chip passa a ficar a **0,75px** do centro da célula. Com o código corrigido, 12px "para o centro"
**não saem mais do chip** — a régua mediria coisas diferentes nas duas versões e deixaria de ser
comparável.

Para baixo o gesto é o mesmo nos dois, com a mesma folga de 1,75px além da borda do chip. O limiar
nessa direção é **11px**, medido, e 12 continua acima dele. As duas tabelas estão no cabeçalho do
spec.

## Prova por mutação

| Mutação (produção) | Teste que morreu | Mensagem real |
|---|---|---|
| **Reaninhar o chip** no `<button>` da célula — mutação **mínima**, `data-testid` e `aria-label` preservados, isolando só o parentesco | `escorrega 12px` + `toque certeiro` | `Error: o escorregão de 12px abriu o "Novo evento": o chip voltou a ser filho do <button> da célula e o click caiu no ancestral comum (#183)` · `Expected: 0 / Received: 1` |
| Reverter `MonthGrid` inteiro para `origin/main` | os 6 | morre no `beforeEach`: `waiting for getByTestId('celula-dia-2026-08-18')` — diagnóstico pobre, por isso a linha acima existe |
| Tirar o `relative` do wrapper (a célula pinta por cima) | 2 | mensagem do #183 + `<button data-testid="celula-dia-…"> intercepts pointer events` |
| Tirar o `aria-label` da célula | `nome acessível` | `Expected pattern: /^Novo evento em 18 de agosto$/ · Received: ""` |
| Chip volta a `<div>` (irmão, não aninhado) | `nome acessível` + `TECLADO` | `toHaveRole Expected: "button" / Received: ""` · `toBeFocused … Received: inactive` |
| `grid-cols-7` → `grid-cols-5` | `grade do mês` | `a grade deixou de ter 7 colunas alinhadas · Expected: 7 / Received: 5` |
| Célula sem `onClick` efetivo | `célula continua abrindo` | `heading "Novo evento" · element(s) not found` |

A primeira tentativa da última mutação **não compilava** (`TS6133: 'onDayClick' is declared but its
value is never read`) — completada até ser válida (`() => void onDayClick`), `tsc` e `eslint` limpos,
medição refeita. Mutação que não compila não conta.

### Os dois controles positivos, medidos necessários

| Cenário (defeito DE PÉ nos dois) | Com o controle | Sem o controle |
|---|---|---|
| aninhado + chip engordado (`py-2`) + guarda geométrica removida | **RED** — `o deslocamento de 12px não saiu do chip — a régua não mediu o aninhamento` | **GREEN — 1 passed**, com o aninhamento de pé |
| aninhado + gesto sem `mouse.down()/up()` | **RED** — `o gesto não emitiu click nenhum — a régua não mediu nada` | **GREEN — 1 passed**, com o aninhamento de pé |

Os dois são ortogonais de propósito: o segundo está escrito como `cliques.filter(...).toEqual([])`,
que **passa** com zero cliques — assim o primeiro é o único que pega o gesto que não escapa, e o
segundo o único que pega o gesto mudo. Sem eles a régua fica verde com o defeito de pé, que foi o que
aconteceu na primeira tentativa do #175.

## A grade em 360px, antes e depois — medida, não olhada

**42 células** nos dois casos, `scrollWidth` **360** nos dois.

| | antes (`origin/main`) | depois |
|---|---|---|
| caixa de cada célula | 44,3×92,0 | 44,3×92,0 |
| colunas (x) | 25,0 / 69,3 / 113,6 / 157,8 / 202,1 / 246,4 / 290,7 | idênticas |
| linhas (y) | 277 / 369 / 461 / 553 / 645 / 737 | idênticas |

Pior caso (3 chips + "+2 mais"): a linha alta vai de **139,5 → 140,5** e a página de **902 → 903**.
Um pixel.

**Ganho não pedido, medido:** o `<button>` centralizava o conteúdo verticalmente, então numa mesma
linha os números do dia ficavam em alturas diferentes conforme a quantidade de chips. Delta do topo,
linha 4: antes `55,8 | 56,8 | 8,0 | 46,5 | 56,8 | 56,8 | 56,8` (**48,8px de dispersão**); depois
`7,0 | 8,0 | 8,0 | 8,0 | 8,0 | 8,0 | 8,0` (**1px**).

## O nome acessível da célula

Antes — reproduz o snapshot do CI do #149:
```
- button "18 08:00 CompromissoNumeroDeOrdem1DoCasamentoDaJuliana 09:00 …2… 10:00 …3… +2 mais"
```
Depois:
```
- button "Novo evento em 18 de agosto"
- text: "18"
- button "08:00 CompromissoNumeroDeOrdem1DoCasamentoDaJuliana"
- button "09:00 …"   - button "10:00 …"   - text: +2 mais
```
Provado por asserção **ancorada** (`/^Novo evento em 18 de agosto$/`), não por "contém 18" — e a
mutação que tira o `aria-label` a mata.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 74 arquivos / 855 testes (AgendaPage.test.tsx entre eles)
E2E_PORT=… pnpm e2e agenda-evento-360 gancho-fantasma-360 agenda-chip-aninhamento-360
   → 12 passed (38.3s)
```

As três suítes que vivem em cima de `AgendaPage` estão aí. `aninhamento-clicavel-360.spec.ts` **não
foi tocado** — os helpers foram copiados para o spec novo, porque aqui o limiar é outro (12px, não
10), a geometria é outra e a prova é outra.

## Fora de escopo

- **`WeekView` e `DayView`** — não há aninhamento lá: o chip da semana é irmão do `<button>` do
  cabeçalho, e o `DayView` é `<li>` sem alvo externo.
- **Alvo de toque do chip (20,5px) segue abaixo dos 44px** — família #56/#144. Engordá-lo aqui faria
  o escorregão de 12px cair dentro dele e a régua passaria a medir *padding*, apagando exatamente
  esta medição. É o que o cenário do "chip gordo" demonstra.
- **`min-h-[92px]` com 3 chips + "+N" ainda estoura a altura mínima** (140,5px). Já era assim antes
  (139,5) — comportamento de grade, não regressão.

Fecha #183.
