### PR TITLE
fix(mutacao): timeout de maquina carregada deixa de virar score otimista em silencio [#213]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,18 @@ jobs:
       #
       # A guarda abaixo reprova o SKIP, mesma lógica do `rls_e2e` logo abaixo: um gate que se pula
       # sozinho fica verde sem proteger nada, e o silêncio é indistinguível de aprovação.
-      - name: Gates de infra/ (Caddyfile e a guarda do deploy.sh)
+      # A guarda de timeouts da mutação (issue #213) entrou nesta lista, e não no job noturno, por
+      # uma razão de RELÓGIO: ela é o que decide se a medição noturna vale, e um guarda verificado
+      # só de madrugada é um guarda que se descobre quebrado depois de já ter deixado passar uma
+      # noite. Aqui ela roda a cada PR, como os outros gates de ferramental.
+      - name: Gates de infra/ (Caddyfile, guarda do deploy.sh e guarda de timeouts da mutação)
         run: |
           set -uo pipefail
           cd apps/api
-          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py --junitxml=infra-gates.xml
+          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py tests/test_guarda_timeouts_mutacao.py --junitxml=infra-gates.xml
           rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=11; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 11 executados: 7 do Caddyfile + 4 da guarda do deploy.sh). Eles dependem de infra/, bash e git alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=24; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 24 executados: 7 do Caddyfile + 4 da guarda do deploy.sh + 13 da guarda de timeouts da mutacao). Eles dependem de infra/, scripts/, bash, git e node alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS, o de timeouts e a issue #213."); sys.exit(0 if ok else 1)'
 
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,12 +25,24 @@
 # QUALIDADE DA SUÍTE, não portaria de mudança — a suíte não muda de qualidade entre duas PRs de
 # terça-feira. O gate de PR continua sendo o job `frontend` do `ci.yml`.
 #
-# ── OBSERVÁVEL PRIMEIRO ──────────────────────────────────────────────────────────────────────────
-# Não há limiar de reprovação. `stryker.config.mjs` traz `thresholds.break: null` de propósito:
-# limiar escrito antes da primeira medição é número sem evidência (Artigo IV da Constitution, "No
-# Invention"). O baseline MEDIDO está no CLAUDE.md §5.3 e é dele que sai o primeiro limiar, depois
-# de um período de observação. Mesmo caminho que `secret-scan`, `sast-semgrep` e `frontend` já
-# percorrem no `ci.yml`: mede antes, barra depois.
+# ── MEDE ANTES, BARRA DEPOIS — E JÁ BARRA ────────────────────────────────────────────────────────
+# Este job nasceu SEM limiar de reprovação, de propósito: limiar escrito antes da primeira medição é
+# número sem evidência (Artigo IV da Constitution, "No Invention"). O período de observação acabou.
+# Hoje `stryker.config.mjs` traz `thresholds.break: 80` (issue #189), derivado do baseline MEDIDO de
+# 83,52% — a aritmética inteira do "por que 80" está no comentário daquele campo. Mesmo caminho que
+# `secret-scan`, `sast-semgrep` e `frontend` já percorreram no `ci.yml`: mede antes, barra depois.
+#
+# ── E O QUE BARRA A MEDIÇÃO QUE NÃO VALE (issue #213) ────────────────────────────────────────────
+# Um limiar de score só significa alguma coisa se o score for confiável, e ele NÃO é em máquina
+# carregada: no Stryker `Timeout` conta como MORTO, então cada mutante que estoura o relógio por
+# contenção de CPU — e não por ter entrado em laço — é creditado como se um teste o tivesse pego. A
+# régua fica otimista exatamente quando o ambiente está pior. Medido no #213: 12 timeouts em
+# `contas.ts` numa máquina com 10 worktrees ativas, contra 0 na CI, e o módulo mediu ~3,8 pontos a
+# mais do que a verdade.
+#
+# O passo `Guarda de timeouts` no fim deste job é quem cobra isso, e por isso este workflow declara:
+# **a corrida só vale em máquina dedicada**. É o que o `concurrency:` abaixo já garante para o
+# runner, e o que o `scripts/gates.sh` pede a quem roda local.
 name: Mutation (noturno)
 
 on:
@@ -264,3 +276,30 @@ jobs:
             gh issue create --label mutacao-tendencia \
               --title "Mutation score caiu ${DELTA} ponto(s), para ${SCORE}%"               --body "$CORPO"
           fi
+
+      # ── A GUARDA DE TIMEOUTS — O SINTOMA VIRA SINAL (issue #213) ──────────────────────────────
+      # `Timeout` conta como MORTO no score do Stryker, e isso não é opção: a soma está em
+      # `mutation-testing-metrics`, `totalDetected = timeout + killed`. Numa máquina disputada, o
+      # mutante estoura o relógio por contenção de CPU e é creditado como se um teste o tivesse
+      # pego — a régua mente A FAVOR justamente quando o ambiente está pior. O raciocínio completo,
+      # a medição de campo e a origem do limiar 5 estão no cabeçalho do script.
+      #
+      # ⚠️ POR ÚLTIMO, e de propósito: se esta guarda reprovar, o resumo já foi para a página da
+      # corrida e o `mutation-report` já subiu como artefato. A evidência de uma medição recusada é
+      # exatamente o que alguém vai querer ler — reprovar antes de publicá-la deixaria o job
+      # vermelho sem material para investigar.
+      #
+      # `if: always()` porque o caso interessante inclui a corrida que o `thresholds.break` já
+      # reprovou: saber que AQUELE número também estava inflado por timeout muda o diagnóstico.
+      - name: Guarda de timeouts (a corrida só vale em máquina dedicada)
+        if: always()
+        working-directory: .
+        run: |
+          set -o pipefail
+          echo '### Guarda de timeouts' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          node scripts/guarda-timeouts-mutacao.mjs \
+            apps/web/reports/mutation/mutation.json | tee -a "$GITHUB_STEP_SUMMARY"
+          rc=$?
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -298,8 +298,12 @@ jobs:
           set -o pipefail
           echo '### Guarda de timeouts' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # `|| rc=$?` e NAO `rc=$?` na linha seguinte: o Actions roda `run:` sob `bash -e`, e
