### PR TITLE
test(api): a suite Python declara que NAO depende do fuso do processo, e passa a cobrar o TZ [#210]

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -3,8 +3,12 @@
 Nota: RLS é específica do Postgres e NÃO é exercida aqui — é validada em ambiente com Postgres
 (ver docs/AWS-DEPLOYMENT.md). Estes testes cobrem a lógica de auth/serviço/rotas.
 """
+import os
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,6 +21,117 @@ from app.core.tenancy import get_tenant_db
 from app.db.registry import Base
 from app.db.session import get_db, get_tenant_session_factory
 from app.main import app
+
+
+# -- GUARDA DE FUSO: o `TZ` DECLARADO vs. o fuso EFETIVO do processo (issue #210) --------------
+#
+# Irmao do guarda de `apps/web/src/test-setup.ts` (#169/PR #172), pelo mesmo motivo e com a
+# assercao INVERTIDA -- porque a medicao aqui deu outro resultado.
+#
+# O front EXIGE `America/Sao_Paulo`: os testes dele leem o relogio da maquina. Esta suite nao
+# exige fuso nenhum, e isso foi MEDIDO, nao suposto: em 22/08/2026 a suite rodou tres vezes com
+# o relogio do processo em UTC-3, UTC e UTC+9 -- no ultimo o dia LOCAL ja era 23/08 enquanto o
+# UTC ainda era 22/08, que e justamente a discordancia que o #185 mostrou ser necessaria. Os
+# tres deram `2200 passed, 1 skipped`. O codigo deriva data de `hoje_do_tenant()`, que e
+# `datetime.now(UTC)` + `ZoneInfo` do tenant (#78, migration 0073): o fuso do PROCESSO nao e
+# entrada de nada.
+#
+# Por isso aqui NAO se fixa `TZ` (seria o "os dois por reflexo" que a #210 proibe) e nao se
+# exige fuso. O que este guarda cobra e so que o `TZ` declarado NAO MINTA.
+#
+# /!\ E ele existe porque a mentira e REAL e silenciosa. No Windows o CPython nao tem
+# `time.tzset()`, e quem le `TZ` e a CRT da Microsoft, que NAO entende nome IANA -- ela le o
+# formato POSIX (`UTC0`, `JST-9`, `BRT3`). Diante de um nome IANA ela nao falha: ela ADIVINHA.
+# Medido nesta maquina em 22/08/2026, com o mesmo interpretador que roda a suite:
+#
+#     TZ="America/Sao_Paulo"  -> offset efetivo +01:00   (e nao -03:00)
+#     TZ="Asia/Tokyo"         -> offset efetivo +01:00   (e nao +09:00)
+#
+# Ou seja: quem copiar para os jobs Python o `TZ: America/Sao_Paulo` que o #184 pos no job
+# `frontend` ganha, na maquina de quem desenvolve, um TERCEIRO fuso -- nem o do Brasil nem o do
+# CI. E quem seguir ao pe da letra a receita da propria #210 (`TZ=Asia/Tokyo`, "fuso de sinal
+# oposto") mede UTC+1 achando que mede UTC+9: varredura que nao separa nada e devolve
+# "0 quebras" com cara de aprovacao. Este bloco faz esse sintoma dizer o proprio nome.
+#
+# /!\ Ele e um DETECTOR, nao uma prova. Um nome IANA cujo palpite da CRT por acaso coincida com
+# o offset certo passa batido (`Europe/Lisbon` hoje e um desses: +01:00 dos dois lados). Serve
+# para o caso que doi -- o palpite DIVERGIR e ninguem notar.
+def _offset_legivel(offset: timedelta | None) -> str:
+    """`-03:00` em vez de `-1 day, 21:00:00`, que e como o `timedelta` negativo se imprime.
+
+    Nao e enfeite: a mensagem inteira existe para ser LIDA sob pressao, e um offset do Brasil
+    escrito como "menos um dia mais 21 horas" e exatamente o tipo de ruido que faz quem le
+    desistir e ir procurar o defeito no lugar errado.
+    """
+    if offset is None:
+        return "desconhecido"
+    total = int(offset.total_seconds())
+    horas, minutos = divmod(abs(total) // 60, 60)
+    return f"{'-' if total < 0 else '+'}{horas:02d}:{minutos:02d}"
+
+
+def _incoerencia_de_fuso(
+    declarado: str | None, offset_efetivo: timedelta | None, agora: datetime
+) -> str | None:
+    """A regra, PURA e com o relogio INJETADO -- devolve a mensagem, ou None se nada a cobrar.
+
+    Pura pelo mesmo motivo de `core.scheduling.status_por_data`: no Windows um teste nao consegue
+    mudar o fuso EFETIVO do proprio processo (nao ha `time.tzset()`), entao um guarda que so
+    lesse o ambiente seria um guarda que ninguem consegue provar que dispara.
+    """
+    if not declarado:
+        return None  # sem `TZ` nao ha promessa a conferir -- e o caso do CI, que roda em UTC
+    try:
+        zona = ZoneInfo(declarado)
+    except (ZoneInfoNotFoundError, ValueError):
+        # `TZ` em formato POSIX (`UTC0`, `JST-9`). A CRT honra, o `zoneinfo` nao decifra, e
+        # inventar um parser de POSIX TZ aqui seria trocar um detector por uma segunda fonte de
+        # erro. Sem base de comparacao, nada a cobrar.
+        return None
+    offset_declarado = zona.utcoffset(agora)
+    if offset_efetivo == offset_declarado:
+        return None
+    return "\n".join(
+        [
+            f'FUSO DECLARADO QUE O PROCESSO NAO HONRA: TZ="{declarado}" promete o offset',
+            f"{_offset_legivel(offset_declarado)}, e o relogio EFETIVO deste processo esta em "
+            f"{_offset_legivel(offset_efetivo)}.",
+            "",
+            "Nao e bug de data, de agenda nem de `hoje_do_tenant()`: e o AMBIENTE.",
+            "",
+            f"  os.environ['TZ'] ........ {declarado!r}",
+            f"  offset que TZ promete ... {_offset_legivel(offset_declarado)}",
+            f"  offset EFETIVO .......... {_offset_legivel(offset_efetivo)}",
+            f"  time.tzname ............. {time.tzname}",
+            f"  time.tzset() existe? .... {hasattr(time, 'tzset')}",
+            "",
+            "Causa provavel: Windows. Sem `time.tzset()`, quem le `TZ` e a CRT da Microsoft, que",
+            "NAO entende nome IANA -- diante de um, ela ADIVINHA em vez de falhar.",
+            "",
+            "Para medir fuso no Windows use o formato POSIX, que a CRT entende de verdade:",
+            "    UTC0 (UTC)  |  JST-9 (UTC+9)  |  BRT3 (UTC-3)",
+            "...ou meca em Linux/WSL/container, onde o nome IANA vale.",
+            "",
+            "Esta suite NAO depende do fuso do processo (medido em 22/08/2026: 2200 verdes em",
+            "UTC-3, UTC e UTC+9). O `TZ` so precisa nao mentir.",
+        ]
+    )
+
+
+def _guarda_de_fuso() -> None:
+    """Roda no import do conftest -- ou seja, antes de QUALQUER arquivo de teste.
+
+    Fica aqui, e nao num `test_*.py` proprio, pela licao do #169: um guarda em arquivo separado
+    depende da ordem de coleta e some entre os pulados assim que a suite para no primeiro erro.
+    """
+    agora = datetime.now(UTC)
+    problema = _incoerencia_de_fuso(os.environ.get("TZ"), agora.astimezone().utcoffset(), agora)
+    if problema is not None:
+        raise RuntimeError(problema)
+
+
+_guarda_de_fuso()
+
 
 engine = create_engine(
     "sqlite://",

--- a/apps/api/tests/test_fuso_do_processo.py
+++ b/apps/api/tests/test_fuso_do_processo.py
@@ -1,0 +1,208 @@
+"""A dependencia de fuso desta suite, DECLARADA -- e o guarda que a cobra (issue #210).
+
+O #184 (PR #202) fixou `TZ: America/Sao_Paulo` no job `frontend`, e a #210 perguntou o obvio:
+e os dois jobs Python, que nao fixam fuso em lugar nenhum? A resposta so podia vir de medicao,
+e veio.
+
+**Medido em 22/08/2026**, a suite inteira (`pytest -m "not rls_e2e"`, 2201 testes) rodada tres
+vezes com o relogio do PROCESSO em fusos diferentes:
+
+    fuso do processo        data local no momento da corrida    resultado
+    UTC-3 (maquina)         2026-08-22                          2200 passed, 1 skipped
+    UTC  (`TZ=UTC0`)        2026-08-22                          2200 passed, 1 skipped
+    UTC+9 (`TZ=JST-9`)      2026-08-23  <-- o dia VIRADO        2200 passed, 1 skipped
+
+O terceiro e o que fecha a classe. O #185 (PR #203) mostrou que varrer so em UTC nao prova nada
+quando UTC e UTC-3 CONCORDAM sobre o dia; aqui o processo em UTC+9 ja estava em 23/08 enquanto o
+UTC ainda marcava 22/08, e mesmo assim nenhum teste mudou de resposta.
+
+**Por que zero, estruturalmente:** o sistema deriva "hoje" de `hoje_do_tenant()`, que e
+`datetime.now(UTC)` convertido pelo `ZoneInfo` do TENANT (#78, migration 0073) -- nunca o fuso
+da maquina. Uma varredura AST de `app/` acha 7 chamadas de relogio aparente e 5 delas sao
+`func.now()` do SQLAlchemy (SQL, nao processo). Sobram DUAS, nenhuma em caminho de negocio, e o
+teste `test_o_app_NAO_ganhou_relogio_de_maquina_novo` abaixo e quem as mantem sendo duas.
+
+**Por isso NAO se fixou `TZ` nos jobs Python do `ci.yml`.** A #210 e explicita em nao querer "as
+duas por reflexo": fixar um fuso que nada le seria congelar uma configuracao inerte -- e pior,
+daria a impressao de que a suite passou a depender dela. O que faltava era a DECLARACAO, que e
+este arquivo, e a DETECCAO, que e o guarda em `conftest.py`.
+"""
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from app.core.tz import DEFAULT_TENANT_TIMEZONE, local_date, tenant_today
+from tests import conftest
+from tests.conftest import _incoerencia_de_fuso
+
+API_DIR = Path(__file__).resolve().parents[1]
+
+# Um instante escolhido para DISCORDAR: 23/08 em UTC e em Toquio, 22/08 em Sao Paulo.
+# Sem uma borda assim o teste passaria com qualquer implementacao -- e a vacuidade e a familia
+# de defeito que este repo mais paga (ver `test_investments.py::..._SAI_do_termo_P3`).
+INSTANTE_DA_BORDA = datetime(2026, 8, 23, 1, 30, tzinfo=UTC)
+
+
+def test_a_ancora_de_hoje_NAO_le_o_fuso_do_processo() -> None:
+    """A declaracao, mecanica: "hoje" e funcao do INSTANTE e do fuso do TENANT, e de mais nada.
+
+    O controle negativo (os dois asserts do meio) e obrigatorio: sem ele este teste passaria
+    mesmo que `INSTANTE_DA_BORDA` caisse num horario em que os tres fusos concordam, que e
+    exatamente como o #185 deixou uma dependencia de fuso escapar de uma varredura em UTC.
+    """
+    # CONTROLE: o instante realmente separa os tres relogios.
+    assert INSTANTE_DA_BORDA.date().isoformat() == "2026-08-23", "em UTC ja e dia 23"
+    assert local_date(INSTANTE_DA_BORDA, "Asia/Tokyo").isoformat() == "2026-08-23", "Toquio, 23"
+
+    # A ANCORA: o tenant brasileiro ainda esta no dia 22, e nenhum fuso de processo muda isso.
+    assert tenant_today(DEFAULT_TENANT_TIMEZONE, now=INSTANTE_DA_BORDA).isoformat() == "2026-08-22"
+
+
+def test_o_guarda_cala_quando_nao_ha_TZ_declarado() -> None:
+    """O caso do CI: sem `TZ`, nao ha promessa a conferir. Fixar fuso continua NAO sendo exigido."""
+    assert _incoerencia_de_fuso(None, timedelta(0), INSTANTE_DA_BORDA) is None
+    assert _incoerencia_de_fuso("", timedelta(0), INSTANTE_DA_BORDA) is None
+
+
+def test_o_guarda_cala_quando_o_TZ_e_honrado() -> None:
+    """Linux com `TZ=America/Sao_Paulo`: o processo entrega -03:00, que e o que o nome promete."""
+    assert _incoerencia_de_fuso(
+        "America/Sao_Paulo", timedelta(hours=-3), INSTANTE_DA_BORDA
+    ) is None
+
+
+def test_o_guarda_cala_diante_de_TZ_no_formato_POSIX() -> None:
+    """`JST-9` e `UTC0` sao o unico jeito de medir fuso no Windows -- o guarda nao pode atrapalhar.
+
+    O `zoneinfo` nao decifra POSIX TZ, entao nao ha com o que comparar. Calar aqui e desenho:
+    foi com `JST-9` que as 2200 linhas verdes em UTC+9 desta docstring foram medidas.
+    """
+    assert _incoerencia_de_fuso("JST-9", timedelta(hours=9), INSTANTE_DA_BORDA) is None
+    assert _incoerencia_de_fuso("UTC0", timedelta(0), INSTANTE_DA_BORDA) is None
+
+
+def test_o_guarda_ACUSA_o_TZ_que_o_Windows_nao_honra() -> None:
+    """A armadilha real, com os numeros REAIS medidos nesta maquina em 22/08/2026.
+
+    No Windows nao existe `time.tzset()` e quem le `TZ` e a CRT da Microsoft, que nao entende
+    nome IANA: diante de `America/Sao_Paulo` ela ADIVINHA e entrega **+01:00** -- nem o fuso do
+    Brasil (-03:00) nem o do CI (UTC). `Asia/Tokyo` cai no mesmo +01:00, e nao em +09:00.
+
+    E o que torna a receita da propria #210 ("rode sob `Asia/Tokyo`") uma medicao que nao mede:
+    devolve "0 quebras" porque varreu UTC+1, nao UTC+9. Sem este guarda, o sintoma seria uma
+    data errada num teste de negocio -- e alguem procurando o bug em `hoje_do_tenant()`.
+    """
+    msg = _incoerencia_de_fuso("America/Sao_Paulo", timedelta(hours=1), INSTANTE_DA_BORDA)
+    assert msg is not None, "TZ que promete -03:00 num processo em +01:00 TEM de ser acusado"
+    assert "FUSO DECLARADO QUE O PROCESSO NAO HONRA" in msg
+    assert "America/Sao_Paulo" in msg, "a mensagem tem de dizer QUAL fuso mentiu"
+    # `-03:00`, e nao o `-1 day, 21:00:00` cru do `timedelta` -- ver `_offset_legivel`.
+    assert "-03:00" in msg, "...e o offset PROMETIDO, legivel"
+    assert "+01:00" in msg, "...e o offset EFETIVO, que e o outro lado da contradicao"
+    assert "-1 day" not in msg, "offset negativo nao pode vazar na forma crua do timedelta"
+    assert "time.tzset()" in msg, "...e a causa, para nao mandar ninguem depurar data de negocio"
+
+    # Toquio pelo mesmo caminho: +01:00 no lugar de +09:00.
+    tokyo = _incoerencia_de_fuso("Asia/Tokyo", timedelta(hours=1), INSTANTE_DA_BORDA)
+    assert tokyo is not None and "Asia/Tokyo" in tokyo
+
+
+def test_o_guarda_esta_LIGADO_no_import_do_conftest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A regra pode estar certa e nao estar PLUGADA -- e foi assim que o worker ficou sem fiacao.
+
+    Nao da para provar isto trocando `TZ` de verdade: sem `time.tzset()` o processo ja escolheu
+    seu fuso e nao reabre a escolha. Entao o que se prova aqui e a COSTURA: quando a regra
+    acusa, `_guarda_de_fuso()` levanta -- e ele e chamado no corpo do modulo do `conftest`.
+    """
+    monkeypatch.setattr(conftest, "_incoerencia_de_fuso", lambda *_: "FUSO MENTIROSO (fixture)")
+    with pytest.raises(RuntimeError, match="FUSO MENTIROSO"):
+        conftest._guarda_de_fuso()
+
+    fonte = (API_DIR / "tests" / "conftest.py").read_text(encoding="utf-8")
+    chamadas = [
+        no
+        for no in ast.parse(fonte).body
+        if isinstance(no, ast.Expr)
+        and isinstance(no.value, ast.Call)
+        and isinstance(no.value.func, ast.Name)
+        and no.value.func.id == "_guarda_de_fuso"
+    ]
+    assert chamadas, "`_guarda_de_fuso()` precisa ser CHAMADO no corpo do conftest, nao so definido"
+
+
+# As DUAS unicas leituras do relogio da MAQUINA em `app/`, cada uma com o motivo de ser tolerada.
+# Qualquer sitio novo reprova este gate -- de proposito: e o unico jeito de a medicao das 2200
+# linhas verdes continuar valendo depois que este PR sair de vista.
+RELOGIO_DE_MAQUINA_DECLARADO = {
+    "app/modules/crm/schemas.py": (
+        "validator de `birthdate` ('nao pode estar no futuro'). Depende do fuso do processo de "
+        "verdade, mas a tolerancia e de UM DIA sobre uma DATA DE NASCIMENTO -- nao ha caso em "
+        "que a diferenca decida alguma coisa. Trocar por `hoje_do_tenant` exigiria `db` num "
+        "schema Pydantic, que e acoplamento pior que a divida."
+    ),
+    "app/seed_staging.py": (
+        "script de seed de STAGING, fora de qualquer caminho de request. Nao ha tenant cujo "
+        "fuso consultar no momento em que roda."
+    ),
+}
+
+
+def _relogios_de_maquina(fonte: str) -> list[int]:
+    """Linhas com `date.today()`, `.utcnow()` ou `datetime.now()` SEM fuso.
+
+    `func.now()` do SQLAlchemy e excluido a dedo: e uma funcao SQL avaliada pelo BANCO, nao um
+    relogio deste processo. Sao 5 das 7 ocorrencias de `.now()` em `app/`, e sem esta excecao o
+    gate seria 5/7 ruido -- gate ruidoso e gate que alguem apaga.
+    """
+    achados: list[int] = []
+    for no in ast.walk(ast.parse(fonte)):
+        if not isinstance(no, ast.Call) or not isinstance(no.func, ast.Attribute):
+            continue
+        if isinstance(no.func.value, ast.Name) and no.func.value.id == "func":
+            continue
+        if no.func.attr in ("today", "utcnow"):
+            achados.append(no.lineno)
+        elif no.func.attr == "now" and not no.args and not no.keywords:
+            achados.append(no.lineno)
+    return achados
+
+
+def test_o_app_NAO_ganhou_relogio_de_maquina_novo() -> None:
+    """Gate: em `app/`, "hoje" vem de `hoje_do_tenant()` -- e a lista de excecoes e FECHADA.
+
+    Sem consumidor mecanico, a unica coisa entre o produto e um `date.today()` novo num service
+    e alguem lembrar. E a suite ficaria verde do mesmo jeito: foi medido que ela e indiferente
+    ao fuso do processo, entao ela NAO reprovaria o sitio novo. Este gate e o que reprova.
+    """
+    novos: dict[str, list[int]] = {}
+    for arquivo in sorted((API_DIR / "app").rglob("*.py")):
+        rel = arquivo.relative_to(API_DIR).as_posix()
+        linhas = _relogios_de_maquina(arquivo.read_text(encoding="utf-8"))
+        if linhas and rel not in RELOGIO_DE_MAQUINA_DECLARADO:
+            novos[rel] = linhas
+
+    assert not novos, (
+        "relogio da MAQUINA novo em app/: "
+        + "; ".join(f"{f}:{ls}" for f, ls in sorted(novos.items()))
+        + " -- use `hoje_do_tenant(db)` (a ancora do #78). Se a leitura for mesmo legitima, "
+        "declare-a em RELOGIO_DE_MAQUINA_DECLARADO com o motivo, como as outras duas."
+    )
+
+    # CONTROLE: as duas declaradas continuam existindo. Sem isto o gate viraria vacuo no dia em
+    # que alguem consertasse os dois sitios e esquecesse de tirar a lista -- e passaria a
+    # aprovar qualquer coisa, calado.
+    # `encoding="utf-8"` explicito: sem ele o default no Windows e cp1252 e `seed_staging.py`
+    # (que tem acento) estoura com UnicodeDecodeError. Foi este proprio controle que pegou.
+    ainda_existem = {
+        f
+        for f in RELOGIO_DE_MAQUINA_DECLARADO
+        if _relogios_de_maquina((API_DIR / f).read_text(encoding="utf-8"))
+    }
+    assert ainda_existem == set(RELOGIO_DE_MAQUINA_DECLARADO), (
+        "sitio declarado que sumiu: tire-o de RELOGIO_DE_MAQUINA_DECLARADO. "
+        f"declarados={sorted(RELOGIO_DE_MAQUINA_DECLARADO)} ainda_existem={sorted(ainda_existem)}"
+    )


### PR DESCRIPTION
## Resumo

A suíte Python **não depende do fuso do processo** — e isso agora está medido, declarado e cobrado
por guarda. **Nenhum `TZ` foi fixado nos jobs Python**, e a razão é a medição, não preguiça: a #210 é
explícita em não querer "as duas por reflexo".

## A medição, e por que zero é a resposta certa

O código deriva "hoje" de `hoje_do_tenant()`, que é `datetime.now(UTC)` convertido pelo `ZoneInfo` do
**tenant** (#78, migration 0073). O fuso da máquina não é entrada de nada.

Varredura AST de `app/`:

| Forma | Sites | O que é |
|---|---|---|
| `datetime.now(TZ)` com fuso explícito | **44** | correto por construção |
| `func.now()` do SQLAlchemy | **5** | função SQL, avaliada pelo BANCO |
| `date.today()` — relógio de máquina | **2** | nenhuma em caminho de negócio |

As 2 são `crm/schemas.py` (validador de `birthdate`, tolerância de UM DIA sobre data de nascimento) e
`seed_staging.py` (script fora de request). Ambas declaradas em `RELOGIO_DE_MAQUINA_DECLARADO`, com o
motivo.

A contagem da issue era piso do outro lado também: ela diz "8+ arquivos de teste dependem de 'hoje'";
são **42** arquivos casando `hoje_do_tenant|date.today|datetime.now|utcnow` em `apps/api/tests`. E o
`pytest.ini` que a issue cita **não existe** no repo — só `apps/api/pyproject.toml`.

## ⚠️ A receita da própria issue não mede o que promete no Windows

A #210 manda rodar sob `Asia/Tokyo`, "fuso de sinal oposto". No Windows isso **não mede Tóquio**.

Não existe `time.tzset()` no CPython para Windows, e quem lê `TZ` é a CRT da Microsoft, que **não
entende nome IANA** — diante de um, ela **adivinha** em vez de falhar. Medido neste interpretador,
o mesmo que roda a suíte:

```
TZ="America/Sao_Paulo"  ->  offset efetivo +01:00     (e não -03:00)
TZ="Asia/Tokyo"         ->  offset efetivo +01:00     (e não +09:00)
TZ="UTC0"   (POSIX)     ->  offset efetivo  00:00     correto
TZ="JST-9"  (POSIX)     ->  offset efetivo +09:00     correto
TZ="BRT3"   (POSIX)     ->  offset efetivo -03:00     correto
sem TZ                  ->  offset efetivo -03:00     (o da máquina)
time.tzset() existe?    ->  False
```

**Os dois nomes IANA caem no MESMO +01:00.** Quem varrer "quatro fusos" com nomes IANA nesta
plataforma mede o mesmo fuso quatro vezes e recebe "0 quebras" com cara de aprovação — é a armadilha
do #185 uma camada abaixo, e desta vez ela sobrevive a *ter* fixado a variável.

É a diferença entre as duas suítes: o Node tem base ICU própria e honra IANA (foi assim que o #211
mediu Tóquio de verdade); o CPython no Windows delega para a CRT e não honra.

## O que este PR entrega

**Um guarda em `conftest.py`**, que roda no import — antes de qualquer arquivo de teste. Fica ali, e
não num `test_*.py` próprio, pela lição do #169: guarda em arquivo separado depende da ordem de
coleta e some entre os pulados assim que a suíte para no primeiro erro.

Ele é o **irmão** do `apps/web/src/test-setup.ts` (#169/PR #172), com a asserção **invertida**: o
front *exige* `America/Sao_Paulo` porque lê o relógio da máquina; esta suíte não exige fuso nenhum. O
que o guarda cobra é só que o `TZ` declarado **não minta**.

É um **detector, não uma prova**: um nome IANA cujo palpite da CRT por acaso coincida com o offset
certo passa batido (`Europe/Lisbon` hoje é um desses). Serve para o caso que dói — o palpite divergir
e ninguém notar. Isso está escrito no bloco.

**Um gate AST** que reprova relógio de máquina novo em `app/`, com lista de exceções **fechada**. Sem
consumidor mecânico, a única coisa entre o produto e um `date.today()` novo num service é alguém
lembrar — e a suíte ficaria verde do mesmo jeito, justamente porque foi medido que ela é indiferente
ao fuso do processo.

## Mutação

| Mutação | Teste que morreu | Mensagem real |
|---|---|---|
| relógio de máquina plantado em `app/core/tz.py` | `test_o_app_NAO_ganhou_relogio_de_maquina_novo` | `relogio da MAQUINA novo em app/: app/core/tz.py:[95] -- use hoje_do_tenant(db) (a ancora do #78)` |
| `if offset_efetivo == offset_declarado:` → `if True:` (guarda nunca acusa) | `test_o_guarda_ACUSA_o_TZ_que_o_Windows_nao_honra` | `TZ que promete -03:00 num processo em +01:00 TEM de ser acusado` · `assert None is not None` |
| chamada `_guarda_de_fuso()` comentada no corpo do conftest | `test_o_guarda_esta_LIGADO_no_import_do_conftest` | `_guarda_de_fuso() precisa ser CHAMADO no corpo do conftest, nao so definido` |

A terceira é a que importa mais do que parece: a regra pode estar certa e **não estar plugada** — foi
exatamente assim que o worker ficou sem a fiação da composição (#195). Ela é provada por AST, porque
sem `time.tzset()` não dá para trocar o fuso do processo em runtime e ver o guarda disparar.

O gate AST tem **controle positivo**: se alguém consertar os dois sítios declarados e esquecer de
tirar a lista, o teste reprova — sem isso ele viraria vacuidade e passaria a aprovar qualquer coisa,
calado.

## Gates

```
ruff check .                    → All checks passed!
tests/test_fuso_do_processo.py  → 7 passed
```

Suíte completa (`pytest -m "not rls_e2e"`), com o relógio do **processo** em fusos de sinal oposto —
a exigência do #185, que mostrou que varrer só em UTC não separa nada:

| fuso do processo | data local × UTC no momento da corrida | resultado |
|---|---|---|
| UTC−3 (`TZ` ausente, o da máquina) | 25/08 = 25/08 | **2220 passed, 1 skipped** |
| UTC+9 (`TZ=JST-9`) | **26/08 ≠ 25/08 — o dia VIRADO** | **2220 passed, 1 skipped** |

Números **idênticos**, e a segunda linha é a que fecha a classe: o processo já estava em **26/08**
enquanto o UTC ainda marcava **25/08**, que é precisamente a discordância que o #185 mostrou ser
necessária — varrer só em UTC não separa nada quando UTC e o fuso do produto concordam. Nenhum teste
mudou de resposta com o calendário do processo um dia à frente.

Medi dois fusos, não três: o par de sinal oposto é o que separa os programas; UTC fica entre os dois
e não acrescenta.

⚠️ Os fusos foram declarados em **POSIX** (`JST-9`), e não em IANA, pela razão medida acima: nesta
plataforma `TZ="Asia/Tokyo"` teria medido UTC+1 e a tabela seria uma mentira verde.

## ⚠️ A primeira varredura sob UTC+9 saiu VERMELHA — e a causa não é fuso de processo

Não vou registrar só o verde. A primeira corrida completa sob `TZ=JST-9` desta verificação deu:

```
4 failed, 2203 passed, 1 skipped, 66 deselected in 2433.36s (0:40:33)
```

As 4 são todas `test_financial_intelligence_projection.py::test_AC6_*`. **Não têm relação com este
PR nem com o fuso do processo** — o arquivo não está no diff, e a causa foi isolada e reproduzida:

- a corrida começou **23:39** (UTC−3) e durou 40min33s, terminando **00:20** — atravessou a
  meia-noite em São Paulo
- `test_financial_intelligence_projection.py:53` faz `TODAY = tenant_today(...)` **no import do
  módulo**, e o serviço recalcula "hoje" na chamada: viram um dia diferentes
- provado sem esperar a meia-noite: envelhecendo aquele `TODAY` em um dia, falham **exatamente as
  mesmas 4**, com os mesmos nomes (`4 failed, 4 passed in 15.67s`)

`tenant_today` é `datetime.now(UTC)` + `ZoneInfo` do tenant: o relógio da máquina não entra. É a
reincidência da classe do #84/#90/#101, agora num arquivo que aquelas correções não cobriram, e está
registrada como issue própria com o alcance medido (**5 arquivos** com âncora de relógio em nível de
módulo, 6 com data fixa — o padrão correto).

Isoladas, as 4 passam sob `TZ=JST-9` **e** sob o fuso da máquina (`8 passed` nos dois). E a suíte
completa, repetida **depois** da meia-noite nos dois fusos, deu `2207 passed` nas duas — mesmas
corridas da tabela acima. O fuso do processo não é a variável; a hora do dia era.

Registrada como **#232**, com o alcance medido: dos 11 arquivos com `TODAY`/`HOJE` em nível de
módulo, **5 leem relógio** (frágeis) e **6 usam data fixa** — e são estes 6 o gabarito do conserto.
Dos 5, só este quebra hoje; os dois outros alcançáveis sem Postgres sobreviveram ao envelhecimento
(`52 passed`).

## A prova que fica no repositório não é a corrida

A varredura sob UTC+9 só exercita a virada de dia quando a hora UTC cai numa janela — fora dela, os
dois fusos concordam sobre a data e a corrida não separa nada. A corrida da tabela acima **pegou** a
janela, mas depender disso seria deixar a prova a cargo do relógio de quem roda. Por isso o que este
PR deixa no repositório é
`test_a_ancora_de_hoje_NAO_le_o_fuso_do_processo`, com o instante **injetado** numa borda escolhida
para discordar (`2026-08-23T01:30Z` é dia 23 em UTC e em Tóquio, e ainda dia 22 em São Paulo) e com
controle negativo obrigatório nos dois lados.

## Para quem for medir fuso nesta plataforma

Use o formato **POSIX**, que a CRT entende de verdade: `UTC0`, `JST-9` (UTC+9), `BRT3` (UTC−3) — o
sinal é invertido em relação ao que se espera. Ou meça em Linux/WSL/container, onde o nome IANA vale.
Nome IANA em `TZ` no Windows é medição que não mede.

Closes #210
