### PR TITLE
fix(web): guarda por forma em 15 setters de payload cru — o pior estoura ANTES do JSX [#207]

### DIFF
--- a/apps/web/src/components/Attachments.test.tsx
+++ b/apps/web/src/components/Attachments.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../lib/api";
+import { assentar } from "../test/assentar";
+import Attachments from "./Attachments";
+
+// issue #207 — `setItems(data)`: payload cru no setter, SEM operador nenhum. Este NÃO é uma tela,
+// é um bloco embutido em várias (boleto, contrato...): sem ErrorBoundary no app, o `items.map` de
+// um não-array não deixa o bloco vazio — leva junto a tela que o hospeda.
+vi.mock("../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+const SLOTS = [{ key: "comprovante", label: "Comprovante" }];
+
+function renderBloco() {
+  return render(<Attachments ownerType="payable" ownerId="p-1" slots={SLOTS} />);
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("Attachments — lista de anexos fora de forma não derruba quem hospeda (#207)", () => {
+  // ⚠️ Objeto e número saem da lista por medição: o render é guardado por `items.length > 0`, e
+  // `.length` deles é `undefined` — `undefined > 0` é falso e o `.map` nunca roda. Mutante
+  // equivalente para essas duas formas. As duas abaixo passam pelo portão.
+  it.each([
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → o bloco de upload continua de pé", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    renderBloco();
+    await assentar();
+
+    expect(screen.getByRole("button", { name: /Comprovante/ })).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: anexo de verdade continua listado", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [{ id: "a-1", filename: "nota.pdf", label: "comprovante", size: 2048 }],
+    } as never);
+    renderBloco();
+    await assentar();
+
+    expect(screen.getByText("nota.pdf")).toBeInTheDocument();
+    expect(screen.getByText("2 KB")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/Attachments.tsx
+++ b/apps/web/src/components/Attachments.tsx
@@ -24,7 +24,10 @@ export default function Attachments({
     const { data } = await api.get<Attachment[]>(
       `/attachments?owner_type=${ownerType}&owner_id=${ownerId}`,
     );
-    setItems(data);
+    // `Array.isArray`, e aqui não havia operador NENHUM: o payload cru virava estado e ia direto
+    // para `items.map` no render. O app não tem ErrorBoundary — um `.map` de não-array não deixa
+    // este bloco vazio, desmonta a ÁRVORE INTEIRA, e este componente é embutido em várias telas.
+    setItems(Array.isArray(data) ? data : []);
   }, [ownerType, ownerId]);
 
   useEffect(() => {

--- a/apps/web/src/features/admin/PlatformCustomers.test.tsx
+++ b/apps/web/src/features/admin/PlatformCustomers.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
+import PlatformCustomers from "./PlatformCustomers";
+
+// issue #207 — `setCustomers(data)`: payload cru no setter, SEM operador nenhum. `customers.reduce`
+// roda no CORPO do componente (o chip de "compras"), sem portão de `.length` na frente — qualquer
+// forma que não seja array estoura no render, longe do alcance do `.then`.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+const VAZIO =
+  "Ainda não há clientes. Eles aparecem aqui quando um escritório vende um produto ou curso.";
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("PlatformCustomers — lista de clientes fora de forma não derruba a aba (#207)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a aba mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    render(<PlatformCustomers />);
+    await assentar();
+
+    expect(screen.getByText(VAZIO)).toBeInTheDocument();
+  });
+
+  it("contra-teste: cliente de verdade continua contado nos chips e listado", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [
+        {
+          id: "c-1",
+          name: "Maria Souza",
+          email: "maria@exemplo.com",
+          tenant_name: "Escritório Alpha",
+          purchases: 3,
+        },
+      ],
+    } as never);
+    render(<PlatformCustomers />);
+    await assentar();
+
+    expect(screen.getByText("Maria Souza")).toBeInTheDocument();
+    expect(screen.queryByText(VAZIO)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/admin/PlatformCustomers.tsx
+++ b/apps/web/src/features/admin/PlatformCustomers.tsx
@@ -26,7 +26,10 @@ export default function PlatformCustomers() {
   useEffect(() => {
     api
       .get<PlatformCustomerCard[]>("/admin/customers")
-      .then(({ data }) => setCustomers(data))
+      // `Array.isArray`, e aqui não havia operador nenhum: `customers.filter` roda no `useMemo`
+      // logo abaixo e `customers.reduce` no corpo do componente — os dois em tempo de RENDER, que
+      // não cai neste `.then`. Sem ErrorBoundary no app, isso é tela branca, não lista vazia.
+      .then(({ data }) => setCustomers(Array.isArray(data) ? data : []))
       .finally(() => setLoading(false));
   }, []);
 

--- a/apps/web/src/features/admin/PlatformUsers.test.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import PlatformUsers from "./PlatformUsers";
 
 // Story 7.18 — Task 4. Rede sempre mockada (IV2): nenhum teste bate em /admin real.
@@ -274,5 +275,44 @@ describe("PlatformUsers — a confirmação do convite diz a verdade sobre a ent
 
     expect(await screen.findByRole("heading", { name: "Conta criada" })).toBeInTheDocument();
     expect(screen.queryByText("Senha temporária")).not.toBeInTheDocument();
+  });
+});
+
+// ── `GET /admin/users` fora de forma (issue #207) ─────────────────────────────
+//
+// `setNodes(data)` recebia o payload CRU, sem operador nenhum. `nodes.reduce` roda dentro do
+// `useMemo` dos totais, em tempo de RENDER — fora do alcance de qualquer `catch` do `load`. E o
+// app não tem ErrorBoundary: o `TypeError` não deixa a lista vazia, desmonta a árvore inteira.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante: sem ele o `getByText` acerta o estado vazio
+// INICIAL e passa antes de o payload chegar ao setter. Ver `src/test/assentar.ts`.
+describe("PlatformUsers — lista de contas fora de forma não derruba a aba (#207)", () => {
+  function mockUsers(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/admin/users") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a aba mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    mockUsers(payload);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Nenhuma conta ainda.")).toBeInTheDocument();
+  });
+
+  it("contra-teste: escritório de verdade continua listado", async () => {
+    mockUsers([officeNode]);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Escritório Alpha Ltda")).toBeInTheDocument();
+    expect(screen.queryByText("Nenhuma conta ainda.")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/admin/PlatformUsers.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.tsx
@@ -121,7 +121,9 @@ export default function PlatformUsers() {
 
   const load = useCallback(async () => {
     const { data } = await api.get<TenantUsers[]>("/admin/users");
-    setNodes(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: `nodes.reduce`/`nodes.filter` rodam nos
+    // `useMemo` abaixo, em tempo de RENDER — fora do alcance de qualquer `catch` deste `load`.
+    setNodes(Array.isArray(data) ? data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/agenda/AgendaPage.test.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import AgendaPage from "./AgendaPage";
 
 // Story 7.15 — Task 2. Rede sempre mockada (IV2): nenhum teste bate em /agenda real.
@@ -178,5 +179,60 @@ describe("AgendaPage — chipLabel (Task 3, Onda 2): atalho de nome só para kin
 
     await waitFor(() => expect(container.textContent).toContain("Alinhamento do casamento 12/12"));
     expect(container.textContent).not.toContain("Cliente Vinculado");
+  });
+});
+
+// ── `GET /agenda/events` fora de forma (issue #207) ───────────────────────────
+//
+// `setEvents(data)` recebia o payload CRU, sem operador nenhum. A grade chama `eventsOfDay(events,
+// d)` para CADA dia visível, e `eventsOfDay` abre com `events.filter` (`grade.ts`) — em tempo de
+// render, fora do alcance do `.then`. Sem ErrorBoundary no app, o estouro no primeiro dia do mês
+// desmonta a árvore inteira: a agenda é a tela que o dono abre primeiro no dia.
+//
+// ⚠️ Este site NÃO aparece numa varredura por `estado.map`/`.length`/`.filter` no arquivo: o
+// consumo é indireto, através de `eventsOfDay`. Foi assim que ele escapou da triagem inicial.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante — ver `src/test/assentar.ts`.
+describe("AgendaPage — eventos fora de forma não derrubam a grade (#207)", () => {
+  function mockEventos(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/agenda/events") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a grade do mês continua montada, sem nenhum chip", async (_rotulo, payload) => {
+    mockEventos(payload);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByRole("button", { name: "Hoje" })).toBeInTheDocument();
+    expect(screen.queryByText("Atendimento fora de forma")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: evento de verdade continua virando chip no dia", async () => {
+    const hoje = new Date();
+    const ymd = `${hoje.getFullYear()}-${String(hoje.getMonth() + 1).padStart(2, "0")}-${String(
+      hoje.getDate(),
+    ).padStart(2, "0")}`;
+    mockEventos([
+      {
+        id: "e-1",
+        title: "Atendimento real",
+        kind: "atendimento",
+        all_day: true,
+        starts_at: `${ymd}T09:00:00Z`,
+        ends_at: `${ymd}T10:00:00Z`,
+      } satisfies Partial<AgendaEvent> as AgendaEvent,
+    ]);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Atendimento real")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -54,7 +54,10 @@ export default function AgendaPage() {
     const { data } = await api.get<AgendaEvent[]>("/agenda/events", {
       params: paramsDaGrade(start, end),
     });
-    setEvents(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: a grade chama `eventsOfDay(events, d)`
+    // para CADA dia visível, e `eventsOfDay` abre com `events.filter` (`grade.ts`). Payload fora de
+    // forma estoura no primeiro dia do mês — antes de qualquer célula existir, com a tela em branco.
+    setEvents(Array.isArray(data) ? data : []);
   }, [start, end]);
 
   useEffect(() => {

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
 import ConversasPage from "./ConversasPage";
 
 vi.mock("../../lib/api", () => ({
@@ -620,5 +621,57 @@ describe("ConversasPage — carregando vs. vazia", () => {
     expect(await screen.findByPlaceholderText(/mensagem/i)).toBeInTheDocument();
     expect(visivelNoCelular(screen.getByTestId("lista-conversas"))).toBe(false);
     expect(visivelNoCelular(screen.getByTestId("painel-conversa"))).toBe(true);
+  });
+});
+
+// ── `GET /whatsapp-conversations` fora de forma (issue #207) ──────────────────
+//
+// `setConversations(data)` recebia o payload CRU, sem operador nenhum, e o `finally` do `load`
+// trata falha como "resolveu" — nunca como "resolveu com dado VÁLIDO". `conversations.find` roda
+// no CORPO do componente, em tempo de render, longe daquele `try`. Sem ErrorBoundary no app, é a
+// mesma armadilha que o `ClientTimeline` já derrubou nesta tela — agora pela lista principal, que
+// é a coluna de onde o dono navega.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante — ver `src/test/assentar.ts`.
+describe("ConversasPage — lista de conversas fora de forma não derruba a tela (#207)", () => {
+  function mockLista(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a coluna mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    mockLista(payload);
+    renderNaRota("/conversas");
+    await assentar();
+
+    expect(screen.getByText("Nenhuma conversa ainda.")).toBeInTheDocument();
+    expect(screen.getByTestId("lista-conversas")).toBeInTheDocument();
+  });
+
+  it("contra-teste: conversa de verdade continua na coluna", async () => {
+    mockLista([
+      {
+        chat_id: "c1",
+        kind: "direct" as const,
+        title: "Doro Eventos",
+        phone: "5511999999999",
+        client_id: "c1",
+        last_message_at: "2026-07-19T10:00:00Z",
+        last_message_preview: "Oi, quero o cardápio",
+        unread: false,
+      },
+    ]);
+    renderNaRota("/conversas");
+    await assentar();
+
+    expect(screen.getByText("Doro Eventos")).toBeInTheDocument();
+    expect(screen.queryByText("Nenhuma conversa ainda.")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -66,7 +66,11 @@ export default function ConversasPage() {
   const loadConversations = useCallback(async () => {
     try {
       const { data } = await api.get<ConversationSummary[]>("/whatsapp-conversations");
-      setConversations(data);
+      // `Array.isArray`, e aqui não havia operador nenhum. O `finally` abaixo trata falha como
+      // "resolveu", nunca como "resolveu com dado VÁLIDO" — e `conversations.find` roda no corpo
+      // do componente, em tempo de render, longe deste `try`. É a mesma armadilha que o
+      // `ClientTimeline` já derrubou nesta tela, agora pela lista principal.
+      setConversations(Array.isArray(data) ? data : []);
     } finally {
       // No `finally`, não no `try`: mesmo se a primeira chamada falhar, "ainda carregando"
       // não pode durar para sempre — mas sucesso e falha são tratados como "resolveu", não

--- a/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import ContasSaldosPage from "./ContasSaldosPage";
 import type {
   BankAccount,
@@ -1299,5 +1300,56 @@ describe("checkpoints fora de formato não viram saldo declarado", () => {
     renderPage();
 
     await waitFor(() => expect(screen.getByText(/Saldo declarado em/)).toBeInTheDocument());
+  });
+});
+
+// ── `GET /bank/accounts` fora de forma (issue #207) ───────────────────────────
+//
+// `setAccounts(res.data)` recebia o payload CRU, sem operador nenhum — é um dos dois exemplos que
+// a issue cita pelo nome. Aqui a consequência é DUPLA, e por isso a guarda saneia uma lista local
+// em vez de só o estado:
+//
+//   1. `res.data.map` alimentava o `Promise.all` dos checkpoints DENTRO do `try` — o `TypeError`
+//      virava "erro de rede" na tela, que é uma mentira sobre a causa;
+//   2. `accounts.map` roda no RENDER, onde nenhum `catch` chega, e sem ErrorBoundary no app isso
+//      é tela branca.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante — ver `src/test/assentar.ts`.
+describe("ContasSaldosPage — contas fora de forma não derrubam a tela (#207)", () => {
+  const VAZIO = /Nenhuma conta cadastrada ainda/;
+
+  function mockContas(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/bank/accounts") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    mockContas(payload);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText(VAZIO)).toBeInTheDocument();
+    // E o erro NÃO é rotulado como falha de rede: o `Promise.all` dos checkpoints nunca chegou a
+    // receber um não-array, então o `catch` do `load` não disparou.
+    expect(screen.queryByText("Erro inesperado")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: conta de verdade continua listada com seus checkpoints", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/bank/accounts") return Promise.resolve({ data: [conta()] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Itaú PJ")).toBeInTheDocument();
+    expect(screen.queryByText(VAZIO)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -110,12 +110,17 @@ export default function ContasSaldosPage() {
       const res = await api.get<BankAccount[]>("/bank/accounts", {
         params: { include_archived: includeArchived },
       });
-      setAccounts(res.data);
+      // `Array.isArray`, e aqui não havia operador nenhum. Duas consequências, não uma: o
+      // `contas.map` abaixo estoura DENTRO do `try` (vira "erro de rede" que não é), e
+      // `accounts.map` estoura no RENDER, que nenhum `catch` alcança. A lista saneada serve aos
+      // dois — não adianta guardar só o estado e deixar `res.data` cru alimentando o `Promise.all`.
+      const contas = Array.isArray(res.data) ? res.data : [];
+      setAccounts(contas);
       // Último saldo declarado por conta: `limit=1` numa rota já paginada e ordenada por
       // `reference_date` desc (8.4). São N chamadas, mas N é o número de contas do dono (poucas) e
       // saem em paralelo — não existe rota em lote e a IV3 proíbe criar uma aqui.
       const pares = await Promise.all(
-        res.data.map(async (a) => {
+        contas.map(async (a) => {
           try {
             const cps = await api.get<BankBalanceCheckpoint[]>(
               `/bank/accounts/${a.id}/checkpoints`,

--- a/apps/web/src/features/financeiro/InvestimentosPage.test.tsx
+++ b/apps/web/src/features/financeiro/InvestimentosPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import InvestimentosPage from "./InvestimentosPage";
+
+// issue #207 — `setAccounts(data)` de `GET /investments`: payload cru no setter, SEM operador
+// nenhum. `accounts.map` é o corpo da tela, e o mesmo `data` alimentava o `Promise.all` do `load`.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+const VAZIO = 'Nenhuma conta de investimento ainda. Clique em "Nova conta de investimento".';
+
+/** Só `/investments` é corrompido — `/bank/accounts` fica válido para a falha ser atribuível. */
+function mockInvestments(payload: unknown) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/investments") return Promise.resolve({ data: payload } as never);
+    if (url === "/bank/accounts") return Promise.resolve({ data: [] } as never);
+    return Promise.resolve({ data: { total_yield: 0 } } as never);
+  });
+}
+
+function renderPage() {
+  return render(
+    <PageActionsProvider>
+      <InvestimentosPage />
+    </PageActionsProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("InvestimentosPage — lista de aplicações fora de forma não derruba a tela (#207)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    mockInvestments(payload);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText(VAZIO)).toBeInTheDocument();
+  });
+
+  it("contra-teste: aplicação de verdade continua listada", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/investments")
+        return Promise.resolve({
+          data: [
+            {
+              id: "i-1",
+              name: "CDB Banco X",
+              kind: "CDB",
+              index_rate_label: "110% CDI",
+              principal: 1000,
+              bank_account_id: null,
+              archived_at: null,
+            },
+          ],
+        } as never);
+      if (url === "/bank/accounts") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: { total_yield: 0 } } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("CDB Banco X")).toBeInTheDocument();
+    expect(screen.queryByText(VAZIO)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/InvestimentosPage.tsx
+++ b/apps/web/src/features/financeiro/InvestimentosPage.tsx
@@ -44,12 +44,16 @@ export default function InvestimentosPage() {
 
   const load = useCallback(async () => {
     const { data } = await api.get<InvestmentAccount[]>("/investments");
-    setAccounts(data);
+    // `Array.isArray`, e aqui não havia operador nenhum. `accounts.map` é o corpo da tela (linha
+    // 112) e nenhum `catch` alcança o render. A lista saneada também alimenta o `Promise.all`
+    // abaixo: guardar só o estado deixaria o `data.map` cru estourando na mesma resposta.
+    const lista = Array.isArray(data) ? data : [];
+    setAccounts(lista);
     const { data: bancarias } = await api.get<BankAccount[]>("/bank/accounts");
     setContas(contasDeAplicacao(bancarias));
     const params = hasPeriod ? { start, end } : undefined;
     const entries = await Promise.all(
-      data.map(async (a) => {
+      lista.map(async (a) => {
         const { data: r } = await api.get<Rentability>(`/investments/${a.id}/rentability`, {
           params,
         });

--- a/apps/web/src/features/financeiro/PlanoContasPage.test.tsx
+++ b/apps/web/src/features/financeiro/PlanoContasPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import PlanoContasPage from "./PlanoContasPage";
+
+// issue #207 — `setAccounts(data)`: payload cru no setter, SEM operador nenhum. É o PIOR site da
+// leva: `buildHierarchy(accounts)` roda no CORPO do componente, antes de qualquer JSX, e abre com
+// `for (const acc of accounts)`. Payload não iterável estoura ali, e sem ErrorBoundary no app a
+// árvore inteira some.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+function renderPage() {
+  return render(
+    <PageActionsProvider>
+      <PlanoContasPage />
+    </PageActionsProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("PlanoContasPage — plano de contas fora de forma não derruba a tela (#207)", () => {
+  // ⚠️ A string sai da lista por medição, não por conveniência: string É iterável (por caractere),
+  // o `for..of` passa, cada caractere devolve `grupo_dre === undefined`, o `byGroup.has` recusa e o
+  // resultado é a hierarquia vazia. Mutante equivalente para essa forma. As três abaixo NÃO são
+  // iteráveis e estouram.
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    renderPage();
+    await assentar();
+
+    expect(
+      screen.getByText(
+        'Nenhuma categoria ainda. Clique em "Nova categoria" ou use as categorias sugeridas.',
+      ),
+    ).toBeInTheDocument();
+    // Os 6 grupos DRE saem SEMPRE (`buildHierarchy` é total): vê-los prova que o corpo do
+    // componente rodou até o fim em vez de estourar no `for..of`.
+    expect(screen.getByText("Receita")).toBeInTheDocument();
+    expect(screen.getByText("Investimento")).toBeInTheDocument();
+  });
+
+  it("contra-teste: categoria de verdade continua agrupada no grupo DRE", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [
+        {
+          id: "a-1",
+          grupo_dre: "RECEITA",
+          categoria: "Consultoria",
+          archived_at: null,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Consultoria")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Nenhuma categoria ainda. Clique em "Nova categoria" ou use as categorias sugeridas.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/PlanoContasPage.tsx
+++ b/apps/web/src/features/financeiro/PlanoContasPage.tsx
@@ -27,7 +27,11 @@ export default function PlanoContasPage() {
     const { data } = await api.get<ChartAccount[]>("/chart-of-accounts", {
       params: { include_archived: includeArchived },
     });
-    setAccounts(data);
+    // `Array.isArray`, e aqui não havia operador nenhum — este é o pior da classe. `buildHierarchy`
+    // é chamado no CORPO do componente e abre com `for (const acc of accounts)`: payload fora de
+    // forma estoura antes de a primeira linha de JSX existir, e sem ErrorBoundary a árvore inteira
+    // some. Nem o `accounts.length > 0` abaixo denuncia — em objeto, `.length` é `undefined`.
+    setAccounts(Array.isArray(data) ? data : []);
   }, [includeArchived]);
 
   useEffect(() => {

--- a/apps/web/src/features/funis/FunisPage.test.tsx
+++ b/apps/web/src/features/funis/FunisPage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import FunisPage from "./FunisPage";
+
+// issue #207 — `setFunnels(data)`: payload cru no setter, SEM operador nenhum. Rede sempre
+// mockada (IV2).
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <FunisPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+// ── `GET /funnels` fora de forma (issue #207) ────────────────────────────────
+//
+// Sem a guarda, `funnels.length` de um objeto é `undefined`, `undefined === 0` é falso, e o fluxo
+// cai justamente no `funnels.map` — que estoura no RENDER, fora do alcance do `.then`. O app não
+// tem ErrorBoundary: isso desmonta a árvore inteira, não só esta lista.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante: sem ele o `getByText` acerta o estado vazio
+// INICIAL e passa antes de o payload chegar ao setter. Ver `src/test/assentar.ts`.
+describe("FunisPage — lista de funis fora de forma não derruba a tela (#207)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText('Nenhum funil ainda. Clique em "Novo funil".')).toBeInTheDocument();
+  });
+
+  it("contra-teste: funil de verdade continua chegando à grade", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [{ id: "f-1", name: "Funil de vendas", node_count: 3 }],
+    } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Funil de vendas")).toBeInTheDocument();
+    expect(screen.getByTestId("abrir-funil-f-1")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/funis/FunisPage.tsx
+++ b/apps/web/src/features/funis/FunisPage.tsx
@@ -11,7 +11,10 @@ export default function FunisPage() {
 
   const load = useCallback(async () => {
     const { data } = await api.get<FunnelSummary[]>("/funnels");
-    setFunnels(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: `funnels.map` É a tela, e o `.length === 0`
+    // logo acima não protege — em objeto `.length` é `undefined`, e `undefined === 0` é falso, então
+    // o fluxo cai justamente no ramo que faz o `.map`.
+    setFunnels(Array.isArray(data) ? data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
 import FunnelBuilderPage from "./FunnelBuilderPage";
 
 // Story 7.16 — Task 3. Rede sempre mockada (IV2): nenhum teste bate em /funnels real.
@@ -217,5 +218,52 @@ describe("funil com nodes/edges fora de formato não derruba o builder", () => {
     renderEdit();
 
     await waitFor(() => expect(screen.getByDisplayValue("Funil real")).toBeInTheDocument());
+  });
+});
+
+// ── `GET /funnels/components` fora de forma (issue #207) ──────────────────────
+//
+// `setCatalog(data)` recebia o payload CRU, sem operador NENHUM — o outro exemplo que a issue cita
+// pelo nome. É o terceiro payload desta mesma tela: o PR #197 guardou `nodes`/`edges` (que ao
+// menos tinham `?? []`) e o catálogo ficou de fora justamente por não ter operador algum e por
+// isso não aparecer na varredura por `??`. `catalog.map` monta a paleta no render, fora do alcance
+// do `.then`.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante — ver `src/test/assentar.ts`.
+describe("catálogo de componentes fora de forma não derruba o builder (#207)", () => {
+  function mockCatalogo(payload: unknown) {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/funnels/components") return Promise.resolve({ data: payload } as never);
+      if (url === "/settings/profile") return Promise.resolve({ data: profile(null) } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → o builder monta com a paleta vazia em vez de estourar", async (_rotulo, payload) => {
+    mockCatalogo(payload);
+    renderNew();
+    await assentar();
+
+    // O canvas e a barra de ações continuam de pé...
+    expect(screen.getByRole("button", { name: "Salvar" })).toBeInTheDocument();
+    // ...e a paleta simplesmente não tem itens.
+    expect(screen.queryByText("Novo Lead")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: catálogo de verdade continua montando a paleta", async () => {
+    mockCatalogo(catalog);
+    renderNew();
+    await assentar();
+
+    expect(screen.getByText("Novo Lead")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -213,7 +213,12 @@ function Builder() {
   }, []);
 
   useEffect(() => {
-    api.get<FunnelComponentCategory[]>("/funnels/components").then(({ data }) => setCatalog(data));
+    // `Array.isArray`, e aqui não havia operador nenhum: `catalog.map` monta a paleta no render, e
+    // o `.then` não alcança o render. O PR #197 já guardou `nodes`/`edges` deste mesmo arquivo — o
+    // catálogo era o terceiro payload da mesma tela, e ficou de fora.
+    api
+      .get<FunnelComponentCategory[]>("/funnels/components")
+      .then(({ data }) => setCatalog(Array.isArray(data) ? data : []));
     api
       .get<TenantProfile>("/settings/profile")
       .then(({ data }) => setWhatsappProvider(data.whatsapp_provider))

--- a/apps/web/src/features/juridico/JuridicoPage.test.tsx
+++ b/apps/web/src/features/juridico/JuridicoPage.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
+import JuridicoPage from "./JuridicoPage";
+
+// issue #207 — DOIS sites de payload cru no mesmo arquivo, com consequências DIFERENTES:
+//   `setDocs(data)`   → `docs.slice(0, 6).map` no render
+//   `setSkills(data)` → `for (const s of skills)` dentro do `useMemo`
+// O segundo é o que a varredura por `.map`/`.length`/`.filter` NÃO enxerga — e é igualmente fatal.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+const SKILL_OK = [
+  {
+    skill: "peticao-inicial",
+    label: "Petição inicial",
+    description: "Redige a peça",
+    category: "core",
+    output_type: "peça",
+  },
+];
+const DOC_OK = [
+  {
+    id: "d-1",
+    title: "Contrato de prestação",
+    category: "core",
+    client_name: "Cliente A",
+    status: "ready",
+  },
+];
+
+/** Só UM dos dois endpoints é corrompido por vez — a falha tem de ser atribuível ao seu site. */
+function mock({ skills, docs }: { skills: unknown; docs: unknown }) {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/juridico/skills") return Promise.resolve({ data: skills } as never);
+    if (url === "/juridico/documents") return Promise.resolve({ data: docs } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <JuridicoPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+describe("JuridicoPage — `GET /juridico/documents` fora de forma (#207)", () => {
+  // ⚠️ Nem toda forma mata este site, e isso é medição, não escolha de conveniência: o render é
+  // guardado por `docs.length > 0`, e em objeto ou número `.length` é `undefined` — `undefined > 0`
+  // é falso e o `.map` nunca roda. Para ESSAS duas formas o mutante é equivalente. As duas abaixo
+  // são as que passam pelo portão: string tem `.length` e não tem `.map`; `null` estoura no
+  // próprio `.length`.
+  it.each([
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela renderiza sem os documentos, e as skills continuam de pé", async (_r, payload) => {
+    mock({ skills: SKILL_OK, docs: payload });
+    renderPage();
+    await assentar();
+
+    // A seção de skills fica DEPOIS da de documentos na árvore: vê-la é a prova de que o render
+    // chegou ao fim em vez de estourar no meio.
+    expect(screen.getByText("Petição inicial")).toBeInTheDocument();
+    expect(screen.queryByText("Documentos recentes")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: documento de verdade continua aparecendo", async () => {
+    mock({ skills: SKILL_OK, docs: DOC_OK });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Documentos recentes")).toBeInTheDocument();
+    expect(screen.getByText("Contrato de prestação")).toBeInTheDocument();
+  });
+});
+
+describe("JuridicoPage — `GET /juridico/skills` fora de forma (#207)", () => {
+  // ⚠️ Aqui o consumo é `for (const s of skills)`: o que mata é ser NÃO ITERÁVEL, não a falta de
+  // `.map`. Por isso a string sai da lista — string é iterável (por caractere), o `for..of` passa,
+  // e o resultado é um mapa de categorias vazio. Mutante equivalente para essa forma, medido.
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela renderiza sem as skills, e os documentos continuam de pé", async (_r, payload) => {
+    mock({ skills: payload, docs: DOC_OK });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contrato de prestação")).toBeInTheDocument();
+    expect(screen.queryByText("Petição inicial")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: skill de verdade continua agrupada na categoria", async () => {
+    mock({ skills: SKILL_OK, docs: DOC_OK });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Essenciais")).toBeInTheDocument();
+    expect(screen.getByText("Petição inicial")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/juridico/JuridicoPage.tsx
+++ b/apps/web/src/features/juridico/JuridicoPage.tsx
@@ -12,11 +12,17 @@ export default function JuridicoPage() {
 
   const loadDocs = useCallback(async () => {
     const { data } = await api.get<LegalDocumentSummary[]>("/juridico/documents");
-    setDocs(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: `docs.slice(0, 6).map` roda no render.
+    setDocs(Array.isArray(data) ? data : []);
   }, []);
 
   useEffect(() => {
-    api.get<LegalSkillSummary[]>("/juridico/skills").then(({ data }) => setSkills(data));
+    // `Array.isArray`, e aqui não havia operador nenhum. Este site escapa da varredura por
+    // `.map`/`.length`/`.filter`: o consumo é `for (const s of skills)` dentro do `useMemo` abaixo —
+    // igualmente em tempo de render, e igualmente fatal com payload não iterável.
+    api
+      .get<LegalSkillSummary[]>("/juridico/skills")
+      .then(({ data }) => setSkills(Array.isArray(data) ? data : []));
     loadDocs();
   }, [loadDocs]);
 

--- a/apps/web/src/features/marketing/MarketingPage.test.tsx
+++ b/apps/web/src/features/marketing/MarketingPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import MarketingPage from "./MarketingPage";
+
+// issue #207 — `setCarousels(data)`: payload cru no setter, SEM operador nenhum.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <MarketingPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+// Sem a guarda, `carousels.length === 0` de um objeto é `undefined === 0` → falso, e o fluxo cai
+// no `carousels.map`, que estoura no render. O `assentar()` é o que traz esse estouro para dentro
+// da asserção — ver `src/test/assentar.ts`.
+describe("MarketingPage — lista de carrosséis fora de forma não derruba a tela (#207)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    renderPage();
+    await assentar();
+
+    expect(
+      screen.getByText('Nenhum carrossel ainda. Clique em "Novo carrossel".'),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: carrossel de verdade continua chegando à grade", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [
+        {
+          id: "c-1",
+          topic: "Lançamento de agosto",
+          status: "ready",
+          slides: [{ title: "Slide 1", body: "corpo" }],
+        },
+      ],
+    } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Lançamento de agosto")).toBeInTheDocument();
+    expect(screen.getByTestId("abrir-carrossel-c-1")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/marketing/MarketingPage.tsx
+++ b/apps/web/src/features/marketing/MarketingPage.tsx
@@ -12,7 +12,9 @@ export default function MarketingPage() {
 
   const load = useCallback(async () => {
     const { data } = await api.get<Carousel[]>("/marketing/carousels");
-    setCarousels(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: `carousels.map` É a tela, e o
+    // `.length === 0` acima não desvia — em objeto `.length` é `undefined`, nunca `0`.
+    setCarousels(Array.isArray(data) ? data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/pagar/ComprovantePage.test.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
 import ComprovantePage from "./ComprovantePage";
 
 vi.mock("../../lib/api", () => ({
@@ -637,5 +638,48 @@ describe("bandeja fora de formato não identifica comprovante nenhum", () => {
     renderPage();
 
     await waitFor(() => expect(screen.getByText("Comprovante recebido")).toBeInTheDocument());
+  });
+});
+
+// ── `GET /payables/receipts/candidates` fora de forma (issue #207) ────────────
+//
+// `setCandidates(data)` recebia o payload CRU, sem operador nenhum. O `.catch` do efeito mostra a
+// mensagem de erro e a tela segue — mas `candidates.find` (no `useMemo` da conta selecionada) e
+// `candidates.map` rodam DEPOIS, no render, onde nenhum `catch` chega. Sem ErrorBoundary no app,
+// é tela branca.
+//
+// É o mesmo arquivo do `setReceipt` guardado no PR #197, e a diferença de peso é o ponto: lá o
+// payload era o NOME do arquivo (contexto — "sem ele a tela opera igual"); aqui é a lista de
+// contas, que é a razão de a tela existir.
+//
+// ⚠️ O `assentar()` é a metade que MATA o mutante — ver `src/test/assentar.ts`.
+describe("ComprovantePage — candidatas fora de forma não derrubam a tela (#207)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fusoDoTenant = "America/Sao_Paulo";
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    mockApi(payload as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Nenhuma conta encontrada.")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Buscar conta por nome ou fornecedor")).toBeInTheDocument();
+  });
+
+  it("contra-teste: candidata de verdade continua listada", async () => {
+    mockApi();
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Energia")).toBeInTheDocument();
+    expect(screen.queryByText("Nenhuma conta encontrada.")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -132,7 +132,11 @@ export default function ComprovantePage() {
     load()
       .then((data) => {
         if (cancelled) return;
-        setCandidates(data);
+        // `Array.isArray`, e aqui não havia operador nenhum. O `.catch` abaixo mostra a mensagem
+        // de erro e segue — mas `candidates.find` (useMemo) e `candidates.map` rodam no RENDER,
+        // depois do `.then`, onde nenhum `catch` chega. Mesmo arquivo do `setReceipt` guardado no
+        // #197: aquele era o nome do arquivo (contexto), este é a lista que a tela existe para ter.
+        setCandidates(Array.isArray(data) ? data : []);
       })
       .catch((err) => {
         if (cancelled) return;

--- a/apps/web/src/features/sites/SitesPage.test.tsx
+++ b/apps/web/src/features/sites/SitesPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import SitesPage from "./SitesPage";
+
+// issue #207 — `setPages(data)`: payload cru no setter, SEM operador nenhum.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: () => "Erro inesperado",
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <SitesPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+// Sem a guarda, `pages.length === 0` de um objeto é `undefined === 0` → falso, e o fluxo cai no
+// `pages.map`, que estoura no render. Ver `src/test/assentar.ts` para por que o `assentar()`.
+describe("SitesPage — lista de páginas fora de forma não derruba a tela (#207)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["string no lugar da lista", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+    ["número no lugar da lista", 7],
+  ])("%s → a tela mostra o estado vazio em vez de estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText('Nenhuma página ainda. Clique em "Nova página".')).toBeInTheDocument();
+  });
+
+  it("contra-teste: página de verdade continua chegando à grade", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: [
+        {
+          id: "p-1",
+          title: "Landing de agosto",
+          model: "captura",
+          status: "published",
+          public_slug: "landing-agosto",
+        },
+      ],
+    } as never);
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Landing de agosto")).toBeInTheDocument();
+    expect(screen.getByText("Captura de leads")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sites/SitesPage.tsx
+++ b/apps/web/src/features/sites/SitesPage.tsx
@@ -19,7 +19,9 @@ export default function SitesPage() {
 
   const load = useCallback(async () => {
     const { data } = await api.get<PageSummary[]>("/pages");
-    setPages(data);
+    // `Array.isArray`, e aqui não havia operador nenhum: `pages.map` É a tela, e o `.length === 0`
+    // acima não desvia — em objeto `.length` é `undefined`, nunca `0`.
+    setPages(Array.isArray(data) ? data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/test/assentar.ts
+++ b/apps/web/src/test/assentar.ts
@@ -1,0 +1,42 @@
+import { act } from "@testing-library/react";
+
+/**
+ * Deixa as promessas já resolvidas COMPROMETEREM seus `setState` dentro de `act` — e faz um erro
+ * de render nascido nesse commit reprovar o teste (issue #207).
+ *
+ * ## Por que isto existe, medido
+ *
+ * A forma óbvia de afirmar "payload fora de forma não derruba a tela" é `waitFor(() =>
+ * expect(screen.getByText(estadoVazio)).toBeInTheDocument())`. Ela é FALSA CONFIANÇA quando o
+ * estado inicial já é `[]`: o texto do estado vazio está no DOM desde a montagem, o primeiro
+ * poll do `waitFor` acerta, e o teste retorna ANTES de o payload sequer chegar ao setter.
+ *
+ * Medido em 22/08/2026 em `FunisPage`, com a guarda `Array.isArray` REMOVIDA da produção:
+ *
+ *     TypeError: funnels.map is not a function   (4x, em stderr)
+ *     Test Files  1 passed (1)
+ *     Tests       5 passed (5)
+ *
+ * Cinco testes verdes sobre um render que estourou quatro vezes. O `TypeError` sai em stderr
+ * porque o React o captura no commit e o relata; ninguém o converte em reprovação. Guarda cuja
+ * mutação sobrevive não é proteção — é a mesma dívida um nível acima, a lição que o #179 registra.
+ *
+ * Com o flush DENTRO de `act`, o mesmo mutante reprova com a mensagem de verdade:
+ *
+ *     TypeError: funnels.map is not a function
+ *     Test Files  1 failed (1)
+ *
+ * ## Por que `voltas`
+ *
+ * Uma volta esvazia um nível de microtarefa. Um `load` com `await` encadeado (`api.get` →
+ * `Promise.all` → `setState`) precisa de uma volta por elo, senão o commit que interessa fica
+ * pendente e o teste volta a passar por não ter chegado lá. Na dúvida, sobra volta — cada uma
+ * custa uma microtarefa, e passar do necessário é inofensivo.
+ */
+export async function assentar(voltas = 4): Promise<void> {
+  for (let i = 0; i < voltas; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}


### PR DESCRIPTION
## Resumo

Fecha a fatia de maior consequência da classe medida na #207: payload cru de API direto no setter,
**sem operador nenhum**. A issue mediu 67 sites e proibiu varredura única — 67 num PR vira diff
irrevisável. Este PR guarda **15**, com asserção própria por site, e deixa o resto medido.

## A triagem mudou o número, e a heurística de `grep` é a razão

| | Sites |
|---|---|
| `setX(data)` / `setX(res.data)` / `setX(r.data)`, excluindo testes | **67** — bate com a issue |
| destes, estado `useState<T[]>([])` consumido no render | **34** |
| não-array (objeto/escalar), fora por desenho | **33** |
| **guardados aqui** | **15** |
| adiados por corte de tamanho, todos reais | **19** |

A triagem inicial desta leva apontou 31, não 34. A diferença é instrutiva: `grep` por
`.map`/`.length`/`.filter` **não vê consumo indireto**. Os três que escapavam:

- `agenda/AgendaPage.tsx:57` — `events` vai como prop para `MonthView`/`WeekView`/`DayView`, e o
  `.filter` mora em `grade.ts:66`, outro arquivo
- `juridico/JuridicoPage.tsx:19` — `for (const s of skills)` num `useMemo`
- `conversas/ConversasPage.tsx:275` — vai como prop `templates={...}` para um filho

**Zero falsos positivos** nos 34: nenhum é o análogo do `FunnelAutomation:37` que o #179 reverteu.

## O pior dos 15

`financeiro/PlanoContasPage.tsx:30`. `buildHierarchy(accounts)` roda no **corpo do componente** e
abre com `for..of` — estoura antes da primeira linha de JSX. O `accounts.length > 0` logo abaixo não
protege: em objeto, `.length` é `undefined`.

E `grep -rn "ErrorBoundary\|componentDidCatch\|getDerivedStateFromError" src` **não devolve nada**.
Sem boundary, um `TypeError` no render não deixa a lista vazia — desmonta a árvore inteira.

## O achado que quase repetiu o "5 de 5 sobreviveram"

A primeira redação dos testes passou **verde com a guarda removida**:

```
TypeError: funnels.map is not a function   (4x, em stderr)
Test Files  1 passed (1) · Tests  5 passed (5)
```

O estado inicial já é `[]`, então o texto de estado vazio está no DOM desde a montagem: o primeiro
poll do `waitFor` acerta e o teste retorna **antes de o payload chegar ao setter**. Daí
`src/test/assentar.ts` — flush de microtarefas **dentro de `act`**, que converte o erro de commit em
reprovação.

Medido na reverificação, com a guarda de `FunisPage` removida:

| | testes mortos |
|---|---|
| com `assentar` | **4 de 5** |
| com `assentar` neutralizado (no-op) | **1 de 5** |

Sem ele, 3 das 5 asserções seriam falsa confiança.

## Mutação: 15 mutantes, 15 mortos

Cada guarda desfeita na produção, teste correspondente morrendo com mensagem real. Amostra:

| Mutação | Mensagem real |
|---|---|
| `setAccounts(data)` (PlanoContas) | `TypeError: accounts is not iterable` |
| `setEvents(data)` | `TypeError: events.filter is not a function` |
| `setCatalog(data)` | `TypeError: catalog.map is not a function` |
| `setCandidates(data)` | `TypeError: candidates.find is not a function` |

Formas **dispensadas por medição**, com a razão gravada no código: objeto e número em
`Attachments`/`JuridicoPage:15` (o portão `.length > 0` já as recusa); string em
`PlanoContasPage`/`JuridicoPage:19` (string **é** iterável, o `for..of` passa).

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 84 arquivos / 984 testes verdes
```

Base em `origin/main`: 76 arquivos / 915 testes. Diff: 29 arquivos, 970 inserções.

## O que fica de fora, com número

- **19 sites** adiados, todos reais, todos em modal/painel/seletor auxiliar → issue nova
- **33 não-array** → issue nova, e um deles é o pior caso em forma de objeto:
  `crm/CrmPage.tsx:24` faz `setBoard(data)` com `board.columns.map` no render — precisa de
  `Array.isArray(data?.columns)`, não de `Array.isArray(data)`
- `InvestimentosPage:52` — classe **vizinha**: payload cru direto numa função pura que itera,
  dentro de `load()` async sem `try/catch` e `useEffect` sem `.catch`

Closes #207