+          # ali um pipeline que falha ABORTA o passo antes da proxima linha. Medido: a cerca de
+          # codigo ficava ABERTA e engolia o resto do summary; o guarda reprovava certo, e o
+          # relatorio dele saia ilegivel. Dentro de uma lista `||` o `-e` nao dispara.
+          rc=0
           node scripts/guarda-timeouts-mutacao.mjs \
-            apps/web/reports/mutation/mutation.json | tee -a "$GITHUB_STEP_SUMMARY"
-          rc=$?
+            apps/web/reports/mutation/mutation.json | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"

--- a/apps/api/tests/test_guarda_timeouts_mutacao.py
+++ b/apps/api/tests/test_guarda_timeouts_mutacao.py
@@ -1,0 +1,267 @@
+"""A guarda de timeouts da corrida de mutação dispara com o NÚMERO REAL na mensagem (issue #213).
+
+⚠️ Este teste EXECUTA `scripts/guarda-timeouts-mutacao.mjs`, o arquivo de verdade — não uma
+reimplementação da regra escrita aqui. Uma cópia passaria a concordar consigo mesma no dia em que
+alguém editasse o script, que é a família de teste que este repositório documenta como "passa e não
+prova nada" (§5.1). Mesma escolha do `test_deploy_guarda_checkout_limpo.py`, que extrai a linha do
+`deploy.sh` em tempo de teste.
+
+O defeito que ele fecha: no Stryker, `Timeout` conta como MORTO
+(`mutation-testing-metrics`, `totalDetected = timeout + killed`). Numa máquina carregada os
+mutantes estouram o relógio por CONTENÇÃO DE CPU e são creditados como se um teste os tivesse
+pego — a régua fica otimista exatamente quando o ambiente está pior. Medido no #213: 12 timeouts
+em `contas.ts` local (todos `StringLiteral` em declaração de constante, onde não existe laço
+possível) contra 0 na CI, e o módulo mediu ~3,8 pontos a mais do que a verdade.
+
+Por que um teste em Python para um script Node: é onde este repositório já testa ferramental que
+não é código de aplicação (o `Caddyfile` e o `deploy.sh` têm os seus aqui), e é o job
+`cross-tenant-rls` — required em `main` — que os roda, com a guarda anti-vacuidade que REPROVA o
+skip. Um guarda de CI que só rodasse no job noturno seria verificado uma vez por dia, tarde.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+def _acha_guarda() -> pathlib.Path | None:
+    """Sobe procurando o script — o mesmo motivo do gate do Caddyfile e do `deploy.sh`.
+
+    A suíte também roda DENTRO da imagem da API (`test-in-prod-image`), onde só `apps/api` foi
+    copiado: `scripts/` não existe lá. Resolver a raiz por índice fixo (`parents[3]`) estoura
+    `IndexError` na COLETA e derruba o job inteiro por um teste que nem era sobre a API.
+    """
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "scripts" / "guarda-timeouts-mutacao.mjs"
+        if candidato.is_file():
+            return candidato
+    return None
+
+
+GUARDA = _acha_guarda()
+
+pytestmark = pytest.mark.skipif(
+    GUARDA is None or shutil.which("node") is None,
+    reason=(
+        "precisa de scripts/guarda-timeouts-mutacao.mjs e do node — o job cross-tenant-rls "
+        "tem os dois, e lá o SKIP é reprovado pela guarda anti-vacuidade"
+    ),
+)
+
+
+def _relatorio(
+    tmp_path: pathlib.Path,
+    *,
+    timeouts: int,
+    mortos: int = 100,
+    sobreviventes: int = 10,
+    sem_cobertura: int = 0,
+    quebra: float | None = 80,
+    mutador: str = "StringLiteral",
+) -> str:
+    """Escreve um `mutation.json` no formato que o Stryker emite (schemaVersion 1.0).
+
+    O formato é o do artefato REAL: `files[caminho].mutants[]` com `status`, `mutatorName` e
+    `location.start.line`. Conferido contra o `mutation-report` da corrida 32557684625.
+    """
+    mutantes = []
+    linha = 1
+
+    def empurra(quantos: int, status: str, nome: str) -> None:
+        nonlocal linha
+        for _ in range(quantos):
+            mutantes.append(
+                {
+                    "id": str(linha),
+                    "mutatorName": nome,
+                    "status": status,
+                    "replacement": '""',
+                    "location": {
+                        "start": {"line": linha, "column": 1},
+                        "end": {"line": linha, "column": 9},
+                    },
+                }
+            )
+            linha += 1
+
+    empurra(timeouts, "Timeout", mutador)
+    empurra(mortos, "Killed", "ConditionalExpression")
+    empurra(sobreviventes, "Survived", "StringLiteral")
+    empurra(sem_cobertura, "NoCoverage", "StringLiteral")
+
+    relatorio: dict = {
+        "schemaVersion": "1.0",
+        "files": {
+            "src/features/financeiro/contas.ts": {
+                "language": "typescript",
+                "source": "",
+                "mutants": mutantes,
+            }
+        },
+    }
+    if quebra is not None:
+        relatorio["thresholds"] = {"high": 80, "low": 60, "break": quebra}
+
+    destino = tmp_path / "mutation.json"
+    destino.write_text(json.dumps(relatorio), encoding="utf-8")
+    return str(destino)
+
+
+def _roda(*args: str) -> subprocess.CompletedProcess[str]:
+    assert GUARDA is not None
+    return subprocess.run(
+        ["node", str(GUARDA), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+
+
+# ── O LIMIAR ─────────────────────────────────────────────────────────────────────────────────────
+
+
+def test_limiar_padrao_e_cinco(tmp_path: pathlib.Path) -> None:
+    """5 é o limiar embutido — e a mensagem o DIZ, sem ninguém precisar passar `--limiar`.
+
+    Pin do número: `LIMIAR_PADRAO = 5` sai da folga entre o regime medido (1 timeout, reproduzido
+    em 3 de 3 corridas de CI, sempre o mesmo mutante de laço real em `grade.ts:294`) e o defeito
+    observado (12 timeouts num único módulo na máquina carregada). Trocar o 5 sem trocar a
+    evidência quebra este teste.
+    """
+    r = _roda(_relatorio(tmp_path, timeouts=0))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "limiar: 5" in r.stdout
+
+
+def test_dentro_do_limiar_passa_e_nao_grita(tmp_path: pathlib.Path) -> None:
+    """1 timeout — o número que a CI mede — passa, e a saída não fala em medição não confiável."""
+    r = _roda(_relatorio(tmp_path, timeouts=1))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert r.stdout.startswith("OK: 1 timeout(s)")
+    assert "NAO E CONFIAVEL" not in r.stdout
+
+
+def test_acima_do_limiar_reprova_com_o_numero_real_na_mensagem(tmp_path: pathlib.Path) -> None:
+    """O caso do #213: 12 timeouts. Reprova, e a mensagem carrega o 12 — não um texto genérico."""
+    r = _roda(_relatorio(tmp_path, timeouts=12))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "ERRO: 12 timeouts" in r.stdout
+    assert "limiar: 5" in r.stdout
+    assert "MEDICAO NAO E CONFIAVEL" in r.stdout
+    assert "maquina dedicada" in r.stdout
+
+
+def test_empate_exato_no_limiar_passa(tmp_path: pathlib.Path) -> None:
+    """Comparação ESTRITA (`>`), a mesma convenção do `thresholds.break` do Stryker.
+
+    Este teste e o seguinte são o par que mata a mutação `>` → `>=`: um deles fica vermelho em
+    qualquer das duas trocas.
+    """
+    r = _roda(_relatorio(tmp_path, timeouts=5))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert r.stdout.startswith("OK: 5 timeout(s)")
+
+
+def test_um_acima_do_limiar_reprova(tmp_path: pathlib.Path) -> None:
+    r = _roda(_relatorio(tmp_path, timeouts=6))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "ERRO: 6 timeouts" in r.stdout
+
+
+def test_limiar_pela_cli_substitui_o_padrao(tmp_path: pathlib.Path) -> None:
+    """`--limiar N` existe para quem mede um módulo só, onde 5 é folgado demais."""
+    relatorio = _relatorio(tmp_path, timeouts=3)
+    assert _roda(relatorio).returncode == 0
+    apertado = _roda(relatorio, "--limiar", "2")
+    assert apertado.returncode == 1, apertado.stdout + apertado.stderr
+    assert "limiar: 2" in apertado.stdout
+
+
+# ── OS MUTANTES APARECEM, COM ARQUIVO, LINHA E MUTADOR ───────────────────────────────────────────
+
+
+def test_lista_os_mutantes_que_estouraram(tmp_path: pathlib.Path) -> None:
+    """Sem a lista, "12 timeouts" não é acionável: é a lista que separa laço real de máquina.
+
+    `StringLiteral` em declaração de constante não pode enlaçar — foi assim que o #213 provou que
+    os 12 eram contenção de CPU, e não mutantes lentos.
+    """
+    r = _roda(_relatorio(tmp_path, timeouts=2, mutador="StringLiteral"), "--limiar", "1")
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "src/features/financeiro/contas.ts:1 (StringLiteral)" in r.stdout
+    assert "src/features/financeiro/contas.ts:2 (StringLiteral)" in r.stdout
+
+
+# ── A ARITMÉTICA DO PIOR CASO ────────────────────────────────────────────────────────────────────
+
+
+def test_score_medido_reproduz_o_numero_do_stryker(tmp_path: pathlib.Path) -> None:
+    """Réplica da corrida 32478357936, que o próprio Stryker reportou como 83,52.
+
+    1479 mortos + 1 timeout + 269 sobreviventes + 23 sem cobertura = 1772 válidos;
+    (1479 + 1) / 1772 = 83,52%. Se este número deixar de bater, a fórmula do script divergiu da do
+    Stryker e todo o resto da saída passa a mentir junto.
+    """
+    r = _roda(_relatorio(tmp_path, timeouts=1, mortos=1479, sobreviventes=269, sem_cobertura=23))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "Score medido: 83.52%" in r.stdout
+    # Sem o timeout no numerador: 1479 / 1772 = 83,47.
+    assert "seria 83.47%" in r.stdout
+    assert "ate 0.06 ponto(s) de otimismo" in r.stdout
+
+
+def test_avisa_quando_o_pior_caso_cruza_o_break(tmp_path: pathlib.Path) -> None:
+    """A pergunta que importa: a dúvida é grande o bastante para derrubar o `thresholds.break`?
+
+    80 mortos + 12 timeouts + 8 sobreviventes = 100 válidos. Medido 92; sem os timeouts, 80,00 —
+    que NÃO cruza (a comparação é estrita). Com 13 timeouts o pior caso vira 79 e cruza.
+    """
+    acima = _roda(_relatorio(tmp_path, timeouts=12, mortos=80, sobreviventes=8), "--limiar", "99")
+    assert acima.returncode == 0, acima.stdout + acima.stderr
+    assert "ainda fica acima dele (80.00 >= 80)" in acima.stdout
+
+    cruza = _roda(_relatorio(tmp_path, timeouts=13, mortos=79, sobreviventes=8), "--limiar", "99")
+    assert "CRUZA o limiar (79.00 < 80)" in cruza.stdout
+
+
+def test_relatorio_sem_thresholds_nao_quebra(tmp_path: pathlib.Path) -> None:
+    """Corridas anteriores ao #189 não trazem `thresholds` no JSON — o artefato de e422278 é uma."""
+    r = _roda(_relatorio(tmp_path, timeouts=1, quebra=None))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "thresholds.break" not in r.stdout
+
+
+# ── FALHA-DURA ANTI-VACUIDADE ────────────────────────────────────────────────────────────────────
+
+
+def test_sem_relatorio_nao_e_aprovacao(tmp_path: pathlib.Path) -> None:
+    """Entrada faltando devolve 2, e NÃO 0.
+
+    Um guarda que fica verde quando não achou o que guardar é a mesma falha que o `ci.yml` já
+    reprova no `rls_e2e` e nos gates de `infra/`: silêncio indistinguível de aprovação.
+    """
+    r = _roda(str(tmp_path / "nao-existe.json"))
+    assert r.returncode == 2
+    assert "NAO e aprovacao" in r.stderr
+
+
+def test_json_invalido_nao_e_aprovacao(tmp_path: pathlib.Path) -> None:
+    quebrado = tmp_path / "mutation.json"
+    quebrado.write_text("{ isto nao e json", encoding="utf-8")
+    r = _roda(str(quebrado))
+    assert r.returncode == 2
+
+
+def test_sem_argumento_ensina_o_uso(tmp_path: pathlib.Path) -> None:
+    """Regressão: o filtro de `--limiar` já comeu o caminho do relatório quando a flag estava
+    ausente (`k !== i + 1` vira `k !== 0`), e o uso mais comum devolvia 2 reclamando de argumento
+    faltando. Este teste fixa que o 2 só sai quando o argumento REALMENTE falta."""
+    r = _roda()
+    assert r.returncode == 2
+    assert "uso: node scripts/guarda-timeouts-mutacao.mjs" in r.stderr

