### PR TITLE
refactor(web): as 15 copias locais de `brl` passam a importar `formatBRL` [#209]

### DIFF
--- a/apps/web/src/features/admin/AdminDashboard.tsx
+++ b/apps/web/src/features/admin/AdminDashboard.tsx
@@ -4,9 +4,7 @@ import { useEffect, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
 import PlatformCustomers from "./PlatformCustomers";
 import PlatformUsers from "./PlatformUsers";
-
-const brl = (cents: number) =>
-  (cents / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+import { formatBRL } from "../financeiro/dre";
 
 type Tab = "offices" | "customers" | "settings";
 
@@ -141,12 +139,12 @@ function PlatformEarningsCard() {
       <div className="space-y-3 text-sm">
         <div className="flex justify-between">
           <span className="text-neutral-500">Volume transacionado (GMV)</span>
-          <span className="font-medium tabular-nums">{e ? brl(e.gmv_cents) : "—"}</span>
+          <span className="font-medium tabular-nums">{e ? formatBRL(e.gmv_cents) : "—"}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-neutral-500">Taxas retidas</span>
           <span className="font-bold tabular-nums text-accent-700">
-            {e ? brl(e.fees_cents) : "—"}
+            {e ? formatBRL(e.fees_cents) : "—"}
           </span>
         </div>
         <div className="flex justify-between">

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -22,8 +22,7 @@ import {
 } from "./grade";
 import { useFuso } from "../../store/auth";
 import NewEventModal from "./NewEventModal";
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+import { formatBRL } from "../financeiro/dre";
 
 type View = "month" | "week" | "day";
 
@@ -441,7 +440,7 @@ function EventDetailModal({ event, onClose }: { event: AgendaEvent; onClose: () 
           </p>
         )}
         {event.amount_cents != null && (
-          <p className="text-base font-bold text-neutral-800">{brl(event.amount_cents)}</p>
+          <p className="text-base font-bold text-neutral-800">{formatBRL(event.amount_cents)}</p>
         )}
         {event.description && <p className="text-neutral-600">{event.description}</p>}
 

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -16,11 +16,10 @@ import { VOCAB_ENTRADA } from "../pagar/baixa";
 import { DialogDeBaixa, HOJE_DO_TENANT } from "../pagar/EscolhaDaBaixa";
 import { rotuloDaRota } from "./rota";
 import { formatDay } from "../../lib/datetime";
+import { formatBRL } from "../financeiro/dre";
 
 /** Grupos DRE cabíveis numa RECEITA (Cobranças nunca lança em Despesa/Tributo/Investimento). */
 const REVENUE_GROUPS = GRUPOS_DRE.filter((g) => g === "RECEITA");
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 const KINDS = [
   ["service", "Serviço"],
@@ -150,9 +149,9 @@ export default function CobrancasPage() {
       <GanchoDaVima gancho="receivables.cobranca.criada" />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Stat label="A vencer" value={brl(summary.open_cents)} hint={`${summary.open_count} ${pluralize(summary.open_count, "cobrança", "cobranças")}`} tone="text-blue-700" />
-        <Stat label="Vencido" value={brl(summary.overdue_cents)} hint={`${summary.overdue_count} em atraso`} tone="text-danger" />
-        <Stat label="Recebido" value={brl(summary.paid_cents)} hint="total" tone="text-accent-700" />
+        <Stat label="A vencer" value={formatBRL(summary.open_cents)} hint={`${summary.open_count} ${pluralize(summary.open_count, "cobrança", "cobranças")}`} tone="text-blue-700" />
+        <Stat label="Vencido" value={formatBRL(summary.overdue_cents)} hint={`${summary.overdue_count} em atraso`} tone="text-danger" />
+        <Stat label="Recebido" value={formatBRL(summary.paid_cents)} hint="total" tone="text-accent-700" />
         {/* [8.15] O agendado tem cartão PRÓPRIO e **some quando é zero** — mesmo tratamento do
             agendado da 8.14. Sem ele, a cobrança agendada não apareceria em nenhum dos três
             cartões (nem "a vencer", nem "vencido", nem "recebido"): o modo de falha "o dinheiro
@@ -164,7 +163,7 @@ export default function CobrancasPage() {
         {summary.scheduled_cents > 0 && (
           <Stat
             label={AGENDADO_ENTRADA_LABEL}
-            value={brl(summary.scheduled_cents)}
+            value={formatBRL(summary.scheduled_cents)}
             hint="recebido fora do trilho, com dia marcado"
             tone="text-amber-700"
           />
@@ -220,7 +219,7 @@ export default function CobrancasPage() {
                     <td className="px-4 py-3 tabular-nums text-neutral-600">
                       {formatDay(c.due_date)}
                     </td>
-                    <td className="px-4 py-3 font-medium tabular-nums">{brl(c.amount_cents)}</td>
+                    <td className="px-4 py-3 font-medium tabular-nums">{formatBRL(c.amount_cents)}</td>
                     <td className="px-4 py-3">
                       <span className={`rounded-pill px-2 py-0.5 text-xs ${st.cls}`}>{st.label}</span>
                       {/* [8.15] A linha liquidada FORA DO TRILHO diz QUAL conta recebeu e QUANDO.
@@ -280,7 +279,7 @@ export default function CobrancasPage() {
         <DialogDeBaixa
           titulo="Recebi direto na conta"
           descricao={recebendo.client_name || recebendo.description || "Cobrança"}
-          valor={`${brl(recebendo.amount_cents)} · vence ${formatDay(recebendo.due_date)}`}
+          valor={`${formatBRL(recebendo.amount_cents)} · vence ${formatDay(recebendo.due_date)}`}
           // Default = HOJE (não o vencimento): o gesto aqui é "caiu na minha conta", um fato que o
           // dono está observando agora — a assimetria com a baixa de Contas a Pagar é deliberada.
           // ⚠️ **`HOJE_DO_TENANT`, não um hoje montado aqui** (#136). Esta tela passava
@@ -319,7 +318,7 @@ export default function CobrancasPage() {
         <Modal title="Contrato / documentos da cobrança" open onClose={() => setDocs(null)}>
           <div className="space-y-3">
             <p className="text-sm text-neutral-500">
-              {docs.client_name ?? docs.description ?? "Cobrança"} — {brl(docs.amount_cents)}
+              {docs.client_name ?? docs.description ?? "Cobrança"} — {formatBRL(docs.amount_cents)}
             </p>
             <p className="text-xs font-medium text-neutral-600">Anexar arquivos (PDF, JPEG ou PNG)</p>
             <Attachments

--- a/apps/web/src/features/cockpit/CockpitPage.tsx
+++ b/apps/web/src/features/cockpit/CockpitPage.tsx
@@ -7,6 +7,7 @@ import { api } from "../../lib/api";
 import { formatDay, today } from "../../lib/datetime";
 import { useAuth, useFuso } from "../../store/auth";
 import { TOTAL_EM_CONTAS_LABEL, origemLabel } from "../financeiro/contas";
+import { formatBRL } from "../financeiro/dre";
 
 const EMPTY: CockpitSummary = {
   agenda: { today_count: 0, today_events: [], upcoming_critical: [] },
@@ -55,14 +56,13 @@ export default function CockpitPage() {
   }
 
   const conv = `${Math.round((summary.crm?.conversion_rate ?? 0) * 100)}%`;
-  const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
   const faturamento = summary.finance?.net_revenue_cents != null
-    ? brl(summary.finance.net_revenue_cents)
+    ? formatBRL(summary.finance.net_revenue_cents)
     : "R$ —";
   // `null` = nenhuma conta cadastrada. Mostrar "R$ 0,00" aqui afirmaria "você não tem nada no
   // banco" — falso, e indistinguível de um saldo genuinamente zerado (princípio da Onda 0).
   const emConta = summary.finance?.saldo_em_conta_cents != null
-    ? brl(summary.finance.saldo_em_conta_cents)
+    ? formatBRL(summary.finance.saldo_em_conta_cents)
     : "R$ —";
 
   return (
@@ -148,7 +148,7 @@ export default function CockpitPage() {
                     <span className="ml-2 text-xs text-neutral-500">{o.description}</span>
                   )}
                   <span className="block text-xs text-neutral-400">
-                    {brl(o.amount_cents)} · venceu {formatDay(o.due_date)}
+                    {formatBRL(o.amount_cents)} · venceu {formatDay(o.due_date)}
                   </span>
                 </div>
                 <button

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -22,8 +22,8 @@ import BlocoDaConversa from "./BlocoDaConversa";
 import ClientTimeline from "./ClientTimeline";
 import { VOCAB_ENTRADA } from "../pagar/baixa";
 import { DialogDeBaixa, HOJE_DO_TENANT } from "../pagar/EscolhaDaBaixa";
+import { formatBRL } from "../financeiro/dre";
 
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 /** Aceita as DUAS espécies: `"2026-08-05"` (data de calendário) e ISO completo (instante). */
 const dt = (s: string, tz: string) => (s.length === 10 ? formatDay(s) : formatDate(s, tz));
 
@@ -118,9 +118,9 @@ export default function ClientDetailPage() {
 
       {/* Resumo financeiro */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Stat label="A receber (a vencer)" value={brl(openSum)} tone="text-neutral-700" />
-        <Stat label="Vencido" value={brl(overdueSum)} tone="text-danger" />
-        <Stat label="Recebido" value={brl(paidSum)} tone="text-accent-700" />
+        <Stat label="A receber (a vencer)" value={formatBRL(openSum)} tone="text-neutral-700" />
+        <Stat label="Vencido" value={formatBRL(overdueSum)} tone="text-danger" />
+        <Stat label="Recebido" value={formatBRL(paidSum)} tone="text-accent-700" />
         {/* [issue #154] Espelho EXATO do quarto cartão da `CobrancasPage` (Story 8.15): mesmo
             rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
             Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
@@ -131,7 +131,7 @@ export default function ClientDetailPage() {
             import atravessa feature de propósito e não inventa convenção — é a mesma forma do
             `VOCAB_ENTRADA` (`pagar/baixa.ts`) que esta tela já importa acima. */}
         {scheduledSum > 0 && (
-          <Stat label={AGENDADO_ENTRADA_LABEL} value={brl(scheduledSum)} tone="text-amber-700" />
+          <Stat label={AGENDADO_ENTRADA_LABEL} value={formatBRL(scheduledSum)} tone="text-amber-700" />
         )}
       </div>
 
@@ -214,7 +214,7 @@ export default function ClientDetailPage() {
               <li key={q.id} className="flex items-center justify-between py-2.5">
                 <button onClick={() => navigate(`/orcamentos/${q.id}`)} className="text-left text-sm font-medium text-neutral-700 hover:text-primary-600">
                   {q.title}
-                  <span className="ml-2 text-xs text-neutral-400">{brl(q.total_cents)}</span>
+                  <span className="ml-2 text-xs text-neutral-400">{formatBRL(q.total_cents)}</span>
                 </button>
                 <StatusBadge status={q.status} />
               </li>
@@ -267,7 +267,7 @@ export default function ClientDetailPage() {
         <DialogDeBaixa
           titulo="Recebi direto na conta"
           descricao={recebendo.description || client.name}
-          valor={`${brl(recebendo.amount_cents)} · vence ${dt(recebendo.due_date, fuso)}`}
+          valor={`${formatBRL(recebendo.amount_cents)} · vence ${dt(recebendo.due_date, fuso)}`}
           // `HOJE_DO_TENANT`: o hoje é resolvido (e validado) no fuso do tenant, dentro do
           // `useEscolhaDaBaixa` — não montado aqui pelo relógio do navegador (#136).
           dataPadrao={HOJE_DO_TENANT}
@@ -322,7 +322,7 @@ function ChargeRow({
     <li className="flex flex-wrap items-center justify-between gap-2 py-3">
       <div className="min-w-0">
         <p className="font-medium text-neutral-800">
-          {brl(c.amount_cents)}
+          {formatBRL(c.amount_cents)}
           {c.protested_at && (
             <span className="ml-2 rounded-pill bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-danger">PROTESTADA</span>
           )}

--- a/apps/web/src/features/estoque/EstoquePage.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.tsx
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+import { formatBRL } from "../financeiro/dre";
 
 export default function EstoquePage() {
   const empty: StockSummary = { item_count: 0, total_value_cents: 0, low_stock_count: 0 };
@@ -38,7 +37,7 @@ export default function EstoquePage() {
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="Itens ativos" value={String(summary.item_count)} tone="text-neutral-700" />
-        <Stat label="Valor em estoque" value={brl(summary.total_value_cents)} tone="text-accent-700" />
+        <Stat label="Valor em estoque" value={formatBRL(summary.total_value_cents)} tone="text-accent-700" />
         <Stat
           label="Estoque baixo"
           value={String(summary.low_stock_count)}
@@ -84,8 +83,8 @@ export default function EstoquePage() {
                       </span>
                     )}
                   </td>
-                  <td className="px-4 py-3 tabular-nums text-neutral-600">{brl(i.unit_cost_cents)}</td>
-                  <td className="px-4 py-3 font-medium tabular-nums">{brl(i.value_cents)}</td>
+                  <td className="px-4 py-3 tabular-nums text-neutral-600">{formatBRL(i.unit_cost_cents)}</td>
+                  <td className="px-4 py-3 font-medium tabular-nums">{formatBRL(i.value_cents)}</td>
                   <td className="px-4 py-3 text-right">
                     <button
                       onClick={() => setAdjust(i)}

--- a/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
+++ b/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
@@ -12,6 +12,7 @@ import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
 import { DialogDeBaixa } from "../pagar/EscolhaDaBaixa";
 import { formatDay } from "../../lib/datetime";
+import { formatBRL } from "./dre";
 
 /**
  * Fila de Pagamentos (Story 5.9) — painel único do que pagar hoje e nos próximos dias, com baixa
@@ -37,8 +38,6 @@ import { formatDay } from "../../lib/datetime";
  * sai do meu caixa nos próximos dias"*. Os quatro baldes antigos e os oito campos antigos do
  * `PaymentQueueSummary` **não mudaram de definição** e continuam calculados na leitura.
  */
-const brl = (c: number) =>
-  (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 const EMPTY: PaymentQueue = {
   atrasados: [],
@@ -124,10 +123,10 @@ export default function FilaPagamentosPage() {
       {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <Stat label="Atrasados" value={brl(s.atrasados_cents)} count={s.atrasados_count} tone="text-danger" />
-        <Stat label="Hoje" value={brl(s.hoje_cents)} count={s.hoje_count} tone="text-amber-700" />
-        <Stat label="Próximos 7 dias" value={brl(s.proximos_7_dias_cents)} count={s.proximos_7_dias_count} tone="text-neutral-700" />
-        <Stat label="Próximos 30 dias" value={brl(s.proximos_30_dias_cents)} count={s.proximos_30_dias_count} tone="text-neutral-700" />
+        <Stat label="Atrasados" value={formatBRL(s.atrasados_cents)} count={s.atrasados_count} tone="text-danger" />
+        <Stat label="Hoje" value={formatBRL(s.hoje_cents)} count={s.hoje_count} tone="text-amber-700" />
+        <Stat label="Próximos 7 dias" value={formatBRL(s.proximos_7_dias_cents)} count={s.proximos_7_dias_count} tone="text-neutral-700" />
+        <Stat label="Próximos 30 dias" value={formatBRL(s.proximos_30_dias_cents)} count={s.proximos_30_dias_count} tone="text-neutral-700" />
       </div>
 
       {loading && <p className="text-sm text-neutral-400">Carregando fila…</p>}
@@ -182,7 +181,7 @@ export default function FilaPagamentosPage() {
 
       {!nada && (
         <p className="text-right text-xs text-neutral-400">
-          Total pendente na fila (30 dias): <strong>{brl(totalPendente)}</strong>
+          Total pendente na fila (30 dias): <strong>{formatBRL(totalPendente)}</strong>
         </p>
       )}
 
@@ -190,7 +189,7 @@ export default function FilaPagamentosPage() {
         <DialogDeBaixa
           titulo="Dar baixa nesta conta"
           descricao={pagando.description || pagando.supplier || "Conta"}
-          valor={`${brl(pagando.amount_cents)} · vence ${formatDay(pagando.due_date)}`}
+          valor={`${formatBRL(pagando.amount_cents)} · vence ${formatDay(pagando.due_date)}`}
           dataPadrao={pagando.due_date}
           onClose={() => setPagando(null)}
           onPago={(corpo) => pay(pagando.id, corpo)}
@@ -255,7 +254,7 @@ function Bucket({
               </span>
             </div>
             <span className="shrink-0 font-medium tabular-nums text-neutral-800">
-              {brl(p.amount_cents)}
+              {formatBRL(p.amount_cents)}
             </span>
             {p.payment_code && (
               <button

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -9,12 +9,10 @@ import ChartAccountSelect from "./ChartAccountSelect";
 import type { CostCenter } from "./costCenters";
 import CostCenterSelect from "./CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "./planoContas";
+import { formatBRL } from "./dre";
 
 /** Grupos DRE cabíveis numa venda da Carteira (é sempre receita, nunca despesa). */
 const REVENUE_GROUPS = GRUPOS_DRE.filter((g) => g === "RECEITA");
-
-export const brl = (cents: number) =>
-  (cents / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 const KINDS = [
   ["service", "Serviço"],
@@ -121,10 +119,10 @@ export default function FinanceiroPage() {
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Stat label="Disponível para saque" value={brl(summary.available_cents)} tone="accent" />
-        <Stat label="A receber" value={brl(summary.pending_cents)} tone="info" />
-        <Stat label="Já sacado" value={brl(summary.withdrawn_cents)} tone="neutral" />
-        <Stat label="Taxas da plataforma" value={brl(summary.fees_total_cents)} tone="neutral" />
+        <Stat label="Disponível para saque" value={formatBRL(summary.available_cents)} tone="accent" />
+        <Stat label="A receber" value={formatBRL(summary.pending_cents)} tone="info" />
+        <Stat label="Já sacado" value={formatBRL(summary.withdrawn_cents)} tone="neutral" />
+        <Stat label="Taxas da plataforma" value={formatBRL(summary.fees_total_cents)} tone="neutral" />
       </div>
 
       {summary.available_cents > 0 && (
@@ -132,7 +130,7 @@ export default function FinanceiroPage() {
           onClick={payout}
           className="rounded-pill bg-primary-500 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-600"
         >
-          Sacar {brl(summary.available_cents)}
+          Sacar {formatBRL(summary.available_cents)}
         </button>
       )}
 
@@ -188,12 +186,12 @@ export default function FinanceiroPage() {
                   <td className="px-4 py-3 text-neutral-500">
                     {(t.cost_center_id && costCenterLabel[t.cost_center_id]) || "—"}
                   </td>
-                  <td className="px-4 py-3 tabular-nums text-neutral-600">{brl(t.gross_cents)}</td>
+                  <td className="px-4 py-3 tabular-nums text-neutral-600">{formatBRL(t.gross_cents)}</td>
                   <td className="px-4 py-3 tabular-nums text-danger">
-                    -{brl(t.platform_fee_cents)}
+                    -{formatBRL(t.platform_fee_cents)}
                   </td>
                   <td className="px-4 py-3 font-medium tabular-nums text-accent-700">
-                    {brl(t.net_cents)}
+                    {formatBRL(t.net_cents)}
                   </td>
                   <td className="px-4 py-3">
                     <span className="rounded-pill bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">

--- a/apps/web/src/features/financeiro/PayoutHistory.tsx
+++ b/apps/web/src/features/financeiro/PayoutHistory.tsx
@@ -1,10 +1,10 @@
 import { formatDay } from "../../lib/datetime";
+import { formatBRL } from "./dre";
 
-// Mesmo padrão de toda página do app (`AgendaPage`, `CobrancasPage`, `EstoquePage`, `CockpitPage`
-// …): cada uma define o seu. **Não** importe o `brl` exportado por `FinanceiroPage.tsx` — ela
-// importa este componente, e o ciclo quebraria o build. Unificar os ~8 `brl` do repo num helper
-// compartilhado é refactor legítimo, e não é desta onda.
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+// Issue #209 — a cópia local de `brl` que morava aqui virou `formatBRL` de `dre.ts`, a fonte única
+// já declarada (`costCenters.ts`, `projecao.ts`). O aviso antigo continua válido no que importava:
+// **não** importe dinheiro de `FinanceiroPage.tsx` — ela importa este componente, e o ciclo
+// quebraria o build. `dre.ts` não importa tela nenhuma (só `planoContas.ts`), então não há ciclo.
 
 export type Payout = {
   id: string;
@@ -59,7 +59,7 @@ export function PayoutHistory({
             </p>
           </div>
           <span className="whitespace-nowrap text-sm font-semibold text-neutral-800">
-            {brl(p.amount_cents)}
+            {formatBRL(p.amount_cents)}
           </span>
         </li>
       ))}

--- a/apps/web/src/features/orcamentos/OrcamentosPage.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.tsx
@@ -4,8 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { api } from "../../lib/api";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+import { formatBRL } from "../financeiro/dre";
 
 const statusInfo: Record<Quote["status"], { label: string; cls: string }> = {
   draft: { label: "Rascunho", cls: "bg-neutral-100 text-neutral-500" },
@@ -54,8 +53,8 @@ export default function OrcamentosPage() {
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <Stat label="Rascunhos" value={String(summary.draft_count)} tone="text-neutral-700" />
-        <Stat label="Enviados (aguardando)" value={brl(summary.sent_cents)} tone="text-blue-700" />
-        <Stat label="Aprovados" value={brl(summary.approved_cents)} tone="text-accent-700" />
+        <Stat label="Enviados (aguardando)" value={formatBRL(summary.sent_cents)} tone="text-blue-700" />
+        <Stat label="Aprovados" value={formatBRL(summary.approved_cents)} tone="text-accent-700" />
       </div>
 
       <div className="overflow-hidden rounded-2xl bg-white shadow-sm">
@@ -83,7 +82,7 @@ export default function OrcamentosPage() {
                 >
                   <td className="px-4 py-3 font-medium text-neutral-800">{q.client_name || "—"}</td>
                   <td className="px-4 py-3 text-neutral-600">{q.title}</td>
-                  <td className="px-4 py-3 font-medium tabular-nums">{brl(q.total_cents)}</td>
+                  <td className="px-4 py-3 font-medium tabular-nums">{formatBRL(q.total_cents)}</td>
                   <td className="px-4 py-3">
                     <span className={`rounded-pill px-2 py-0.5 text-xs ${statusInfo[q.status].cls}`}>
                       {statusInfo[q.status].label}

--- a/apps/web/src/features/orcamentos/ProposalView.test.tsx
+++ b/apps/web/src/features/orcamentos/ProposalView.test.tsx
@@ -1,0 +1,85 @@
+import type { PublicProposal } from "@e1p/shared-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ProposalView from "./ProposalView";
+
+/**
+ * Issue #209 — **a asserção que prende o acoplamento com `formatBRL`.**
+ *
+ * Antes desta issue, `brl` estava redefinido em 15 arquivos e importado em 0. Medido: quebrar
+ * `formatBRL` (`dre.ts`) trocando `/ 100` por `/ 1` derrubava **21 testes em 10 arquivos, todos
+ * dentro de `features/financeiro/`** — e **nenhuma** das 15 telas que tinham a cópia local. Cada
+ * tela afirmava contra a própria cópia, então a divergência era invisível por construção.
+ *
+ * `ProposalView` é o pior caso dessa família: **5** call sites de dinheiro e **zero** testes. É
+ * também o alvo mais barato de prender — componente puro, sem `api`, sem router, sem store.
+ *
+ * ⚠️ **Os literais aqui são fixos de propósito.** Comparar contra `formatBRL(x)` seria tautológico
+ * (ele É a implementação sob teste — a mesma lição de `investimentos.test.ts:66`): a mutação
+ * mudaria os dois lados e sobreviveria. Os cinco valores abaixo são distintos entre si e todos
+ * passam do milhar, então três mutações independentes morrem aqui:
+ *   · `/ 100` → `/ 1`            (centavos tratados como reais)
+ *   · `"pt-BR"` → `"en-US"`      (vira "R$1,500.00": ponto e vírgula trocados)
+ *   · `"BRL"` → `"USD"`          (vira "US$ 1.500,00")
+ */
+
+// `toLocaleString("pt-BR", { style: "currency" })` separa "R$" do número com um **NBSP** (U+00A0),
+// não com espaço comum — medido: codepoint 160. Normalizar aqui mantém o fonte 100% ASCII neste
+// ponto (a lição do PR #142: literal com NBSP colado é invisível na revisão).
+const semNbsp = (s: string | null | undefined) => (s ?? "").replace(/\u00a0/g, " ");
+
+/** `getByText` que compara o texto JÁ normalizado — casa "R$ x" sem NBSP invisível no fonte. */
+function porTextoSemNbsp(esperado: string): HTMLElement {
+  return screen.getByText((_conteudo, el) => semNbsp(el?.textContent) === esperado);
+}
+
+/** Cinco valores DISTINTOS, todos acima do milhar (o separador de milhar entra na asserção). */
+const PROPOSTA: PublicProposal = {
+  title: "Reforma do escritório",
+  client_name: "Joana Ré",
+  items: [
+    { description: "Projeto executivo", subtitle: "", quantity: 3, unit_price_cents: 150_000 },
+  ],
+  subtotal_cents: 987_654,
+  discount_cents: 12_345,
+  total_cents: 1_234_567,
+  payment_terms: "",
+  show_gallery: false,
+  gallery: [],
+  show_schedule: false,
+  schedule: [],
+  show_contract: false,
+  contract_text: "",
+  logo_url: "",
+  primary_color: "#123456",
+  bg_color: "#ffffff",
+  text_color: "#000000",
+  accent_color: "#123456",
+  status: "sent",
+  valid_until: null,
+};
+
+describe("ProposalView — o dinheiro na tela vem de `formatBRL` (issue #209)", () => {
+  it("formata os CINCO valores em R$ pt-BR a partir de centavos", () => {
+    render(<ProposalView p={PROPOSTA} />);
+
+    // unitário: 150.000 centavos = R$ 1.500,00 (`quantity > 1` faz a linha "3 × ..." aparecer)
+    expect(porTextoSemNbsp("3 × R$ 1.500,00")).toBeTruthy();
+    // total da linha: 3 × 150.000 = 450.000 centavos = R$ 4.500,00
+    expect(porTextoSemNbsp("R$ 4.500,00")).toBeTruthy();
+    // subtotal, desconto e total: props independentes, valores distintos entre si
+    expect(porTextoSemNbsp("R$ 9.876,54")).toBeTruthy();
+    expect(porTextoSemNbsp("- R$ 123,45")).toBeTruthy();
+    expect(porTextoSemNbsp("R$ 12.345,67")).toBeTruthy();
+  });
+
+  it("não exibe o número cru de centavos em lugar nenhum", () => {
+    const { container } = render(<ProposalView p={PROPOSTA} />);
+    const texto = semNbsp(container.textContent);
+    // A mutação `/ 100` → `/ 1` produz exatamente estes; afirmá-los ausentes mata também a
+    // regressão em que uma tela volta a imprimir `{p.total_cents}` sem passar pelo formatador.
+    expect(texto).not.toContain("1.234.567");
+    expect(texto).not.toContain("987.654");
+    expect(texto).not.toContain("150.000");
+  });
+});

--- a/apps/web/src/features/orcamentos/ProposalView.tsx
+++ b/apps/web/src/features/orcamentos/ProposalView.tsx
@@ -1,7 +1,7 @@
 import type { PublicProposal } from "@e1p/shared-types";
 import { CalendarClock, Check, FileText, Image as ImageIcon } from "lucide-react";
+import { formatBRL } from "../financeiro/dre";
 
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 // só permite http(s) ou caminho relativo como origem de imagem (defesa contra src maliciosa)
 const safeSrc = (u: string) => (/^(https?:\/\/|\/)/i.test(u.trim()) ? u.trim() : "");
 
@@ -42,12 +42,12 @@ export default function ProposalView({
               {it.subtitle && <p className="text-sm opacity-60">{it.subtitle}</p>}
               {it.quantity > 1 && (
                 <p className="mt-1 text-xs opacity-50">
-                  {it.quantity} × {brl(it.unit_price_cents)}
+                  {it.quantity} × {formatBRL(it.unit_price_cents)}
                 </p>
               )}
             </div>
             <p className="shrink-0 font-semibold tabular-nums">
-              {brl(it.quantity * it.unit_price_cents)}
+              {formatBRL(it.quantity * it.unit_price_cents)}
             </p>
           </div>
         ))}
@@ -57,18 +57,18 @@ export default function ProposalView({
       <div className="mt-4 space-y-1 px-6 text-sm">
         <div className="flex justify-between opacity-70">
           <span>Subtotal</span>
-          <span className="tabular-nums">{brl(p.subtotal_cents)}</span>
+          <span className="tabular-nums">{formatBRL(p.subtotal_cents)}</span>
         </div>
         {p.discount_cents > 0 && (
           <div className="flex justify-between opacity-70">
             <span>Desconto</span>
-            <span className="tabular-nums">- {brl(p.discount_cents)}</span>
+            <span className="tabular-nums">- {formatBRL(p.discount_cents)}</span>
           </div>
         )}
         <div className="flex justify-between border-t border-black/10 pt-2 text-lg font-bold">
           <span>Total</span>
           <span className="tabular-nums" style={{ color: p.primary_color }}>
-            {brl(p.total_cents)}
+            {formatBRL(p.total_cents)}
           </span>
         </div>
       </div>

--- a/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
+++ b/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
@@ -16,8 +16,8 @@ import { api, apiErrorMessage } from "../../lib/api";
 import ProposalView from "./ProposalView";
 import { formatTime } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
+import { formatBRL } from "../financeiro/dre";
 
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 const toCents = (s: string) => Math.round(parseFloat((s || "").replace(",", ".") || "0") * 100);
 const fromCents = (c: number) => (c / 100).toFixed(2).replace(".", ",");
 
@@ -252,7 +252,7 @@ export default function QuoteBuilderPage() {
         <div className="flex flex-wrap items-center justify-end gap-3">
           <div className="text-right">
             <p className="text-xs text-neutral-400">Total</p>
-            <p className="text-lg font-bold text-neutral-800">{brl(total)}</p>
+            <p className="text-lg font-bold text-neutral-800">{formatBRL(total)}</p>
           </div>
           <button onClick={send} disabled={saving || readonly} className="flex items-center gap-1.5 rounded-pill bg-primary-500 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-600 disabled:opacity-50">
             <Send size={14} /> Enviar

--- a/apps/web/src/features/pagar/ComprovantePage.tsx
+++ b/apps/web/src/features/pagar/ComprovantePage.tsx
@@ -12,6 +12,7 @@ import {
   HOJE_DO_TENANT,
   useEscolhaDaBaixa,
 } from "./EscolhaDaBaixa";
+import { formatBRL } from "../financeiro/dre";
 
 /** O que a bandeja devolve por comprovante (`GET /payables/receipts`). */
 interface ReceiptInfo {
@@ -20,7 +21,6 @@ interface ReceiptInfo {
   size: number;
 }
 
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 const kb = (n: number) =>
   n < 1024 * 1024 ? `${Math.round(n / 1024)} KB` : `${(n / 1024 / 1024).toFixed(1)} MB`;
 // Data de calendário: formatada pela string, sem `Date` — não há fuso a errar.
@@ -278,7 +278,7 @@ export default function ComprovantePage() {
                     <p className="mt-1 text-xs text-neutral-500">Vence {dia(c.due_date)}</p>
                   </div>
                   <div className="shrink-0 text-right">
-                    <p className="font-bold text-neutral-800">{brl(c.amount_cents)}</p>
+                    <p className="font-bold text-neutral-800">{formatBRL(c.amount_cents)}</p>
                     <span className={`rounded-pill px-2 py-0.5 text-[10px] font-semibold ${tag.cls}`}>
                       {tag.label}
                     </span>
@@ -331,7 +331,7 @@ export default function ComprovantePage() {
                 <p className="truncate text-sm font-medium text-neutral-700">
                   {chosen.description || chosen.supplier || "Conta"}
                 </p>
-                <p className="text-xs text-neutral-500">{brl(chosen.amount_cents)}</p>
+                <p className="text-xs text-neutral-500">{formatBRL(chosen.amount_cents)}</p>
               </div>
               {chosen.status === "open" && (
                 <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-neutral-600">

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -17,6 +17,7 @@ import { camposDaCopia, type CamposDaConta } from "./duplicar";
 import { formatDay, today } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
 import { apenasTexto, daUrl, type FiltroPagar, filtroPadrao, paraQuery, paraUrl } from "./filtros";
+import { formatBRL } from "../financeiro/dre";
 
 /** Grupos DRE cabíveis numa DESPESA (Contas a Pagar nunca lança em Receita). */
 const EXPENSE_GROUPS = GRUPOS_DRE.filter((g) => g !== "RECEITA");
@@ -51,8 +52,6 @@ function ContractSelect({ value, onChange }: { value: string; onChange: (v: stri
     </label>
   );
 }
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 const RECUR = [
   ["none", "Não repete"],
@@ -262,10 +261,10 @@ export default function PagarPage() {
       )}
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <Stat label="A pagar" value={brl(summary.open_cents)} tone="text-amber-700" />
-        <Stat label="Atrasado" value={brl(summary.overdue_cents)} tone="text-danger" />
-        <Stat label="Nesta semana" value={brl(summary.week_cents)} tone="text-neutral-700" />
-        <Stat label="Pago no mês" value={brl(summary.paid_month_cents)} tone="text-accent-700" />
+        <Stat label="A pagar" value={formatBRL(summary.open_cents)} tone="text-amber-700" />
+        <Stat label="Atrasado" value={formatBRL(summary.overdue_cents)} tone="text-danger" />
+        <Stat label="Nesta semana" value={formatBRL(summary.week_cents)} tone="text-neutral-700" />
+        <Stat label="Pago no mês" value={formatBRL(summary.paid_month_cents)} tone="text-accent-700" />
       </div>
 
       <FiltrosDaLista
@@ -322,7 +321,7 @@ export default function PagarPage() {
                     <td className="px-4 py-3 tabular-nums text-neutral-600">
                       {formatDay(p.due_date)}
                     </td>
-                    <td className="px-4 py-3 font-medium tabular-nums">{brl(p.amount_cents)}</td>
+                    <td className="px-4 py-3 font-medium tabular-nums">{formatBRL(p.amount_cents)}</td>
                     <td className="px-4 py-3">
                       <span className={`rounded-pill px-2 py-0.5 text-xs ${st.cls}`}>{st.label}</span>
                       {/* A data do DÉBITO, não o vencimento: numa agendada as duas divergem por
@@ -421,7 +420,7 @@ export default function PagarPage() {
         <DialogDeBaixa
           titulo="Dar baixa nesta conta"
           descricao={pagando.description || pagando.supplier || "Conta"}
-          valor={`${brl(pagando.amount_cents)} · vence ${formatDay(pagando.due_date)}`}
+          valor={`${formatBRL(pagando.amount_cents)} · vence ${formatDay(pagando.due_date)}`}
           dataPadrao={pagando.due_date}
           onClose={() => setPagando(null)}
           onPago={async (corpo) => {

--- a/apps/web/src/features/produtos/ProdutosPage.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.tsx
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
-
-const brl = (c: number) => (c / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+import { formatBRL } from "../financeiro/dre";
 
 type Tab = "produtos" | "cupons" | "compradores";
 const TAB_LABELS: Record<Tab, string> = {
@@ -104,7 +103,7 @@ export default function ProdutosPage() {
                     </span>
                   )}
                 </div>
-                <p className="text-xl font-bold text-neutral-800">{brl(p.price_cents)}</p>
+                <p className="text-xl font-bold text-neutral-800">{formatBRL(p.price_cents)}</p>
                 <p className="mt-1 text-xs text-neutral-400">
                   {p.students} comprador(es){p.stock != null && ` · estoque ${p.stock}`}
                 </p>
@@ -143,7 +142,7 @@ export default function ProdutosPage() {
                     <td className="px-4 py-3 text-neutral-600">
                       {c.discount_type === "percent"
                         ? `${c.discount_value}%`
-                        : brl(c.discount_value)}
+                        : formatBRL(c.discount_value)}
                     </td>
                     <td className="px-4 py-3 tabular-nums text-neutral-500">
                       {c.uses}
@@ -189,7 +188,7 @@ export default function ProdutosPage() {
                       {a.email && <span className="block text-xs text-neutral-400">{a.email}</span>}
                     </td>
                     <td className="px-4 py-3 text-neutral-600">{a.product_name ?? "—"}</td>
-                    <td className="px-4 py-3 tabular-nums">{brl(a.amount_cents)}</td>
+                    <td className="px-4 py-3 tabular-nums">{formatBRL(a.amount_cents)}</td>
                     <td className="px-4 py-3">
                       <span className="rounded-pill bg-accent-50 px-2 py-0.5 text-xs text-accent-700">
                         {a.status === "active" ? "Ativo" : a.status}
@@ -419,7 +418,7 @@ function SellModal({
       testId="modal-vender-produto"
     >
       <div className="space-y-3">
-        <p className="text-sm text-neutral-500">Preço: {brl(product.price_cents)}</p>
+        <p className="text-sm text-neutral-500">Preço: {formatBRL(product.price_cents)}</p>
         <Field label="Nome do comprador" value={name} onChange={setName} />
         <Field label="E-mail" type="email" value={email} onChange={setEmail} />
         <div className="flex gap-2">


### PR DESCRIPTION
## Resumo

As **15** cópias locais de `brl` passam a importar `formatBRL` de `financeiro/dre.ts`. **Nenhum
módulo novo, nenhuma convenção nova** — a convenção já existia e estava escrita no próprio código.

## A issue pedia para medir antes de unificar. Medido, e a resposta muda a forma do trabalho

A #209 adverte contra "criar um módulo neutro por reflexo de DRY", citando o PR #171. A advertência
é boa e **não se aplica**: não há terceira convenção a inventar.

`financeiro/dre.ts:29` já exporta `formatBRL(cents: number): string`, com corpo **idêntico** ao das
15 cópias, e já é a fonte única declarada — consumida por `contas.ts`, `conferencia.ts`,
`costCenters.ts`, `contratoDre.ts`, `investimentos.ts`, `ledger.ts`, `projecao.ts` e por 8 telas. O
código diz isso por extenso:

- `costCenters.ts:7` — *"`formatBRL` é reusado de dre.ts (**fonte única de formatação de dinheiro**)"*
- `projecao.ts:9` — *"`formatBRL` é reusado de dre.ts (DRY)"*
- `contas.ts:651` — *"`formatBRL` é a correção certa — e está **fora do escopo desta story**"*

## A contagem da issue é piso: são 16, não 15

`git grep 'style: "currency"'` em `apps/web/src`, excluindo testes: **16 sites reais**. Os 15 `brl`
locais **mais** o próprio `formatBRL`, que é o destino. Depois deste PR: **16 → 1**.

**As cópias divergem? Não.** As 15 são idênticas no corpo; a única variação é o nome do parâmetro
(`c` vs `cents`) e a quebra de linha. A pergunta da issue ("se divergirem, é bug ou intencional?")
tem resposta medida: não divergem, e unificar não troca dívida por defeito.

Três pontos além do mecânico:

- `FinanceiroPage.tsx:16` **exportava** o seu `brl` e ninguém consumia — o `export` saiu junto
- `CockpitPage.tsx:58` definia dentro do componente, recriada a cada render
- `PayoutHistory.tsx` trazia um aviso de ciclo ("não importe o `brl` de `FinanceiroPage`") que
  **continua válido** e foi preservado: `dre.ts` não importa tela nenhuma, então não há ciclo por
  esse caminho

## A mutação que mede o acoplamento, e não só o formatador

A medição-chave é a **mesma** mutação antes e depois:

| `(cents / 100)` → `(cents / 1)` em `dre.ts:30` | testes mortos |
|---|---|
| **antes** | 21 testes / 10 arquivos — *todos* em `features/financeiro/` |
| **depois** | 33 testes / 16 arquivos |

Antes, **nenhuma** das 15 telas com cópia local morria. Depois, 6 passam a morrer.

Contraprova executada: com a mutação ativa **e** a cópia local de `PayoutHistory` restaurada, o
teste **sobrevive** (`5 passed`). É exatamente a cegueira que a issue descreve, reproduzida e
depois fechada.

`ProposalView` ganhou teste próprio — era o pior caso da família: **5 call sites de dinheiro e zero
testes**, componente puro. Mutações mortas: `/100` para `/1`, `"pt-BR"` para `"en-US"`,
`currency: "BRL"` para `"USD"`. Os literais são fixos de propósito: comparar contra `formatBRL(x)`
seria tautológico e a mutação sobreviveria (a lição de `investimentos.test.ts:66`).

## A classe irmã fica de fora, e não por deferimento

| Rótulo | Issue | Medido |
|---|---|---|
| "Vencido" | 3 | **3** |
| "Recebido" | 3 | **4** |
| "A pagar" | 2 | **2** |
| "A receber (a vencer)" | 1 | **1** |

Ao ler as linhas, **os literais ocupam papéis diferentes**. "Vencido" em `CobrancasPage.tsx:43` é
badge de status de UMA cobrança; em `CobrancasPage.tsx:153` é rótulo de KPI agregado. "A pagar" tem
três papéis, incluindo prosa dentro de diálogo de confirmação. Extrair por grafia criaria
**identidade falsa**: renomear o KPI mudaria o badge e a frase do diálogo em silêncio — o modo de
falha que o #186 mediu, introduzido de propósito. Vale issue nova, sobre *separar os papéis*.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 77 arquivos / 917 testes verdes
```

## Fora de escopo

**A dívida-espelho é um defeito, não duplicação.** A conversão inversa BRL para centavos está inline
em **12 lugares / 8 arquivos**, e **nenhuma trata o separador de milhar**: medido,
`Math.round(parseFloat("1.234,56".replace(",", ".")) * 100)` devolve **123** centavos em vez de
123456 — erro de 1000x. E `contas.ts:674 parseCentsBRL` **já existe, já é testada e já trata o
caso**. Merece issue própria, com prioridade acima desta.

Closes #209
