### PR TITLE
fix: a régua converte `scrollWidth` para a escala do `transform` [#212]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,13 +748,36 @@ motivo diferente.** Com título de pior caso (74 chars sem espaço), em 360×740
   nenhum, porque `line-clamp-3` já é `overflow: hidden` e ela RECORTA em vez de vazar. Não entrou —
   mudança que nenhuma régua vê é peso morto (§5.4).
 
-**Achado fora do escopo, não consertado:** em `/marketing`, `textoForaDaTela` acusa **+808,4px** num
-`div` dentro do `CarouselThumb`. Não é defeito do produto: o thumb desenha a arte em 1080px e a
-encolhe com `transform: scale()` dentro de um `overflow: hidden` (`CarouselSlideView.tsx:182-185`), e
-`scrollWidth` é medido ANTES do `transform`. É um falso positivo da régua na mesma família da
-exceção `.react-flow` do §5.4, e por isso `/marketing` **não** entrou no catálogo do
-`card-largo-360`. O card de `/marketing` em si está correto (`truncate` + `min-w-0` + `grid-cols-2`)
-— medido, zero sobra.
+**O falso positivo de `/marketing` era da RÉGUA, e foi consertado nela (#212, 2026-08-22).** Em
+`/marketing`, `textoForaDaTela` acusava **+808,4px** num `div` dentro do `CarouselThumb`. O thumb
+desenha a arte em 1080px e a encolhe com `transform: scale()` dentro de um `overflow: hidden`
+(`CarouselSlideView.tsx:179-185`), e `scrollWidth` é medido no espaço de LAYOUT do elemento, **antes
+do `transform`** — enquanto `getBoundingClientRect` já vem transformado. `Math.max(r.right, r.left +
+el.scrollWidth)` somava as duas réguas.
+
+- **O conserto:** `escalaHorizontal(el)` em `support/medidas.ts` — o comprimento, em px de tela, de
+  um vetor horizontal de 1px no espaço local, obtido multiplicando as matrizes de `transform` da
+  cadeia de ancestrais. É `Math.hypot(a, b)` e não `m.a`: para `scale(s)` os dois dão `s`, mas para
+  `rotate(θ)` `m.a` é `cos θ` e encolheria uma tinta que o giro não encolheu. Medido no app: **1**
+  site de `scale` (`CarouselSlideView.tsx:185`) e **2** de `rotate` (`PlatformUsers.tsx:256`,
+  `ContratoDrePage.tsx:264`) — o alcance é estreito, e a correção é exata nos três.
+- **O número, depois:** o mesmo `div` devolve **+2,7px**, e a régua está certa — o handle sobra 68px
+  do próprio bloco de 968px no espaço da arte, que a 0,222222 dão 15,1px, e a arte se recorta em
+  x=264. Mas isso é da ARTE (geometria fixa em px, igual num 4K), não do layout de 360px.
+- **`/marketing` é a SEXTA rota do catálogo**, com pior caso em `topic`, `caption`, `hashtags` e nos
+  quatro slides. O único campo fora do `LONGO` é o `handle`: **medido, a 40 chars já é zero**, e o
+  Instagram — dono do campo (`marketing/models.py:33`) — para em **30**, que é o valor usado. Zero
+  sobra, zero controle inalcançável.
+- ⚠️ **A exceção `.react-flow` do §5.4 NÃO some com isto, e a medição diz por quê:**
+  `controlesInalcancaveis` nunca usou `scrollWidth`, e os dois falsos positivos de `/funis/f1` já
+  vêm com a escala 0,5 aplicada (o nó de x=900 aterrissa em **493,5 → 568,5** contra uma lona que
+  termina em **335**). Está fora de verdade, em qualquer escala: a lona é panorâmica e se arrasta.
+  Mecanismos diferentes, donos diferentes.
+- **Achado fora do escopo, NÃO consertado:** no `/marketing` de 360px o thumb é **cortado em 92px**
+  — `ScaledSlide` pede `width: 240` e o `flex` da coluna o encolhe para **148**, então o terço
+  direito da arte não é desenhado. Nenhuma régua vê, porque `recorte()` para no ancestral MAIS
+  PRÓXIMO (a raiz da arte, que termina em x=264) e não no mais apertado (o wrapper, em x=172).
+  Vale uma issue própria.
 
 ## 6. Estado atual / roadmap
 - [x] Fundação do monorepo, docs, agentes de QA, CI local.

--- a/apps/web/e2e/card-largo-360.spec.ts
+++ b/apps/web/e2e/card-largo-360.spec.ts
@@ -43,6 +43,15 @@ import { semearSessao } from "./support/sessao";
  * `marca` é o PRÓPRIO CARD: aqui toda rota declara um texto que só o card produz, e o teste
  * «reprova sem card» abaixo prova, com payload `[]`, que essa marca de fato reprova.
  *
+ * ## A SEXTA rota, `/marketing`, entrou pelo #212
+ *
+ * Ela ficou de fora do #182 por um falso positivo de **+808,4px** que era da RÉGUA, não da tela: o
+ * `CarouselThumb` encolhe uma arte de 1080px com `transform: scale()`, e `scrollWidth` é medido
+ * ANTES do `transform`. A régua aprendeu a converter a escala (`support/medidas.ts`,
+ * `escalaHorizontal`) e o mesmo elemento passou a devolver **+2,7px**, todos da ARTE e nenhum do
+ * layout de 360px. O conserto foi na régua, não na exceção — ver o controle da escala no fim deste
+ * arquivo, e a razão medida em `CARROSSEIS_LONGOS`.
+ *
  * As duas rotas de que a issue trata (`/funis` e `/juridico`) saíram do estado vazio no catálogo
  * TAMBÉM, porque é lá que mora a cegueira que a issue descreve — e as fixtures delas são
  * importadas daqui para não existirem em duas cópias. As outras três continuam `// vazio` lá: o
@@ -89,6 +98,52 @@ const INVESTIMENTOS_LONGOS = [
     created_at: "2026-01-01T10:00:00Z",
     bank_account_id: null,
     bank_account_name: null,
+  },
+];
+
+/**
+ * `/marketing` (#212). **O `handle` é o único campo que não é `LONGO`, e o número está medido.**
+ *
+ * O `CarouselThumb` desenha uma ARTE de 1080×1350 e a encolhe com `transform: scale(0.222222)`
+ * (`CarouselSlideView.tsx:179-185`). Tudo que o CARD desenha continua em pior caso aqui — `topic`
+ * (o `p.truncate` da lista), `caption`, `hashtags` e os quatro slides com `heading`/`body`/
+ * `secondary` em `LONGO`. Medido nesta issue, com a régua já convertendo a escala: **zero sobra**.
+ *
+ * Com `handle: `@${LONGO}`` (75 chars) a régua acusa **+2,7px** num `div` do rodapé da arte — e
+ * ela está CERTA: aquele texto sobra 68px do próprio bloco de 968px no espaço de 1080px da arte,
+ * que a 0,222222 dão 15,1px de tela, e a arte se recorta em x=264 deixando 2,7px do lado de fora.
+ * Só que isso é defeito da ARTE, que tem geometria fixa em px por construção e não muda com a
+ * largura da tela: nenhum conserto de layout de 360px o alcança, e a mesma sobra existiria num
+ * monitor de 4K. **Medido: a 40 chars já é zero** — e o Instagram, que é o dono do campo
+ * (`marketing/models.py:33`, `# @ do Instagram`), para em **30**. O valor aqui é o teto real do
+ * campo, não um valor curto escolhido para dar verde. Ver o achado fora do escopo no §5.5.
+ */
+const CARROSSEIS_LONGOS = [
+  {
+    id: "m1",
+    tenant_id: "t1",
+    topic: LONGO,
+    platform: "instagram",
+    slides: ["cover", "editorial", "accent", "cta"].map((kind) => ({
+      kind,
+      heading: LONGO,
+      body: LONGO,
+      secondary: LONGO,
+      highlight: "Diagnostico",
+      photo_url: "",
+      photo_position: "mid",
+    })),
+    status: "draft",
+    handle: "@escritorio_de_uma_pessoa_1234",
+    caption: LONGO,
+    hashtags: `#${LONGO}`,
+    template: "editorial",
+    primary_color: "#123456",
+    bg_color: "#ffffff",
+    text_color: "#111111",
+    accent_color: "#ff0000",
+    font: "Inter",
+    created_at: "2026-01-01T10:00:00Z",
   },
 ];
 
@@ -140,6 +195,15 @@ const CARDS: CasoDeCard[] = [
     marcaDoCard: LONGO,
     mocks: { "/investments": INVESTIMENTOS_LONGOS, "/bank/accounts": [] },
     semDado: { "/investments": [], "/bank/accounts": [] },
+  },
+  // A SEXTA rota, acrescentada pelo #212 — ver a razão medida em `CARROSSEIS_LONGOS` acima e o
+  // teste «a régua converte `scrollWidth` para a escala do `transform`» no fim deste arquivo.
+  {
+    rota: "/marketing",
+    marcaDaPagina: "Carrosséis",
+    marcaDoCard: LONGO,
+    mocks: { "/marketing/carousels": CARROSSEIS_LONGOS },
+    semDado: { "/marketing/carousels": [] },
   },
 ];
 