--- a/apps/web/stryker.config.mjs
+++ b/apps/web/stryker.config.mjs
@@ -40,9 +40,13 @@ const RAIZ = "src";
  * O que a regra EXCLUI, e por quê:
  * - `.tsx` — fora de escopo por decisão da issue. Mutação em React é lenta e ruidosa; o
  *   retorno está na aritmética de dinheiro, data e fuso.
- * - `.ts` SEM teste dedicado (hoje 8: `lib/api.ts`, `lib/texto.ts`, `lib/pluralize.ts`,
- *   `lib/whatsappCapabilities.ts`, `features/juridico/categories.ts`,
- *   `store/useIdleTimeout.ts`, `test-setup.ts`, `test/fixtures/agenda.ts`). Módulo sem
+ * - `.ts` SEM teste dedicado (em 22/08/2026 são 9: `features/busca/useBusca.ts`,
+ *   `features/juridico/categories.ts`, `lib/pluralize.ts`, `lib/texto.ts`,
+ *   `lib/whatsappCapabilities.ts`, `store/useIdleTimeout.ts`, `test/fixtures/agenda.ts`,
+ *   `test/paredeDoTenant.ts`, `test-setup.ts`). Esta lista é um INSTANTÂNEO e envelhece sozinha —
+ *   a regra acima é que manda. `lib/api.ts` estava aqui e saiu ao ganhar teste irmão no #197
+ *   (PR do #179): é o 28º módulo entrando no escopo sem ninguém editar este arquivo, exatamente
+ *   como projetado. Módulo sem
  *   teste dedicado pontua perto de zero e não diz nada de novo: já SABEMOS que não tem
  *   teste, e isso é trabalho de cobertura, não de mutação. Misturá-los afogaria o sinal —
  *   o score global viraria uma média de duas perguntas diferentes.
@@ -146,7 +150,9 @@ export default {
   // irmão `.test.ts` entra sozinho, e um módulo novo com teste mediano puxa o total para baixo
   // sem que nenhum teste existente tenha piorado; (b) o timeout conta como morto, então um
   // mutante que hoje estoura o `timeoutMS` pode sobreviver numa noite de runner mais folgado
-  // (é 1 mutante, ~0,06 pt — pequeno, mas não é zero). 80 dá ~3,5 pt = ~63 mutantes de folga:
+  // (é 1 mutante, ~0,06 pt — pequeno, mas não é zero; o erro na direção OPOSTA, o falso morto de
+  // máquina carregada, é bem maior e tem guarda própria — ver `timeoutMS` abaixo e a issue #213).
+  // 80 dá ~3,5 pt = ~63 mutantes de folga:
   // absorve um módulo novo inteiro e ainda pega qualquer desmonte real da suíte.
   //
   // **E por que exatamente 80, o mesmo valor de `high`.** Vira uma regra só em vez de duas:
@@ -163,6 +169,37 @@ export default {
   // arquivos rápidos) e evita marcar como "timeout" o que é só contenção de CPU na máquina
   // de quem roda local — o mesmo tipo de flake que já obrigou o `testTimeout: 15000` do
   // `vitest.config.ts`.
+  //
+  // ── O ERRO TEM DUAS DIREÇÕES, E AS DUAS JÁ FORAM OBSERVADAS ────────────────────────────────
+  // `Timeout` conta como MORTO no score (`totalDetected = timeout + killed`, em
+  // `mutation-testing-metrics`). Como o relógio depende da MÁQUINA e não só do mutante, esse
+  // crédito escorrega para os dois lados:
+  //
+  //   máquina FOLGADA   -> falso SOBREVIVENTE. Um mutante que hoje estoura o `timeoutMS` roda
+  //                        dentro do prazo numa noite de runner mais leve e passa a contar como
+  //                        vivo. A régua fica PESSIMISTA; o score cai sem ninguém ter piorado
+  //                        teste nenhum. (Previsto aqui desde o #189; é o `break: 80` que
+  //                        absorve, com ~3,5 pt de folga.)
+  //
+  //   máquina CARREGADA -> falso MORTO. Sob contenção de CPU o processo estoura o relógio em
+  //                        mutantes que não podem enlaçar, e eles são creditados como pegos. A
+  //                        régua fica OTIMISTA — e mente a favor exatamente quando o ambiente
+  //                        está pior. MEDIDO no #213: `contas.ts` deu 90,79 com 12 timeouts numa
+  //                        máquina com 10 worktrees ativas, contra 86,98 e ZERO timeouts na CI.
+  //                        Os 12 eram `StringLiteral` em declaração de constante; 27 + 12 = 39,
+  //                        os mesmos sobreviventes que a CI viu.
+  //
+  // Afrouxar estes dois números NÃO resolve o segundo caso: contenção não tem teto, e com a
+  // máquina suficientemente carregada qualquer valor finito estoura. Reclassificar `Timeout`
+  // como inconclusivo resolveria — e não é configurável: `@stryker-mutator/core@10.0.0` expõe 45
+  // opções (`@stryker-mutator/api/dist/schema/stryker-core.json`) e nenhuma remapeia status.
+  //
+  // O que fecha o buraco é uma regra de PROCEDIMENTO com guarda automática: **a corrida só vale
+  // em máquina dedicada**, e `scripts/guarda-timeouts-mutacao.mjs` reprova a medição quando os
+  // timeouts passam de 5. As 3 corridas de CI que completaram mediram 1 timeout cada, sempre o
+  // MESMO mutante — `features/agenda/grade.ts:294`, `UpdateOperator` trocando `h++` por `h--` num
+  // `for`, que é laço infinito de verdade e cuja detecção por timeout está CERTA. Em máquina
+  // dedicada o número é estável e explicável; é isso que o torna um sinal.
   timeoutMS: 10000,
   timeoutFactor: 2,
 

--- a/scripts/guarda-timeouts-mutacao.mjs
+++ b/scripts/guarda-timeouts-mutacao.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// A corrida de mutação SÓ VALE EM MÁQUINA DEDICADA — e este script é quem cobra isso (issue #213).
+//
+// ── O DEFEITO DE RÉGUA ───────────────────────────────────────────────────────────────────────────
+// No Stryker, `Timeout` conta como MORTO. A fórmula está em `mutation-testing-metrics@3.8.4`,
+// `dist/src/calculateMetrics.js`, e é literal:
+//
+//     const totalDetected = timeout + killed;
+//     mutationScore = (totalDetected / totalValid) * 100
+//
+// Consequência: todo mutante que estourar o relógio POR CONTENÇÃO DE CPU — e não por ter entrado
+// em laço — é creditado como se um teste o tivesse pego. A régua fica OTIMISTA exatamente quando o
+// ambiente está pior, que é o pior momento para ela mentir a favor.
+//
+// Medido em campo (issue #213, reproduzindo a triagem do #191 em `features/financeiro/contas.ts`):
+//
+//     Onde                                    | Score  | Sobreviventes | Timeouts
+//     ----------------------------------------|--------|---------------|---------
+//     CI (runner dedicado, 2 vCPU)            | 86,98  | 39            | 0
+//     Local, 10 worktrees, ~80 processos node | 90,79  | 27            | 12
+//
+// 27 + 12 = 39: são OS MESMOS mutantes. Doze deles viraram `Timeout` em vez de `Survived`, e o
+// módulo mediu ~3,8 pontos a mais do que a verdade. Os doze eram `StringLiteral` em declaração de
+// constante (`export const KIND_INVESTMENT = "investment";`) — não existe laço possível ali. O
+// timeout era do PROCESSO, não do mutante.
+//
+// ── POR QUE UM LIMIAR, E NÃO MEXER NO `timeoutMS`/`timeoutFactor` ────────────────────────────────
+// Afrouxar o relógio (saída 1 da issue) reduz o falso-morto mas não o elimina: contenção não tem
+// teto — com a máquina suficientemente carregada, QUALQUER `timeoutMS` finito estoura. E o preço é
+// pago no caso que importa: um mutante que causa laço de verdade passaria mais tempo rodando antes
+// de ser detectado, e quem o pegaria seria o teto do job (`timeout-minutes: 120`).
+//
+// Tratar `Timeout` como inconclusivo (saída 2) é o que a semântica pede, e NÃO É CONFIGURÁVEL na
+// versão em uso: `@stryker-mutator/core@10.0.0` expõe 45 opções
+// (`@stryker-mutator/api/dist/schema/stryker-core.json`) e nenhuma remapeia status — só
+// `timeoutMS`, `timeoutFactor`, `dryRunTimeoutMinutes`, `ignoreStatic` e `ignorers` (que ignora
+// mutantes por PADRÃO DE CÓDIGO, na instrumentação, não por resultado). A soma `timeout + killed`
+// é código, não opção.
+//
+// Sobra a saída 3, e ela tem base empírica forte. As TRÊS corridas de CI que completaram mediram,
+// cada uma, exatamente 1 timeout em 1.779 mutantes — e sempre O MESMO mutante:
+//
+//     run 32478357936  21/08/2026  e422278  | 1 timeout | grade.ts:294 UpdateOperator
+//     run 32508528834  21/08/2026  707f28e  | 1 timeout | grade.ts:294 UpdateOperator
+//     run 32557684625  22/08/2026  2d03320  | 1 timeout | grade.ts:294 UpdateOperator
+//
+// Esse mutante é um VERDADEIRO POSITIVO: `grade.ts:294` é
+// `for (let h = HORA_ABERTURA; h < HORA_FECHAMENTO; h++)`, e o `UpdateOperator` troca `h++` por
+// `h--`. É laço infinito de verdade — timeout é a detecção CERTA dele. Ou seja: em máquina
+// dedicada o número de timeouts é estável, pequeno e inteiramente explicável. É justamente isso
+// que o torna um sinal utilizável.
+//
+// ── DE ONDE VEM O 5 ──────────────────────────────────────────────────────────────────────────────
+// Não é gosto; é a folga entre o regime medido e o defeito observado.
+//
+//  - **Piso:** 1, reproduzido em 3 de 3 corridas de CI, sempre o mesmo mutante de laço real.
+//  - **Teto observado do defeito:** 12 timeouts em UM ÚNICO módulo na máquina carregada.
+//  - **Custo de errar para cima:** cada timeout vale, no PIOR caso (se fosse `Survived`),
+//    1/1772 = 0,0564 ponto de otimismo. Cinco valem 0,28 ponto — menos de 10% da margem de
+//    3,52 pontos que separa o baseline (83,52) do `thresholds.break: 80`. Ou seja: uma medição
+//    que PASSA por esta guarda pode estar otimista em no máximo ~0,3 ponto, e nessa escala o
+//    `break` continua significando o que diz.
+//  - **Tolerância a laço real novo:** 5 é 5x o piso. Quatro mutantes de laço genuínos podem
+//    aparecer (código novo entra sozinho, `mutate` é DESCOBERTO) sem que a guarda dispare.
+//
+// 5 fica confortavelmente ACIMA do que a CI mede e confortavelmente ABAIXO do que a contenção
+// produziu. Se um dia a guarda disparar por laço real, o conserto é subir o limiar COM a evidência
+// — os mutantes listados na saída — e não silenciá-la.
+//
+// ── O QUE FAZER QUANDO ELA DISPARA ───────────────────────────────────────────────────────────────
+// 1. Olhe a lista que este script imprime. `UpdateOperator`/`ConditionalExpression` em cabeçalho de
+//    laço são candidatos a laço REAL. `StringLiteral` em declaração de constante não é: é máquina.
+// 2. Se for máquina: a medição não vale. Rode de novo sozinho, sem outra suíte por cima
+//    (`scripts/gates.sh` explica por que suítes concorrentes se contaminam, issue #162).
+// 3. Se for laço real: suba `LIMIAR_PADRAO` aqui, citando a corrida que serviu de evidência.
+//
+// ── COMO RODAR ───────────────────────────────────────────────────────────────────────────────────
+//   node scripts/guarda-timeouts-mutacao.mjs apps/web/reports/mutation/mutation.json
+//   node scripts/guarda-timeouts-mutacao.mjs <relatorio.json> --limiar 3
+//
+// Saída: 0 = dentro do regime · 1 = timeouts acima do limiar (medição suspeita) · 2 = sem
+// relatório legível. O 2 é deliberado: um guarda que se pula sozinho quando falta a entrada fica
+// verde sem ter guardado nada, e é a mesma falha-dura anti-vacuidade que o `ci.yml` já aplica ao
+// `rls_e2e` e aos gates de `infra/`.
+
+import { readFileSync } from "node:fs";
+
+/** Ver "DE ONDE VEM O 5" no cabeçalho. Mexer aqui exige citar a corrida que justifica. */
+export const LIMIAR_PADRAO = 5;
+
+/** Lê um relatório do Stryker; devolve `null` se não existir ou não for JSON válido. */
+export function lerRelatorio(caminho) {
+  try {
+    return JSON.parse(readFileSync(caminho, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extrai o que a guarda precisa de um `mutation.json`: os mutantes que estouraram o relógio e a
+ * contagem por status (esta última alimenta a aritmética do pior caso).
+ */
+export function medirTimeouts(relatorio) {
+  const timeouts = [];
+  const contagem = { Killed: 0, Timeout: 0, Survived: 0, NoCoverage: 0 };
+
+  for (const [caminho, arquivo] of Object.entries(relatorio.files ?? {})) {
+    for (const mutante of arquivo.mutants ?? []) {
+      if (mutante.status in contagem) contagem[mutante.status] += 1;
+      if (mutante.status !== "Timeout") continue;
+      timeouts.push({
+        caminho,
+        linha: mutante.location?.start?.line ?? 0,
+        mutador: mutante.mutatorName ?? "?",
+      });
+    }
+  }
+
+  timeouts.sort((a, b) => a.caminho.localeCompare(b.caminho) || a.linha - b.linha);
+  return { timeouts, contagem };
+}
+
+/**
+ * O score como o Stryker o calcula, e o score do PIOR CASO — aquele em que todo timeout era, na
+ * verdade, um sobrevivente. A distância entre os dois é o tamanho da dúvida que esta guarda mede.
+ *
+ * Fórmula conferida contra a corrida 32478357936, que o Stryker reportou como 83,52:
+ * (1479 + 1) / 1772 = 83,52.
+ */
+export function scores({ Killed, Timeout, Survived, NoCoverage }) {
+  const validos = Killed + Timeout + Survived + NoCoverage;
+  if (validos === 0) return { medido: null, piorCaso: null };
+  return {
+    medido: ((Killed + Timeout) * 100) / validos,
+    piorCaso: (Killed * 100) / validos,
+  };
+}
+
+export function avaliar(relatorio, limiar = LIMIAR_PADRAO) {
+  const { timeouts, contagem } = medirTimeouts(relatorio);
+  return {
+    timeouts,
+    contagem,
+    limiar,
+    ...scores(contagem),
+    // ESTRITO: um empate exato no limiar PASSA — a mesma convenção do `thresholds.break` do
+    // Stryker, cujo `determineExitCode()` compara `mutationScore < break`.
+    dispara: timeouts.length > limiar,
+  };
+}
+
+const n2 = (v) => (v === null || v === undefined ? "—" : v.toFixed(2));
+
+export function montarMensagem(r, limiarBreak) {
+  const n = r.timeouts.length;
+  const linhas = [];
+
+  linhas.push(
+    r.dispara
+      ? `ERRO: ${n} timeouts na corrida de mutacao (limiar: ${r.limiar}). A MEDICAO NAO E CONFIAVEL.`
+      : `OK: ${n} timeout(s) na corrida de mutacao (limiar: ${r.limiar}).`,
+  );
+
+  if (r.medido !== null) {
+    linhas.push(
+      `Score medido: ${n2(r.medido)}%. No pior caso — se TODO timeout fosse na verdade um ` +
+        `sobrevivente — seria ${n2(r.piorCaso)}%, ou seja, ate ${n2(r.medido - r.piorCaso)} ` +
+        `ponto(s) de otimismo.`,
+    );
+    if (typeof limiarBreak === "number") {
+      linhas.push(
+        `O thresholds.break e ${limiarBreak}: o pior caso ` +
+          (r.piorCaso < limiarBreak
+            ? `CRUZA o limiar (${n2(r.piorCaso)} < ${limiarBreak}).`
+            : `ainda fica acima dele (${n2(r.piorCaso)} >= ${limiarBreak}).`),
+      );
+    }
+  }
+
+  if (n > 0) {
+    linhas.push("", "Mutantes que estouraram o relogio:");
+    for (const t of r.timeouts) linhas.push(`  - ${t.caminho}:${t.linha} (${t.mutador})`);
+  }
+
+  if (r.dispara) {
+    linhas.push(
+      "",
+      "UpdateOperator/ConditionalExpression em cabecalho de laco podem ser laco REAL — timeout e a",
+      "deteccao certa deles. StringLiteral em declaracao de constante nao pode enlacar: ali o",
+      "timeout e da MAQUINA, e o score esta otimista (issue #213).",
+      "",
+      "A corrida de mutacao so vale em maquina dedicada. Rode de novo sem outra suite por cima.",
+    );
+  }
+
+  return linhas.join("\n");
+}
+
+export function principal(argv) {
+  const i = argv.indexOf("--limiar");
+  const limiar = i === -1 ? LIMIAR_PADRAO : Number(argv[i + 1]);
+  // ⚠️ O `i === -1` PRECISA ser tratado à parte: sem ele, `k !== i + 1` vira `k !== 0` e o filtro
+  // come justamente o caminho do relatório — o uso mais comum (sem `--limiar`) devolvia exit 2
+  // reclamando de argumento faltando. Pego na primeira execução contra o artefato real da CI.
+  const caminho = (i === -1 ? argv : argv.filter((_, k) => k !== i && k !== i + 1))[0];
+
+  if (!caminho || !Number.isFinite(limiar) || limiar < 0) {
+    process.stderr.write(
+      "uso: node scripts/guarda-timeouts-mutacao.mjs <mutation.json> [--limiar N]\n",
+    );
+    return 2;
+  }
+
+  const relatorio = lerRelatorio(caminho);
+  if (!relatorio) {
+    process.stderr.write(
+      `ERRO: nao consegui ler ${caminho}. A corrida nao produziu relatorio — ela abortou antes de ` +
+        "medir, e nao ha nada a guardar. Isto NAO e aprovacao.\n",
+    );
+    return 2;
+  }
+
+  const r = avaliar(relatorio, limiar);
+  process.stdout.write(montarMensagem(r, relatorio.thresholds?.break) + "\n");
+  return r.dispara ? 1 : 0;
+}
+
+// `import.meta.main` existe do Node 24 em diante — o mesmo Node do job. O fallback cobre quem
+// rodar numa versão anterior na mão.
+if (import.meta.main ?? process.argv[1]?.endsWith("guarda-timeouts-mutacao.mjs")) {
+  process.exit(principal(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Resumo

`Timeout` conta como MORTO no score do Stryker, então máquina carregada mede **otimista** — a régua
fica frouxa exatamente quando o ambiente está pior. Este PR toma a saída (3) da issue: declara que a
corrida só vale em máquina dedicada, e faz o job **reprovar** quando o número de timeouts passa de um
limiar.

## O baseline da CI dá a base empírica

Artefato `mutation-report` da corrida agendada (run `32557684625`, `main` @ `2d03320`):

```
arquivos: 27 · mutantes: 1779
{ "NoCoverage": 23, "Killed": 1479, "Survived": 269, "Ignored": 7, "Timeout": 1 }
timeouts por arquivo:
  src/features/agenda/grade.ts:294  UpdateOperator  h++ → h--
```

Baixadas **as três** corridas que completaram: todas com **1 timeout**, sempre **o mesmo mutante**.
A linha 294 é `for (let h = HORA_ABERTURA; h < HORA_FECHAMENTO; h++)` — laço infinito de verdade. O
único timeout da CI é um **verdadeiro positivo**. Em máquina dedicada o número não é só baixo: é
estável e explicável, e é isso que o torna utilizável como limiar.

⚠️ Essa corrida é de `2d03320`, **anterior** ao #206. Os 269 sobreviventes são o "antes" do #191, e
o commit está citado ao lado de cada número.

## A saída (2) está fechada nesta versão, e isso foi à fonte

`@stryker-mutator/core: 10.0.0`.

- `mutation-testing-metrics@3.8.4`, `dist/src/calculateMetrics.js:170` —
  `const totalDetected = timeout + killed;`. A soma é **código, não opção**.
- `@stryker-mutator/api/.../stryker-core.json` — **45 opções**, nenhuma remapeia status. Só
  `timeoutMS`, `timeoutFactor`, `dryRunTimeoutMinutes`, `ignoreStatic` e `ignorers` — e `ignorers`
  ignora por *padrão de código na instrumentação*, não por resultado.

A saída (1) foi descartada medindo: contenção **não tem teto** — com a máquina carregada o bastante,
qualquer `timeoutMS` finito estoura; e o preço cai justamente no caso que importa, o laço real de
`grade.ts`, que demoraria mais para ser pego.

## Limiar = 5, com a conta escrita

5 timeouts valem no máximo `5 × 1/1772 = 0,28` ponto de otimismo — menos de 10% da margem de 3,52
até `thresholds.break: 80` (#189). Sobra folga para 4 laços reais novos.

O guarda calcula o **score de pior caso** (todo timeout como sobrevivente) e diz se ele cruza o
`break` — quantifica a dúvida em vez de só contar. Contra o cenário do #213 (12 sobreviventes de
`contas.ts` virados Timeout):

```
ERRO: 13 timeouts na corrida de mutacao (limiar: 5). A MEDICAO NAO E CONFIAVEL.
Score medido: 84.20%. No pior caso ... seria 83.47%, ou seja, ate 0.73 ponto(s) de otimismo.
```

Contra o relatório real: `OK: 1 timeout(s)`, score `83.52%` — reproduz o número do próprio Stryker,
confirmando a fórmula.

Ele **falha**, não avisa: um job verde publicando número não confiável é a "noite verde silenciosa"
que este workflow já combate.

O comentário do `stryker.config.mjs` previu o **irmão** deste defeito, na direção oposta (*"um
mutante que hoje estoura o `timeoutMS` pode sobreviver numa noite de runner mais folgado"*). As duas
direções ficam documentadas.

## Mutação: 10 mutantes, 10 mortos

| Mutação no guarda | Teste que morreu | Mensagem real |
|---|---|---|
| `LIMIAR_PADRAO = 5` → `4` | `test_limiar_padrao_e_cinco` | `assert "limiar: 5" in r.stdout` |
| `length > limiar` → `>=` | `test_empate_exato_no_limiar_passa` | `ERRO: 5 timeouts ... (limiar: 5)` · `assert 1 == 0` |
| `medido:` sem `Timeout` | `test_score_medido_reproduz_o_numero_do_stryker` | `assert "Score medido: 83.52%"` |
| `piorCaso` == `medido` | idem | `assert "seria 83.47%"` |
| sem relatório `return 2` → `0` | `test_sem_relatorio_nao_e_aprovacao` | `assert r.returncode == 2` |
| `piorCaso < break` → `<=` | `test_avisa_quando_o_pior_caso_cruza_o_break` | `assert "ainda fica acima dele (80.00 >= 80)"` |

Um bug real caiu na primeira execução contra o artefato: sem `--limiar`, um índice `-1` comia o
caminho do relatório. Corrigido, com teste de regressão.

## YAML por parse, não por leitura

- `ci.yml`: diff estrutural toca **exatamente dois campos** —
  `/jobs/cross-tenant-rls/steps[3]/name` e `/steps[3]/run`. Zero chaves adicionadas ou removidas.
- `mutation.yml`: o job de mutação vai de **10 para 11 passos** (o guarda).
- O bloco `run:` do passo novo foi **extraído do YAML parseado e executado verbatim** nos três
  caminhos: relatório real → exit 0; 13 timeouts → exit 1; sem relatório → exit 2.

**Um defeito foi achado e consertado nesse passo antes do push.** A primeira redação capturava o
código com `rc=$?` na linha seguinte ao pipeline. O Actions roda `run:` sob `bash -e`, e ali um
pipeline que falha **aborta o passo antes dessa linha**: o `exit 1` saía certo, mas a cerca de código
do `GITHUB_STEP_SUMMARY` nunca fechava e engolia o resto do relatório. Medido executando o bloco
extraído do YAML parseado:

| caminho | antes | depois |
|---|---|---|
| guarda reprova (exit 1) | cerca **aberta** | cerca fechada |
| guarda aprova (exit 0) | ok | ok |

`|| rc=$?` põe o pipeline dentro de uma lista, onde o `-e` não dispara.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 915 testes verdes
ruff check .    → All checks passed
pytest          → 24 passed
```

**Stryker local não foi rodado como medição** — havia 57 processos `node` na máquina, e uma corrida
ali mediria o defeito, não o código. É a própria tese desta issue.

## Fora de escopo

- **`src/lib/api.ts` entrou no escopo da mutação** (ganhou teste irmão no #197). O checkout descobre
  **28** módulos; a CI de `2d03320` mediu **27**. A próxima noturna vai mexer o score por escopo
  novo, não por qualidade.
- **`scripts/resumo-mutacao.mjs` não tem teste nenhum** — exporta 4 funções puras e decide quando
  abrir issue de tendência.
- **`scripts/check.sh` mascara falha do vitest com `|| true`** — dívida herdada, continua lá.

Closes #213
