### PR TITLE
test(web): 57 mutantes mortos por operador, e a tabela de menu sai do escopo [#191]

### DIFF
--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -48,6 +48,40 @@ export interface NavSection {
  * Cada grupo é separado por um divisor tracejado (ver AppShell.tsx) — evita a lista única
  * misturando navegação diária com telas de configuração/relatório raramente abertas.
  */
+// ── FORA DO TESTE DE MUTAÇÃO, e a medição que decidiu isso (issue #191) ──────────────────────
+//
+// `navigation.ts` era o PIOR score da árvore — 55,65%, 51 dos 269 sobreviventes da primeira
+// corrida completa (run 32478357936). Ordenado por contagem, seria o alvo nº1. Medido por TIPO,
+// não é dívida nenhuma.
+//
+// Os 115 mutantes deste arquivo são, sem exceção: 53 `StringLiteral`, 26 `BooleanLiteral`,
+// 30 `ObjectLiteral` e 6 `ArrayDeclaration`. **Zero** `ConditionalExpression`, `LogicalOperator`,
+// `EqualityOperator` ou `ArithmeticOperator` — e não é coincidência: este módulo não exporta
+// função nenhuma, só a tabela abaixo. Não há expressão para mutar porque não há lógica. A
+// pergunta que a mutação faz ("o teste prende a lógica?") não tem sujeito aqui.
+//
+// Matar os 51 sobreviventes significaria afirmar cada `label` e cada `ready` num teste — uma
+// SEGUNDA CÓPIA desta tabela, que dobra o custo de mexer no menu e não pega nada que um humano
+// não veja na tela em um segundo. Seria dívida nova, não dívida paga.
+//
+// E há a prova de que o número era um artefato da régua, não do código: a corrida exclui
+// `.test.tsx` de propósito (ver `vitest.mutation.config.ts`), e `ClientDetailPage.test.tsx:880`
+// clica em `findByRole("button", { name: /CRM & Kanban/ })` — esse teste MATA um dos 26 mutantes
+// de string. Os 51 mediam a ausência de teste de componente na corrida, não a qualidade do
+// `navigation.test.ts`.
+//
+// **Por que aqui e não em `stryker.config.mjs`.** A regra de descoberta de lá ("todo `.ts` com um
+// irmão `.test.ts`") é boa e não deve ganhar a primeira exceção por nome de arquivo — a segunda
+// viria fácil. O `disable` fica no lugar onde a próxima pessoa lê o motivo, e é BRACKETADO: se um
+// dia alguém exportar uma função daqui, ela nasce fora do bloco e entra na corrida sozinha.
+//
+// O `navigation.test.ts` continua rodando e continua guardando o que importa — as quatro travas
+// da Story 8.7 e as 24 rotas pré-existentes. Isto não afrouxa teste nenhum; só para de pontuar
+// uma tabela de dados como se fosse lógica.
+//
+// Impacto medido no score GLOBAL: 83,52% → 85,46% (1.480/1.772 → 1.416/1.657) só por sair.
+//
+// Stryker disable all : tabela de dados declarativa, sem lógica — ver o bloco acima (issue #191)
 export const navSections: NavSection[] = [
   {
     // Núcleo: o que se abre todo dia.
@@ -111,3 +145,5 @@ export const navSections: NavSection[] = [
     items: [{ label: "Configurações", to: "/config", icon: Settings, ready: true }],
   },
 ];
+
+// Stryker restore all

--- a/apps/web/src/features/cobrancas/rota.test.ts
+++ b/apps/web/src/features/cobrancas/rota.test.ts
@@ -57,6 +57,25 @@ describe("rotuloDaRota — o que a linha da lista diz", () => {
     const c = { ...BASE, bank_account_id: "acc-sumida", paid_at: null } as Charge;
     expect(rotuloDaRota(c, nome)).toBe("recebido direto na conta");
   });
+
+  it("conta desconhecida MAS com data: nada de 'caiu no  em 04/08' com o buraco no meio", () => {
+    // Provado por mutação (issue #191). O caso acima tinha `paid_at: null`, então conta E dia eram
+    // vazios juntos e o `&&` da linha 53 nunca era exercido de verdade — trocá-lo por `||`
+    // sobrevivia à suíte. Este é o caso que separa os dois: a lista de contas ainda não chegou
+    // (nome vazio) mas o crédito tem data. Com o `||`, o dono leria "caiu no  em 04/08", uma frase
+    // com um buraco onde deveria estar o nome do banco.
+    const c = { ...BASE, bank_account_id: "acc-sumida", paid_at: "2026-08-04T00:00:00Z" } as Charge;
+    expect(rotuloDaRota(c, nome)).toBe("recebido direto na conta");
+  });
+
+  it("conta conhecida SEM data: diz o banco e cala sobre o dia, em vez de calar sobre os dois", () => {
+    // Provado por mutação (issue #191): o ramo `if (conta) return \`caiu no ${conta}\`` era o único
+    // dos três sem caso próprio — apagá-lo passava verde. É o estado real de uma baixa manual sem
+    // `paid_at`: o e1p sabe ONDE o dinheiro caiu e não sabe QUANDO. Degradar para "recebido direto
+    // na conta" jogaria fora a metade que ele sabe.
+    const c = { ...BASE, bank_account_id: "acc-1", paid_at: null } as Charge;
+    expect(rotuloDaRota(c, nome)).toBe("caiu no Itaú PJ");
+  });
 });
 
 describe("diaDoCredito — data de CALENDÁRIO, nunca horário local", () => {
@@ -69,5 +88,14 @@ describe("diaDoCredito — data de CALENDÁRIO, nunca horário local", () => {
 
   it("sem data, string vazia (nada a dizer)", () => {
     expect(diaDoCredito(null)).toBe("");
+  });
+
+  it("data TRUNCADA não vira 'undefined/08' na tela", () => {
+    // Provado por mutação (issue #191): o `dia && mes ?` da linha 40 podia virar `true` ou `dia ||
+    // mes` sem quebrar teste, porque todo caso testado era um ISO completo ou `null` — os dois
+    // extremos, nenhum meio-termo. `"2026-08"` é o meio-termo: `split("-")` devolve duas partes, o
+    // dia sai `undefined` e o template interpolaria a palavra "undefined" direto na linha da lista.
+    expect(diaDoCredito("2026-08")).toBe("");
+    expect(diaDoCredito("2026")).toBe("");
   });
 });

--- a/apps/web/src/features/financeiro/contas.test.ts
+++ b/apps/web/src/features/financeiro/contas.test.ts
@@ -335,6 +335,38 @@ describe("parseCentsBRL / centsToInput — dinheiro em centavos até a borda", (
     expect(parseCentsBRL("0.5")).toBe(50);
   });
 
+  it("o grupo de milhar vale com 2 e 3 dígitos na frente, não só com 1", () => {
+    // Provado por mutação (issue #191). Os dois casos de milhar que existiam — "1.234" e
+    // "1.234.567" — começam ambos com UM dígito. Isso deixava o `{1,3}` de
+    // `/^-?\d{1,3}(\.\d{3})+$/` inteiramente solto: trocá-lo por `\d` (exatamente um dígito)
+    // passava verde. E o mutante não erra pouco: "12.345" viraria R$ 12,35 em vez de
+    // R$ 12.345,00 — mil vezes menos, num campo de saldo de conta.
+    expect(parseCentsBRL("12.345")).toBe(1234500);
+    expect(parseCentsBRL("123.456")).toBe(12345600);
+  });
+
+  it("as DUAS âncoras do detector de milhar estão presas (`^` e `$`)", () => {
+    // Provado por mutação (issue #191): os três mutantes de `Regex` do módulo estavam todos nesta
+    // linha, e dois deles eram exatamente apagar uma âncora. É a lição do `HEX_RE` do `theme.ts`
+    // (CLAUDE.md §5.3) reaparecendo — só que aqui em cima de dinheiro, e errando por 1000x.
+    //
+    // Sem o `$`: "1.2345" casaria pelo prefixo "1.234" e seria lido como milhar → R$ 12.345,00
+    // em vez de R$ 1,23. Um dígito a mais digitado sem querer multiplicaria o saldo por 10.000.
+    expect(parseCentsBRL("1.2345")).toBe(123);
+    // Sem o `^`: "1234.567" casaria no MEIO ("234.567") e viraria R$ 1.234.567,00 em vez de
+    // R$ 1.234,57. O `^` é o que obriga o grupo de milhar a começar onde o número começa.
+    expect(parseCentsBRL("1234.567")).toBe(123457);
+  });
+
+  it("espaço no meio do número é limpo — inclusive como separador de milhar", () => {
+    // Provado por mutação (issue #191): apagar o `.trim().replace(/\s/g, "")` inteiro sobrevivia,
+    // porque o único caso com espaço era `"   "` (só espaço), que dá 0 nos dois programas. O caso
+    // que separa é o espaço INTERNO — o formato que extrato de banco e planilha exportam. Sem a
+    // limpeza, "1 234,56" para no primeiro espaço e vira R$ 1,00.
+    expect(parseCentsBRL("1 234,56")).toBe(123456);
+    expect(parseCentsBRL(" 1234,56 ")).toBe(123456);
+  });
+
   it("aceita negativo (conta no limite é saldo de abertura legítimo)", () => {
     expect(parseCentsBRL("-250,00")).toBe(-25000);
   });
@@ -358,6 +390,15 @@ describe("formatDateBR — data de calendário por STRING, nunca `new Date` loca
     // fuso que sumiu com eventos da Agenda (CLAUDE.md §6.0).
     expect(formatDateBR("2026-01-01")).toBe("01/01/2026");
     expect(formatDateBR("2026-07-30T00:00:00Z")).toBe("30/07/2026");
+  });
+
+  it("data INCOMPLETA volta como veio, em vez de virar 'undefined/07/2026'", () => {
+    // Provado por mutação (issue #191): o guarda `d && m && y ?` tinha os mesmos QUATRO mutantes
+    // vivos que `lib/datetime.ts:formatDay` e `cobrancas/rota.ts:diaDoCredito` — a suíte só usava
+    // ISO completo, nunca uma string com partes faltando. É a terceira ocorrência do MESMO padrão
+    // no repositório, e as três estão fechadas neste PR.
+    expect(formatDateBR("2026-07")).toBe("2026-07");
+    expect(formatDateBR("2026")).toBe("2026");
   });
 });
 

