### PR TITLE
test(web): eventsOfDay lido pela hora de parede do navegador, nao por literal Z [#211]

### DIFF
--- a/apps/web/src/features/agenda/grade.test.ts
+++ b/apps/web/src/features/agenda/grade.test.ts
@@ -35,6 +35,34 @@ const FUSO_DISTANTE = "Asia/Tokyo";
 
 // Sábado 10/10/2026 — o dia que o dono clicou na grade.
 const DIA = new Date(2026, 9, 10);
+
+/**
+ * Um instante que, no fuso do NAVEGADOR, cai em `2026-10-{dia}` às `hora`:00 — seja qual for esse
+ * fuso (issue #211).
+ *
+ * ## A dependência não declarada que isto fecha
+ *
+ * `eventsOfDay`/`eventYmd` leem o evento pelo fuso do NAVEGADOR — e isso é afirmado de propósito
+ * num único teste, "evento com horário é lido pelo fuso do NAVEGADOR", que é o gabarito. Num teste
+ * que NÃO é sobre fuso, um literal `"…T18:00:00Z"` faz o dia do evento ser escolhido pelo fuso da
+ * MÁQUINA sem dizer que faz: sob `America/Sao_Paulo` (o pin do `vitest.config.ts`) e sob UTC as
+ * 18:00Z caem em 10/10 e tudo passa, mas sob `Asia/Tokyo` caem em 11/10, o evento SOME do filtro e
+ * o teste de ordenação reprova com `expected [ 'manha' ] to deeply equal [ 'manha', 'tarde' ]` —
+ * uma mensagem que fala de agenda quando o defeito é ambiente. É a mesma classe do #169, e ela
+ * aparece de verdade sob o pool `threads` que o Stryker força, onde o pin chega tarde.
+ *
+ * Construir o instante a partir das partes LOCAIS põe a fixture no MESMO sistema de coordenadas de
+ * `DIA` (que também é local) e da asserção. Sob o pin da suíte os instantes são IDÊNTICOS aos
+ * literais que substituem — `instanteLocal(10, 9)` é `2026-10-10T12:00:00Z` em UTC−3 — então o que
+ * se mede não muda; some só a dependência que ninguém declarou.
+ *
+ * ⚠️ Isto NÃO é um segundo relógio (CLAUDE.md §5.2): não escolhe fuso nenhum, usa o que o processo
+ * já tem. Só os testes que passam pelo fuso do NAVEGADOR usam este helper — quem recebe `FUSO`
+ * explícito (`eventosDoDia`, `densidadePorDia`, `faixasLivres`) já é independente da máquina e
+ * segue com os literais `Z`, que ali são o instante bruto que o backend devolveria.
+ */
+const instanteLocal = (dia: number, hora: number) => new Date(2026, 9, dia, hora).toISOString();
+
 // Um "agora" bem distante do DIA, para que o corte do passado não interfira nos casos que não
 // são sobre ele.
 const ONTEM = new Date("2026-10-01T12:00:00Z");
@@ -469,20 +497,32 @@ describe("eventYmd / eventsOfDay", () => {
   });
 
   it("eventsOfDay filtra pelo dia e ORDENA por horário de início", () => {
-    const tarde = evento({ id: "tarde", starts_at: "2026-10-10T18:00:00Z", ends_at: "2026-10-10T19:00:00Z" });
-    const manha = evento({ id: "manha", starts_at: "2026-10-10T12:00:00Z", ends_at: "2026-10-10T13:00:00Z" });
-    const outroDia = evento({ id: "outro", starts_at: "2026-10-12T12:00:00Z", ends_at: "2026-10-12T13:00:00Z" });
+    // Fixtures em hora de parede do NAVEGADOR (`instanteLocal`), não em literal `Z`: o assunto
+    // aqui é filtro + ordenação, e qual relógio decide o dia é assunto do teste acima (#211).
+    const tarde = evento({ id: "tarde", starts_at: instanteLocal(10, 15), ends_at: instanteLocal(10, 16) });
+    const meio = evento({ id: "meio", starts_at: instanteLocal(10, 12), ends_at: instanteLocal(10, 13) });
+    const manha = evento({ id: "manha", starts_at: instanteLocal(10, 9), ends_at: instanteLocal(10, 10) });
+    const outroDia = evento({ id: "outro", starts_at: instanteLocal(12, 9), ends_at: instanteLocal(12, 10) });
 
     // A lista entra FORA de ordem de propósito: com ela já ordenada, um comparador quebrado
     // devolve a mesma saída e o teste passa sem exercer a ordenação.
-    const doDia = eventsOfDay([tarde, manha, outroDia], DIA);
+    //
+    // E são TRÊS do dia, não dois — medido por mutação (#211). Com só dois, a mutação do #121
+    // (`-new Date(a) - +new Date(b)`, comparador sempre NEGATIVO) SOBREVIVIA aqui: num par, "põe
+    // o primeiro argumento antes" acerta a ordem por acidente. O irmão `eventosDoDia` já usava
+    // três exatamente por isso; `eventsOfDay` tinha a fresta aberta.
+    const doDia = eventsOfDay([tarde, manha, outroDia, meio], DIA);
 
-    expect(doDia.map((e) => e.id)).toEqual(["manha", "tarde"]);
+    expect(doDia.map((e) => e.id)).toEqual(["manha", "meio", "tarde"]);
   });
 
   it("eventsOfDay não modifica a lista recebida", () => {
-    const tarde = evento({ id: "tarde", starts_at: "2026-10-10T18:00:00Z", ends_at: "2026-10-10T19:00:00Z" });
-    const manha = evento({ id: "manha", starts_at: "2026-10-10T12:00:00Z", ends_at: "2026-10-10T13:00:00Z" });
+    // Também em hora de parede do navegador, e aqui a razão é sutil: com o literal `18:00:00Z` o
+    // teste NÃO reprovava em Tóquio — `tarde` era filtrado, sobrava um elemento, e a asserção
+    // sobre a ENTRADA continuava verdadeira. Ou seja, degradava em silêncio para um caso de um
+    // item só, que nenhum `.sort()` in-place reordena: o teste passaria com a produção mutada.
+    const tarde = evento({ id: "tarde", starts_at: instanteLocal(10, 15), ends_at: instanteLocal(10, 16) });
+    const manha = evento({ id: "manha", starts_at: instanteLocal(10, 9), ends_at: instanteLocal(10, 10) });
     const entrada = [tarde, manha];
 
     eventsOfDay(entrada, DIA);


### PR DESCRIPTION
## Resumo

`grade.test.ts` tinha uma segunda dependência de fuso, **acidental e não declarada**, invisível fora
de Tóquio. Ela sai; o gabarito da linha 468 fica, porque ali o fuso **é** o assunto. Nenhum arquivo
de produção mudou.

## Medição: 6 sites do instante de risco, 1 defeito

`18:00:00Z` aparece em **6** linhas do arquivo (74, 234, 235, 415, 472, 484) — a issue trata de 1.
Mas os 6 não são o mesmo defeito:

| linha | função | fuso vem de | quebra em Tóquio? |
|---|---|---|---|
| 74, 234, 235, 415 | `eventosDoDia` / `densidadePorDia` | `FUSO` explícito | não |
| **472** | `eventsOfDay` | **navegador** | **SIM** |
| 484 | `eventsOfDay` | **navegador** | não — mas degradava em silêncio |

## Fuso por fuso, antes e depois

| fuso | ANTES | DEPOIS |
|---|---|---|
| `America/Sao_Paulo` | 0 / 40 | 0 / 40 |
| `America/New_York` | 0 / 40 | 0 / 40 |
| UTC | **1** — só o gabarito | **1** — só o gabarito |
| `Asia/Tokyo` | **2** | **1** — só o gabarito |

As duas falhas do ANTES:

```
× evento com horário é lido pelo fuso do NAVEGADOR → expected '2026-10-11' to be '2026-10-10'
× eventsOfDay filtra pelo dia e ORDENA por horário de início
    → expected [ 'manha' ] to deeply equal [ 'manha', 'tarde' ]
```

**Havia DOIS pins de fuso, não um**: `vitest.config.ts:18` (`env: { TZ }`) e um guarda duro em
`src/test-setup.ts:33` que dá `throw` se o fuso efetivo divergir. Os dois foram neutralizados para
medir e restaurados por cópia de arquivo.

## Veredito por teste

| teste | veredito | razão |
|---|---|---|
| l.468 `lido pelo fuso do NAVEGADOR` | **legítima — fica** | o fuso *é* o assunto; o literal `Z` é o que distingue "lê pelo navegador" de "lê a data crua" |
| l.471 `filtra pelo dia e ORDENA` | **acidental — REMOVIDA** | o assunto é filtro + ordenação; fixtures agora vêm de `instanteLocal(dia, hora)` |
| l.484 `não modifica a lista recebida` | **acidental — REMOVIDA** | e esta **não reprovava**: em Tóquio sobrava um elemento, e a asserção sobre a *entrada* seguia verdadeira |
| l.74, 234, 235, 415 | **não é dependência — ficam** | recebem `FUSO` explícito; o `Z` é o instante bruto do backend |

Sob o pin da suíte os instantes novos são **idênticos** aos literais que substituem
(`instanteLocal(10, 9)` === `2026-10-10T12:00:00Z` em UTC−3). O que se mede não mudou.

## O achado do meio do caminho: dois eventos não medem ordenação

Com **dois** eventos, a mutação do #121 (comparador sempre negativo) **SOBREVIVIA**: num par, "põe o
primeiro argumento antes" acerta a ordem por acidente. O irmão `eventosDoDia` já usava três
exatamente por isso; `eventsOfDay` tinha a fresta aberta. O teste ganhou um terceiro elemento.

Medido na reverificação, com o comparador mutado:

- teste de **2 elementos** (estado anterior): `1 passed` — **sobrevive**
- teste de **3 elementos** (este PR): `expected [ 'meio', 'manha', 'tarde' ] to deeply equal
  [ 'manha', 'meio', 'tarde' ]` — **morre**

## Mutação: 6 mutantes, 6 mortos

| Mutação em `grade.ts` | Teste que morreu | Mensagem real |
|---|---|---|
| `eventsOfDay` sem `.sort()` | `filtra pelo dia e ORDENA` | `expected [ 'tarde', 'manha', 'meio' ] to deeply equal [ 'manha', 'meio', 'tarde' ]` |
| comparador invertido | `filtra pelo dia e ORDENA` | `expected [ 'tarde', 'meio', 'manha' ] ...` |
| comparador sempre negativo (#121) | `filtra pelo dia e ORDENA` | `expected [ 'meio', 'manha', 'tarde' ] ...` |
| filtro neutralizado | `filtra pelo dia e ORDENA` | `expected [ 'manha', 'meio', 'tarde', 'outro' ] ...` |
| `eventYmd` lê a data CRUA | **`lido pelo fuso do NAVEGADOR`** | `expected '2026-10-11' to be '2026-10-10'` |
| `eventsOfDay` ordena IN PLACE | `não modifica a lista recebida` | `expected [ 'manha', 'tarde' ] to deeply equal [ 'tarde', 'manha' ]` |

A quinta linha é a resposta ao "desacoplou ou apagou": a mutação de **relógio** morre só pelo
gabarito, nunca pelo teste desacoplado. O gabarito diz *qual* relógio; os outros dizem o que fazer
com ele.

Um mutante foi **descartado por não compilar** (remover o `.filter` deixava uma variável sem uso,
`TS6133`) e trocado por um equivalente válido.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 915 testes verdes
```

Diff: **1 arquivo**, 47 inserções / 7 remoções. **Nenhum arquivo de produção mudou.**

## Varredura além do escopo: nada quebrado

Os outros 6 `.test.ts` com instantes `Z` sob Tóquio: `6 passed (133 testes)`. O escopo inteiro do job
de mutação (28 arquivos `.test.ts`) sob Tóquio: `1 failed | 27 passed` — e a única falha é o gabarito
declarado. Nenhuma issue nova a abrir.

⚠️ Para reproduzir, fixe o fuso pelo **PowerShell** (`$env:TZ='Asia/Tokyo'`). Pelo Git Bash a
variável não chega ao Node nesta plataforma e a varredura devolve zero quebras, parecendo aprovação.

Closes #211