@@ -244,4 +308,74 @@ test("a régua enxerga tinta fora da borda com a caixa dentro dela", async ({ pa
     cortes.map((c) => c.descricao),
     "a régua ficou CEGA para a classe do #182: tinta além da borda com a caixa dentro dela",
   ).toContain("p.isca-182");
+});
+
+/**
+ * CONTROLE DA ESCALA — a régua converte `scrollWidth` para o tamanho em que o dono vê a tinta.
+ *
+ * `scrollWidth` é medido no espaço de LAYOUT do elemento, ANTES de qualquer `transform` de
+ * ancestral; `getBoundingClientRect` já vem transformado. Somar um ao outro mistura duas réguas, e
+ * foi o que manteve `/marketing` fora deste catálogo: o `div` do rodapé da arte, dentro do
+ * `scale(0.222222)` do `CarouselThumb`, reportava `scrollWidth` 1036 ocupando **215,1px** de tela,
+ * e a régua acusava **+808,4px** de um elemento que cabia (#182, §5.5). Com a conversão o mesmo
+ * elemento devolve **+2,7px** — a tinta que de fato sobra, medida na escala em que ela é vista.
+ *
+ * ⚠️ **Este teste é o par do `isca-182` acima, e existe pela razão OPOSTA.** Aquele prova que a
+ * régua VÊ tinta que a caixa esconde; este prova que ela não ficou CEGA dentro de um `transform`
+ * ao aprender a não inventar. Uma correção que simplesmente ignorasse elementos escalados passaria
+ * no `/marketing` do catálogo e falharia aqui — e é por isso que a asserção é o NÚMERO: sem a
+ * conversão a régua devolveria `cru`, que a medição abaixo exige ser mais de 3× maior.
+ */
+test("a régua converte `scrollWidth` para a escala do `transform`", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/funnels": [] });
+  await page.goto("/funis");
+  await expect(page.getByText("Funis de Vendas").first()).toBeVisible();
+
+  expect(await textoForaDaTela(page, "main")).toEqual([]);
+
+  // Uma LONA como a do `CarouselThumb`: tinta desenhada grande, encolhida por `transform: scale`
+  // dentro de um `overflow: hidden`. Ela sobra de VERDADE — mas só 1/4 do que o `scrollWidth` cru
+  // diz, porque o `scale` encolheu a tinta junto.
+  await page.evaluate((palavra) => {
+    const lona = document.createElement("div");
+    lona.className = "lona-212";
+    lona.style.cssText = "width:120px;overflow:hidden";
+    const escalada = document.createElement("div");
+    escalada.style.cssText = "transform:scale(0.25);transform-origin:top left";
+    const isca = document.createElement("p");
+    isca.className = "isca-212";
+    isca.style.cssText = "white-space:nowrap;width:200px;font-size:60px";
+    isca.textContent = palavra;
+    escalada.appendChild(isca);
+    lona.appendChild(escalada);
+    document.querySelector("main")!.appendChild(lona);
+  }, LONGO);
+
+  const medido = await page.evaluate(() => {
+    const el = document.querySelector(".isca-212")!;
+    const r = el.getBoundingClientRect();
+    const limite = Math.min(
+      document.querySelector(".lona-212")!.getBoundingClientRect().right,
+      document.documentElement.clientWidth,
+    );
+    return {
+      escala: +(r.width / (el as HTMLElement).offsetWidth).toFixed(4),
+      caixaDireita: +r.right.toFixed(1),
+      naEscala: +(r.left + el.scrollWidth * 0.25 - limite).toFixed(1),
+      cru: +(r.left + el.scrollWidth - limite).toFixed(1),
+    };
+  });
+  // O `scale` de fato encolheu, e a CAIXA cabe na tela: só o caminho do `scrollWidth` pode acusar.
+  expect(medido.escala).toBe(0.25);
+  expect(medido.caixaDireita).toBeLessThanOrEqual(360);
+  expect(medido.cru).toBeGreaterThan(medido.naEscala * 3);
+
+  const corte = (await textoForaDaTela(page, "main")).find((c) => c.descricao === "p.isca-212");
+  expect(corte, "a régua ficou CEGA para tinta dentro de um `transform: scale`").toBeDefined();
+  expect(
+    corte!.forcaFora,
+    `a régua somou \`scrollWidth\` CRU (${medido.cru}px) à borda já transformada, ` +
+      `em vez do valor na escala (${medido.naEscala}px)`,
+  ).toBeCloseTo(medido.naEscala, 1);
 });

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -169,6 +169,16 @@ export interface Inalcancavel {
  * (81 -> 531) e a `div` do nó de x=900 (493,5 -> 568,5) — que nenhum conserto de layout
  * resolve, porque a lona é para ser navegada e não para caber. Os CONTROLES DE TELA do construtor (cabeçalho, paleta,
  * painel lateral) ficam FORA de `.react-flow` e continuam medidos — é lá que mora o #144.
+ *
+ * ⚠️ **A correção de `transform` do #212 NÃO dispensa esta exceção, e a medição diz por quê.** A
+ * suspeita registrada no #212 era de que as duas fossem o mesmo mecanismo. Não são, em dois
+ * pontos: (a) esta régua não usa `scrollWidth` em lugar nenhum — ela mede `getBoundingClientRect`,
+ * que **já vem transformado**, e portanto nunca teve o defeito que `textoForaDaTela` tinha; (b)
+ * medido em `/funis/f1` em 22/08/2026, o `.react-flow__viewport` está em
+ * `matrix(0.5, 0, 0, 0.5, -233,5, 111,5)` e os dois falsos positivos têm escala **0,5** já
+ * aplicada: o nó de x=900 do desenho aterrissa em **493,5 → 568,5** na tela, contra uma lona que
+ * termina em **335**. Ele está fora de verdade, e continua fora em qualquer escala — porque a lona
+ * é panorâmica e o dono a arrasta. Não há número a converter; há uma pergunta que não se aplica.
  */
 export const EXCECOES_DE_ALCANCE = [".react-flow"];
 
@@ -245,6 +255,32 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       }
       return document.documentElement;
     };
