### PR TITLE
test(web): campo de hora lido pelo INSTANTE, não pela string do navegador [#185]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,40 @@ estava certa; o que faltava era um teste capaz de dizer isso.**
   Escolher um fuso só para o arquivo inteiro deixaria metade da linha sem medição — é a régua "nem
   toda asserção com data deve trocar de fuso" aplicada dentro de uma expressão só.
 
+- ✅ **`toHaveValue("2026-10-10T09:00")` num `datetime-local` é asserção sobre a MÁQUINA — paga
+  pela issue #185 (2026-08-21).** O HTML define o valor desse input como "naive": as partes locais
+  de quem abriu a tela, sem fuso. Cinco testes `.tsx` afirmavam essa string literal enquanto o nome
+  deles falava do tenant, e eram **invisíveis ao job de mutação** — `vitest.mutation.config.ts`
+  exclui `.tsx`, então o Stryker nunca os executou nem para reprovar. Não quebravam: o
+  `env: { TZ }` do `vitest.config.ts` chega a tempo sob o pool `forks`. Quebravam sob `threads`, que
+  é o que o `@stryker-mutator/vitest-runner` força — a mesma armadilha do #169, um andar acima.
+  **Medido varrendo os 74 arquivos da suíte** (não os 21 "sensíveis a fuso": o recorte por grep
+  depende do grep, a suíte inteira não): com o pin de fuso do config neutralizado, **6 falhas em 3
+  arquivos** sob UTC. Agora **0** nos `.tsx` sob UTC, `America/Sao_Paulo`, `Asia/Tokyo` e
+  `America/New_York`.
+  **A regra que fica:** campo de hora se lê pelo INSTANTE, nunca pela string —
+  `src/test/paredeDoTenant.ts` faz `new Date(el.value)` (desfaz exatamente o que o navegador
+  escreveu) e formata no fuso do tenant. O mesmo resultado em qualquer máquina, e a afirmação passa
+  a ser sobre o relógio de que o teste fala.
+  ⚠️ **Ida e volta não substituem a prova de fuso.** Com tenant e máquina no mesmo fuso, elas se
+  cancelam por construção: mutar `instanteNoFuso(...)` para uma string ingênua **sobrevive** aos
+  quatro testes de fuso-do-runner e só morre no de Tóquio (`expected '11/10/2026 02:00' to be
+  '10/10/2026 14:00'`). Um arquivo precisa dos dois tipos de teste, e é por isso que os testes de
+  costura (`BlocoDaAgenda`) continuam no fuso do runner **com a razão escrita**.
+  ⚠️ **O jsdom sanitiza o `datetime-local`, e isso cria mutante EQUIVALENTE de formato.** Medido:
+  `"…T09:00:00"` e `"2026-10-10 09:00"` (separador em branco) voltam os DOIS como `"…T09:00"` —
+  nenhuma leitura de `el.value` pode matá-las, nem a antiga nem a nova. Quem for triar sobreviventes
+  de `paraInputLocal` não perca tempo aí. O que a sanitização **não** desfaz é segundo diferente de
+  zero (`"…T09:00:30"` → `"…T09:00:30.000"`), e só uma asserção de FORMA o pega: `paredeDoTenant`
+  formata hora e minuto e devolveria "09:00" na mesma. Por isso o `toMatch(/^…T\d{2}:\d{2}$/)` fica.
+  ⚠️ **Dívida aberta:** `grade.test.ts` tem **duas** dependências do fuso do navegador, não uma. A
+  do `eventYmd` (linha 468) é o gabarito — legítima, declarada no nome e no comentário, e o relógio
+  que a serve é UM só (o `env` do config + a guarda do #172); mexer nela criaria o segundo relógio
+  que esta seção existe para proibir. A **segunda não estava declarada e não aparecia na varredura
+  em UTC**: `"eventsOfDay filtra pelo dia e ORDENA por horário de início"` usa um evento às
+  `18:00Z`, que em `Asia/Tokyo` cai no dia SEGUINTE e some do filtro. Varrer só em UTC não fecha a
+  classe — UTC e UTC−3 concordam sobre o dia de `18:00Z`, Tóquio não.
+
 ### 5.3 O teste de mutação (`apps/web/stryker.config.mjs`, desde 2026-08-18)
 
 **A suíte verde não prova que os testes seguram alguma coisa.** Na PR #119 o QA achou NOVE

--- a/apps/web/src/features/agenda/NewEventModal.test.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
+import { paredeDoTenant } from "../../test/paredeDoTenant";
 import NewEventModal from "./NewEventModal";
 
 // Onda 2, Task 5: extração do NewEventModal de AgendaPage.tsx para arquivo próprio, para que a
@@ -9,6 +10,14 @@ import NewEventModal from "./NewEventModal";
 // Rede sempre mockada (IV2): nenhum teste bate em /agenda real.
 // O fuso do TENANT é trocável por teste: o `vitest.config.ts` fixa o fuso da MÁQUINA em
 // America/Sao_Paulo, e é justamente a diferença entre os dois que este arquivo precisa exercitar.
+//
+// ⚠️ Os campos de horário são lidos por `paredeDoTenant`, NUNCA por `toHaveValue("…T09:00")`
+// (issue #185). O valor de um `<input type="datetime-local">` é naive e sai nas partes locais da
+// MÁQUINA: a string literal amarrava estes testes a America/Sao_Paulo sem dizer isso em lugar
+// nenhum — três deles reprovavam com uma HORA errada assim que a suíte rodasse em outro fuso, que
+// é o que o pool `threads` do Stryker produz. E `.tsx` está FORA do `vitest.mutation.config.ts`,
+// então o job de mutação nunca os executou nem para reprovar. A leitura por instante → fuso do
+// tenant dá o mesmo resultado em São Paulo, em UTC e em Tóquio.
 let fusoDoTenant = "America/Sao_Paulo";
 vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
 
@@ -101,8 +110,21 @@ describe("NewEventModal (Onda 2, Task 5)", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Início")).toHaveValue("2026-10-10T09:00");
-    expect(screen.getByLabelText("Fim")).toHaveValue("2026-10-10T10:00");
+    // 09:00–10:00 é a faixa default no relógio do TENANT — quem não escolheu hora nenhuma. O
+    // fuso da máquina não participa da afirmação, então ela não pode ser escrita como a string
+    // que a máquina escreveria.
+    const inicio = screen.getByLabelText("Início");
+    expect(paredeDoTenant(inicio, fusoDoTenant)).toBe("10/10/2026 09:00");
+    expect(paredeDoTenant(screen.getByLabelText("Fim"), fusoDoTenant)).toBe("10/10/2026 10:00");
+
+    // A FORMA do valor é afirmada à parte, e o recorte dela foi MEDIDO (issue #185). O jsdom
+    // aplica a sanitização do HTML no `datetime-local`, então boa parte das mutações de formato
+    // do `paraInputLocal` é EQUIVALENTE — ele mesmo as desfaz antes de qualquer asserção:
+    // `"…T09:00:00"` e `"… 09:00"` (separador em branco) voltam os dois como `"…T09:00"`, e
+    // nenhuma leitura de `el.value` pode matá-las. O que a sanitização NÃO desfaz é segundo
+    // diferente de zero: `"…T09:00:30"` sobrevive como `"…T09:00:30.000"`, e aí só esta linha
+    // pega — `paredeDoTenant` formata hora e minuto e devolveria "09:00" na mesma.
+    expect((inicio as HTMLInputElement).value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
   });
 
   it("pré-preenche a hora escolhida no seletor, e a seguinte no fim", () => {
@@ -116,16 +138,21 @@ describe("NewEventModal (Onda 2, Task 5)", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Início")).toHaveValue("2026-10-10T14:00");
-    expect(screen.getByLabelText("Fim")).toHaveValue("2026-10-10T15:00");
+    // Mesma régua do teste acima: 14:00–15:00 é o relógio do TENANT, não o da máquina.
+    expect(paredeDoTenant(screen.getByLabelText("Início"), fusoDoTenant)).toBe("10/10/2026 14:00");
+    expect(paredeDoTenant(screen.getByLabelText("Fim"), fusoDoTenant)).toBe("10/10/2026 15:00");
   });
 
   it("a hora escolhida é a hora do TENANT, mesmo com o navegador em outro fuso", () => {
     // O seletor decide as faixas no fuso do tenant; o `<input type="datetime-local">` fala no fuso
     // do NAVEGADOR. Entregar "14:00" como string ingênua fazia `new Date(...)` reinterpretá-la na
     // máquina de quem abriu a tela — o dono viajando marcava 15:00 achando que marcava 14:00.
-    // Tenant em Tóquio (UTC+9), runner em São Paulo (UTC−3): 14:00 em Tóquio é 05:00Z, que o
-    // navegador escreve como 02:00 do mesmo dia.
+    //
+    // Este é o ÚNICO teste do arquivo que existe para provar fuso, e por isso é o único a mexer em
+    // `fusoDoTenant`: com tenant e máquina no mesmo fuso, a ida (`instanteNoFuso`) e a volta
+    // (`new Date` do campo) se cancelam por construção e a conversão ausente sobreviveria — a
+    // família do `toContain("flex-wrap")` do CLAUDE.md §5.1. Tóquio (UTC+9) discorda do runner
+    // (UTC−3) em 12h: os dois caminhos divergem até sobre que DIA é.
     fusoDoTenant = "Asia/Tokyo";
 
     render(
@@ -139,8 +166,12 @@ describe("NewEventModal (Onda 2, Task 5)", () => {
     );
 
     const inicio = screen.getByLabelText("Início") as HTMLInputElement;
-    expect(inicio).toHaveValue("2026-10-10T02:00");
-    // O que importa não é a string e sim o INSTANTE que ela produz na hora de salvar.
+    // 14:00 em Tóquio, lido de volta no fuso do tenant — a afirmação que o nome do teste faz.
+    // A string crua do campo seria "2026-10-10T02:00" num runner em UTC−3 e "T05:00" em UTC:
+    // afirmá-la seria afirmar sobre a máquina, que é justamente o que este teste NÃO quer dizer.
+    expect(paredeDoTenant(inicio, fusoDoTenant)).toBe("10/10/2026 14:00");
+    // E o INSTANTE, que é o que vai para o `save()` — literal, sem passar por função nenhuma da
+    // produção, e igual em qualquer máquina.
     expect(new Date(inicio.value).toISOString()).toBe("2026-10-10T05:00:00.000Z");
   });
 });

--- a/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaAgenda.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
+import { paredeDoTenant } from "../../test/paredeDoTenant";
 import BlocoDaAgenda from "./BlocoDaAgenda";
 
 // Task 6 (Onda 2): o bloco reusa o `NewEventModal` da Task 5 — por isso o mock de `api` também
@@ -19,6 +20,12 @@ vi.mock("../../lib/api", () => ({
 // do tenant e lê-lo pelas partes locais do `Date` dá o MESMO resultado, e a asserção de fuso fica
 // estruturalmente incapaz de falhar (§5.1 do CLAUDE.md, a família do `toContain("flex-wrap")`).
 let fusoDoTenant = "America/Sao_Paulo";
+// ⚠️ Os campos de horário do formulário são lidos por `paredeDoTenant`, nunca por
+// `toHaveValue("…T10:00")` (issue #185): o valor de um `<input type="datetime-local">` sai nas
+// partes locais da MÁQUINA, então a string literal amarrava dois testes daqui a America/Sao_Paulo
+// sem dizer isso — e `.tsx` está fora do `vitest.mutation.config.ts`, então o job de mutação nunca
+// os executou nem para reprovar. Ler pelo instante e formatar no fuso do tenant vale em qualquer
+// máquina, e mantém a afirmação onde ela é: no relógio do tenant.
 // Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner — sob ele os dois caminhos
 // discordam até sobre que DIA é.
 const FUSO_DISTANTE = "Asia/Tokyo";
@@ -152,15 +159,20 @@ describe("BlocoDaAgenda", () => {
     // O seletor sai de cena e o formulário entra com a escolha já feita — o dono não redigita
     // a data que acabou de apontar no calendário.
     //
-    // ⚠️ Fuso do runner de propósito: este teste é sobre a COSTURA (a escolha atravessa do
-    // seletor para o formulário), não sobre fuso. A prova de que a hora escolhida é a hora de
+    // ⚠️ Tenant no fuso do runner de propósito: este teste é sobre a COSTURA (a escolha atravessa
+    // do seletor para o formulário), não sobre fuso. A prova de que a hora escolhida é a hora de
     // PAREDE DO TENANT — `instanteNoFuso` + `paraInputLocal`, com tenant em Tóquio — já vive em
     // `features/agenda/NewEventModal.test.tsx`, no dono da conversão. Trocar o fuso aqui só
     // trocaria a string esperada por outra igualmente arbitrária e duplicaria aquela prova.
+    //
+    // O que MUDA (#185) é como o campo é lido: a faixa que o dono apontou foi "10:00–11:00" no
+    // relógio do tenant, e é isso que a asserção diz. A string crua do campo diria "10:00" só
+    // enquanto a máquina estivesse em UTC−3 — afirmação sobre o runner, disfarçada de afirmação
+    // sobre a costura.
     expect(screen.getByRole("heading", { name: "Novo evento" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Marcar com Loana" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Início")).toHaveValue("2026-08-20T10:00");
-    expect(screen.getByLabelText("Fim")).toHaveValue("2026-08-20T11:00");
+    expect(paredeDoTenant(screen.getByLabelText("Início"), fusoDoTenant)).toBe("20/08/2026 10:00");
+    expect(paredeDoTenant(screen.getByLabelText("Fim"), fusoDoTenant)).toBe("20/08/2026 11:00");
 
     // Depois de abrir, a próxima chamada a `GET /agenda/events` já devolve o evento recém-criado
     // — é isso que prova que a lista recarregou, e não só que o modal fechou.
@@ -226,6 +238,9 @@ describe("BlocoDaAgenda", () => {
 
     expect(screen.getByLabelText("Dia inteiro")).not.toBeChecked();
     expect(screen.getByLabelText("Título")).toHaveValue("");
-    expect(screen.getByLabelText("Início")).toHaveValue("2026-08-21T14:00");
+    // A hora NOVA (14:00 no relógio do tenant), não a da escolha abandonada — lida pelo instante
+    // para não depender do fuso da máquina (#185). "Título" segue com `toHaveValue`: string vazia
+    // não tem fuso.
+    expect(paredeDoTenant(screen.getByLabelText("Início"), fusoDoTenant)).toBe("21/08/2026 14:00");
   });
 });

--- a/apps/web/src/test/paredeDoTenant.ts
+++ b/apps/web/src/test/paredeDoTenant.ts
@@ -1,0 +1,42 @@
+import { formatDateTime } from "../lib/datetime";
+
+/**
+ * Lê um `<input type="datetime-local">` como HORA DE PAREDE DO TENANT — não como a string crua
+ * que o navegador escreveu (issue #185).
+ *
+ * ## O defeito que isto fecha
+ *
+ * O HTML define que o valor de um `datetime-local` é "naive": `"2026-10-10T09:00"`, sem fuso,
+ * nas partes LOCAIS de quem abriu a tela. Um `expect(campo).toHaveValue("2026-10-10T09:00")`
+ * está, portanto, afirmando sobre o fuso da MÁQUINA que roda a suíte — mesmo quando o teste
+ * acha que fala do tenant. Enquanto o `env: { TZ: "America/Sao_Paulo" }` do `vitest.config.ts`
+ * chega a tempo (pool `forks`), a asserção passa; sob qualquer runner que force `threads` — o
+ * caso do `@stryker-mutator/vitest-runner` — o mesmo teste reprova com uma HORA errada, e a
+ * mensagem fala de agenda em vez de ambiente. Foi o que a issue #169 pagou em `grade.test.ts`.
+ *
+ * A conversão de volta desfaz exatamente o que o navegador fez — `new Date(valor)` interpreta a
+ * string naive no fuso local, o mesmo em que ela foi escrita — e entrega o INSTANTE, que não tem
+ * fuso. Formatá-lo no fuso do TENANT dá a única leitura que o teste realmente quer afirmar, e ela
+ * é a mesma em São Paulo, em UTC ou em Tóquio.
+ *
+ * ## O que isto NÃO faz
+ *
+ * Não substitui a prova de fuso: com o tenant no MESMO fuso da máquina, ida e volta se cancelam
+ * por construção e uma conversão de tenant ausente na produção sobrevive. Quem mata essa mutação
+ * é o teste que roda com `fusoDoTenant = "Asia/Tokyo"` — ver `NewEventModal.test.tsx` e a régua
+ * do CLAUDE.md §5.2.
+ *
+ * @param el o campo `datetime-local` já obtido pela query do testing-library
+ * @param tz fuso do tenant vigente NAQUELE teste (o mesmo que o `vi.mock` de `store/auth` devolve)
+ * @returns `"10/10/2026 09:00"`, ou uma mensagem legível quando o campo não tem data válida —
+ *          uma mutação que esvazia o campo tem de aparecer como campo vazio no diff da asserção,
+ *          nunca como um `RangeError: Invalid time value` sem relação com o que se media.
+ */
+export function paredeDoTenant(el: HTMLElement, tz: string): string {
+  const valor = (el as HTMLInputElement).value;
+  const instante = new Date(valor);
+  if (Number.isNaN(instante.getTime())) {
+    return `(campo sem datetime-local válido: ${JSON.stringify(valor)})`;
+  }
+  return formatDateTime(instante.toISOString(), tz);
+}


### PR DESCRIPTION
## O que é

Cinco testes `.tsx` afirmavam o valor **cru** de um `<input type="datetime-local">`
(`toHaveValue("2026-10-10T09:00")`). Esse valor é *naive* por definição do HTML — as partes locais da
**máquina** — então a asserção falava do runner enquanto o nome do teste falava do tenant.

Eram invisíveis ao job de mutação: `vitest.mutation.config.ts` **exclui `.tsx`**. Fecha #185.

Não quebravam sob `forks` (o `env: { TZ }` do `vitest.config.ts` chega a tempo); quebrariam sob
`threads`, que é o pool que o Stryker força — a mesma armadilha do #169, um andar acima.

## ⚠️ Como medir, porque o caminho óbvio devolve zero e parece aprovação

`$env:TZ='UTC'; pnpm test` dá **verde antes e verde depois** — o `env` do `vitest.config.ts`
sobrescreve a máquina sob `forks`. As 6 falhas só aparecem com esse pin neutralizado, que é o que o
pool `threads` produz na prática.

A medição usou uma sonda temporária (config + guarda parametrizada), **removida antes do commit** —
`git status` limpo, nenhum `.bak`, nenhum arquivo de sonda no diff.

E pelo **PowerShell**, nunca pelo Git Bash: nesta máquina a variável não chega ao Node pelo Bash, e a
varredura devolve zero quebras.

```
$env:TZ='UTC'; node -e "…"
TZ env: UTC | resolved: UTC | offset(min): 0
```

## O alcance, medido — 6 falhas em 3 arquivos, confirmado

Não usei a lista de "21 arquivos sensíveis": **varri os 74 arquivos da suíte**. O recorte por grep
depende do grep — o padrão estrito do CLAUDE.md §5.2 dá **19**, o ampliado dá **23**, e nenhum dá 21.
O número certo é irrelevante quando a suíte inteira roda em 3,5min.

```
 Test Files  3 failed | 71 passed (74)
      Tests  6 failed | 849 passed (855)
```

| Arquivo | Falhas |
|---|---|
| `agenda/grade.test.ts` | 1 |
| `agenda/NewEventModal.test.tsx` | **3** |
| `crm/BlocoDaAgenda.test.tsx` | **2** |

## A decisão, teste a teste — não as duas por reflexo

| Teste | Veredito | Razão |
|---|---|---|
| `NewEventModal` › pré-preenche 09:00–10:00 | **desacoplado** | Afirma o *default* (9h) no relógio do tenant. O navegador não participa da frase |
| `NewEventModal` › pré-preenche a hora escolhida | **desacoplado** | Afirma a *propagação* de `initialHour` |
| `NewEventModal` › a hora escolhida é a hora do TENANT | **desacoplado, com o fuso distante mantido** | O nome diz "mesmo com o navegador em outro fuso": passa a valer para **qualquer** navegador. `Asia/Tokyo` fica, com a razão escrita — é o único do arquivo a trocar de fuso, e é ele que impede que ida e volta se cancelem |
| `BlocoDaAgenda` › escolher um horário abre o formulário | **desacoplado** | O comentário já dizia "este teste é sobre a COSTURA". Estava certo sobre a intenção e errado sobre a asserção |
| `BlocoDaAgenda` › o formulário nasce limpo | **desacoplado** | Afirma reset de estado. Fuso não é o assunto |
| `grade.test.ts:468` › lido pelo fuso do NAVEGADOR | **explícito — fica como está** | Aqui a dependência **é o assunto**, e nome e comentário já a declaram. Fazê-lo fixar o próprio TZ criaria um **segundo relógio** decidindo o fuso da suíte — exatamente o que o §5.2 proíbe |

Mecanismo comum: `src/test/paredeDoTenant.ts` — `new Date(el.value)` desfaz exatamente o que o
navegador escreveu, e `formatDateTime` a lê no fuso do tenant. Campo inválido vira mensagem legível
em vez de `RangeError: Invalid time value`.

**Nenhum arquivo de produção mudou.**

## As corridas de fuso

| | UTC | Sao_Paulo | Tokyo | New_York |
|---|---|---|---|---|
| antes | 6 falhas / 3 arquivos | 0 | — | — |
| depois | **1** (só o gabarito de `grade.test.ts`) | 0 | **2** (ver dívida) | **0 / 855** |

Nos `.tsx` o número é **zero nos quatro fusos** — 6 → 0. Não chamo isso de "zero absoluto": o que
sobra é `grade.test.ts`, explicado acima e na dívida abaixo.

## Prova por mutação — 7 mutações, 6 mortas

| Mutação | Mortos | Mensagem real |
|---|---|---|
| `initialHour ?? 9` → `?? 8` | 1 | `expected '10/10/2026 08:00' to be '10/10/2026 09:00'` |
| `(h + 1) * 60` → `h * 60` | 3 | `expected '10/10/2026 09:00' to be '10/10/2026 10:00'` |
| `d.getHours()` → `d.getUTCHours()` | **5 — todos os reescritos** | `expected '10/10/2026 12:00' to be '10/10/2026 09:00'` |
| `instanteNoFuso(...)` → string ingênua | 1 (só o de Tóquio) | `expected '11/10/2026 02:00' to be '10/10/2026 14:00'` |
| `initialHour={escolha?.hora ?? null}` → `{null}` | 2 | `expected '20/08/2026 09:00' to be '20/08/2026 10:00'` |
| `paraInputLocal` escreve segundos `:30` | 2 | `expected '2026-10-10T09:00:30.000' to match /^\d{4}-…$/` |
| `setStart("")` | 3 | `expected '(campo sem datetime-local válido: "")' to be '10/10/2026 09:00'` |

A terceira foi **refeita de forma independente na revisão**: mata os 5.

**Sobreviventes, ditos e não escondidos.** Duas mutações de formato (`:00` de segundos; separador `T`
→ espaço) sobrevivem porque o **jsdom aplica a sanitização do HTML** no `datetime-local` e as desfaz
antes de qualquer asserção:

```
"2026-10-10T09:00:00" -> "2026-10-10T09:00"
"2026-10-10 09:00"    -> "2026-10-10T09:00"
"2026-10-10T09:00:30" -> "2026-10-10T09:00:30.000"
"banana"              -> ""
```

São **mutantes equivalentes na fronteira do DOM** — nenhuma leitura de `el.value` pode matá-las, nem
a nova nem a antiga. Não é regressão introduzida aqui.

A quarta sobrevive aos quatro testes de fuso-do-runner **por desenho**: com tenant e máquina no mesmo
fuso, ida e volta se cancelam por construção. Quem a mata é o de Tóquio — é o risco de "mutante
equivalente ao desacoplar", medido e coberto.

## Dívida que este PR abre (não corrigida aqui)

`grade.test.ts` tem uma **segunda** dependência de fuso, **não declarada**, que a varredura em UTC não
vê: `"eventsOfDay filtra pelo dia e ORDENA"` usa um evento às `18:00Z`, que em `Asia/Tokyo` cai no
**dia seguinte** e some do filtro. UTC e UTC−3 concordam sobre o dia de `18:00Z`, por isso ela é
invisível.

Está num `.test.ts` — **dentro** do escopo do job de mutação. A lição de método: varrer só em UTC não
fecha a classe; é preciso um fuso positivo também.

## Gates

`pnpm lint` exit 0 · `pnpm typecheck` exit 0 · `$env:TZ='UTC'; pnpm test` → 74 files / 855 tests,
exit 0.

Fecha #185.
