### PR TITLE
test(web): triagem de mutação dos 11 módulos nunca triados — 21 mortos, 38 dispensados [#214]

### DIFF
--- a/apps/web/src/features/agenda/grade.test.ts
+++ b/apps/web/src/features/agenda/grade.test.ts
@@ -194,6 +194,20 @@ describe("faixasLivres", () => {
     expect(faixasLivres([viagem], DIA, FUSO, ONTEM)).toEqual([]);
   });
 
+  it("o compromisso que já TERMINOU em outro dia não ocupa nada", () => {
+    // Achado por mutação (#214): a guarda de `intervaloNoDia` é `ymd < diaInicio || diaFim < ymd`,
+    // e todos os testes acima só exercitavam o primeiro lado (evento no FUTURO do dia pedido) ou
+    // eventos que encostam no dia. Apagando o segundo lado, um compromisso do dia 8 volta como
+    // `{ inicio: 0, fim: minFim }` — ele cai no ramo "termina neste dia" e ocupa da meia-noite
+    // até as 11h do dia 10. A grade de 42 dias manda a janela INTEIRA para cá, sem pré-filtro
+    // por dia: todo compromisso passado do mês fecharia a manhã de todos os dias seguintes.
+    const semanaPassada = evento({ starts_at: "2026-10-08T13:00:00Z", ends_at: "2026-10-08T14:00:00Z" });
+
+    const fx = faixasLivres([semanaPassada], DIA, FUSO, ONTEM);
+
+    expect(horas(fx)).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+  });
+
   it("na hora cheia exata, a faixa que começa AGORA já não é oferecida", () => {
     // Borda: às 14:00:00 em ponto a faixa das 14h não tem mais nem um minuto de antecedência.
     // O caso de 14:30 (acima) passa com `<` e com `<=`; só a hora cheia separa os dois.
@@ -471,13 +485,19 @@ describe("eventYmd / eventsOfDay", () => {
   it("eventsOfDay filtra pelo dia e ORDENA por horário de início", () => {
     const tarde = evento({ id: "tarde", starts_at: "2026-10-10T18:00:00Z", ends_at: "2026-10-10T19:00:00Z" });
     const manha = evento({ id: "manha", starts_at: "2026-10-10T12:00:00Z", ends_at: "2026-10-10T13:00:00Z" });
+    const noite = evento({ id: "noite", starts_at: "2026-10-10T21:00:00Z", ends_at: "2026-10-10T22:00:00Z" });
     const outroDia = evento({ id: "outro", starts_at: "2026-10-12T12:00:00Z", ends_at: "2026-10-12T13:00:00Z" });
 
     // A lista entra FORA de ordem de propósito: com ela já ordenada, um comparador quebrado
     // devolve a mesma saída e o teste passa sem exercer a ordenação.
-    const doDia = eventsOfDay([tarde, manha, outroDia], DIA);
+    //
+    // São TRÊS eventos, e não dois, por achado de mutação (#214): com dois, trocar o `+` do
+    // primeiro operando por `-` (comparador sempre negativo) faz o V8 apenas INVERTER o par —
+    // e a inversão de `[tarde, manha]` é exatamente `[manha, tarde]`, a resposta certa. Medido:
+    // com três, `[tarde, manha, noite]` sai `[noite, manha, tarde]` sob o mutante.
+    const doDia = eventsOfDay([tarde, manha, noite, outroDia], DIA);
 
-    expect(doDia.map((e) => e.id)).toEqual(["manha", "tarde"]);
+    expect(doDia.map((e) => e.id)).toEqual(["manha", "tarde", "noite"]);
   });
 
   it("eventsOfDay não modifica a lista recebida", () => {

--- a/apps/web/src/features/financeiro/contratoDre.test.ts
+++ b/apps/web/src/features/financeiro/contratoDre.test.ts
@@ -51,6 +51,14 @@ describe("formatMarginPct", () => {
   it("mostra '—' quando não há receita (null)", () => {
     expect(formatMarginPct(null)).toBe("—");
   });
+
+  it("arredonda em UMA casa decimal (não despeja o dízimo da razão)", () => {
+    // Achado por mutação (#214): trocar `{ maximumFractionDigits: 1 }` por `{}` sobrevivia,
+    // porque 0.6 e 0.125 já cabem em 1 casa. O default do `toLocaleString` é 3 casas, e a razão
+    // que o backend manda é uma DIVISÃO — 60000/486000 = 0,12345679… A margem na tela viraria
+    // "12,346%" em vez de "12,3%".
+    expect(formatMarginPct(0.12345)).toBe("12,3%");
+  });
 });
 
 describe("breakEvenLabel", () => {
@@ -60,6 +68,16 @@ describe("breakEvenLabel", () => {
 
   it("avisa quando não atingível (margem não cobre custos fixos)", () => {
     const d = dre({ break_even_reachable: false, break_even_cents: null });
+    expect(breakEvenLabel(d)).toMatch(/não atingível/i);
+  });
+
+  it("avisa também quando o backend diz 'atingível' mas não manda o valor", () => {
+    // Achado por mutação (#214). Os dois testes acima só usavam os cantos CONCORDANTES
+    // (true+valor, false+null), e nessas duas entradas `||` e `&&` devolvem o mesmo resultado —
+    // por isso o `LogicalOperator` e o segundo operando do `||` sobreviviam os dois. Este é o
+    // caso DISCORDANTE, e é o que a guarda existe para pegar: sem ele, `formatBRL(null)`
+    // renderiza "R$ 0,00" e a tela afirma que o contrato empata com receita ZERO.
+    const d = dre({ break_even_reachable: true, break_even_cents: null });
     expect(breakEvenLabel(d)).toMatch(/não atingível/i);
   });
 });

--- a/apps/web/src/features/financeiro/diagnostico.test.ts
+++ b/apps/web/src/features/financeiro/diagnostico.test.ts
@@ -43,6 +43,10 @@ describe("countByLevel", () => {
 describe("sourceLabel", () => {
   it("traduz as origens conhecidas e devolve o cru para desconhecidas", () => {
     expect(sourceLabel("lucratividade")).toBe("Lucratividade por contrato");
+    // Achado por mutação (#214): `projecao` era a única origem do `switch` que NENHUM teste
+    // afirmava. Apagar o corpo do `case` faz ele CAIR no case seguinte — e a projeção de caixa
+    // passa a se chamar "Investimentos" na tela do diagnóstico, sem nada quebrar.
+    expect(sourceLabel("projecao")).toBe("Projeção de caixa");
     expect(sourceLabel("investimento")).toBe("Investimentos");
     expect(sourceLabel("desconhecido")).toBe("desconhecido");
   });
@@ -86,6 +90,12 @@ describe("completudeCaveat", () => {
   it("avisa quando a completude está 🟡", () => {
     const texto = completudeCaveat([sig("amarelo", "completude")]);
     expect(texto).toContain("possivelmente incompletos");
+    // Achado por mutação (#214): "possivelmente incompletos" é a metade COMUM aos dois textos,
+    // então fixar `level === "vermelho"` em `true` passava neste teste — o 🟡 exibia a redação do
+    // 🔴 ("divergência acima da tolerância", uma afirmação de fato) sem ninguém perceber. O que
+    // separa os dois estados é justamente a abertura.
+    expect(texto).toContain("Ainda não dá para afirmar");
+    expect(texto).not.toContain("divergência acima da tolerância");
   });
 
   it("cala quando a completude está 🟢 ou ausente", () => {

--- a/apps/web/src/features/financeiro/dreMatrix.test.ts
+++ b/apps/web/src/features/financeiro/dreMatrix.test.ts
@@ -100,4 +100,16 @@ describe("splitGroupsAroundInvestment", () => {
     expect(before).toEqual(groups);
     expect(after).toEqual([]);
   });
+
+  it("group_by=cost_center: é o MODO que decide, não o nome da chave", () => {
+    // Achado por mutação (#214): apagar a guarda `groupBy !== "dre"` sobrevivia porque o teste
+    // acima usa chaves ("cc-a", "_unassigned") que o filtro não pegaria de qualquer jeito — a
+    // saída era idêntica com e sem a guarda. Aqui a chave COLIDE de propósito com os nomes de
+    // grupo DRE: em cost_center o `key` é o id do centro de custo (uuid) ou "_unassigned", e
+    // nenhum deles pode ser arrancado para a seção de investimento.
+    const groups = [group({ key: "INVESTIMENTO" }), group({ key: "SEM_CATEGORIA" })];
+    const { before, after } = splitGroupsAroundInvestment(groups, "cost_center");
+    expect(before.map((g) => g.key)).toEqual(["INVESTIMENTO", "SEM_CATEGORIA"]);
+    expect(after).toEqual([]);
+  });
 });

--- a/apps/web/src/features/financeiro/dreMatrixEntries.ts
+++ b/apps/web/src/features/financeiro/dreMatrixEntries.ts
@@ -17,14 +17,29 @@ export function sortDescending(entries: DreMatrixEntry[]): DreMatrixEntry[] {
   // ficar em linhas SEPARADAS para que o `disable` abaixo mire só um deles — o `>` continua
   // mutável, e o teste de empate abaixo o mata.
   //
-  // Stryker disable next-line EqualityOperator
   // Trocar `<` por `<=` faz o comparador devolver 1 para itens de MESMA data, o que viola o
   // contrato de antissimetria do `Array.prototype.sort`: o resultado passa a ser definido pelo
   // motor, não por nós. Sob o V8 (Node na suite, Chrome/Edge no navegador) ele coincide com o
   // original — verificado por força bruta com 7.000+ arranjos aleatórios, de 2 a 60 itens, com
   // datas repetidas: ZERO divergências. Um teste que "matasse" este mutante estaria fixando o
   // comportamento do motor, não a regra do extrato.
+  //
+  // ⚠️ Até a triagem #214 o `disable` ficava sete linhas ACIMA do alvo — e por isso não fazia
+  // nada: `next-line` é a linha seguinte LITERAL, e a linha seguinte era outro comentário. O
+  // relatório da CI trazia o mutante como `Survived`, não `Ignored`; a supressão que o parágrafo
+  // acima descreve nunca chegou a existir. A directive tem de ENCOSTAR na linha alvo, como em
+  // `features/pagar/baixa.ts`. Por isso ela desceu para dentro do `sort`.
+  //
+  // O outro sobrevivente desta linha, `ConditionalExpression → false`, também é EQUIVALENTE — e
+  // por um motivo mais forte que "o V8 coincide": `false ? 1 : a.date > b.date ? -1 : 0` devolve
+  // 0 onde o original devolve 1, e o `sort` só observa o SINAL do comparador (`< 0` ou não). 1 e
+  // 0 estão na MESMA classe de sinal, então nenhuma implementação de sort consegue separar os
+  // dois programas. Medido: 23.600 arranjos de 2 a 60 itens com datas repetidas, ZERO
+  // divergências. Não leva `disable` porque a directive é por MUTADOR, e desligar
+  // `ConditionalExpression` aqui apagaria junto o mutante `true`, que HOJE morre no teste de
+  // empate.
   return [...entries].sort((a, b) =>
+    // Stryker disable next-line EqualityOperator
     a.date < b.date
       ? 1
       : a.date > b.date

--- a/apps/web/src/features/financeiro/ledger.ts
+++ b/apps/web/src/features/financeiro/ledger.ts
@@ -31,14 +31,29 @@ export function sortDescending(entries: LedgerEntry[]): LedgerEntry[] {
   // ficar em linhas SEPARADAS para que o `disable` abaixo mire só um deles — o `>` continua
   // mutável, e o teste de empate abaixo o mata.
   //
-  // Stryker disable next-line EqualityOperator
   // Trocar `<` por `<=` faz o comparador devolver 1 para itens de MESMA data, o que viola o
   // contrato de antissimetria do `Array.prototype.sort`: o resultado passa a ser definido pelo
   // motor, não por nós. Sob o V8 (Node na suite, Chrome/Edge no navegador) ele coincide com o
   // original — verificado por força bruta com 7.000+ arranjos aleatórios, de 2 a 60 itens, com
   // datas repetidas: ZERO divergências. Um teste que "matasse" este mutante estaria fixando o
   // comportamento do motor, não a regra do extrato.
+  //
+  // ⚠️ Até a triagem #214 o `disable` ficava sete linhas ACIMA do alvo — e por isso não fazia
+  // nada: `next-line` é a linha seguinte LITERAL, e a linha seguinte era outro comentário. O
+  // relatório da CI trazia o mutante como `Survived`, não `Ignored`; a supressão que o parágrafo
+  // acima descreve nunca chegou a existir. A directive tem de ENCOSTAR na linha alvo, como em
+  // `features/pagar/baixa.ts`. Por isso ela desceu para dentro do `sort`.
+  //
+  // O outro sobrevivente desta linha, `ConditionalExpression → false`, também é EQUIVALENTE — e
+  // por um motivo mais forte que "o V8 coincide": `false ? 1 : a.date > b.date ? -1 : 0` devolve
+  // 0 onde o original devolve 1, e o `sort` só observa o SINAL do comparador (`< 0` ou não). 1 e
+  // 0 estão na MESMA classe de sinal, então nenhuma implementação de sort consegue separar os
+  // dois programas. Medido: 23.600 arranjos de 2 a 60 itens com datas repetidas, ZERO
+  // divergências. Não leva `disable` porque a directive é por MUTADOR, e desligar
+  // `ConditionalExpression` aqui apagaria junto o mutante `true`, que HOJE morre no teste de
+  // empate.
   return [...entries].sort((a, b) =>
+    // Stryker disable next-line EqualityOperator
     a.date < b.date
       ? 1
       : a.date > b.date

--- a/apps/web/src/features/financeiro/periodRange.test.ts
+++ b/apps/web/src/features/financeiro/periodRange.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { monthKeyToRange, resolvePeriod } from "./periodRange";
+import {
+  monthKeyToRange,
+  PERIOD_SHORTCUT_LABEL,
+  type PeriodShortcut,
+  resolvePeriod,
+} from "./periodRange";
 
 const TODAY = new Date(Date.UTC(2026, 6, 21)); // 21/07/2026 (mês = 6 = julho, 0-indexed)
 
@@ -67,5 +72,29 @@ describe("monthKeyToRange", () => {
 
   it("respeita ano bissexto (fevereiro com 29 dias)", () => {
     expect(monthKeyToRange("2028-02")).toEqual({ start: "2028-02-01", end: "2028-02-29" });
+  });
+});
+
+describe("PERIOD_SHORTCUT_LABEL", () => {
+  it("tem entrada para TODO atalho do seletor", () => {
+    // Achado por mutação (#214): trocar o objeto inteiro por `{}` sobrevivia. Este mapa é lido
+    // direto no `<option>` do `PeriodPicker`; sem entrada, o seletor de período de TODA a área
+    // financeira (DRE, Lucratividade, Conferência, Contas) vira sete linhas em branco. O
+    // `PeriodPicker.test.tsx` não pega — ele dirige o `<select>` por `value`, nunca pelo texto —
+    // e a corrida de mutação exclui `.test.tsx` de propósito, então não havia rede nenhuma.
+    //
+    // A asserção é sobre a ESTRUTURA (existe rótulo para cada atalho), não sobre a redação: o
+    // texto de cada rótulo é escolha de produto e continua livre para mudar.
+    const atalhos: PeriodShortcut[] = [
+      "this_month",
+      "last_month",
+      "this_quarter",
+      "this_year",
+      "last_12_months",
+      "all",
+      "custom",
+    ];
+
+    expect(Object.keys(PERIOD_SHORTCUT_LABEL).sort()).toEqual([...atalhos].sort());
   });
 });

--- a/apps/web/src/features/financeiro/planoContas.test.ts
+++ b/apps/web/src/features/financeiro/planoContas.test.ts
@@ -38,6 +38,18 @@ describe("buildHierarchy (plano de contas — Story 5.1)", () => {
     expect(despesa.categorias.map((c) => c.categoria)).toEqual(["Aluguel"]);
   });
 
+  it("ignora grupo desconhecido em vez de estourar", () => {
+    // Achado por mutação (#214): fixar `byGroup.has(...)` em `true` sobrevivia porque nenhum
+    // teste mandava um grupo fora do enum. O `!` da linha seguinte é uma promessa ao TypeScript,
+    // não uma checagem em runtime: sem a guarda, `byGroup.get(desconhecido)` é `undefined` e o
+    // `.push` derruba a PlanoContasPage inteira — a defesa que o comentário do código promete
+    // ("o backend é a fonte da verdade") não estava provada.
+    const desconhecido = { ...acc({ categoria: "Nova" }), grupo_dre: "GRUPO_NOVO_NO_BACKEND" as never };
+    const groups = buildHierarchy([desconhecido, acc({ grupo_dre: "TRIBUTOS", categoria: "ISS" })]);
+    expect(groups.map((g) => g.grupo_dre)).toEqual([...GRUPOS_DRE]);
+    expect(groups.flatMap((g) => g.categorias.map((c) => c.categoria))).toEqual(["ISS"]);
+  });
+
   it("expõe rótulos PT-BR por grupo", () => {
     const groups = buildHierarchy([]);
     const financeiro = groups.find((g) => g.grupo_dre === "FINANCEIRO")!;

--- a/apps/web/src/lib/shareInbox.test.ts
+++ b/apps/web/src/lib/shareInbox.test.ts
@@ -5,6 +5,7 @@
 // bug do shareInbox.ts. Sob "node", `File` é o global nativo, que clona corretamente
 // (confirmado manualmente: `structuredClone(new File(...))` preserva name/type/conteúdo).
 // @vitest-environment node
+import { readFileSync } from "node:fs";
 import "fake-indexeddb/auto";
 import { describe, expect, it } from "vitest";
 import { SHARE_DB_NAME, SHARE_STORE, takeSharedFile } from "./shareInbox";
@@ -41,5 +42,250 @@ describe("shareInbox", () => {
 
   it("devolve null para chave inexistente em vez de lançar", async () => {
     expect(await takeSharedFile("nao-existe")).toBeNull();
+  });
+});
+
+/**
+ * Um limite de tempo, para separar "resolveu/rejeitou" de "PENDUROU".
+ *
+ * Achado por mutação (#214): três handlers deste arquivo (`onerror` do open, `onerror` do get,
+ * `onerror` da transação de apagar) existem só para TERMINAR a promessa. Esvaziar qualquer um
+ * deles não produz erro nenhum — produz uma promessa que nunca assenta, e a rota `/compartilhar`
+ * gira para sempre com o comprovante do dono dentro. Um `rejects.toThrow()` sozinho não pega
+ * isso: ele espera para sempre junto. O limite é o que transforma "pendurou" em asserção.
+ */
+const PENDUROU = Symbol("pendurou");
+function comLimite<T>(p: Promise<T>, ms = 500): Promise<T | typeof PENDUROU> {
+  let t: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    p.finally(() => clearTimeout(t)),
+    new Promise<typeof PENDUROU>((r) => {
+      t = setTimeout(() => r(PENDUROU), ms);
+    }),
+  ]);
+}
+
+type Fase = "open" | "get" | "delete";
+type Handler = ((e: unknown) => void) | undefined;
+
+/**
+ * Um `indexedDB` de mentira que falha numa fase escolhida. O `fake-indexeddb` implementa o
+ * caminho FELIZ com fidelidade, mas não oferece gatilho para forçar `onerror` — e é justamente o
+ * caminho de erro que não tinha prova nenhuma.
+ */
+function indexedDbQueFalhaEm(fase: Fase, arquivo: File): IDBFactory {
+  const dispararDepois = (alvo: Record<string, unknown>, nome: string) => {
+    setTimeout(() => (alvo[nome] as Handler)?.({}), 0);
+  };
+  return {
+    open() {
+      const req: Record<string, unknown> = {
+        result: null,
+        error: new Error("falha simulada em " + fase),
+      };
+      setTimeout(() => {
+        if (fase === "open") {
+          dispararDepois(req, "onerror");
+          return;
+        }
+        req.result = {
+          close: () => {},
+          transaction: (_lojas: string, modo: string) => {
+            const tx: Record<string, unknown> = {
+              objectStore: () => ({
+                get: () => {
+                  const r: Record<string, unknown> = {
+                    result: undefined,
+                    error: new Error("falha simulada no get"),
+                  };
+                  setTimeout(() => {
+                    if (fase === "get") {
+                      (r.onerror as Handler)?.({});
+                      return;
+                    }
+                    r.result = arquivo;
+                    (r.onsuccess as Handler)?.({});
+                  }, 0);
+                  return r;
+                },
+                delete: () => {},
+              }),
+            };
+            if (modo === "readwrite") {
+              dispararDepois(tx, fase === "delete" ? "onerror" : "oncomplete");
+            }
+            return tx;
+          },
+        };
+        (req.onsuccess as Handler)?.({});
+      }, 0);
+      return req;
+    },
+  } as unknown as IDBFactory;
+}
+
+async function comIndexedDbFalho<T>(fase: Fase, arquivo: File, fn: () => Promise<T>): Promise<T> {
+  const real = globalThis.indexedDB;
+  globalThis.indexedDB = indexedDbQueFalhaEm(fase, arquivo);
+  try {
+    return await fn();
+  } finally {
+    globalThis.indexedDB = real;
+  }
+}
+
+/**
+ * Um `indexedDB` de mentira em que o banco AINDA NÃO EXISTE: o `open` dispara
+ * `onupgradeneeded` antes do `onsuccess`, e a transação só funciona se o store tiver sido
+ * criado ali. É de mentira, e não um `deleteDatabase` no `fake-indexeddb` real, porque um
+ * `deleteDatabase` bloqueado por conexão vazada fica ENFILEIRADO e trava todo `open` seguinte
+ * do arquivo — o que trocaria a asserção deste teste por um `Test timed out` de 15s em todos.
+ */
+function indexedDbComBancoNovo(): IDBFactory {
+  return {
+    open() {
+      const req: Record<string, unknown> = { result: null, error: null };
+      let temStore = false;
+      setTimeout(() => {
+        req.result = {
+          createObjectStore: (nome: string) => {
+            temStore = nome === SHARE_STORE;
+          },
+          close: () => {},
+          transaction: (lojas: string) => {
+            if (!temStore) {
+              throw new DOMException(`No objectStore named ${lojas}`, "NotFoundError");
+            }
+            return {
+              objectStore: () => ({
+                get: () => {
+                  const r: Record<string, unknown> = { result: undefined };
+                  setTimeout(() => (r.onsuccess as Handler)?.({}), 0);
+                  return r;
+                },
+              }),
+            };
+          },
+        };
+        (req.onupgradeneeded as Handler)?.({});
+        (req.onsuccess as Handler)?.({});
+      }, 0);
+      return req;
+    },
+  } as unknown as IDBFactory;
+}
+
+describe("shareInbox — os caminhos que só a mutação cobrava (#214)", () => {
+  it("cria o object store quando o banco ainda NÃO existe", async () => {
+    // Esvaziar o `onupgradeneeded` do `openDb` sobrevivia porque o `seed()` acima (que imita o
+    // service worker) cria o store ANTES, e aí `openDb` só encontra banco pronto. Na vida real a
+    // ordem pode ser a inversa — o app abre /compartilhar num navegador onde o SW ainda não
+    // gravou nada — e sem o store a leitura estoura NotFoundError em vez de devolver `null`.
+    const real = globalThis.indexedDB;
+    globalThis.indexedDB = indexedDbComBancoNovo();
+    try {
+      await expect(comLimite(takeSharedFile("qualquer"))).resolves.toBeNull();
+    } finally {
+      globalThis.indexedDB = real;
+    }
+  });
+
+  it("o banco que não ABRE vira null — e não uma promessa pendurada", async () => {
+    const r = await comIndexedDbFalho("open", new File([""], "n.pdf"), () =>
+      comLimite(takeSharedFile("k")),
+    );
+
+    expect(r).toBeNull();
+  });
+
+  it("a LEITURA que falha rejeita — e não uma promessa pendurada", async () => {
+    const r = await comIndexedDbFalho("get", new File([""], "n.pdf"), () =>
+      comLimite(
+        takeSharedFile("k")
+          .then(() => "resolveu" as const)
+          .catch(() => "rejeitou" as const),
+      ),
+    );
+
+    expect(r).toBe("rejeitou");
+  });
+
+  it("apagar é best-effort: a transação que FALHA ainda entrega o arquivo", async () => {
+    // A produção promete, em comentário, "apagar é best-effort; o arquivo já foi entregue". Sem
+    // este teste, esvaziar o `tx.onerror` transformava a promessa da ENTREGA numa que nunca
+    // assenta: o dono perde o comprovante em vez de perder só a limpeza da chave.
+    const arquivo = new File(["c"], "comprovante.pdf", { type: "application/pdf" });
+
+    const r = await comIndexedDbFalho("delete", arquivo, () => comLimite(takeSharedFile("k")));
+
+    expect(r).not.toBe(PENDUROU);
+    expect((r as File | null)?.name).toBe("comprovante.pdf");
+  });
+
+  it("chave inexistente NÃO abre transação de escrita", async () => {
+    // Fixar `if (file)` em `true` devolve o mesmo `null`, porque apagar chave que não existe é um
+    // no-op silencioso. O que muda é o MODO da transação: toda leitura vazia passaria a tomar o
+    // lock de escrita do store. E leitura vazia é o caso COMUM — é o que acontece a cada
+    // recarregar/voltar em /compartilhar.
+    const modos: string[] = [];
+    const original = IDBDatabase.prototype.transaction;
+    IDBDatabase.prototype.transaction = function (
+      this: IDBDatabase,
+      lojas: string | string[],
+      modo?: IDBTransactionMode,
+    ) {
+      modos.push(modo ?? "readonly");
+      return original.call(this, lojas, modo);
+    };
+    try {
+      await seed("k-modo", new File(["x"], "x.pdf"));
+      modos.length = 0;
+      expect(await takeSharedFile("nao-existe-mesmo")).toBeNull();
+    } finally {
+      IDBDatabase.prototype.transaction = original;
+    }
+
+    expect(modos).toEqual(["readonly"]);
+  });
+
+  // ÚLTIMO do arquivo de propósito: é o único que deixa o banco APAGADO, e sob o mutante que
+  // vaza a conexão ele deixa um `deleteDatabase` pendurado para sempre.
+  it("FECHA a conexão: a conexão vazada trava a próxima migração do banco", async () => {
+    // Apagar o `finally { db.close() }` (ou só a chamada dentro dele) não quebra nada visível — a
+    // leitura devolve o arquivo do mesmo jeito. O que vaza é a CONEXÃO, e conexão aberta bloqueia
+    // qualquer `versionchange` futuro. Este arquivo e o `sw.js` compartilham o banco de propósito
+    // ("Mantenha DB_NAME/STORE em sincronia"): a primeira migração travaria em `onblocked`.
+    await seed("k-fecha", new File(["x"], "x.pdf", { type: "application/pdf" }));
+    expect(await takeSharedFile("k-fecha")).not.toBeNull();
+
+    const eventos: string[] = [];
+    const apagou = new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase(SHARE_DB_NAME);
+      req.onblocked = () => eventos.push("blocked");
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+
+    const r = await comLimite(apagou);
+
+    expect(eventos).toEqual([]);
+    expect(r).not.toBe(PENDUROU);
+  });
+});
+
+describe("o contrato com o service worker (#214)", () => {
+  it("DB_NAME e STORE são os MESMOS de public/sw.js", () => {
+    // O cabeçalho de `shareInbox.ts` manda: "Mantenha DB_NAME/STORE em sincronia com public/sw.js
+    // — são o mesmo banco". Nada verificava isso. Achado por mutação (#214): zerar qualquer um
+    // dos dois literais sobrevive à suíte INTEIRA, `CompartilharPage.test.tsx` incluído, porque
+    // todo consumidor dentro do `src/` (e o próprio `seed()` deste arquivo) lê a constante
+    // exportada — a mentira é consistente consigo mesma. Quem grava do outro lado é o `sw.js`,
+    // um arquivo fora do `src/` que nenhum teste importa, e ele tem os nomes cravados. Sob a
+    // divergência, o share do Android grava num banco e a rota /compartilhar lê de outro: o
+    // comprovante do dono some sem erro nenhum na tela.
+    const sw = readFileSync(new URL("../../public/sw.js", import.meta.url), "utf8");
+
+    expect(sw).toContain(`const DB_NAME = "${SHARE_DB_NAME}";`);
+    expect(sw).toContain(`const STORE = "${SHARE_STORE}";`);
   });
 });


### PR DESCRIPTION
## Resumo

Os **59 sobreviventes em 11 módulos** que nunca foram triados na #191. **Zero restantes**: 21 mortos
com prova manual, 38 dispensados com razão escrita. Nenhuma fatia ficou de fora.

## O baseline vale, e isso foi verificado

Artefato `mutation-report` da CI (run `32557684625`, `main` @ `2d03320`), cruzado com os 11 módulos
já fechados pelo #206. O resto fecha exatamente o número da issue: **59 sobreviventes, 11 módulos**.

`origin/main` está em `d3a6ee7`. `git log 2d03320..origin/main -- <arquivo>` devolveu **0 commits**
para os 11 fontes **e** para os 11 `.test.ts` irmãos — o baseline anterior ao #206 vale integralmente
para eles.

## Por módulo

| módulo | sobreviventes | de operador | mortos | dispensados | restantes |
|---|---|---|---|---|---|
| `lib/shareInbox.ts` | 9 | 7 | **9** | 0 | 0 |
| `financeiro/contratoDre.ts` | 3 | 3 | **3** | 0 | 0 |
| `financeiro/diagnostico.ts` | 14 | 2 | **4** | 10 | 0 |
| `agenda/grade.ts` | 8 | 4 | **2** | 6 | 0 |
| `financeiro/periodRange.ts` | 9 | 1 | **1** | 8 | 0 |
| `financeiro/planoContas.ts` | 5 | 1 | **1** | 4 | 0 |
| `financeiro/dreMatrix.ts` | 1 | 1 | **1** | 0 | 0 |
| `financeiro/ledger.ts` | 2 | 2 | 0 | 2 | 0 |
| `financeiro/dreMatrixEntries.ts` | 2 | 2 | 0 | 2 | 0 |
| `busca/resultado.ts` | 5 | 0 | 0 | 5 | 0 |
| `lib/uploadPublicImage.ts` | 1 | 0 | 0 | 1 | 0 |
| **total** | **59** | **23** | **21** | **38** | **0** |

Ordenado por **tipo de mutador**, não por contagem: dos 23 de operador, 17 mortos e 6 dispensados
como equivalentes provados; dos 36 literais, 4 mortos de carona e 32 dispensados.

## As mortes, provadas à mão

Método em todas: substituição exata do dossiê aplicada na produção pelas coordenadas do
`mutation.json`, `vitest run`, saída lida, restauração por **cópia de arquivo** com
`restaurado idêntico` conferido byte a byte. Amostra:

| mutante | teste que morreu | mensagem real |
|---|---|---|
| `shareInbox.ts:37` ConditionalExpression → `true` | `chave inexistente NÃO abre transação de escrita` | `expected [ 'readonly', 'readwrite' ] to deeply equal [ 'readonly' ]` |
| `shareInbox.ts:18` ArrowFunction → `() => undefined` | `o banco que não ABRE vira null` | `expected Symbol(pendurou) to be null` |
| `contratoDre.ts:48` LogicalOperator → `&&` | `avisa quando o backend diz 'atingível' mas não manda o valor` | `expected 'R$ 0,00' to match /não atingível/i` |
| `planoContas.ts:55` ConditionalExpression → `true` | `ignora grupo desconhecido em vez de estourar` | `TypeError: Cannot read properties of undefined (reading 'push')` |
| `dreMatrix.ts:74` ConditionalExpression → `false` | `é o MODO que decide, não o nome da chave` | `expected [] to deeply equal [ 'INVESTIMENTO', 'SEM_CATEGORIA' ]` |
| `grade.ts:167` ConditionalExpression → `false` | `o compromisso que já TERMINOU em outro dia não ocupa nada` | perdia as faixas 8, 9 e 10 |

Os dois pontos em que o #191 avisou apareceram:

- **`splitGroupsAroundInvestment` usava a chave errada.** O teste de `cost_center` usava
  `cc-a`/`_unassigned`, que o filtro não pegaria de jeito nenhum: saída idêntica com e sem a guarda
  — o mesmo `padding: 0` do `projecao.ts`. O teste novo usa chaves que **colidem** com nomes de
  grupo DRE.
- **`eventsOfDay` com dois eventos não mede ordenação** (ver conflito com a #211, abaixo).

## Os 38 dispensados

**Equivalentes provados numericamente (4).** `grade.ts:240` e `grade.ts:251` são as duas metades do
memo de `Intl.DateTimeFormat`: **526.080 comparações** (10 fusos × 6 anos hora a hora, com todas as
viradas de horário de verão) entre a versão com cache, a sem acerto e a sem gravação — **zero
divergências**. A única diferença é a identidade do objeto, e nem `FORMATADORES` nem `formatadorDe`
são exportados.

`ledger.ts:42` e `dreMatrixEntries.ts:28`, `ConditionalExpression → false`: prova **estrutural**, mais
forte que força bruta. `false ? 1 : a.date > b.date ? -1 : 0` devolve `0` onde o original devolve
`1`, e `Array.prototype.sort` só observa o **sinal**. Mesma classe de sinal nos três casos, então
nenhuma implementação de sort separa os dois programas. Confirmado por 23.600 arranjos.

**Inalcançável (1).** `diagnostico.ts:134`, o `"0"` de `String(lastDay).padStart(2, "0")`. Varridos
1.572 meses (1970–2100): mínimo **28**, máximo 31 — sempre 2 dígitos, o pad nunca dispara.

**Já morto por `.test.tsx` (1).** `resultado.ts:11` `"Clientes"`: sob o mutante,
`BuscaGlobal.test.tsx` falha com `Unable to find an element with the text: Clientes`. Aparece como
sobrevivente só porque `vitest.mutation.config.ts` exclui `.test.tsx` de propósito.

**Redação sem consequência mensurável (30).** Entre elas, 6 classes Tailwind de `diagnostico.ts` —
afirmar string de classe é a família do `toContain("flex-wrap")` que o CLAUDE.md §5.1 proíbe. O que
valeria é medir a `DiagnosticoPage` com a régua de 360px, e ela não está entre as telas medidas.
**Dívida nova, não paga aqui.** E os 4 dias da semana de `grade.ts`, cujo teste diz por extenso que a
asserção que importa é a **posição**, não o rótulo — fixá-los contradiz a intenção documentada.

## A directive de supressão estava quebrada há dois relatórios

`ledger.ts` e `dreMatrixEntries.ts` traziam `// Stryker disable next-line EqualityOperator` **sete
linhas acima do alvo** — e `next-line` é a linha seguinte **literal**, que era outro comentário. A
supressão que o parágrafo descrevia **nunca existiu**.

Prova no baseline da CI: nesses dois arquivos os mutantes aparecem como `Survived` e o campo
`Ignored` do arquivo é **0**; em `baixa.ts:197`, onde a directive encosta na linha, aparecem 6
mutantes `Ignored using a comment`.

A directive desceu para dentro do `sort`. **Mudança só de comentário, provada por parse:**
transpilando as duas versões com `removeComments`, o código emitido é **byte-idêntico** (172 bytes em
`dreMatrixEntries.ts`, 411 em `ledger.ts`).

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 928 testes verdes
```

Diff: 9 arquivos, 383 inserções / 6 remoções — **7 são `.test.ts`**; os 2 de produção são os da
directive acima.

## ⚠️ Conflita com a #211, e a resolução está medida

Os dois PRs fortalecem o **mesmo** teste (`eventsOfDay filtra pelo dia e ORDENA`) pelo **mesmo**
motivo: com dois eventos, o comparador sempre-negativo do #121 sobrevive.

Simulado o merge sequencial numa worktree descartável: conflito em `grade.test.ts`, **e só ali**.
**A resolução é tomar o lado da #211** — a versão dela tem o terceiro elemento **e** está desacoplada
de fuso (`instanteLocal`), enquanto esta reintroduz literais `Z`. Verificado depois de resolver
assim: com as 8 branches mergeadas, `85 arquivos / 999 testes verdes`, e o mutante-alvo deste PR
(`grade.ts:67 UnaryOperator`) **continua morrendo**:

```
× eventsOfDay filtra pelo dia e ORDENA por horário de início
  → expected [ 'meio', 'manha', 'tarde' ] to deeply equal [ 'manha', 'meio', 'tarde' ]
```

## Fora de escopo

- **A directive quebrada é uma classe, não um caso.** Um guard de lint ("`Stryker disable next-line`
  tem de ser a última linha antes de código") impediria a reincidência.
- **O fenômeno do #213, observado ao vivo.** Numa corrida ilustrativa de `ledger.ts`,
  `ledger.ts:17 ObjectLiteral → {}` saiu `Timeout` — no baseline da CI ele estava `Killed`. Máquina
  carregada (9 worktrees) transforma morte-por-asserção em Timeout, que o score conta como morto.
- **Três telas com rótulo PT-BR sem asserção em lugar nenhum:** `DiagnosticoPage`, `PlanoContasPage`,
  `ChartAccountSelect` não têm `.test.tsx`. É de onde vêm 10 dos 32 literais dispensados.

Closes #214