+    /**
+     * Comprimento, em px de TELA, de um vetor horizontal de 1px no espaco de LAYOUT do elemento.
+     *
+     * `scrollWidth` e medido no layout do proprio elemento, ANTES de qualquer `transform` de
+     * ancestral; `getBoundingClientRect` ja vem transformado. Somar um ao outro mistura duas
+     * reguas. Medido em `/marketing` (#212): o `div` do handle dentro do `CarouselThumb`
+     * (`scale(0.222222)`) reporta `scrollWidth` 1036 ocupando 215,1px de tela, e a regua acusava
+     * **+808,4px** de um elemento que cabe. Com a conversao, o mesmo elemento devolve +2,7px --
+     * que e a tinta que de fato sobra, medida na escala em que o dono a ve.
+     *
+     * `Math.hypot(a, b)` e o comprimento do vetor, nao `m.a`: para `scale(s)` os dois dao `s`,
+     * mas para `rotate(θ)` `m.a` e `cos θ` (encolheria uma tinta que o giro nao encolheu) e o
+     * comprimento e 1, que e o certo. Ha dois `rotate` no app (`PlatformUsers.tsx:256`,
+     * `ContratoDrePage.tsx:264`) e um `scale` (`CarouselSlideView.tsx:185`) -- medido.
+     */
+    const escalaHorizontal = (el: Element): number => {
+      let a = 1;
+      let b = 0;
+      for (let p: Element | null = el; p; p = p.parentElement) {
+        const t = getComputedStyle(p).transform;
+        if (t === "none") continue;
+        const m = new DOMMatrixReadOnly(t);
+        [a, b] = [m.a * a + m.c * b, m.b * a + m.d * b];
+      }
+      return Math.hypot(a, b);
+    };
     const vw = document.documentElement.clientWidth;
     const fora: { texto: string; descricao: string; forcaFora: number }[] = [];
     const escopo: ParentNode = raizSel ? (document.querySelector(raizSel) ?? document.body) : document.body;
