### PR TITLE
fix(web): as 3 telas sem shell entram na regua de 360px, e a /dna/nucleo rolava 636px [#208]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,9 +533,9 @@ arquivar um centro de custo num celular de 360px**. O `<a>` do bloco "botão" va
 **página pública** (`PageBlocks.tsx` é o mesmo componente), onde ele é a única conversão que existe:
 rótulo longo sem espaço media **626px** de largura.
 
-**Cobertura: 30 das 47 rotas não-públicas de `App.tsx`** — **43 no `ProtectedLayout`** (com shell:
-sidebar + topbar) **+ 4 no `ProtectedBareLayout`** (sem shell). **17 de fora**, e as duas caixas
-falham por motivos diferentes:
+**Cobertura: 33 das 47 rotas não-públicas de `App.tsx`** — **43 no `ProtectedLayout`** (com shell:
+sidebar + topbar) **+ 4 no `ProtectedBareLayout`** (sem shell). **14 de fora, todas do
+`ProtectedLayout`**: a caixa SEM SHELL fechou no #208, e o denominador dela agora é 4/4.
 
 **14 do `ProtectedLayout`.** `/`, `/config`, `/crm`, `/financeiro/conferencia` **quebram com o mock
 default `[]`** (endpoint que devolve objeto) e precisam de fixture própria — medido: as quatro
@@ -545,15 +545,45 @@ renderizam **em branco** (`pageerror` real: `reading 'some'`/`'trim'`/`'filter'`
 `/juridico/novo`, `/juridico/:id` (as duas últimas exigem `?skill=`) e `/admin` (exige
 `is_platform_admin`) pedem fixture ou sessão própria. `*` (ComingSoon) não tem controle.
 
-**3 do `ProtectedBareLayout`** (eram as 4 da categoria INTEIRA até o #178): `/dna/nucleo`,
-`/compartilhar`, `/comprovante/:id`. **Nenhuma das três está no catálogo** — não por triagem, por
-omissão do denominador. E não são periferia: o comentário do próprio `App.tsx` diz que
-`/dna/nucleo` é **"desenhado para 360px"**, e `/comprovante/:id` é **tela de dinheiro** que já
-carrega dívida de medição registrada no §5.1 (*"Segue de pé a dívida da `ComprovantePage` … aquela
-tela não está entre as medidas"*) — o `ALTURA_DA_BARRA` do `baixa.ts` tem seis mutantes
-sobreviventes justamente porque o número é medida do DOM e ninguém mede aquela tela. **Não foram
-medidas nesta issue de propósito** (o pedido era o número honesto, não mais cobertura): se
-alguma tiver defeito, vira issue própria com o número medido.
+**0 do `ProtectedBareLayout`** — eram as 4 da categoria INTEIRA até o #178, e as 3 que restavam
+(`/dna/nucleo`, `/compartilhar`, `/comprovante/:id`) entraram no catálogo pelo **#208**. A
+suspeita que as trouxe estava certa em uma das três, e era a que o próprio `App.tsx` anuncia como
+**"desenhada para 360px"**: `/dna/nucleo` reprovou **na primeira medição**, com
+`documentElement.scrollWidth` = **636px** numa viewport de 360.
+
+| Rota | 1ª medição | Causa | Conserto |
+|---|---|---|---|
+| `/dna/nucleo` | **636px** | `pergunta.texto` e `opcoes[].rótulo` do catálogo do servidor (`dna/catalog.py`), sem quebra | `break-words` nos dois, em `PerguntaDaVima` |
+| `/comprovante/r1` | 360px | — (o `truncate` dos cartões e o `min-w-0` seguram) | — |
+| `/compartilhar?erro=falha` | 360px | — (rota de trânsito, duas frases curtas) | — |
+
+Os 636px da `/dna/nucleo` são **a mesma classe dos 649px da `/vima`**, pela mesma razão
+estrutural: sem shell não há `main.overflow-x-hidden`, o que não cabe VAZA em vez de ficar
+recortado, e a página inteira rola. Medidos um a um em 360×740: o `texto` da pergunta sozinho
+vale **636px**, os botões de opção sozinhos valem **559px**, e só com os dois quebrando a página
+volta a 360. `PerguntaDaVima` é o componente de TRÊS superfícies (núcleo, gancho, config), então o
+conserto vale nas seis telas que montam o gancho também.
+
+- **Limite declarado da `/comprovante/:id`:** a **barra fixa do rodapé** (`EscolhaDaBaixa` + o
+  rótulo com o nome da conta) só monta depois de TOCAR numa candidata, e o catálogo não toca em
+  nada. Ela segue **fora** de qualquer medida — a dívida do `ALTURA_DA_BARRA` do `baixa.ts` (seis
+  mutantes sobreviventes, §5.1) **continua de pé**, e o #208 não a fecha.
+- **Limite declarado da `/compartilhar`:** dos dois estados que ela desenha, o catálogo mede o
+  **erro** (`?erro=falha`, o valor que o `sw.js` emite de verdade). O ramo `?k=<chave consumida>`
+  fica **preso no spinner em desenvolvimento** — achado do #208, registrado abaixo.
+
+**Achado fora do escopo do #208, NÃO consertado — `/compartilhar?k=` trava no spinner sob
+StrictMode.** Medido em 22/08/2026, contra o Vite de desenvolvimento: `/compartilhar?k=<qualquer
+chave>` fica em *"Enviando comprovante..."* para sempre; a mensagem de erro nunca aparece. **Não é
+a fixture** — provado por mutação: tirando `<React.StrictMode>` de `main.tsx` a mesma URL desenha
+*"Não encontramos o arquivo compartilhado. Ele pode já ter sido enviado."* na hora. O mecanismo é o
+guard `startedFor` casando com o `cancelled` por execução (`CompartilharPage.tsx`): a primeira
+montagem começa o trabalho assíncrono e a limpeza a cancela; a segunda vê o **mesmo token** e
+desiste; ninguém chama `setError`. O ramo `?erro=` é síncrono e sobrevive à dobra — por isso é ele
+que o catálogo mede. Efeito em produção: o build não dobra os efeitos, então o caminho feliz e o
+"chave já consumida" funcionam — mas o guard é frágil pelo mesmo motivo em qualquer re-execução de
+efeito com token igual. **Vira issue própria**: consertar o `CompartilharPage` estava fora do
+pedido do #208, que era pôr as três telas sob régua.
 
 ⚠️ **`/vima` saiu dessa lista no #178, e o que ela tinha escondido era defeito de verdade.** É a
 PORTA DO DIA (`EntradaDoDia` manda a raiz autenticada para lá enquanto o briefing de hoje não foi

--- a/apps/web/e2e/alcance-360.spec.ts
+++ b/apps/web/e2e/alcance-360.spec.ts
@@ -41,14 +41,16 @@ import { semearSessao } from "./support/sessao";
  *      deslizador que rola e exige que ela NÃO o acuse. Sem o primeiro ninguém sabe se ela
  *      enxerga; sem o segundo ninguém sabe se ela sabe parar.
  *
- * Cobertura: as 30 rotas de `support/rotas.ts` (as mesmas que `rotas-360.spec.ts` mede), de 47
- * não-públicas. As 17 que ficaram de fora estão listadas no CLAUDE.md §5.4, uma a uma, com o
- * motivo — inclusive as 3 do `ProtectedBareLayout` que seguem sem medida (`/dna/nucleo`,
- * `/compartilhar`, `/comprovante/:id`). A quarta, `/vima`, entrou no catálogo pelo #178: é a
- * PORTA DO DIA (`EntradaDoDia` manda a raiz autenticada para lá enquanto o briefing de hoje não
- * foi lido) e era a única das seis telas que montam `GanchoDaVima` sem régua nenhuma. Antes de
- * mexer nesse número, leia o "COMO RECONTAR" da §5.4: contar só uma das duas caixas de layout
- * já errou o denominador duas vezes.
+ * Cobertura: as 33 rotas de `support/rotas.ts` (as mesmas que `rotas-360.spec.ts` mede), de 47
+ * não-públicas. As 14 que ficaram de fora estão listadas no CLAUDE.md §5.4, uma a uma, com o
+ * motivo — e agora são **todas do `ProtectedLayout`**: a caixa sem shell fechou. `/vima` entrou
+ * pelo #178 (é a PORTA DO DIA — `EntradaDoDia` manda a raiz autenticada para lá enquanto o
+ * briefing de hoje não foi lido — e era a única das seis telas que montam `GanchoDaVima` sem
+ * régua nenhuma); as outras três do `ProtectedBareLayout` entraram pelo #208, e a primeira
+ * medição de `/dna/nucleo` deu **636px** numa viewport de 360 — a mesma classe dos 649px que a
+ * `/vima` tinha escondido, pela mesma razão (sem shell não há `main.overflow-x-hidden`). Antes
+ * de mexer nesse número, leia o "COMO RECONTAR" da §5.4: contar só uma das duas caixas de
+ * layout já errou o denominador duas vezes.
  */
 
 for (const { rota, marca, mocks } of CASOS) {

--- a/apps/web/e2e/rotas-360.spec.ts
+++ b/apps/web/e2e/rotas-360.spec.ts
@@ -46,12 +46,12 @@ for (const { rota, marca, mocks } of CASOS) {
 }
 
 /**
- * CONTROLE POSITIVO — o que impede as 18 asserções acima de serem enfeite.
+ * CONTROLE POSITIVO — o que impede as 33 asserções acima de serem enfeite.
  *
  * Medido nesta issue (#135), e é o achado que reescreve a premissa: `main` é
  * `overflow-x-hidden` (`AppShell.tsx:64`). Uma tabela larga demais NÃO faz o documento rolar —
  * ela é recortada, e `larguraDaPagina` devolve 360 com a coluna da direita inalcançável. Provado
- * por mutação: tirar `overflow-x-auto` da `DrePage` (o deslizador da DRE de 12 meses) deixa as 18
+ * por mutação: tirar `overflow-x-auto` da `DrePage` (o deslizador da DRE de 12 meses) deixa as 33
  * rotas VERDES. Logo, esta régua não mede "conteúdo largo" — ela mede exatamente uma coisa, e é a
  * classe do #135: um elemento que ESCAPA do recorte e passa a contar no `scrollWidth` do
  * documento. É o que um `position: absolute` SEM offsets faz quando não há ancestral posicionado:
@@ -60,7 +60,7 @@ for (const { rota, marca, mocks } of CASOS) {
  *
  * Este teste planta essa classe de propósito, na `DrePage` (cujo `overflow-x-auto` da linha 131
  * não tem `relative`), e exige que a conta a enxergue. Se algum dia ele passar a devolver 360, a
- * medição ficou cega e as 18 asserções acima pararam de significar qualquer coisa — mesmo
+ * medição ficou cega e as 33 asserções acima pararam de significar qualquer coisa — mesmo
  * continuando verdes.
  */
 test("a régua enxerga a classe do #135 plantada num deslizador sem `relative`", async ({ page }) => {

--- a/apps/web/e2e/support/rotas.ts
+++ b/apps/web/e2e/support/rotas.ts
@@ -178,6 +178,78 @@ const BRIEFING = {
   created_at: "2026-08-21T08:00:00Z",
 };
 
+/**
+ * `/dna/faltantes` devolve LISTA (`DnaPergunta[]`, `packages/shared-types/src/index.ts:1182`), e o
+ * `[]` default de `mockarApi` é o pior mock que existe para esta rota: com a lista vazia a
+ * `NucleoPage` chama `sair()` e **NAVEGA para a raiz** (`NucleoPage.tsx:110`). A régua mediria o
+ * PAINEL acreditando ter medido o núcleo — 360 verdinho, tela errada. Por isso a `marca` é o texto
+ * da PRIMEIRA pergunta, e não o título fixo "Me conta do seu negócio".
+ *
+ * **Só `perguntas[0]` está na tela por vez** — a página renderiza um índice, não a lista. Então o
+ * pior caso mora na primeira; as seis continuam aqui porque o denominador é impresso ("1 de 6") e
+ * porque `ehPergunta` (`GanchoDaVima.tsx:45`) filtra item a item: uma forma quebrada no meio da
+ * lista muda o denominador sem derrubar a tela, e é assim que a produção se comporta.
+ *
+ * `formato: "escolha"` na primeira não é conveniência: é o ramo que rende os blocos de largura
+ * inteira do `PerguntaDaVima` (`px-4 py-3`, um por opção) — a caixa mais larga que esta tela
+ * desenha sem ninguém tocar em nada. Os outros dois formatos ficam nas seguintes.
+ *
+ * O catálogo mora no SERVIDOR (`apps/api/app/modules/dna/catalog.py`) e hoje é português
+ * editorial, com espaço para quebrar — mas o front **não tem cópia dele** (é o que o próprio
+ * `DnaPergunta` declara), e pergunta nova é um deploy. `LONGO` é o que guarda a PRÓXIMA: sem
+ * espaço para quebrar, dentro do `max-w-md` de uma tela que não recorta nada.
+ */
+const NUCLEO_PERGUNTAS = [
+  { key: "oferta.o_que_vende", classe: "retrato", eixo: "oferta", texto: `O que você vende, ${LONGO}?`,
+    formato: "escolha", opcoes: [{ rotulo: LONGO, valor: "servico_recorrente" }, { rotulo: `${LONGO} avulso`, valor: "servico_projeto" }] },
+  { key: "oferta.em_uma_frase", classe: "retrato", eixo: "oferta", texto: LONGO, formato: "texto", opcoes: [] },
+  { key: "oferta.como_cobra", classe: "retrato", eixo: "oferta", texto: LONGO, formato: "escolha_multipla",
+    opcoes: [{ rotulo: LONGO, valor: "hora" }] },
+  { key: "oferta.ticket_tipico", classe: "retrato", eixo: "oferta", texto: LONGO, formato: "escolha", opcoes: [{ rotulo: LONGO, valor: 1 }] },
+  { key: "cliente.como_chega", classe: "retrato", eixo: "cliente", texto: LONGO, formato: "escolha", opcoes: [{ rotulo: LONGO, valor: "indicacao" }] },
+  { key: "limites.nunca_faco", classe: "retrato", eixo: "limites", texto: LONGO, formato: "texto", opcoes: [] },
+];
+
+/**
+ * A BANDEJA do comprovante (`/comprovante/:id`) — duas listas, e as duas precisam de forma.
+ *
+ * `/payables/receipts` devolve `ReceiptInfo[]` (declarado em `ComprovantePage.tsx:17`; não existe
+ * `GET /payables/receipts/{id}`, a tela FILTRA a bandeja pelo `id` da URL). O `id` daqui tem de
+ * casar com o da rota (`/comprovante/r1`), senão `receipt` fica `null` e o cabeçalho cai no texto
+ * genérico — verde medindo o estado de fallback em vez do estado real.
+ *
+ * `/payables/receipts/candidates` devolve `Payable[]`
+ * (`packages/shared-types/src/index.ts:459`). Vence a chave MAIS LONGA em `mockarApi`, então as
+ * duas convivem. Com o `[]` default as duas caem no estado vazio — cabeçalho genérico e "Nenhuma
+ * conta encontrada" —, que mede 360 por não ter desenhado a tela que interessa.
+ *
+ * Pior caso plausível na forma real: `description`/`supplier` são DIGITADOS pelo dono (o
+ * fornecedor vem do app do banco, copiado no celular) e `filename` vem do share sheet do
+ * Android — nenhum dos três tem espaço garantido. `amount_cents` acompanha as demais fixtures do
+ * catálogo (`RELATORIO_CC`): R$ 1.234.567,89, que é o que faz a coluna `shrink-0` da direita
+ * valer o que ela vale. A segunda candidata é `description: ""` + `status: "paid"`, os dois
+ * ramos que o cartão tem de próprio (`c.description || c.supplier` e o chip "Pago").
+ *
+ * ⚠️ **A barra fixa do rodapé fica FORA desta medida**: `EscolhaDaBaixa` e o rótulo com o nome da
+ * conta só montam depois de TOCAR numa candidata (`daBaixa`), e este catálogo não toca em nada. O
+ * que a barra tem de próprio continua sendo assunto de spec dedicada — é a dívida do
+ * `ALTURA_DA_BARRA` registrada no §5.1, e esta entrada não a fecha.
+ */
+const RECEIPTS = [{ id: "r1", filename: `${LONGO}.pdf`, size: 3_670_016 }];
+
+const CANDIDATAS = [
+  { id: "p1", tenant_id: "t1", description: LONGO, category: LONGO, supplier: LONGO,
+    amount_cents: 123456789, due_date: "2026-08-19", chart_account_id: null, contract_id: null,
+    cost_center_id: null, status: "open", is_overdue: true, paid_at: null, recurrence: "none",
+    recurrence_count: 0, recurrence_group: null, payment_code: LONGO, attachment_url: "",
+    created_at: "2026-08-01T10:00:00Z" },
+  { id: "p2", tenant_id: "t1", description: "", category: "Geral", supplier: LONGO,
+    amount_cents: 987654321, due_date: "2026-09-30", chart_account_id: null, contract_id: null,
+    cost_center_id: null, status: "paid", is_overdue: false, paid_at: "2026-08-20T10:00:00Z",
+    recurrence: "none", recurrence_count: 0, recurrence_group: null, payment_code: "",
+    attachment_url: "", created_at: "2026-08-01T10:00:00Z" },
+];
+
 export interface Caso {
   rota: string;
   /** Texto que PRECISA estar visível antes de medir. Sem ele, 360 significaria "tela em branco". */
@@ -228,4 +300,29 @@ export const CASOS: Caso[] = [
   // logo sem o `main.overflow-x-hidden`: aqui o que não cabe faz a PÁGINA rolar em vez de ficar
   // recortado, e é a régua do #135 que o pega primeiro.
   { rota: "/vima", marca: "Seu dia", mocks: { "/vima/briefing": BRIEFING } },
+  // AS OUTRAS TRÊS DO `ProtectedBareLayout` (#208). Mesma caixa de layout da `/vima`, e foi a
+  // FORMA dessa caixa — não a tela — que produziu os 649px do #178: sem shell não há
+  // `main.overflow-x-hidden`, então o que não cabe VAZA em vez de ficar recortado. Entram no fim
+  // do array de propósito: a ordem das anteriores é o histórico das issues que as trouxeram.
+  { rota: "/dna/nucleo", marca: LONGO, mocks: { "/dna/faltantes": NUCLEO_PERGUNTAS } },
+  // `/compartilhar` é a única das quatro que NÃO é dirigida por payload: é rota de trânsito do
+  // Web Share Target e desenha dois estados só — o spinner e o erro. O que se mede é o ERRO, o
+  // único com conteúdo; e `?erro=` é como o service worker o reporta quando o POST do share
+  // sheet falha (`public/sw.js:55` — o valor `falha` é o que o SW emite de verdade; o outro é
+  // `sem-arquivo`). A `marca` é a frase que SÓ esse ramo produz: sem ela o teste
+  // passaria medindo "Enviando comprovante...", que é a tela em branco desta rota.
+  //
+  // ⚠️ **Por que `?erro=` e não `?k=<chave já consumida>`**, que seria o caminho mais comum em
+  // campo: medido no #208, com `?k=` a tela fica PRESA no spinner em modo de desenvolvimento e a
+  // `marca` reprova. Não é defeito da fixture — é o guard de StrictMode do `CompartilharPage`
+  // (`startedFor`) casando com o `cancelled` por execução: a primeira montagem começa o trabalho
+  // assíncrono e é cancelada na limpeza, a segunda vê o mesmo token e desiste, e ninguém chama
+  // `setError`. O ramo do `?erro=` é SÍNCRONO, então o estado sobrevive à dobra. Está registrado
+  // como achado fora do escopo do #208; a régua mede o estado que existe, e não fica vermelha
+  // esperando o conserto de outra issue.
+  { rota: "/compartilhar?erro=falha", marca: "Não conseguimos receber o arquivo compartilhado" },
+  // TELA DE DINHEIRO, e a que carrega a dívida de medição do §5.1: o `ALTURA_DA_BARRA` do
+  // `baixa.ts` tem seis mutantes sobreviventes porque o número é medida do DOM e ninguém media
+  // esta tela. O `r1` da rota casa com o `id` de `RECEIPTS` — ver a nota da fixture.
+  { rota: "/comprovante/r1", marca: LONGO, mocks: { "/payables/receipts": RECEIPTS, "/payables/receipts/candidates": CANDIDATAS } },
 ];

--- a/apps/web/src/features/dna/PerguntaDaVima.tsx
+++ b/apps/web/src/features/dna/PerguntaDaVima.tsx
@@ -53,7 +53,13 @@ export default function PerguntaDaVima({ pergunta, source, onPronto, onPular }: 
 
   return (
     <div className="rounded-xl border border-neutral-200 bg-white p-4">
-      <p className="text-base font-medium text-neutral-800">{pergunta.texto}</p>
+      {/* ⚠️ **`break-words` não é enfeite** (#208, medido em 360×740). O catálogo do DNA mora no
+          servidor (`dna/catalog.py`) e o front não tem cópia dele: um `texto` sem espaço para
+          quebrar não tem onde quebrar. Em `/dna/nucleo` isso vale `documentElement.scrollWidth`
+          = **636px** numa viewport de 360 — sozinho, com os botões já quebrando. E ali não há
+          `main.overflow-x-hidden` que recorte (`ProtectedBareLayout`): o que não cabe VAZA e a
+          PÁGINA inteira rola. É o mesmo defeito e o mesmo conserto do #178 na `/vima`. */}
+      <p className="break-words text-base font-medium text-neutral-800">{pergunta.texto}</p>
       <p className="mt-1 text-xs text-neutral-500">
         {pergunta.classe === "calibracao"
           ? "Isso muda o seu resumo a partir de amanhã."
@@ -68,7 +74,9 @@ export default function PerguntaDaVima({ pergunta, source, onPronto, onPular }: 
               type="button"
               disabled={salvando}
               onClick={() => responder(o.valor)}
-              className="w-full rounded-lg border border-neutral-200 px-4 py-3 text-left text-sm text-neutral-700 hover:border-neutral-400 disabled:opacity-50"
+              // `break-words`: o rótulo da opção vem do mesmo catálogo do servidor que o
+              // `texto` acima. Medido no #208: as opções sozinhas valem 559px em 360.
+              className="w-full break-words rounded-lg border border-neutral-200 px-4 py-3 text-left text-sm text-neutral-700 hover:border-neutral-400 disabled:opacity-50"
             >
               {o.rotulo}
             </button>
@@ -90,7 +98,8 @@ export default function PerguntaDaVima({ pergunta, source, onPronto, onPular }: 
                     ativa ? marcadas.filter((v) => v !== o.valor) : [...marcadas, o.valor],
                   )
                 }
-                className={`w-full rounded-lg border px-4 py-3 text-left text-sm disabled:opacity-50 ${
+                // `break-words` pelo mesmo motivo do ramo `escolha` acima (#208).
+                className={`w-full break-words rounded-lg border px-4 py-3 text-left text-sm disabled:opacity-50 ${
                   ativa
                     ? "border-neutral-800 bg-neutral-800 text-white"
                     : "border-neutral-200 text-neutral-700 hover:border-neutral-400"


### PR DESCRIPTION
## Resumo

As outras **3** rotas do `ProtectedBareLayout` entram nas duas réguas de 360px. A #178 pôs `/vima`
no catálogo e a régua **reprovou na primeira medição** (`scrollWidth` = 649 numa viewport de 360);
`/dna/nucleo`, `/compartilhar` e `/comprovante/:id` têm a mesma forma de caixa e não tinham régua
nenhuma. Catálogo: **30 → 33 rotas**.

## A suspeita era certa: `/dna/nucleo` estava quebrada

Na primeira medição, com payload de pior caso na forma real do schema:

```
a rota /dna/nucleo estourou a viewport de 360px
Expected: 360   Received: 636
```

Sem shell não há `main.overflow-x-hidden`, então o que não cabe **vaza** em vez de ficar recortado.
Conserto: `break-words` no texto da pergunta e nos botões de opção de `PerguntaDaVima.tsx`.

## A dívida menor era maior — e a issue erra duas vezes

A issue diz que "as 18 asserções" está em **duas** linhas (54 e 63). São **três**: 49, 54 e 63.
E a frase literal *"as 18 asserções acima"* está em **49 e 63** — a linha 54 diz *"deixa as 18
rotas VERDES"*, que é outra frase. A issue citou 54+63 e acertou uma das duas ocorrências da frase
que citou.

O número da linha 54 **não é contador, é medição**. Reescrevê-lo sem remedir seria inventar, então
a mutação foi refeita: tirar `overflow-x-auto` da `DrePage` deixa **34 passed** em
`rotas-360.spec.ts` (33 rotas + o controle positivo).

## As 3 entradas, com a forma do schema que foi lida

| Rota | Schema | marca |
|---|---|---|
| `/dna/nucleo` | `DnaPergunta` (`shared-types/src/index.ts:1182`) + o predicado `ehPergunta` | `LONGO` |
| `/compartilhar?erro=falha` | nenhum — rota de trânsito do Web Share Target | "Não conseguimos receber o arquivo compartilhado" |
| `/comprovante/r1` | `Payable` (`index.ts:459`) + `ReceiptInfo` (`ComprovantePage.tsx:17`) | `LONGO` |

Detalhes que a forma real impôs: em `/dna/nucleo` só a primeira pergunta está na tela por vez, e com
lista vazia a página chama `sair()` e **navega para a raiz** — mediria o painel achando que mediu o
núcleo. Em `/comprovante/r1` o `id` da rota tem de casar com o de `RECEIPTS`, porque não existe
`GET /payables/receipts/{id}`: a tela **filtra** a bandeja.

## Mutação

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| `break-words` fora do texto da pergunta | `rotas-360 › /dna/nucleo` | `Expected: 360 · Received: 636` |
| `break-words` fora dos 2 botões de opção | `rotas-360 › /dna/nucleo` | `Expected: 360 · Received: 559` |
| `"/dna/faltantes": []` | `rotas-360` **e** `alcance-360` de `/dna/nucleo` | `element(s) not found` |
| `"/payables/receipts": []` + `candidates: []` | as duas de `/comprovante/r1` | `element(s) not found` |
| ramo `?erro=` sem `setError` | as duas de `/compartilhar` | `element(s) not found` |

A mutação de payload-vazio matou as **6** asserções novas. É a armadilha que a issue manda fechar:
com payload vazio a tela mede 360 **por não ter desenhado nada**.

## Mutante de alcance: DISPENSADO, e medido

Na primeira rodada `/dna/nucleo` estava em **636px** com os botões pendurados fora da tela, e
`alcance-360 › /dna/nucleo` passou **VERDE**. Repetiu em 636 e em 559: `rotas-360` morre,
`alcance-360` fica verde nas duas.

Sem shell não há ancestral que recorte, a página inteira rola, e `medirControles` marca
`deslizador = "document"`, absolvendo todo controle. Não há mutação de uma linha que mate
`alcance-360` nessas 3 telas sem primeiro introduzir um recorte — e aí o mutante seria o recorte.
A entrada continua nas duas listas como guarda do dia em que essas telas ganharem um cartão com
recorte, que é o cenário medido pelo #178.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 915 testes verdes
E2E_PORT=5328 pnpm e2e → 184 passed (9.4m)
```

## Fora de escopo, não consertado

- **`/compartilhar?k=<chave>` trava no spinner sob StrictMode** — defeito real, dev-only. Provado
  tirando `React.StrictMode`: a mesma URL desenha o erro na hora. O guard `startedFor` casa com o
  `cancelled` por execução, e ninguém chama `setError`. Merece issue própria.
- **A barra fixa do rodapé da `/comprovante/:id` continua sem medida** — `EscolhaDaBaixa` só monta
  depois de tocar numa candidata. A dívida do `ALTURA_DA_BARRA` do `baixa.ts` (6 mutantes
  sobreviventes) **não foi fechada aqui**, e isso está declarado no comentário da fixture.

Closes #208