--- a/apps/web/src/features/financeiro/projecao.test.ts
+++ b/apps/web/src/features/financeiro/projecao.test.ts
@@ -89,6 +89,48 @@ describe("toPolylinePoints", () => {
   it("retorna string vazia sem pontos", () => {
     expect(toPolylinePoints([], { width: 10, height: 10 })).toBe("");
   });
+
+  it("reserva `padding` nas QUATRO bordas — com o padding 12 que a tela usa de verdade", () => {
+    // Provado por mutação (issue #191): os dois testes acima mediam só a ORDEM relativa das
+    // coordenadas, e o principal usava `padding: 0` — onde `padding * 2`, `padding / 2` e
+    // `padding + ...` valem todos zero. Resultado: 17 mutantes de aritmética sobreviviam nas
+    // linhas 89-99, e a única frase concreta do docstring ("reserva `padding` nas bordas")
+    // não tinha nenhuma asserção. Pior: `ProjecaoCaixaPage.tsx:248` desenha com `padding: 12`,
+    // ou seja, o valor que EMBARCA era exatamente o que nenhum teste exercitava.
+    //
+    // As quatro âncoras abaixo são o contrato inteiro da normalização, e são exatas de
+    // propósito (não `toBeCloseTo`): x do primeiro dia = borda esquerda, x do último dia =
+    // borda direita, y do maior saldo = topo, y do menor saldo = base. Qualquer troca de
+    // sinal, de fator ou de operando nessa aritmética tira um dos quatro do lugar.
+    const width = 200;
+    const height = 100;
+    const padding = 12;
+    const poly = toPolylinePoints(trajectoryPoints(projection()), { width, height, padding });
+    const coords = poly.split(" ").map((p) => p.split(",").map(Number));
+
+    expect(coords).toHaveLength(4);
+    // Eixo X: dia 0 encosta na borda esquerda, o último dia (90) encosta na direita.
+    expect(coords[0][0]).toBe(padding); // 12
+    expect(coords[3][0]).toBe(width - padding); // 188
+    // Eixo Y invertido: o MAIOR saldo (90000, o primeiro ponto) vai para o topo; o MENOR
+    // (-80000, o último) vai para a base. Nenhum dos dois invade o padding.
+    expect(coords[0][1]).toBe(padding); // 12
+    expect(coords[3][1]).toBe(height - padding); // 88
+
+    // Os pontos internos são proporcionais aos DIAS (não à posição no array): 30/90 e 60/90 da
+    // largura útil. É o que prende o `pt.days / maxDays` — uma divisão trocada por multiplicação
+    // mantém a ordem crescente e só aparece no valor.
+    const util = width - padding * 2; // 176
+    expect(coords[1][0]).toBeCloseTo(padding + (30 / 90) * util, 1); // 70.7
+    expect(coords[2][0]).toBeCloseTo(padding + (60 / 90) * util, 1); // 129.3
+    // E nenhuma coordenada escapa do viewBox.
+    for (const [x, y] of coords) {
+      expect(x).toBeGreaterThanOrEqual(padding);
+      expect(x).toBeLessThanOrEqual(width - padding);
+      expect(y).toBeGreaterThanOrEqual(padding);
+      expect(y).toBeLessThanOrEqual(height - padding);
+    }
+  });
 });
 
 describe("runwayLabel", () => {
@@ -196,6 +238,43 @@ describe("parcelasSaldoInicial (Story 8.8 AC5)", () => {
     const parcelas = parcelasSaldoInicial(sacouTudo);
     expect(parcelas).toHaveLength(2);
     expect(parcelas[1]).toEqual({ rotulo: ROTULO_PLATAFORMA, cents: 0 });
+  });
+
+  it("sob 'misto' com o BANCO zerado as duas parcelas continuam saindo — é o `||` que garante", () => {
+    // Alvo nº1 da issue #191, e o único sobrevivente de `ConditionalExpression` fora do gráfico.
+    // O `if (p.saldo_inicial_origem === "misto" || banco.cents !== 0)` tinha o lado ESQUERDO
+    // solto: todos os casos `misto` existentes traziam banco != 0, então o segundo operando
+    // sozinho já decidia e trocar o primeiro por `false` (ou o literal "misto" por "") não
+    // quebrava teste nenhum. Até o caso "conta nova zerada" do teste da soma passava com o
+    // mutante, porque com total 0 a soma fecha com uma parcela ou com duas.
+    //
+    // O caso que separa os dois programas é este: origem `misto`, banco EXATAMENTE 0 e
+    // plataforma com dinheiro — quem declarou as duas origens mas ainda não conciliou o banco
+    // (ou zerou a conta). O docstring já promete "sob `misto`, as DUAS parcelas saem sempre,
+    // inclusive uma zerada"; o teste de cima cobria só a metade com a PLATAFORMA zerada. Esta é
+    // a metade que faltava, e é a que o `||` governa. Com o mutante, o usuário perderia a linha
+    // "no banco: R$ 0,00" e voltaria a ver um saldo inicial que não diz de onde vem — o bug de
+    // produção que o Epic 8 existe para corrigir.
+    const bancoZerado = misto({
+      saldo_inicial_cents: 90000,
+      saldo_inicial_banco_cents: 0,
+      saldo_inicial_plataforma_cents: 90000,
+    });
+    expect(parcelasSaldoInicial(bancoZerado)).toEqual([
+      { rotulo: ROTULO_BANCO, cents: 0 },
+      { rotulo: ROTULO_PLATAFORMA, cents: 90000 },
+    ]);
+
+    // E o contraste que prova que é a ORIGEM decidindo, não o valor: o mesmo par de números com
+    // origem `plataforma` continua devolvendo só uma parcela.
+    const soPlataforma = projection({
+      saldo_inicial_cents: 90000,
+      saldo_inicial_banco_cents: 0,
+      saldo_inicial_plataforma_cents: 90000,
+    });
+    expect(parcelasSaldoInicial(soPlataforma)).toEqual([
+      { rotulo: ROTULO_PLATAFORMA, cents: 90000 },
+    ]);
   });
 
   it("a soma das parcelas é SEMPRE o total (a invariante do AC2, também na tela)", () => {

--- a/apps/web/src/features/pagar/filtros.test.ts
+++ b/apps/web/src/features/pagar/filtros.test.ts
@@ -29,6 +29,23 @@ describe("fimDoMesSeguinte", () => {
   it("acerta o ano secular nao bissexto", () => {
     expect(fimDoMesSeguinte("2100-01-10")).toBe("2100-02-28");
   });
+
+  it("acerta o ano secular BISSEXTO — a metade da regra gregoriana que faltava", () => {
+    // Provado por mutacao (issue #191). O teste de 2100 acima ja mostrava que o autor se importava
+    // com anos seculares, mas so cobria a metade "divisivel por 100 nao e bissexto". A outra
+    // metade — `|| ano % 400 === 0` — nao tinha nenhum caso: apagar a clausula inteira ou trocar
+    // o `%` por `*` passava verde. Sem esta linha, `bissexto` estava escrito com tres quartos da
+    // regra testados e um quarto por fe.
+    expect(fimDoMesSeguinte("2000-01-10")).toBe("2000-02-29");
+  });
+
+  it("num ano bissexto os OUTROS meses nao herdam os 29 dias", () => {
+    // Provado por mutacao (issue #191): trocar `mes === 2` por `true` sobrevivia a suite inteira,
+    // porque todo caso bissexto que existia caia em fevereiro e todo caso nao-fevereiro caia em
+    // ano comum. Com o mutante, setembro de 2028 fecharia dia 29 e o horizonte padrao de Contas a
+    // Pagar esconderia um dia inteiro de vencimentos — em silencio, um ano a cada quatro.
+    expect(fimDoMesSeguinte("2028-08-18")).toBe("2028-09-30");
+  });
 });
 
 describe("filtroPadrao", () => {
@@ -76,6 +93,58 @@ describe("paraQuery", () => {
     const q = paraQuery(filtroPadrao("2026-08-18"), 50, 100);
     expect(q.limit).toBe(50);
     expect(q.offset).toBe(100);
+  });
+
+  it("manda o piso de data como `from` quando o dono escolhe um — nao so o teto", () => {
+    // Provado por mutacao (issue #191): `if (f.de) q.from = f.de` podia virar `if (false)` sem
+    // quebrar teste nenhum, porque NENHUM caso preenchia `de` (o padrao e `null` de proposito, e
+    // todos os testes partiam do padrao). O sintoma seria mudo e caro: o dono aplica o periodo
+    // "de 01/08 a 30/09", a tela mostra o recorte marcado e a API devolve tudo desde o comeco do
+    // mundo — sem erro, sem aviso, so uma lista maior do que ele pediu.
+    const f = { ...filtroPadrao("2026-08-18"), de: "2026-08-01" };
+    expect(paraQuery(f, 50, 0).from).toBe("2026-08-01");
+  });
+
+  it("o texto vai APARADO, e so espaco nao vira busca", () => {
+    // Provado por mutacao (issue #191): os dois `.trim()` da linha podiam sumir sem quebrar nada.
+    // O primeiro e o guarda ("   " nao e uma busca, e omitir a chave e o que traz a lista inteira
+    // de volta); o segundo e o que impede um `?q=%20anthropic%20` de nao casar com nada no
+    // servidor. Sao dois efeitos diferentes na mesma linha, por isso as duas asseracoes.
+    const soEspaco = { ...filtroPadrao("2026-08-18"), q: "   " };
+    expect(paraQuery(soEspaco, 50, 0)).not.toHaveProperty("q");
+
+    const comSobra = { ...filtroPadrao("2026-08-18"), q: "  anthropic  " };
+    expect(paraQuery(comSobra, 50, 0).q).toBe("anthropic");
+  });
+});
+
+describe("paraQuery — a ORDEM da lista (olhar para tras x olhar para a frente)", () => {
+  // Provado por mutacao (issue #191): o unico caso de ordenacao que existia era `status: ["paid"]`
+  // ⇒ `desc`. Isso deixava metade do predicado solto — o `.every` podia virar `.some`, o
+  // `"canceled"` podia virar `""` e o `status.length > 0` podia virar `>= 0`, tudo verde. Os tres
+  // casos abaixo sao os que separam esses programas, e cada um e uma tela que o dono abre.
+  const base = filtroPadrao("2026-08-18");
+
+  it("historico cancelado tambem e olhar para tras", () => {
+    // `canceled` e `paid` sao o MESMO gesto (arquivo); so `paid` estava preso.
+    expect(paraQuery({ ...base, status: ["canceled"], ate: null }, 50, 0).order).toBe("desc");
+    expect(paraQuery({ ...base, status: ["paid", "canceled"], ate: null }, 50, 0).order).toBe(
+      "desc",
+    );
+  });
+
+  it("recorte MISTO olha para a frente — basta uma conta viva para o proximo vencimento mandar", () => {
+    // `every`, nao `some`: com uma aberta no meio do recorte, o que interessa e o que vence
+    // primeiro. Trocado por `some`, a lista abriria pelo passado e o dono perderia de vista
+    // exatamente a conta que ainda pode pagar.
+    expect(paraQuery({ ...base, status: ["paid", "open"], ate: null }, 50, 0).order).toBe("asc");
+  });
+
+  it("sem nenhum status marcado ('todos') a ordem e crescente, nao decrescente", () => {
+    // Pegadinha real do `every`: `[].every(...)` e `true` por vacuidade, entao o `status.length > 0`
+    // e a UNICA coisa segurando o caso "todos" no lado certo. Trocado por `>= 0`, a visao "todos"
+    // abriria pelo mais antigo — a lista que ninguem quer ver primeiro.
+    expect(paraQuery({ ...base, status: [], ate: null }, 50, 0).order).toBe("asc");
   });
 });
 

--- a/apps/web/src/lib/datetime.test.ts
+++ b/apps/web/src/lib/datetime.test.ts
@@ -7,6 +7,7 @@ import {
   formatDateTime,
   formatDay,
   formatTime,
+  formatWeekday,
   fusoValido,
   today,
 } from "./datetime";
@@ -59,6 +60,47 @@ describe("formatação de data de calendário", () => {
   it("tolera vazio", () => {
     expect(formatDay(null)).toBe("");
     expect(formatDay("")).toBe("");
+  });
+
+  it("data INCOMPLETA devolve vazio em vez de interpolar 'undefined'", () => {
+    // Provado por mutação (issue #191). O guarda `y && m && d ?` tinha QUATRO mutantes vivos: os
+    // testes só usavam ISO completo, `null` e `""` — nunca uma string com algumas partes. As duas
+    // linhas abaixo são as duas metades do `&&` encadeado:
+    //   • `"2026-08"` (falta o dia) mata `true` e `y && m || d`;
+    //   • `"-08-05"` (falta o ano) mata `y && m → true` e `y && m → y || m`.
+    // Sem elas, uma `due_date` truncada pela API sairia como "undefined/08/2026" na tela — pior que
+    // um campo vazio, porque parece um dado.
+    expect(formatDay("2026-08")).toBe("");
+    expect(formatDay("-08-05")).toBe("");
+  });
+});
+
+describe("os vazios de cada formatador (nenhum devolve 'Invalid Date')", () => {
+  // Provado por mutação (issue #191): só `formatDateTime` e `formatDateShort` tinham o caso nulo
+  // preso. Os ramos `: ""` de `formatDate` e `formatTime` estavam sem asserção, e o contrato do
+  // módulo — "devolve string vazia em vez de 'Invalid Date'" — vale para todos eles igualmente.
+  it("nulo e indefinido saem vazios em todas as variantes", () => {
+    expect(formatDate(null, FUSO_PADRAO)).toBe("");
+    expect(formatDate(undefined, FUSO_PADRAO)).toBe("");
+    expect(formatTime(null, FUSO_PADRAO)).toBe("");
+    expect(formatTime(undefined, FUSO_PADRAO)).toBe("");
+    expect(formatWeekday(null, FUSO_PADRAO)).toBe("");
+  });
+});
+
+describe("formatWeekday", () => {
+  // Provado por mutação (issue #191): a função inteira estava SEM COBERTURA — 5 mutantes
+  // `NoCoverage`, incluindo esvaziar o corpo (`{}`) e apagar o objeto de opções. Não é dívida de
+  // mutação e sim de cobertura: `formatWeekday` é a única porta do módulo que ninguém chamava num
+  // teste, e ela é a que a Agenda usa no cabeçalho do dia.
+  it("dia da semana por extenso, no fuso do TENANT", () => {
+    expect(formatWeekday(NOITE_DO_DIA_5, "America/Sao_Paulo")).toBe("quarta-feira, 05 de agosto");
+  });
+
+  it("o fuso é parâmetro de verdade — em UTC já é outro dia, e outro dia da semana", () => {
+    // 2026-08-06T01:30Z: para o dono ainda é quarta 05; em UTC já é quinta 06. Se as opções
+    // (`weekday`/`day`/`month`) ou o fuso se perdessem, esta linha e a de cima colapsariam na mesma.
+    expect(formatWeekday(NOITE_DO_DIA_5, "UTC")).toBe("quinta-feira, 06 de agosto");
   });
 });
 


### PR DESCRIPTION
## Resumo

Primeira fatia da triagem da #191. **Não mata os 269** — mata **57** e entrega a triagem escrita do
resto, com número medido. O `thresholds.break: 80` já está ligado (#189), então isto é dívida de
qualidade de suíte com folga, não urgência.

## A ordem por contagem levava ao alvo errado

138 dos 269 são `StringLiteral`. Ordenado por **tipo**, o sinal estava nos operadores — e o alvo nº1
era **uma linha**:

```ts
// financeiro/projecao.ts:183, em parcelasSaldoInicial
if (p.saldo_inicial_origem === "misto" || banco.cents !== 0) return [banco, plataforma];
```

O lado esquerdo do `||` estava solto porque **todo caso `misto` testado trazia banco ≠ 0**. O caso
que separa os dois programas — `misto` com banco zerado — é o mesmo domínio que já produziu bug real
em produção no Epic 8.

## A fatia fechada

| Módulo | Score antes | depois | mutantes mortos |
|---|---:|---:|---:|
| `financeiro/projecao.ts` | 76,24 | **95,05** | +19 |
| `pagar/filtros.ts` | 91,93 | **98,76** | +11 |
| `lib/datetime.ts` | 78,79 | **98,48** | +13 |
| `cobrancas/rota.ts` | 80,56 | **97,22** | +6 |
| `financeiro/contas.ts` | — | (prova manual) | +8 |

47 sobreviventes + 10 sem-cobertura = **57 mutantes**. Sobreviventes globais: **269 → 171**.

Detalhe que a tabela da issue não mostra e que muda a leitura: os 18 operadores de `projecao.ts`
estavam vivos porque **o teste principal usava `padding: 0`** — onde `padding*2`, `padding/2` e
`padding+…` valem todos zero — enquanto `ProjecaoCaixaPage.tsx:248` desenha com `padding: 12`. O
valor que embarca era o único não exercitado.

**Os 3 mutantes `Regex` do repositório inteiro** estavam todos no detector de milhar de
`parseCentsBRL`, e dois eram apagar uma âncora: sem `$`, `"1.2345"` vira R$ 12.345,00; sem `^`,
`"1234.567"` vira R$ 1.234.567,00. É a lição do `HEX_RE` (§5.3), agora em cima de **dinheiro**.

## `navigation.ts` sai do escopo — e a medição é o argumento

Era o pior score da árvore (55,65%, 51 sobreviventes). Ordenado por contagem, seria o alvo nº1.
Medido por tipo, **não é dívida**: os 115 mutantes são 53 `StringLiteral` + 26 `BooleanLiteral` +
30 `ObjectLiteral` + 6 `ArrayDeclaration` — **zero** `ConditionalExpression`, `LogicalOperator`,
`EqualityOperator` ou `ArithmeticOperator`. O módulo não exporta função nenhuma, só a tabela
declarativa `navSections`. **Não há expressão para mutar porque não há lógica.**

E há a prova de que o número era artefato da régua: a corrida exclui `.test.tsx` de propósito, e
`ClientDetailPage.test.tsx:880` clica em `findByRole("button", { name: /CRM & Kanban/ })` — esse teste
**mataria** um dos 26 mutantes de string. Os 51 mediam a ausência de teste de componente na corrida,
não a qualidade do `navigation.test.ts`.

**Impacto medido no global: 83,52% → 85,46%** (1.480/1.772 → 1.416/1.657), só por sair.

**Por que no arquivo e não em `stryker.config.mjs`.** A regra de descoberta de lá ("todo `.ts` com um
irmão `.test.ts`") é boa e não deve ganhar a primeira exceção por nome de arquivo — a segunda viria
fácil. O `disable` fica onde a próxima pessoa lê o motivo, e é **bracketado**: se alguém exportar uma
função daqui um dia, ela nasce fora do bloco e volta a ser medida sozinha. `navigation.test.ts`
continua rodando intacto — **nenhum teste foi afrouxado**.

O run do módulo caiu de 3m04s para 28s: `navigation.ts | n/a | n/a | 0 | 0 | 0 | 0`, `{"Ignored":115}`.

## Prova por mutação

Os 8 de `contas.ts` por mutação manual (cópia de arquivo), com a mensagem real da morte:

| Mutante | Teste que matou | Mensagem |
|---|---|---|
| `Regex` L660 apaga `$` | "as DUAS âncoras do detector de milhar" | `expected 1234500 to be 123` |
| `Regex` L660 apaga `^` | idem | `expected 123456700 to be 123457` |
| `Regex` L660 `\d{1,3}`→`\d` | "o grupo de milhar vale com 2 e 3 dígitos" | `expected 1235 to be 1234500` |
| `MethodExpression` L655 apaga `.trim().replace(/\s/g,"")` | "espaço no meio do número é limpo" | `expected 100 to be 123456` |
| `ConditionalExpression` L727 `d&&m&&y`→`true` | "data INCOMPLETA volta como veio" | `expected 'undefined/07/2026' to be '2026-07'` |
| `LogicalOperator` L727 →`d&&m\|\|y` | idem | idem |
| `ConditionalExpression` L727 `d&&m`→`true` | idem | idem |
| `LogicalOperator` L727 →`d\|\|m` | idem | idem |

Os outros 49 estão provados pelo antes/depois do Stryker. Destaque, o alvo nº1:
`projecao.ts:183 ConditionalExpression → false` morre em *"sob 'misto' com o BANCO zerado as duas
parcelas continuam saindo"*.

## Mutantes examinados e DISPENSADOS — esta lista é entrega, não sobra

**Equivalentes** (os dois programas são o mesmo), provados numericamente:

1. `projecao.ts:86` `if (points.length===0) return ""` → `if (false)`. Com `[]`, o caminho mutante
   termina em `[].map(...).join(" ")` = `""`. Saída idêntica nas duas.
2. `filtros.ts:32` `padStart(2,"0")` → `padStart(2,"")`. `dias ∈ {28,29,30,31}` — sempre 2 chars,
   no-op nos dois. Verificado nos quatro valores.
3. `datetime.ts:54` `if (!iso) return ""` → `if (false)`. Com `iso` nulo, `formatDate(null, tz)` já
   devolve `""` e a função retorna `""` do mesmo jeito.

**Inalcançáveis** (ramo defensivo morto — teste seria impossível, não caro):

4. `rota.ts:51` o `: ""` de `bank_account_id ? … : ""`. Só é alcançado com `rota === "banco"` **e**
   `bank_account_id` falsy — mas `rotaDaCobranca` só devolve `"banco"` *porque* ele é truthy.
5. `filtros.ts:124` o `?? ""` de `u.set("de", f.de ?? "")`. Exige `f.de !== padrao.de` **e**
   `f.de === null`; `filtroPadrao` sempre põe `de: null`.
6. `projecao.ts:210` `parts.join(" e ") || "0 dias"`. `runwayLabel` retorna cedo para `days <= 0`,
   então `parts` nunca é vazio.

**Vivos de propósito** (matar seria dívida nova):

7. `projecao.ts:113-115` `ORIGEM_LABEL` → `""`. O único rótulo que carrega requisito real
   (`plataforma` não pode dizer "conta bancária") **já está preso**. Afirmar os outros três seria
   copiar o mapa para dentro do teste.

## Alcance — a tabela da issue confere, com uma ressalva medida

Medi rodando Stryker por módulo e lendo `reports/mutation/mutation.json`, não o log. `projecao.ts`,
`filtros.ts`, `rota.ts`, `datetime.ts` e `navigation.ts` batem exatamente.

⚠️ **`contas.ts` não é medível com confiança numa máquina carregada.** Localmente deu 90,79% com
**12 timeouts**, e os 12 são todos `StringLiteral` em declaração de constante
(`export const KIND_INVESTMENT = "investment"`) — nada que possa entrar em laço. São artefato de
carga. E **27 + 12 = 39**, exatamente o número da CI: a issue está certa, e a diferença é ruído de
medição de ~3,8 pontos num módulo. Vira issue nova.

## Triagem do que ficou — para virar issue(s), com número medido

| Prioridade | Módulo | Sobrev. restantes | Operadores | Nota |
|---|---|---:|---:|---|
| **A** | `contas.ts` | 31 | **6** | `MethodExpression` L311/L760/L761, `OptionalChaining` L463, `LogicalOperator`+`ConditionalExpression` L468 |
| **B** | `investimentos.ts` | 9 | **6** | melhor densidade restante |
| **C** | `pagar/duplicar.ts` | 6 | **5** | pequeno e denso |
| **D** | `lib/idleTimer.ts` | 6 | **3** | |
| **E** | `pagar/baixa.ts` | 25 | 5 | pior score restante (65,79), mas 17 são `StringLiteral` |
| **F** | `conferencia.ts` | 29 | 4 | 25 `StringLiteral` — grande e barato de ignorar |
| — | **11 módulos fora da tabela da issue** | **59** | ? | **nunca triados** — a tabela da issue cobre 11 dos 22 módulos e soma 210 dos 269 |

**Segunda issue recomendada:** *"a corrida de `contas.ts` mede ~4 pontos a mais numa máquina
carregada"* — 12 `StringLiteral` viram `Timeout` (que conta como **morto**) em vez de `Survived`, por
contenção de CPU, não por laço. É exatamente o risco que o comentário do `stryker.config.mjs` previu
(*"um mutante que hoje estoura o `timeoutMS` pode sobreviver numa noite de runner mais folgado"*),
observado no campo e na direção oposta. Mexer em `timeoutFactor`/`timeoutMS` muda a régua de todo
mundo — não foi feito aqui.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 74 arquivos / 875 testes verdes (75,65s)
```

Diff: 6 arquivos, **295 inserções, 0 remoções** — 5 de teste e 1 de produção (`navigation.ts`).
`contas.ts` de produção ficou **byte-idêntico**.

A mudança em `navigation.ts` é **só comentário e pragma**, provado por parse: transpilando as duas
versões com `removeComments`, o código emitido é idêntico (**2874 bytes** nos dois), e o controle
positivo (trocar um `ready: true`) mostra que a comparação enxerga mudança real.

⚠️ Fixe o fuso **fora** do Node para reproduzir: `$env:TZ='America/Sao_Paulo'` no PowerShell. O `env`
do `vitest.config.ts` não pega no pool `threads` que o Stryker força (#169), e pelo Git Bash a
variável não chega ao Node. E não passe `--reporters` na CLI — derruba a corrida por injeção do
typed-inject.

Fecha a primeira fatia da #191.