@@ -267,7 +303,7 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       // devia ficar mais afiada.
       const direita =
         getComputedStyle(el).overflowX === "visible" && el.scrollWidth > el.clientWidth + 0.5
-          ? Math.max(r.right, r.left + el.scrollWidth)
+          ? Math.max(r.right, r.left + el.scrollWidth * escalaHorizontal(el))
           : r.right;
       const sobra = +(direita - limite).toFixed(1);
       if (sobra > 0.5) {


### PR DESCRIPTION
## Resumo

A régua de card do #182 passa a **enxergar `transform`**, e `/marketing` entra no catálogo como sexta
rota. Os **+808,4px** que a issue relata eram falso positivo real, reproduzidos ao pixel e depois
convertidos para **+2,7px**.

## O mecanismo, medido

`CarouselSlideView.tsx:185` desenha a arte em 1080px e a encolhe com `transform: scale()` dentro de
um `overflow: hidden`. `scrollWidth` é medido **antes** do transform.

```
r.left = 36,4 · rectRight = 251,6 · scrollWidth = 1036 · offsetWidth = 968
escala = 0,222222 · limite = 264
36,4 + 1036 − 264            = +808,4     (régua cega ao transform)
36,4 + 1036 × 0,222222 − 264 = +2,7       (régua com a conversão)
```

O card de `/marketing` em si está certo — `controlesInalcancaveis` devolve `[]`, confirmando a
medição do #182.

## Decisão: (1), com um pedaço da (3) — pela medição

**`transform: scale` tem exatamente 1 site em todo `apps/web/src`.** Com alcance desse tamanho, o
conserto na régua saiu em ~10 linhas, e foi mais barato que uma exceção.

`escalaHorizontal(el)` multiplica as matrizes da cadeia de ancestrais e devolve `Math.hypot(a, b)` —
**não `m.a`**: para `scale(s)` os dois dão `s`, mas para `rotate(θ)` `m.a` é `cos θ` e encolheria
tinta que o giro não encolheu. Os **2 `rotate`** do app (`PlatformUsers.tsx:256`,
`ContratoDrePage.tsx:264`) tornam isso concreto, não teórico.

O pedaço da (3): o **+2,7px residual é real e ficou escrito**. É da ARTE (geometria fixa em px,
idêntica num 4K), não do layout de 360px.

## A premissa da issue sobre `.react-flow` está errada

A issue supõe que ensinar a régua a ver `transform` faria a exceção `.react-flow` sumir. **Não faz**,
e a razão é estrutural:

- **`controlesInalcancaveis` nunca usou `scrollWidth`.** Ela mede `getBoundingClientRect`, que já vem
  transformado. O conserto é em `textoForaDaTela`, outra função — não podia tocá-la nem em princípio.
- **Os falsos positivos já vêm com a escala aplicada.** `.react-flow__viewport` é
  `matrix(0.5, 0, 0, 0.5, …)`; os dois elementos acusados têm `escala: 0.5` medida, e o nó de x=900
  aterrissa em 493,5 → 568,5 contra uma lona que termina em **335**. Está fora de verdade, em
  qualquer escala. Não há número a converter.

Registrado no doc de `EXCECOES_DE_ALCANCE` para a pergunta não ser reaberta.

## A fixture de `/marketing`, e por que não é enfraquecida

Pior caso em `topic`, `caption`, `hashtags` e nos 4 slides. **O único campo fora do `LONGO` é o
`handle`**, com o número ao lado: a 40 chars já é zero sobra, e o Instagram — dono do campo
(`marketing/models.py:33`) — para em 30.

## Mutação

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| `* escalaHorizontal(el)` removido | «a régua converte `scrollWidth` para a escala do `transform`» | `a régua somou 'scrollWidth' CRU (1991px) à borda já transformada, em vez do valor na escala (407.8px)` — Expected 407.8, Received 1991 |
| `scale(${scale})` → `scale(1)` | `/marketing` não deixa o card passar da borda | `+380.8px span «@escritorio_de_uma_pessoa_1234»`, `+704px span «Agosto 2026»`, `+688px div`, … |
| card sem `truncate`/`min-w-0` | `/marketing` não deixa o card passar da borda | `+171px p.text-sm.font-medium «RelatorioDeDiagnostico…»` |
| régua cega (`sobra > 0.5` → `> 1e9`) | **ambos** os controles | `a régua ficou CEGA para a classe do #182` · `… para tinta dentro de um 'transform: scale'` |

**Achado honesto sobre a primeira:** `/marketing` no catálogo **sobreviveu** à remoção do conserto —
com `handle` de 30 chars nenhuma folha da arte tem `scrollWidth > clientWidth`, então o caminho
defeituoso nem é exercido. Quem mata essa mutação é só o controle novo. É por isso que ele existe, e
está escrito no comentário dele.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 915 testes verdes
E2E_PORT=5332 pnpm e2e → 181 passed (13.7m)
card-largo-360.spec.ts isolado → 14/14
```

`e2e/support/rotas.ts` **não foi tocado** — zero colisão com a #208.

## Fora de escopo, não consertado

- **O thumb de `/marketing` é cortado em 92px a 360px.** `ScaledSlide` pede `width: 240` e o `flex`
  da coluna o encolhe para **148** — o terço direito da arte não é desenhado. Nenhuma régua vê,
  porque `recorte()` para no ancestral **mais próximo** (x=264) e não no **mais apertado** (x=172).
  Vale issue própria.
- **`textoForaDaTela` não tem mecanismo de exceção.** Apontada para `/funis/f1` ela acusa dentro da
  lona do react-flow. Hoje ninguém a aponta para lá.
- **A arte do carrossel não quebra palavra.** Com `handle` de 75 chars (que a API aceita —
  `max_length=120`) o texto é recortado **no PNG exportado**, em qualquer viewport. É defeito do
  gerador, não do responsivo.

Closes #212
