### PR TITLE
fix(web): 79 campos de digitacao vao a 44px em 16 telas, e a regua passa a medi-los [#215]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,10 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   com outro projeto nas máquinas de dev) e intercepta a API com `page.route` (`e2e/support/api.ts`).
   Sem backend, sem Docker, sem banco: foi por achar que medir custava caro que **seis telas** subiram
   sem medição e **três PRs de correção em campo** foram pagos (#56, #58, #89).
-- **A régua** é `e2e/support/medidas.ts`: `medirPagina`, `alvosPequenos` (mínimo tocável **44px**) e
-  `textoForaDaTela` (o texto que só existe se o dono rolar de lado — o defeito que a Onda 2b-ii achou
-  na primeira medição, `R$ 3.` no lugar de `R$ 3.000,00`).
+- **A régua** é `e2e/support/medidas.ts`: `medirPagina`, `alvosPequenos` (mínimo tocável **44px**),
+  `camposBaixos` (o mesmo mínimo, mas só ALTURA e só no que se DIGITA — ver "Campo de digitação"
+  abaixo) e `textoForaDaTela` (o texto que só existe se o dono rolar de lado — o defeito que a Onda
+  2b-ii achou na primeira medição, `R$ 3.` no lugar de `R$ 3.000,00`).
 - **As fixtures são de PIOR CASO PLAUSÍVEL** (nome longo de banco, valor de 6 dígitos, título de
   grupo comprido), nas formas reais de `packages/shared-types`. Dado curto sempre cabe: medir com ele
   é medir uma tela que não existe.
@@ -95,6 +96,32 @@ certo, e a tela estava errada. **Nenhum teste de `apps/web/e2e/` pode aferir cla
   "Declarar saldo"/"Lançar movimento" (`contas-modais-360`), "Movimentar: {item.name}" do Estoque
   (`estoque-movimentar-360`), "Vender: {product.name}" dos Produtos (`produtos-vender-360`) e
   "Transferir"/"Editar movimento"/"Ignorar movimento" (`contas-movimento-360`).
+- **CAMPO DE DIGITAÇÃO: 44px vêm de `.campos-tocaveis`, não de `className` em cada campo** (#215,
+  desde 2026-08-22). A regra vive em `apps/web/src/styles/index.css` e vale para `<input>` (menos
+  `checkbox`/`radio`/`file`/`color`/`range`), `<select>` e `<textarea>` DENTRO de um contêiner que
+  declare a classe. Quem já a declara: a **caixa do `components/Modal.tsx`** (logo, todo modal do
+  app), o cartão do `auth/LoginPage.tsx`, os **dois modais escritos à mão** do
+  `funis/FunnelBuilderPage.tsx` e o formulário do `juridico/JuridicoWizardPage.tsx`. Alcance
+  auditável em uma linha: `grep -rn "campos-tocaveis" apps/web/src/`.
+  - **Por que não `min-h-11` no `Field`.** O `Field` são **84 usos em 14 telas**, mas ao lado de
+    quase todo `<Field>` há um `<select>` escrito à mão com a MESMA classe (`px-3 py-2 text-sm`) e
+    a mesma altura errada, e existem **3 cópias locais** do componente (`LoginPage.tsx:203`,
+    `FunnelBuilderPage.tsx:736`, `JuridicoWizardPage.tsx:178`) que um conserto no componente não
+    alcança. Consertar só o `Field` pagaria 84 campos e deixaria ~35 em pé **com a aparência de
+    dívida paga** — que é a forma de defeito que a issue existia para evitar.
+  - **Por que OPT-IN e não global.** Medido em 22/08/2026 no catálogo de `e2e/support/rotas.ts`:
+    fora dos formulários há mais **~90** campos abaixo de 44px, e eles moram nos CONSTRUTORES —
+    `/marketing/m1` (30), `/sites/s1` (15), `/marketing/novo` (12), `/orcamentos/novo` (7),
+    `/contratos/novo` (4) —, editores densos de `px-2 py-1.5 text-xs` com **27 a 34px**. Engordá-los
+    junto mudaria cinco telas que nenhuma régua mede por ALTURA, sem ninguém ter olhado o resultado;
+    e uma allowlist para excluí-los seria allowlist sem razão. Dívida aberta, com número.
+  - **Consequência a lembrar:** `<Field>` usado FORA de um `Modal` volta aos 38px. Quem o fizer
+    declara `campos-tocaveis` no contêiner do formulário — e acrescenta o caso à régua.
+  - **A régua** é `apps/web/e2e/campo-modal-360.spec.ts`: abre o modal em **16 telas** e mede
+    `camposBaixos` com o recorte no overlay. Antes do conserto: **79 campos abaixo de 44px** (38px
+    o `<input>` do `Field`, 37–39px os `<select>`, 40px os `date`/`datetime-local`). Cada caso
+    declara **quantos** campos tem: modal que não renderizou campo nenhum devolveria lista vazia e
+    passaria por conserto.
 - ⚠️ **`scrollWidth` NÃO vê o defeito do título — a BORDA vê.** Sem `min-w-0`, o `<h2>` é item de flex
   com `min-width: auto`: ele **cresce** em vez de transbordar. Com o conserto do #119 revertido e
   medido, `scrollWidth === clientWidth` seguia **verde** enquanto a borda direita do título ia a
@@ -619,13 +646,15 @@ duas ações e na **linha inteira** do rótulo do checkbox — nunca engordando 
 viraria um quadrado do tamanho de um botão. Travado por `apps/web/e2e/toque-360.spec.ts`, com
 varredura de `alvosPequenos` no documento inteiro (não só nos três alvos conhecidos).
 
-- **Dívida:** o modal de cadastro/edição desta rota tem **2** alvos abaixo de 44 — o `<input>` do
-  `Field` (**38px**, a dívida GERAL do componente compartilhado, já registrada na Onda 2) e o
-  `<select>` de tipo (**39px**). Fora do escopo do #181, que mede a superfície da PÁGINA.
-- **Dívida:** a varredura filtra `input` por construção — `alvosPequenos` mede o ELEMENTO, e a
-  caixinha do checkbox tem 20×20 por convenção do repo. O custo, medido: tirar o `h-5 w-5` do
-  `<input>` (volta a 13×13) e o `px-1` dos botões são **mutantes equivalentes** — sobrevivem à
-  régua, porque o que ela exige é ÁREA de toque, não quadrado desenhado.
+- ~~**Dívida:** o modal de cadastro/edição desta rota tem **2** alvos abaixo de 44 — o `<input>` do
+  `Field` (**38px**) e o `<select>` de tipo (**39px**).~~ **PAGA no #215** (2026-08-22), e a
+  contagem de 2 era piso: eram **79 campos em 16 telas**. Ver "Campo de digitação" abaixo.
+- **Dívida (estreitada no #215):** a varredura filtrava TODO `input` por construção — `alvosPequenos`
+  mede o ELEMENTO, e a caixinha do checkbox tem 20×20 por convenção do repo. O custo estava escrito
+  no spec ("um campo de TEXTO de 38px passaria por aqui") **e foi cobrado**: os 2 alvos acima eram
+  exatamente isso. `Alvo` passou a carregar `tipo` e o filtro hoje recorta só `checkbox`/`radio`.
+  O que continua sendo mutante equivalente: tirar o `h-5 w-5` do `<input>` (volta a 13×13) e o
+  `px-1` dos botões — a régua exige ÁREA de toque, não quadrado desenhado.
 
 
 ### 5.5 As suítes pesadas não se sobrepõem (issue #162, 2026-08-20)
@@ -1779,10 +1808,10 @@ desde a Onda 0 **sem gatilho nenhum**; esta story é o gatilho.
     `footer`.** Alvo dos rádios e de "Conta principal": 44px na **linha inteira** do rótulo, não no
     círculo. O erro continua no corpo — na barra ele empurraria o botão para fora justamente quando
     o dono mais precisa dele. Travado por `apps/web/e2e/modal-conta-360.spec.ts`.
-  - **Dívida:** os campos de texto do `Field` têm **38px** de altura (mínimo tocável é 44). Não
-    foram engordados aqui porque `Field` é compartilhado por todos os modais do app e a mudança
-    sairia do escopo deste PR — o spec afirma sobre BOTÃO, com o recorte escrito no próprio teste
-    em vez de escondido num filtro.
+  - ~~**Dívida:** os campos de texto do `Field` têm **38px** de altura (mínimo tocável é 44).~~
+    **PAGA no #215** (2026-08-22). A razão de não engordá-los aqui continua boa para o escopo
+    daquele PR; o #215 existiu para pagar a dívida com o alcance declarado. Ver "Campo de
+    digitação" abaixo.
 - **Dívida:** conta `is_known=false` + recuo de data pede um saldo cujo campo está escondido no
   formulário; tem saída (marcar *"sei o saldo"* revela o campo), mas a mensagem de erro pede algo que
   não está visível.
@@ -1869,8 +1898,8 @@ onda já fechada. O único teste que tocava a função afirmava que ela era `cal
 - [x] **O aceite em ~360px do campo de vínculo FOI MEDIDO (2026-08-10) e PASSOU.** Com o 409
   acionável disparado, o modal de rendimento tem **596px numa viewport de 740** — cabe sem rolagem
   interna, "Registrar rendimento" fica visível sem rolar, o seletor de conta renderiza e a largura
-  não passa de 360. Sem conserto necessário. (Os campos de `Field` têm 38px — dívida geral do
-  componente, registrada na 8.21.)
+  não passa de 360. Sem conserto necessário. (Os campos de `Field` tinham 38px — dívida geral do
+  componente, registrada na 8.21 e **paga no #215**.)
 - **Dívida:** ~~a 2b-ii continua com o único backfill do épico, e ele continua sendo o item de
   maior risco.~~ **FECHADA na 2b-ii (2026-08-08): o backfill não foi mitigado, deixou de
   existir.** Ver a seção da Onda 2b-ii, logo abaixo.

--- a/apps/web/e2e/campo-modal-360.spec.ts
+++ b/apps/web/e2e/campo-modal-360.spec.ts
@@ -1,0 +1,257 @@
+import { expect, test, type Page } from "@playwright/test";
+import crmFixtures from "./fixtures/crm.json" with { type: "json" };
+import { mockarApi } from "./support/api";
+import { camposBaixos, medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * O CAMPO DE DIGITAÇÃO em 360×740 — a quarta régua da família, e a primeira que atravessa telas.
+ *
+ * A pergunta é a do `toque-360.spec.ts` ("o alvo tem tamanho de dedo?") feita sobre o que se
+ * DIGITA, e não sobre o que se clica. As três anteriores mediam botão, link e caixinha; o `Field`
+ * de `components/Modal.tsx` nunca entrou em nenhuma delas.
+ *
+ * ⚠️ **Por que uma régua transversal, e não mais um spec por tela.** O `Field` é UM componente
+ * usado por **84 `<Field>` em 14 telas**, e cada `<select>` ao lado dele é escrito à mão com a
+ * mesma classe (`px-3 py-2 text-sm`). Medido contra `origin/main` em 22/08/2026, com o modal
+ * ABERTO, **63 campos em 12 modais** estavam abaixo de 44px:
+ *
+ *   /agenda            Novo evento                    7   input 280×38 · select 183×39 · datetime 198×40
+ *   /crm               Novo cliente                   3   input 280×38 (nome, telefone, tags)
+ *   /cobrancas         Nova cobrança                 10   select 280×37 · input 114×38 · date 158×40
+ *   /estoque           Novo item                      7   input 136×38 · select 280×39
+ *   /financeiro        Registrar venda                6   select 280×39 · input 280×38
+ *   /financeiro/contas Nova conta                     7   input 280×38 · select 280×39 · date 280×40
+ *   .../centros-custo  Novo centro de custo           2   input 280×38 · select 280×39   ← a issue #215
+ *   .../investimentos  Nova conta de investimento     5   input 280×38 · select 280×39
+ *   .../plano-contas   Nova categoria                 2   select 280×39 · input 280×38
+ *   /pagar             Nova conta                     8   input 119×38 · select 136×39
+ *   /produtos          Novo produto                   4   input 280×38 · select 280×39
+ *   /sites             Nova página                    2   input 280×38 · select 280×39
+ *
+ * A issue #215 contava **2** — o `<input>` do `Field` (38px) e o `<select>` de tipo (39px) de
+ * `/financeiro/centros-custo` — e dizia por extenso que era PISO. Era: 2 dos 63.
+ *
+ * ⚠️ **O buraco que deixou isto passar pelo #181, e o que foi feito com ele.** O
+ * `toque-360.spec.ts` filtrava `!descricao.startsWith("input")` para não exigir 44px da CAIXINHA
+ * do checkbox (20×20 por convenção do repo; quem cumpre os 44 é o `<label>` em volta). O filtro
+ * jogava fora, junto, todo campo de TEXTO — e o próprio spec escreveu o custo: "um campo de texto
+ * de 38px acrescentado a esta página passaria por aqui". Duas coisas mudaram: `Alvo` passou a
+ * carregar `tipo`, e lá o filtro agora recorta só `checkbox`/`radio`. Esta régua não depende
+ * daquele filtro: `camposBaixos` tem conjunto próprio (só o que se digita) e mede só ALTURA —
+ * um `<input type="number">` de 80px de largura para quantidade é layout, não defeito.
+ *
+ * ⚠️ **A `marca` não é conveniência.** Um modal que não renderizou campo nenhum devolve lista
+ * vazia e PASSA. Por isso cada caso declara quantos campos de digitação tem, e o total medido é
+ * conferido antes do veredito — foi assim que `/crm` denunciou que o mock de `/crm/board` estava
+ * errado (a tela quebrava em branco e o botão "Novo cliente" nem existia).
+ */
+
+/** O overlay do `components/Modal.tsx`. Recorte obrigatório: a página por trás é de outros specs. */
+const OVERLAY = ".fixed.inset-0.z-50";
+
+interface CasoDeModal {
+  rota: string;
+  /** Rótulo do botão que abre — quase sempre a ação primária desenhada pelo shell. */
+  abrir: string;
+  /** Título do modal. Sem ele, "zero campos baixos" poderia significar "o modal não abriu". */
+  marca: string;
+  /** Campos de digitação que o modal tem. Piso medido, não teto: acrescentar campo não quebra. */
+  campos: number;
+  mocks?: Record<string, unknown>;
+}
+
+const CENTRO = {
+  id: "cc1",
+  tenant_id: "t1",
+  name: "Sócio João",
+  kind: "operacional",
+  archived_at: null,
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+const RELATORIO_CC = { start: "2026-08-01", end: "2026-08-31", buckets: [], notes: [] };
+
+const MODAIS: CasoDeModal[] = [
+  { rota: "/agenda", abrir: "Novo evento", marca: "Novo evento", campos: 7 },
+  // `/crm/board` devolve OBJETO (`{ columns: [] }`). Com o `[]` default de `mockarApi` a tela
+  // quebra antes de montar o cabeçalho e o botão "Novo cliente" não existe — medido.
+  {
+    rota: "/crm",
+    abrir: "Novo cliente",
+    marca: "Novo cliente",
+    campos: 3,
+    mocks: crmFixtures as Record<string, unknown>,
+  },
+  { rota: "/cobrancas", abrir: "Nova cobrança", marca: "Nova cobrança", campos: 10 },
+  { rota: "/estoque", abrir: "Novo item", marca: "Novo item de estoque", campos: 7 },
+  { rota: "/financeiro", abrir: "Registrar venda", marca: "Registrar venda", campos: 6 },
+  { rota: "/financeiro/contas", abrir: "Nova conta", marca: "Nova conta", campos: 7 },
+  {
+    rota: "/financeiro/centros-custo",
+    abrir: "Novo centro de custo",
+    marca: "Novo centro de custo",
+    campos: 2,
+    mocks: { "/cost-centers": [CENTRO], "/financial-intelligence/by-cost-center": RELATORIO_CC },
+  },
+  {
+    rota: "/financeiro/investimentos",
+    abrir: "Nova conta de investimento",
+    marca: "Nova conta de investimento",
+    campos: 5,
+  },
+  { rota: "/financeiro/plano-contas", abrir: "Nova categoria", marca: "Nova categoria", campos: 2 },
+  { rota: "/pagar", abrir: "Nova conta", marca: "Nova conta a pagar", campos: 8 },
+  { rota: "/produtos", abrir: "Novo produto", marca: "Novo produto", campos: 4 },
+  { rota: "/sites", abrir: "Nova página", marca: "Nova página", campos: 2 },
+];
+
+/** O MESMO conjunto de `camposBaixos`, contado. É a `marca` do conteúdo: sem ela, um modal que
+ * não desenhou campo nenhum devolveria lista vazia e passaria por conserto. */
+async function contarCampos(page: Page, raiz: string): Promise<number> {
+  const naoDigitaveis = '[type="hidden"],[type="checkbox"],[type="radio"],[type="file"],[type="color"],[type="range"]';
+  return page
+    .locator(`${raiz} input:not(${naoDigitaveis}), ${raiz} select, ${raiz} textarea`)
+    .count();
+}
+
+for (const caso of MODAIS) {
+  test(`os campos de «${caso.marca}» (${caso.rota}) são tocáveis com o polegar`, async ({
+    page,
+  }) => {
+    // Relógio congelado: `/agenda` abre no mês corrente e o modal de evento nasce com a data de
+    // hoje. Sem isto o teste mede uma tela diferente a cada dia.
+    await page.clock.setFixedTime(new Date("2026-08-18T12:00:00Z"));
+    await semearSessao(page);
+    await mockarApi(page, caso.mocks ?? {});
+    await page.goto(caso.rota);
+
+    await page.getByRole("button", { name: caso.abrir }).first().click();
+    await expect(page.getByRole("heading", { name: caso.marca })).toBeVisible();
+
+    expect(
+      await contarCampos(page, OVERLAY),
+      `${caso.rota}: campos de digitação`,
+    ).toBeGreaterThanOrEqual(caso.campos);
+
+    expect(
+      await camposBaixos(page, OVERLAY),
+      `${caso.rota} — campos abaixo de 44px`,
+    ).toEqual([]);
+
+    // 44px de altura em 7 campos empilhados cresce a caixa: o que as outras réguas garantem
+    // continua garantido depois do conserto.
+    expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+  });
+}
+
+// ── /admin ────────────────────────────────────────────────────────────────────────
+// A tela com MAIS `<Field>` do app (12) e a única atrás de `is_platform_admin`. Ficaria fora de
+// qualquer varredura que só percorresse o catálogo de rotas de `support/rotas.ts`.
+test("os campos de «Nova conta (escritório + dono)» (/admin) são tocáveis com o polegar", async ({
+  page,
+}) => {
+  await semearSessao(page);
+  await page.addInitScript(() => {
+    const u = JSON.parse(localStorage.getItem("e1p_user") ?? "{}");
+    localStorage.setItem("e1p_user", JSON.stringify({ ...u, is_platform_admin: true }));
+  });
+  await mockarApi(page, { "/admin/users": [] });
+  await page.goto("/admin");
+  await page.getByRole("button", { name: "Nova conta" }).first().click();
+  await expect(page.getByRole("heading", { name: "Nova conta (escritório + dono)" })).toBeVisible();
+
+  expect(await contarCampos(page, OVERLAY), "/admin: campos de digitação").toBeGreaterThanOrEqual(6);
+  expect(await camposBaixos(page, OVERLAY), "/admin — campos abaixo de 44px").toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+// ── Os TRÊS CLONES do `Field` ─────────────────────────────────────────────────────
+// Consertar `components/Modal.tsx` NÃO os alcança: cada um tem cópia própria da mesma classe
+// (`px-3 py-2 text-sm`, 38px medidos). Sem estes três casos, "a classe está fechada" seria falso
+// e ninguém saberia — que é exatamente a forma de defeito que esta issue existe para pagar.
+//   auth/LoginPage.tsx:203               5 usos — a PRIMEIRA tela do produto
+//   funis/FunnelBuilderPage.tsx:736      6 usos — modal escrito à mão (`.absolute.inset-0.z-30`)
+//   juridico/JuridicoWizardPage.tsx:178  1 uso  — formulário de página inteira, não modal
+
+test("os campos do LOGIN são tocáveis com o polegar", async ({ page }) => {
+  await mockarApi(page, {});
+  await page.goto("/login");
+  await expect(page.getByRole("button", { name: "Entrar" })).toBeVisible();
+  expect(await contarCampos(page, "form"), "login: campos").toBeGreaterThanOrEqual(2);
+  expect(await camposBaixos(page, "form"), "login — campos abaixo de 44px").toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+const FUNIL_ACAO = {
+  id: "f1",
+  tenant_id: "t1",
+  name: "Funil de teste",
+  nodes: [
+    {
+      id: "n1",
+      type: "default",
+      position: { x: 0, y: 0 },
+      data: { label: "Gerar orçamento", key: "quote", action: "create_quote" },
+    },
+  ],
+  edges: [],
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+test("os campos do executor de nó do FUNIL são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/funnels/components": [
+      { category: "gatilhos", label: "Gatilhos", color: "#123456", items: [] },
+    ],
+    "/funnels/f1": FUNIL_ACAO,
+    "/crm/clients": [{ id: "c1", name: "Cliente Exemplo" }],
+  });
+  await page.goto("/funis/f1");
+  await page.getByText("Gerar orçamento").first().click();
+  // Clique NO ELEMENTO, e não no PONTO dele: em 360px o painel lateral do construtor (`w-60
+  // shrink-0`) cobre a coordenada do botão, e nem `force` resolve — o `mousedown` vai para o
+  // painel. Essa é a dívida de ALCANCE do #144, que tem dono próprio em `alcance-360.spec.ts`.
+  // Aqui a pergunta é a ALTURA dos campos do executor, e um clique bloqueado por outra dívida não
+  // pode impedir esta régua de medi-los.
+  await page
+    .getByRole("button", { name: "Executar ação" })
+    .evaluate((el: HTMLElement) => el.click());
+
+  // O executor é um modal ESCRITO À MÃO — não passa por `components/Modal.tsx`, e por isso o
+  // conserto de lá não chega até aqui sozinho.
+  const CAIXA = ".absolute.inset-0.z-30";
+  await expect(page.locator(CAIXA)).toBeVisible();
+  expect(await contarCampos(page, CAIXA), "funil: campos").toBeGreaterThanOrEqual(3);
+  expect(await camposBaixos(page, CAIXA), "funil — campos abaixo de 44px").toEqual([]);
+});
+
+const PECA = {
+  skill: "peticao",
+  label: "Petição inicial",
+  description: "Peça inicial cível.",
+  steps: [
+    {
+      id: "partes",
+      title: "Partes",
+      description: "Quem está de cada lado.",
+      fields: [
+        { key: "autor", label: "Autor", type: "text", required: true },
+        { key: "reu", label: "Réu", type: "text", required: true },
+        { key: "foro", label: "Foro", type: "select", options: ["Cível", "Trabalhista"] },
+        { key: "fatos", label: "Fatos", type: "textarea" },
+      ],
+    },
+  ],
+};
+
+test("os campos do WIZARD JURÍDICO são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/juridico/skills/peticao": PECA, "/crm/clients": [] });
+  await page.goto("/juridico/novo?skill=peticao");
+  await expect(page.getByRole("heading", { name: "Petição inicial" })).toBeVisible();
+  expect(await contarCampos(page, "main"), "jurídico: campos").toBeGreaterThanOrEqual(4);
+  expect(await camposBaixos(page, "main"), "jurídico — campos abaixo de 44px").toEqual([]);
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});

