### PR TITLE
refactor(web): 'Agendado para entrar' passa a vir da constante nas 2 telas [#186]

### DIFF
--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -8,7 +8,7 @@ import { pluralize } from "../../lib/pluralize";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
-import type { BankAccount } from "../financeiro/contas";
+import { AGENDADO_ENTRADA_LABEL, type BankAccount } from "../financeiro/contas";
 import type { CostCenter } from "../financeiro/costCenters";
 import CostCenterSelect from "../financeiro/CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
@@ -154,12 +154,16 @@ export default function CobrancasPage() {
         <Stat label="Vencido" value={brl(summary.overdue_cents)} hint={`${summary.overdue_count} em atraso`} tone="text-danger" />
         <Stat label="Recebido" value={brl(summary.paid_cents)} hint="total" tone="text-accent-700" />
         {/* [8.15] O agendado tem cartão PRÓPRIO e **some quando é zero** — mesmo tratamento do
-            "Agendado para entrar" da 8.14. Sem ele, a cobrança agendada não apareceria em nenhum
-            dos três cartões (nem "a vencer", nem "vencido", nem "recebido"): o modo de falha "o
-            dinheiro some da tela" que esta onda existe para eliminar. */}
+            agendado da 8.14. Sem ele, a cobrança agendada não apareceria em nenhum dos três
+            cartões (nem "a vencer", nem "vencido", nem "recebido"): o modo de falha "o dinheiro
+            some da tela" que esta onda existe para eliminar.
+            ⚠️ [#186] O rótulo vem de `AGENDADO_ENTRADA_LABEL` (`financeiro/contas.ts`) e não de um
+            literal: `ContasSaldosPage` e `crm/ClientDetailPage` mostram o MESMO estado e têm de
+            mudar de nome junto com este cartão. Escrito solto, um rename desincronizava as três
+            com a suíte inteira verde. */}
         {summary.scheduled_cents > 0 && (
           <Stat
-            label="Agendado para entrar"
+            label={AGENDADO_ENTRADA_LABEL}
             value={brl(summary.scheduled_cents)}
             hint="recebido fora do trilho, com dia marcado"
             tone="text-amber-700"

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -16,6 +16,7 @@ import { api, apiErrorMessage } from "../../lib/api";
 import { formatDate, formatDay } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
 import { rotaDaCobranca } from "../cobrancas/rota";
+import { AGENDADO_ENTRADA_LABEL } from "../financeiro/contas";
 import BlocoDaAgenda from "./BlocoDaAgenda";
 import BlocoDaConversa from "./BlocoDaConversa";
 import ClientTimeline from "./ClientTimeline";
@@ -124,9 +125,13 @@ export default function ClientDetailPage() {
             rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
             Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
             ação de dinheiro, e uma terceira convenção para o mesmo estado seria a assimetria que
-            esta issue existe para fechar. */}
+            esta issue existe para fechar.
+            ⚠️ [#186] É por isso que o rótulo é IMPORTADO de `financeiro/contas.ts` em vez de
+            escrito solto: "vem de lá" precisava continuar valendo quando alguém o renomear. O
+            import atravessa feature de propósito e não inventa convenção — é a mesma forma do
+            `VOCAB_ENTRADA` (`pagar/baixa.ts`) que esta tela já importa acima. */}
         {scheduledSum > 0 && (
-          <Stat label="Agendado para entrar" value={brl(scheduledSum)} tone="text-amber-700" />
+          <Stat label={AGENDADO_ENTRADA_LABEL} value={brl(scheduledSum)} tone="text-amber-700" />
         )}
       </div>
 

--- a/apps/web/src/features/financeiro/contas.ts
+++ b/apps/web/src/features/financeiro/contas.ts
@@ -537,7 +537,27 @@ export const DISPONIVEL_CAIXA_LABEL = "Disponível como caixa";
  * "no banco", que são vocabulário de **saldo**. Não são sinônimos e a tela não pode sugerir que são.
  */
 export const AGENDADO_SAIDA_LABEL = "Agendado para sair";
-/** O par simétrico. Só passa a ter valor com a Story 8.15 (recebimento com data futura). */
+/**
+ * O par simétrico. Só passa a ter valor com a Story 8.15 (recebimento com data futura).
+ *
+ * ⚠️ **[#186] FONTE ÚNICA do rótulo — três telas o exibem e NENHUMA o escreve solto.**
+ *
+ * As três leem o número de origens diferentes e mesmo assim usam esta string, porque para o dono
+ * elas nomeiam **a mesma ideia**: dinheiro com dia marcado que ainda não caiu.
+ *
+ * | Tela | De onde vem o número |
+ * |---|---|
+ * | `financeiro/ContasSaldosPage` | `resumoSaldos()`, sobre `agendado_entrada_cents` da conta |
+ * | `cobrancas/CobrancasPage` | `summary.scheduled_cents` (cobranças `scheduled`) |
+ * | `crm/ClientDetailPage` | as cobranças `scheduled` **do cliente** (issue #154) |
+ *
+ * Até o #186 as duas últimas escreviam o literal. A medição que fechou a questão: renomear esta
+ * constante deixava **183 testes verdes** e as telas passavam a exibir DOIS nomes para o mesmo
+ * estado — desincronia silenciosa, sem nenhum teste para denunciá-la. Importar daqui amarra as
+ * três e **não inventa convenção nova**: é a mesma forma do `VOCAB_ENTRADA` (`pagar/baixa.ts`),
+ * que essas duas telas já importam. Um módulo neutro só para duas strings, esse sim, seria a
+ * terceira convenção que o PR #171 recusou com razão.
+ */
 export const AGENDADO_ENTRADA_LABEL = "Agendado para entrar";
 
 /** Tipos que NÃO são caixa imediato — espelha o default de `active_balance_total` (design §6.1). */


### PR DESCRIPTION
## Resumo

`AGENDADO_ENTRADA_LABEL = "Agendado para entrar"` existe em `financeiro/contas.ts:541` desde a Story
8.14, e mesmo assim **as telas escreviam o literal solto**. Este PR liga os dois call sites reais à
constante. Fecha #186.

## O alcance, confirmado — 2 call sites, não 3

```
$ git grep -n 'Agendado para entrar' -- apps/web/src | grep -v '\.test\.'
contas.ts:541                 export const AGENDADO_ENTRADA_LABEL = …   ← definição
CobrancasPage.tsx:162         label="Agendado para entrar"              ← CALL SITE
ClientDetailPage.tsx:129      <Stat label="Agendado para entrar" …>     ← CALL SITE
CobrancasPage.tsx:157         …"Agendado para entrar" da 8.14…          ← prosa
contas.ts:595                 * - **"Agendado para sair"** / …          ← prosa
```

**5 ocorrências, 2 duplicatas.** A issue já registrava a contagem errada de propósito: o relatório
que a originou disse 3 porque o `grep` contou comentário.

O irmão `"Agendado para sair"`: **zero** call sites soltos — já é consumido só via constante. Os
outros rótulos de dinheiro (`"Vencido"`, `"Recebido"`, `"A pagar"`) não têm constante nenhuma, então
não estão nesta classe.

## Por que extrair, se o PR #171 decidiu NÃO extrair

O #171 recusou **inventar uma terceira convenção**, e isso continua certo: `brl` está redefinido
localmente em **15 arquivos e importado em 0** — um módulo neutro de rótulos seria exatamente essa
convenção nova. **Este PR não cria módulo nenhum.**

Usa a forma que já existe e que **estes dois arquivos já usam**: `VOCAB_ENTRADA` (`pagar/baixa.ts`),
um pacote de strings de interface importado por `CobrancasPage.tsx:15` e `ClientDetailPage.tsx:22`.
A premissa do #171 ("importar rótulo entre features acopla") é contrariada por uma linha do próprio
arquivo.

Custo do acoplamento, medido: `CobrancasPage` **já** importava de `../financeiro/contas` — **0 edges
novos**. `crm` ganha 1, somando aos 3 cross-feature que já tinha. `contas.ts` é módulo puro.

## A medição que decidiu

| Mutação | Antes deste PR | Depois |
|---|---|---|
| `AGENDADO_ENTRADA_LABEL` → `"Agendado para CAIR"` | **183/183 verdes** | **3 testes mortos**, 2 arquivos |

Não era duplicação inerte de duas strings: era **dessincronização silenciosa sem rede**. Um rename
deixava as três telas exibindo dois nomes para o mesmo estado, com a suíte inteira verde.

## Prova por mutação

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| constante → `"Agendado para CAIR"` | `CobrancasPage.test.tsx › 8.15 › a cobrança AGENDADA tem rótulo próprio` | `Unable to find an element with the text: Agendado para entrar` |
| idem | `ClientDetailPage.test.tsx › #145/#154 › 'a vencer' EXCLUI a vencida` | idem |
| idem | `ClientDetailPage.test.tsx › #154 › a AGENDADA tem cartão PRÓPRIO` | idem |

`contas.test.ts` (69 testes) e `ContasSaldosPage.test.tsx` **sobrevivem por projeto** — afirmam pela
constante, então acompanham o rename. Os testes de tela seguem afirmando o **literal** de propósito:
é isso que os torna a rede.

Mutação refeita de forma independente na revisão, com o mesmo resultado.

## Gates

`eslint . --max-warnings 0` exit 0 · `tsc --noEmit` exit 0 · `vitest run` 854/855.

A única falha é `PlatformUsers` (`Test timed out in 15000ms`) — arquivo sem qualquer referência a
rótulo de dinheiro, **7/7 verde isolado**. Contenção de CPU, a classe do #162.

## Fora de escopo (vira issue)

- `brl` redefinido em **15** arquivos e importado em **0** — a duplicação cara de verdade.
- `"Vencido"`, `"Recebido"`, `"A pagar"` soltos em 2-3 arquivos cada, sem constante.

Fecha #186.
