### PR TITLE
fix(ci): fixar TZ no job frontend — o verde vinha do pool default do vitest [#184]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,19 @@ jobs:
   # branch protection um no-op).
   frontend:
     runs-on: ubuntu-latest
+
+    # ── FUSO, NO NÍVEL DO JOB (issue #184 — irmão do #169) ──────────────────────────────
+    # PREVENÇÃO: sem esta linha o job fica verde por um DEFAULT DE BIBLIOTECA, não por desenho. O
+    # `env: { TZ }` do `vitest.config.ts` só troca o fuso de verdade sob o pool `forks` (o default
+    # do vitest 2); sob `threads` ele chega TARDE — `process.env.TZ` fica certo e o relógio fica no
+    # fuso do runner, que é UTC. Remedido em 21/08/2026 com a máquina forçada para UTC:
+    # `grade.test.ts` dá 40 passed sob `forks` e 1 failed sob `threads`. Um bump de vitest que mude
+    # esse default, ou qualquer flag que force `threads`, derrubaria este job com uma DATA ERRADA
+    # num teste de agenda — sintoma que não fala o próprio nome (foram duas noites no #169).
+    # (`pnpm e2e` não depende disto: `playwright.config.ts` fixa `timezoneId` por conta própria.)
+    env:
+      TZ: America/Sao_Paulo
+
     defaults:
       run:
         working-directory: apps/web


### PR DESCRIPTION
## Resumo

Uma linha de `env` no job `frontend` do `ci.yml` — a mesma do PR #172, agora no irmão que faltava.
Fecha #184.

## Por quê

O #169 fixou `TZ` no job `mutation` depois de duas noites de vermelho. Ao medir a classe apareceu o
`frontend`: roda `pnpm test` e `pnpm e2e`, e estava verde por um **default de biblioteca**, não por
desenho.

Medido em 21/08/2026 (vitest 2.1.9, Node 24, máquina forçada para `TZ=UTC` **pelo PowerShell** — pelo
Git Bash a variável não chega ao Node), em `grade.test.ts`:

| pool | resultado |
|---|---|
| default (`forks`) | `40 passed` |
| `threads` | `1 failed` |

```
Error: FUSO ERRADO NA SUITE: o fuso EFETIVO deste processo e "UTC", e a suite exige "America/Sao_Paulo".
  process.env.TZ ........ "America/Sao_Paulo"
  fuso efetivo .......... "UTC"
```

Sob `forks` o `env: { TZ }` do `vitest.config.ts` chega a tempo; sob `threads` chega **tarde** — o
`process.env.TZ` fica certo e o relógio fica em UTC. Com `TZ` fixado **fora** do Node, o mesmo
arquivo dá `40 passed` sob `threads`.

Um bump de vitest que mude o pool default, ou qualquer flag que force `threads`, derrubaria este job
com uma **data errada num teste de agenda** — sintoma que não fala o próprio nome.

Esta linha é a **prevenção**. O guarda que o #169 pôs em `test-setup.ts` continua sendo a
**detecção**.

`pnpm e2e` não dependia disto e continua não dependendo: `playwright.config.ts:67` fixa
`timezoneId`, que é override de contexto do navegador e vale com o processo em UTC (verificado).

## Prova por parse — porque diff visual não é prova

Desserializando o `ci.yml` antes e depois e comparando folha a folha:

```
folhas antes: 56 | depois: 57
REMOVIDAS : nenhuma
ALTERADAS : nenhuma
ACRESCIDAS: [('/jobs/frontend/env/TZ', 'America/Sao_Paulo')]
removendo SO o env novo -> objetos IDENTICOS? True
ordem dos jobs preservada? True
steps do frontend: 10 -> 10
env e IRMAO de steps (nivel do job)? True
```

`actionlint` (via Docker): `Found 0 errors in 3 files`.

Varredura de caracteres invisíveis (NBSP/NNBSP/ZWSP/BOM/ZWNJ): **nenhum**. Tabs: **0**. O arquivo é
100% CRLF (263 CRLF, 0 LF solto) e assim continua.

## Nota de escopo — a issue dizia 2 workflows / 6 jobs; são 3 / 7

`caddy-image.yml` entrou em `b63108f` (**21/08/2026 19:30**), um dia depois da medição da issue.
Conferido na fonte: o job `arranque` é `docker build` mais três asserções de arranque de container —
sem data, sem relógio, sem front. **Fora da classe.**

| Workflow / job | Teste sensível a fuso? | Fixa TZ? |
|---|---|---|
| `mutation.yml` / `mutation` | sim | sim (#169) |
| **`ci.yml` / `frontend`** | sim | **não → agora sim** |
| `ci.yml` / `test-in-prod-image`, `cross-tenant-rls`, `secret-scan`, `sast-semgrep` | não | — |
| `caddy-image.yml` / `arranque` | não | — |

## Gates

`pnpm lint` exit 0 · `pnpm typecheck` exit 0 · `pnpm test` 74 files / 855 tests passed.

## Fora de escopo (vira issue)

A suíte Python não fixa fuso em lugar nenhum (nem `conftest`, nem `pytest.ini`, nem `pyproject`) e
tem 8+ arquivos que dependem de "hoje". Os jobs rodam em UTC no runner e estão verdes, e o código
deriva data de `hoje_do_tenant()` — mas a diferença entre a máquina de quem desenvolve e o CI segue
**não declarada**.

Fecha #184.