--- a/apps/web/e2e/modal-conta-360.spec.ts
+++ b/apps/web/e2e/modal-conta-360.spec.ts
@@ -56,11 +56,12 @@ test("a escolha do saldo é tocável com o polegar", async ({ page }) => {
 test("nenhum BOTÃO do modal fica abaixo do mínimo tocável", async ({ page }) => {
   // Escopo no modal: a página por trás é assunto de outros specs.
   //
-  // A asserção é sobre BOTÃO, não sobre todo controle, e o recorte é deliberado: os campos de
-  // texto do `Field` têm 38px de altura e são compartilhados por todos os modais do app —
-  // engordá-los aqui mudaria telas que este PR declara não tocar. O que a dívida mediu como
-  // quebrado foi a ESCOLHA (rádios de 13px, coberta pelo teste acima) e o botão que a efetiva.
-  // Os 38px ficam registrados como dívida no CLAUDE.md, não escondidos num filtro.
+  // A asserção é sobre BOTÃO, não sobre todo controle. O recorte era deliberado e a dívida que o
+  // justificava — "os campos de texto do `Field` têm 38px e engordá-los aqui mudaria telas que
+  // este PR declara não tocar" — foi PAGA pela issue #215: os 7 campos deste modal medem 44px, e
+  // quem os mede é `campo-modal-360.spec.ts`, com o alcance declarado (16 telas). O recorte fica
+  // porque a pergunta deste arquivo continua sendo a do botão; o que mudou é que o resto não
+  // está mais sem dono.
   const pequenos = (await alvosPequenos(page, 44, ".fixed.inset-0.z-50")).filter((a) =>
     a.descricao.startsWith("button"),
   );

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -17,6 +17,14 @@ export interface Medidas {
 
 export interface Alvo {
   descricao: string;
+  /**
+   * `type` do `<input>` — `""` para todo o resto. Existe porque um spec precisa distinguir a
+   * CAIXINHA do checkbox (20×20 por convenção do repo, e o alvo do dedo é o `<label>` em volta)
+   * de um campo de TEXTO pequeno demais. Enquanto não existia, o único recorte possível era
+   * `descricao.startsWith("input")`, que joga os dois fora juntos — e foi por esse buraco que o
+   * `<input>` de 38px do `Field` atravessou o #181 (está escrito no `toque-360.spec.ts`).
+   */
+  tipo: string;
   largura: number;
   altura: number;
 }
@@ -44,6 +52,8 @@ export async function medirPagina(page: Page): Promise<Medidas> {
  */
 interface ControleMedido {
   descricao: string;
+  /** `type` do `<input>`; `""` para `button`, `select`, `a`, `summary` e afins. */
+  tipo: string;
   largura: number;
   altura: number;
   esquerda: number;
@@ -116,6 +126,7 @@ async function medirControles(
         }
         return {
           descricao: descrever(el),
+          tipo: el.tagName === "INPUT" ? ((el as HTMLInputElement).getAttribute("type") ?? "text") : "",
           largura: +r.width.toFixed(1),
           altura: +r.height.toFixed(1),
           esquerda: +r.left.toFixed(1),
@@ -144,7 +155,70 @@ export async function alvosPequenos(page: Page, min = 44, raiz?: string): Promis
   const todos = await medirControles(page, raiz);
   return todos
     .filter((c) => c.altura < min || c.largura < min)
-    .map(({ descricao, largura, altura }) => ({ descricao, largura, altura }));
+    .map(({ descricao, tipo, largura, altura }) => ({ descricao, tipo, largura, altura }));
+}
+
+/** Um campo de digitação medido: só ALTURA, porque é ela que decide se o dedo acerta a linha. */
+export interface Campo {
+  descricao: string;
+  altura: number;
+}
+
+/**
+ * Campos de DIGITAÇÃO abaixo do mínimo tocável — `<input>` de texto, `<select>` e `<textarea>`.
+ *
+ * ⚠️ **Não é `alvosPequenos` com outro nome, e a diferença é o buraco por onde estes campos
+ * passaram.** São duas decisões distintas:
+ *
+ *   - `alvosPequenos` mede ALTURA **e** LARGURA, porque um ícone de 44×16 é tão inatingível
+ *     quanto um de 16×44. Aqui a largura não entra: um `<input type="number">` de `w-20` (80px)
+ *     para quantidade é uma escolha de layout, não um defeito — o que decide se o dedo acerta a
+ *     LINHA certa do formulário é a altura dela.
+ *   - `alvosPequenos` varre todo controle (`button`, `a`, `summary`, `[role]`); aqui o conjunto é
+ *     só o que se DIGITA. `checkbox`, `radio`, `file`, `color` e `range` ficam de fora por
+ *     construção: no repo a caixinha do checkbox tem 20×20 e quem cumpre os 44px é o `<label>`
+ *     em volta (`ContasSaldosPage.tsx:208`), e exigir 44 do quadrado desenhado daria um botão
+ *     onde deve haver um checkbox.
+ *
+ * O nome do campo vem do `<label>` que o envolve quando há um — sem isso o vermelho seria uma
+ * lista de `input.w-full.rounded-lg...` idênticos e ninguém saberia qual dos treze encolheu.
+ *
+ * `raiz` recorta a varredura. **Use sempre ao medir um modal**: sem ele a página por trás entra
+ * na conta. Escopo que não casa cai no documento inteiro — seletor podre tem de virar ruído,
+ * nunca aprovação.
+ */
+export async function camposBaixos(page: Page, raiz?: string, min = 44): Promise<Campo[]> {
+  return page.evaluate(
+    ({ raizSel, minimo }) => {
+      const SEL =
+        'input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"])' +
+        ':not([type="file"]):not([type="color"]):not([type="range"]),select,textarea';
+      const escopo: ParentNode = raizSel
+        ? (document.querySelector(raizSel) ?? document)
+        : document;
+      const visivel = (el: Element): boolean => {
+        const s = getComputedStyle(el);
+        if (s.display === "none" || s.visibility === "hidden" || s.opacity === "0") return false;
+        const r = el.getBoundingClientRect();
+        return r.width > 0 && r.height > 0;
+      };
+      return [...escopo.querySelectorAll(SEL)]
+        .filter(visivel)
+        .map((el) => {
+          const r = el.getBoundingClientRect();
+          const rotulo = (el.closest("label")?.textContent ?? "")
+            .trim()
+            .replace(/\s+/g, " ")
+            .slice(0, 40);
+          const tag =
+            el.tagName.toLowerCase() +
+            (el.tagName === "INPUT" ? `[${el.getAttribute("type") ?? "text"}]` : "");
+          return { descricao: rotulo ? `${tag} «${rotulo}»` : tag, altura: +r.height.toFixed(1) };
+        })
+        .filter((c) => c.altura < minimo);
+    },
+    { raizSel: raiz, minimo: min },
+  );
 }
 
 /** Um controle que o dedo não alcança. `foraPor` e as bordas são px medidos na viewport. */

--- a/apps/web/e2e/toque-360.spec.ts
+++ b/apps/web/e2e/toque-360.spec.ts
@@ -298,19 +298,22 @@ test("as ações do centro de custo são tocáveis com o polegar", async ({ page
   // conhecia. Documento inteiro de propósito: um ícone, um chip, um `summary` ou um controle de
   // filtro acrescentado depois entra na conta sem ninguém precisar lembrar de escrever a linha.
   //
-  // ⚠️ **O `<input>` fica de fora, e o motivo é que `alvosPequenos` mede o ELEMENTO, não a área
-  // que o dedo acerta.** A caixinha do checkbox tem 20×20 DEPOIS do conserto, e continuará tendo:
+  // ⚠️ **`checkbox` e `radio` ficam de fora, e o motivo é que `alvosPequenos` mede o ELEMENTO,
+  // não a área que o dedo acerta.** A caixinha tem 20×20 DEPOIS do conserto, e continuará tendo:
   // quem cumpre os 44px é o `<label>` que a envolve — medido oito linhas acima, e a mesma
   // convenção de `ContasSaldosPage.tsx:208`. Exigir 44 do quadrado desenhado acusaria toda tela
   // que segue o padrão do repo e daria um botão onde deveria haver um checkbox.
   //
-  // O que este filtro CUSTA, dito por extenso em vez de escondido: um campo de TEXTO de 38px
-  // acrescentado a esta página passaria por aqui. É a dívida geral do `Field`, já registrada no
-  // CLAUDE.md e no `modal-conta-360.spec.ts` (o componente é compartilhado por todos os modais do
-  // app), e não é assunto que este PR declare consertar. O modal de cadastro/edição desta rota
-  // também fica fora — ele não está aberto — e tem exatamente esses dois: o `<input>` do `Field`
-  // (38px) e o `<select>` de tipo (39px).
-  const pequenos = (await alvosPequenos(page)).filter((a) => !a.descricao.startsWith("input"));
+  // ⚠️ **O recorte era `!descricao.startsWith("input")` — TODO `<input>` — e o custo estava
+  // escrito aqui: "um campo de TEXTO de 38px acrescentado a esta página passaria por aqui". Ele
+  // passou.** O modal desta mesma rota tinha exatamente dois (`<input>` do `Field` a 38px,
+  // `<select>` de tipo a 39px) e virou a issue #215. `Alvo` passou a carregar `tipo` justamente
+  // para que este filtro pudesse recortar só o que precisa ser recortado: um `<input type="text"`
+  // baixo demais agora reprova AQUI, além de reprovar na régua transversal
+  // (`campo-modal-360.spec.ts`), que mede os campos com o modal ABERTO em 16 telas.
+  const pequenos = (await alvosPequenos(page)).filter(
+    (a) => a.tipo !== "checkbox" && a.tipo !== "radio",
+  );
   expect(pequenos, "alvos abaixo de 44px").toEqual([]);
 
   // O que as outras duas réguas já garantiam continua garantido DEPOIS de os alvos crescerem:

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -43,7 +43,13 @@ export default function Modal({
     >
       <div
         data-testid={testId}
-        className="max-h-[85vh] w-full max-w-md overflow-y-auto rounded-2xl bg-white p-6 shadow-xl"
+        // `campos-tocaveis` (`styles/index.css`): 44px de altura mínima em TODO campo de
+        // digitação desta caixa — o `<input>` do `Field` abaixo e também os `<select>` e
+        // `<input>` que cada tela escreve à mão ao lado dele. Medido em 22/08/2026: eram 38–40px
+        // em 13 modais, 63 campos. É o mínimo do PR #56, onde um alvo pequeno demais fez uma
+        // conta real ser marcada como paga sem o dono ver — num formulário, errar o alvo é
+        // digitar no campo errado. Régua: `e2e/campo-modal-360.spec.ts`.
+        className="campos-tocaveis max-h-[85vh] w-full max-w-md overflow-y-auto rounded-2xl bg-white p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-start justify-between gap-2">
@@ -74,6 +80,22 @@ export default function Modal({
   );
 }
 
+/**
+ * O campo de texto padrão dos modais — 84 usos em 14 telas.
+ *
+ * ⚠️ **A altura NÃO está nesta `className`, e isso é deliberado.** Ela vem da regra
+ * `.campos-tocaveis` (`styles/index.css`), aplicada pela CAIXA do `Modal` acima. A razão é que
+ * este componente nunca foi o problema inteiro: ao lado de quase todo `<Field>` há um `<select>`
+ * escrito à mão com a mesma classe (`px-3 py-2 text-sm`) e a mesma altura errada, e há **três
+ * cópias locais** deste componente que um conserto aqui não alcançaria
+ * (`auth/LoginPage.tsx:203`, `funis/FunnelBuilderPage.tsx:736`,
+ * `juridico/JuridicoWizardPage.tsx:178`). Pôr `min-h-11` aqui consertaria 84 campos e deixaria
+ * outros ~35 em pé, com a aparência de dívida paga.
+ *
+ * Consequência prática: `<Field>` usado FORA de um `Modal` volta aos 38px. Quem o fizer precisa
+ * declarar `campos-tocaveis` no contêiner do formulário — foi o que os três clones acima
+ * receberam, e `e2e/campo-modal-360.spec.ts` mede os três, um a um.
+ */
 export function Field({
   label,
   value,

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -11,7 +11,10 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-primary-500 p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
+      {/* `campos-tocaveis`: esta tela tem CÓPIA PRÓPRIA do `Field` (abaixo, l. ~203) e não passa
+          pelo `components/Modal.tsx` — o conserto de lá não chega até aqui. Medido: e-mail e senha
+          a 38px na PRIMEIRA tela do produto. Ver `styles/index.css`. */}
+      <div className="campos-tocaveis w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
         <div className="mb-6 flex items-center gap-2">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-500 font-bold text-white">
             e1

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -657,7 +657,9 @@ function RunNodeModal({
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/30 p-4" onClick={onClose}>
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-card" onClick={(e) => e.stopPropagation()}>
+      {/* `campos-tocaveis`: modal escrito à MÃO — não passa por `components/Modal.tsx`, e usa a
+          cópia local do `Field` (l. ~736). Medido: 38–39px. Ver `styles/index.css`. */}
+      <div className="campos-tocaveis w-full max-w-md rounded-2xl bg-white p-6 shadow-card" onClick={(e) => e.stopPropagation()}>
         <div className="mb-1 flex items-center gap-2">
           <span className="h-3 w-3 rounded-full" style={{ background: node.data.color }} />
           <h3 className="text-lg font-bold text-neutral-800">{ACTION_TITLE[action] ?? "Executar ação"}</h3>
@@ -826,7 +828,8 @@ function NodeContentEditor({
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-black/30 p-4" onClick={onClose}>
-      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-card" onClick={(e) => e.stopPropagation()}>
+      {/* `campos-tocaveis`: o outro modal escrito à mão desta tela. Mesma razão do de cima. */}
+      <div className="campos-tocaveis w-full max-w-lg rounded-2xl bg-white p-6 shadow-card" onClick={(e) => e.stopPropagation()}>
         <div className="mb-1 flex items-center gap-2">
           <span className="h-3 w-3 rounded-full" style={{ background: node.data.color }} />
           <h3 className="text-lg font-bold text-neutral-800">{title}</h3>

--- a/apps/web/src/features/juridico/JuridicoWizardPage.tsx
+++ b/apps/web/src/features/juridico/JuridicoWizardPage.tsx
@@ -96,7 +96,9 @@ export default function JuridicoWizardPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    // `campos-tocaveis`: terceira cópia do `Field` (l. ~178), em formulário de página inteira —
+    // não é modal, então nada de `components/Modal.tsx` o alcança. Ver `styles/index.css`.
+    <div className="campos-tocaveis mx-auto max-w-2xl space-y-6">
       <button
         onClick={() => navigate("/juridico")}
         className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-800"

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -11,3 +11,43 @@ body {
   background: theme("colors.neutral.50");
   color: theme("colors.neutral.800");
 }
+
+/**
+ * ALVO TOCÁVEL DE CAMPO — 44px de altura mínima para o que se DIGITA.
+ *
+ * O mínimo é o do PR #56, cuja consequência medida foi uma conta real marcada como paga sem o
+ * dono ver: num formulário, errar o alvo é digitar no campo errado.
+ *
+ * ⚠️ **Por que uma regra de CSS, e não `min-h-11` em cada `className`.** O `Field` de
+ * `components/Modal.tsx` é usado por **84 `<Field>` em 14 telas**, e ao lado de cada um há um
+ * `<select>` escrito à mão com a MESMA classe (`px-3 py-2 text-sm`, 38–39px medidos). Consertar
+ * só o `Field` deixaria todos os `<select>` em 39px — e ainda por cima não alcançaria as **3
+ * cópias locais** do `Field` (`auth/LoginPage.tsx:203`, `funis/FunnelBuilderPage.tsx:736`,
+ * `juridico/JuridicoWizardPage.tsx:178`). Medido em 22/08/2026 contra `origin/main`: **79 campos
+ * abaixo de 44px em 16 telas**, dos quais só 2 estavam na issue. Uma regra num lugar só fecha a
+ * classe inteira; 14 arquivos editados fechariam a metade que alguém lembrasse de editar.
+ *
+ * ⚠️ **Por que OPT-IN (uma classe de escopo) e não global.** Medido no mesmo dia, com a varredura
+ * do catálogo de `e2e/support/rotas.ts`: fora dos formulários há mais **~90** campos abaixo de
+ * 44px, e eles vivem nos CONSTRUTORES — `/marketing/m1` (30), `/sites/s1` (15), `/marketing/novo`
+ * (12), `/orcamentos/novo` (7), `/contratos/novo` (4) —, editores densos de `px-2 py-1.5 text-xs`
+ * com 27 a 34px. Engordá-los junto mudaria cinco telas que nenhuma régua deste repo mede por
+ * altura, sem ninguém ter olhado o resultado. Uma allowlist para excluí-los seria allowlist sem
+ * razão, que é exatamente como uma régua vira enfeite. O alcance fica declarado e auditável:
+ * `grep -rn "campos-tocaveis" src/` diz, numa linha, todas as telas que esta regra alcança.
+ *
+ * `checkbox`, `radio`, `file`, `color` e `range` ficam de fora por construção: no repo a caixinha
+ * do checkbox tem 20×20 e quem cumpre os 44px é o `<label>` em volta
+ * (`ContasSaldosPage.tsx:208`) — exigir 44 do quadrado desenhado daria um botão onde deve haver
+ * um checkbox.
+ *
+ * Medido por `e2e/campo-modal-360.spec.ts`, em 16 telas.
+ */
+@layer components {
+  .campos-tocaveis
+    input:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="color"]):not([type="range"]),
+  .campos-tocaveis select,
+  .campos-tocaveis textarea {
+    min-height: 2.75rem; /* 44px */
+  }
+}


### PR DESCRIPTION
## Resumo

A dívida de alvo tocável do `Field` era de **todo modal do produto**, e a contagem da issue era piso
por larga margem: **2 alvos numa rota** viraram **79 campos em 16 telas**, medidos com
`boundingBox()` em 360×740. Todos vão a 44px.

## A medição, e o que ela mudou

| Fonte | Alvos < 44px | Telas |
|---|---|---|
| Issue #215 | **2** | 1 |
| **Medido, com o modal ABERTO** | **79** | **16** |

O que a contagem inicial subestimava: **o `<select>` não é local a uma tela.** Ao lado de quase todo
`<Field>` há um `<select>` escrito à mão com a mesma classe. Repartição:

```
/agenda            Novo evento                  7   38 · 39 · 40
/crm               Novo cliente                 3   38 38 38
/cobrancas         Nova cobrança               10   37 · 38 · 39 · 40
/estoque           Novo item                    7   38x6 · 39
/financeiro        Registrar venda              6   39x4 · 38x2
/financeiro/contas Nova conta                   7   38x5 · 39 · 40
.../centros-custo  Novo centro de custo         2   38 · 39      <- os 2 da issue
.../investimentos  Nova conta de investimento   5
.../plano-contas   Nova categoria               2
/pagar             Nova conta a pagar           8
/produtos          Novo produto                 4
/sites             Nova página                  2
/admin             Nova conta (escritório+dono) 7   <- a tela com MAIS Field (12)
/login             (clone)                      2
/funis/f1          executor de nó (clone)       3
/juridico/novo     wizard (clone)               4
                                              ---
                                               79
```

## Os 3 clones locais: consertados, os três

`components/Modal.tsx:77` não é o único `Field`. Há **3 clones locais** —
`auth/LoginPage.tsx:203`, `funis/FunnelBuilderPage.tsx:736`, `juridico/JuridicoWizardPage.tsx:178` —
que um conserto em `Modal.tsx` **não alcança**. Deixá-los fora seria dizer "a classe está fechada"
com ~11 campos em pé. Cada um recebeu a classe de escopo e **cada um tem caso próprio na régua**, com
mutação própria. Os 2 modais do `FunnelBuilderPage` são escritos à mão (`.absolute.inset-0.z-30`) —
são modais do produto, só não passam por `components/Modal.tsx`.

## O buraco do `alvosPequenos`: corrigido, não contornado

Ele não estava no helper — estava no filtro do spec:
`.filter(a => !a.descricao.startsWith("input"))`, que joga fora a caixinha do checkbox **e todo campo
de texto junto**. É exatamente onde estes alvos moravam. `Alvo`/`ControleMedido` passaram a carregar
`tipo`, e o filtro do `toque-360.spec.ts` recorta agora só `checkbox`/`radio`.

A régua nova **não depende dele**: `camposBaixos()` tem conjunto próprio (só o que se digita) e mede
**só altura** — um `input[type=number]` de `w-20` é layout, não defeito, e `alvosPequenos` o acusaria
por largura.

## A saída VERMELHA, antes do conserto

`E2E_PORT=5335 pnpm exec playwright test campo-modal-360` → **16 failed**:

```
7) os campos de «Novo centro de custo» (/financeiro/centros-custo)      <- os 2 da issue
   Error: /financeiro/centros-custo — campos abaixo de 44px
   + { "altura": 38, "descricao": "input[text] «Nome»" }
   + { "altura": 39, "descricao": "select «TipoSócioÁreaUnidadeOutro»" }

14) login — campos abaixo de 44px
   + { "altura": 38, "descricao": "input[email] «E-mail»" }
   + { "altura": 38, "descricao": "input[password] «Senha»" }
```

## Mutação

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| `campos-tocaveis` fora de `Modal.tsx` | 13 casos (12 modais + /admin) | `{38, "input[text] «Nome»"}`, `{39, "select «TipoSócio…»"}`. **LOGIN sobreviveu** — hospedeiro independente, como projetado |
| `campos-tocaveis` fora do `LoginPage` | LOGIN | `{38, "input[email] «E-mail»"}`, `{38, "input[password] «Senha»"}` |
| `campos-tocaveis` fora do modal do funil | FUNIL | `{37, "select «ClienteSelecione um cliente…»"}`, `{38, input[text]}x2` |
| `campos-tocaveis` fora do `JuridicoWizardPage` | JURÍDICO | `{38, input[text]}x2`, `{39, select}x2` |
| **`min-height: 2.75rem` → `2.6875rem` (43px)** | centros-custo + LOGIN | `{ "altura": 43, "descricao": "input[text] «Nome»" }` — **1px é pego** |
| input de 38px plantado fora do modal | `toque-360` "as ações do centro de custo" | `{altura: 38, largura: 312, tipo: "text", …}` |
| **mesmo input, com o filtro ANTIGO restaurado** | *nenhum* — `1 passed` | prova de que o buraco era real e está fechado |
| `Field` removido + `select` escondido do modal | centros-custo | `Expected: >= 2 / Received: 1` — a marca impede "modal vazio passa verde" |

A mutação de 43px é a que separa régua de enfeite: ela mede, não afirma classe.

Mutante equivalente documentado (herdado do #181): tirar `h-5 w-5` do checkbox e o `px-1` dos botões
— a régua exige área de toque, não quadrado desenhado.

## O conserto é opt-in por classe de escopo, e a razão é medida

`.campos-tocaveis` em `styles/index.css`, não `min-h-11` no `Field` e não regra global. Fora dos
formulários há **mais ~90 campos abaixo de 44px**, todos nos construtores densos, e uma regra global
mudaria 5 telas que nenhuma régua deste repo mede por altura:

```
/marketing/m1  30 campos (27–34px) · /sites/s1  15 · /marketing/novo  12
/orcamentos/novo 7 (38px, mesma classe do Field) · /contratos/novo 4 · outros 8
```

`grep -rn "campos-tocaveis" src/` diz, numa linha, todas as telas que a regra alcança.

## Gates

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 76 arquivos / 915 testes verdes
playwright test (SUÍTE INTEIRA)  → 194 passed (4.2m)
as 5 specs de 360px juntas       → 89 passed (3.5m)
```

Nenhuma foi empurrada pelo engordamento — inclusive `modal-conta-360`, cujo "Cadastrar conta"
continua `toBeInViewport` com os 7 campos 6px mais altos (a barra `sticky` do rodapé é o que segura).

## Fora de escopo, não consertado

- **~90 campos** nos construtores densos, tabulados acima → issue nova
- **`/agenda`, modal "Novo evento": checkbox "Dia inteiro" com 13×13** e sem `min-h-[44px]` na linha
  do label — é a forma literal do PR #56
- **`/financeiro/plano-contas` e `/sites/s1`: checkbox 13×13** sem o `h-5 w-5` da convenção do repo
- **`/funis/f1` em 360px: o painel lateral `w-60 shrink-0` cobre o botão "Executar ação"** — nem
  `click({force:true})` chega. É dívida de ALCANCE (classe do #144), e `alcance-360` está verde
  nessa rota: há fresta lá

Closes #215
