### PR TITLE
fix(web): sub-usuário sem um módulo travava a tela em 'Carregando...' para sempre

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2807,6 +2807,52 @@ primeira rodada.
   ocorrências** quando a contagem real é **190** — o erro de 27× faz a dívida se ler como "ainda
   não vale um componente".
 
+## RBAC no frontend: a sidebar e as rotas passam a respeitar `allowed_modules` (2026-08-25)
+
+**O frontend nunca consultava `allowed_modules` — em lugar nenhum.** A sidebar (`navigation.ts`)
+mostrava os ~20 itens de menu a todo usuário, dono ou sub-usuário restrito, e nenhuma rota sabia
+recusar antes da página tentar buscar dados. O sintoma achado pelo fundador: um sub-usuário sem
+Jurídico/Funis abria a ficha do cliente (`/crm/clients/:id`) e ela ficava presa em **"Carregando
+ficha..." para sempre** — e o mesmo em `/config` (exige o módulo `settings` inteiro).
+
+- **Causa em `ClientDetailPage`:** o `load()` da montagem juntava as seis leituras (cliente,
+  cobranças, contratos, orçamentos, jurídico, funis) num `Promise.all` só. A PRIMEIRA a voltar 403
+  rejeitava o lote inteiro — `client` nunca saía de `null`, e nem os dados PERMITIDOS apareciam.
+  **Causa em `ConfiguracoesPage`:** `load()` não tinha `.catch`; o 403 de `/settings/profile`
+  também deixava `p` preso em `null` para sempre.
+- [x] **`lib/access.ts` — `hasModule(user, module)`**, espelho **exato** de `require_module`
+  (`app/core/tenancy.py`): `role === "owner" || allowed_modules.length === 0 ||
+  allowed_modules.includes(module)`. Porta única desta regra no frontend.
+- [x] **`navigation.ts` — cada item ganhou `module`** (o mesmo nome que `require_module` usa na
+  rota que ele abre) e `visibleNavSections(hasModule)` recorta a sidebar por permissão — seção que
+  fica sem item nenhum some inteira, não deixa título/divisor órfão. `navSections` em si continua
+  a lista COMPLETA e estática (o que `navigation.test.ts` já afirmava).
+  ⚠️ **A função entra FORA do `Stryker disable all` da issue #191** — aquele bloco existe porque o
+  módulo só tinha tabela de dados, sem lógica; `visibleNavSections` é a primeira função exportada
+  daqui, e o comentário do próprio bloco já previa isso ("função nova nasce fora dele").
+- [x] **`App.tsx` — `<Modulo m="...">`** envolve cada rota de módulo de negócio (crm, wallet, bank,
+  receivables, payables, quotes, contracts, products, stock, marketing, funnels, pages, juridico,
+  financial_intelligence, investments, chart_of_accounts, cost_centers, settings): sem o módulo, a
+  página **nem monta** — mostra "sem acesso" em vez de tentar buscar dados que voltariam 403. É a
+  segunda camada, contra link direto/favorito/URL digitada (a sidebar sozinha só esconde o clique).
+  A raiz (`/`, Cockpit) ficou **deliberadamente sem guard**: é a página de entrada do app, e
+  guardá-la arriscava deixar um sub-usuário sem NENHUMA tela de pouso.
+- [x] **`ClientDetailPage.tsx`** — cada leitura secundária só dispara se `hasModule` permitir (não
+  há por que pedir o que já se sabe que vai 403) e tem `.catch` próprio (defesa contra falha por
+  outro motivo — rede, 500 — não travar as demais seções). As cinco seções e o resumo financeiro
+  somem inteiros quando o módulo correspondente falta — nunca mostram contagem zerada de algo que
+  o usuário não tem permissão de ver.
+- [x] **`ConfiguracoesPage.tsx`** — segunda camada de defesa: `load()` ganhou `try/catch`: qualquer
+  falha mostra a mensagem em vez de travar em "Carregando..." para sempre.
+- **Por que também é guard de ROTA, não só de sidebar:** a sidebar é conveniência de navegação; a
+  garantia real precisa valer para quem chega direto pela URL. As duas camadas espelham o padrão
+  que este arquivo já registra em vários lugares (Regra da Origem, Invariante do Trilho): a UI
+  nunca é a única fronteira, o backend (`require_module`) continua sendo o fail-closed de verdade.
+- **Dívida:** nenhuma tela mede em ~360px o estado "sem acesso a este módulo" — texto simples, sem
+  régua própria. E `packages/shared-types` não tem um tipo fechado para os nomes de módulo
+  (`hasModule` recebe `string` solto); um typo no `module` de um item novo de menu não quebraria
+  build nenhum, só esconderia o item em silêncio.
+
 ## Vima: o Registro de Fatos e o briefing (PRs #85 e #90, 2026-08-06/07)
 
 > Spec: `docs/superpowers/specs/2026-08-06-vima-registro-de-fatos-e-briefing-design.md` ·

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -13,15 +13,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // `useAuth` é mockado (mesmo padrão de `LoginPage.test.tsx`) porque o objetivo aqui é o
 // ROTEAMENTO em si — `ProtectedLayout`/`LoginRoute` — não a UI de login nem o AppShell
 // autenticado (que tem suas próprias dependências de rede, fora do escopo deste teste).
-const auth = vi.hoisted(() => ({ isAuthenticated: false }));
+const auth = vi.hoisted(() => ({
+  isAuthenticated: false,
+  user: null as { role: "owner" | "sub_user"; allowed_modules: string[] } | null,
+}));
 vi.mock("../store/auth", () => ({
-  useAuth: () => ({ isAuthenticated: auth.isAuthenticated, user: null }),
+  useAuth: () => ({ isAuthenticated: auth.isAuthenticated, user: auth.user }),
 }));
 vi.mock("../store/useIdleTimeout", () => ({
   useIdleTimeout: () => ({ showWarning: false, stayConnected: vi.fn() }),
 }));
 
-import { LoginRoute, ProtectedBareLayout, ProtectedLayout } from "./App";
+import { LoginRoute, Modulo, ProtectedBareLayout, ProtectedLayout } from "./App";
 
 /** Sonda que expõe a rota atual e o `state` carregado pelo history, para asserções sem UI real. */
 function LocationProbe({ label }: { label: string }) {
@@ -148,5 +151,44 @@ describe("ProtectedBareLayout — mesma proteção do ProtectedLayout, sem sideb
     await waitFor(() => screen.getByText("tela do comprovante"));
     // "Sair" só existe na Sidebar do AppShell — sua ausência prova que o shell não montou.
     expect(screen.queryByText("Sair")).toBeNull();
+  });
+});
+
+// A causa mais funda do defeito relatado (ficha do cliente e Configurações travadas em
+// "Carregando..." para um sub-usuário sem certos módulos): a sidebar mostrava todo item a todo
+// usuário e nenhuma rota sabia recusar antes de a página tentar buscar dados que voltariam 403.
+// `Modulo` é a segunda metade da correção (a primeira é `visibleNavSections`, em
+// `navigation.test.ts`) — protege contra link direto/favorito/URL digitada, não só o clique no
+// menu.
+describe("Modulo — guarda de rota por RBAC (espelha require_module do backend)", () => {
+  it("dono (`allowed_modules` vazio) vê qualquer módulo", () => {
+    auth.user = { role: "owner", allowed_modules: [] };
+    render(
+      <Modulo m="juridico">
+        <p>conteúdo do módulo</p>
+      </Modulo>,
+    );
+    expect(screen.getByText("conteúdo do módulo")).toBeInTheDocument();
+  });
+
+  it("sub-usuário COM o módulo em `allowed_modules` vê o conteúdo", () => {
+    auth.user = { role: "sub_user", allowed_modules: ["crm", "juridico"] };
+    render(
+      <Modulo m="juridico">
+        <p>conteúdo do módulo</p>
+      </Modulo>,
+    );
+    expect(screen.getByText("conteúdo do módulo")).toBeInTheDocument();
+  });
+
+  it("sub-usuário SEM o módulo vê 'sem acesso' em vez do conteúdo — nunca um spinner eterno", () => {
+    auth.user = { role: "sub_user", allowed_modules: ["crm"] };
+    render(
+      <Modulo m="juridico">
+        <p>conteúdo do módulo</p>
+      </Modulo>,
+    );
+    expect(screen.queryByText("conteúdo do módulo")).toBeNull();
+    expect(screen.getByText(/não tem acesso a este módulo/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -48,6 +48,7 @@ import NucleoPage from "../features/dna/NucleoPage";
 import BriefingPage from "../features/vima/BriefingPage";
 import EntradaDoDia from "../features/vima/EntradaDoDia";
 import IdleWarningModal from "../components/IdleWarningModal";
+import { hasModule } from "../lib/access";
 import { AuthProvider, useAuth } from "../store/auth";
 import { useIdleTimeout } from "../store/useIdleTimeout";
 import { PageActionsProvider } from "../store/pageActions";
@@ -75,51 +76,51 @@ export default function App() {
               </EntradaDoDia>
             }
           />
-          <Route path="/agenda" element={<AgendaPage />} />
+          <Route path="/agenda" element={<Modulo m="agenda"><AgendaPage /></Modulo>} />
           <Route path="/busca" element={<BuscaPage />} />
-          <Route path="/crm" element={<CrmPage />} />
-          <Route path="/crm/clients/:id" element={<ClientDetailPage />} />
-          <Route path="/conversas" element={<ConversasPage />} />
+          <Route path="/crm" element={<Modulo m="crm"><CrmPage /></Modulo>} />
+          <Route path="/crm/clients/:id" element={<Modulo m="crm"><ClientDetailPage /></Modulo>} />
+          <Route path="/conversas" element={<Modulo m="crm"><ConversasPage /></Modulo>} />
           {/* A conversa tem URL própria desde a Onda 1: é assim que a ficha 360° aponta para ela, e
               de quebra o botão voltar do navegador passa a funcionar nesta tela. */}
-          <Route path="/conversas/:chatId" element={<ConversasPage />} />
-          <Route path="/financeiro" element={<FinanceiroPage />} />
-          <Route path="/financeiro/contas" element={<ContasSaldosPage />} />
+          <Route path="/conversas/:chatId" element={<Modulo m="crm"><ConversasPage /></Modulo>} />
+          <Route path="/financeiro" element={<Modulo m="wallet"><FinanceiroPage /></Modulo>} />
+          <Route path="/financeiro/contas" element={<Modulo m="bank"><ContasSaldosPage /></Modulo>} />
           {/* Story 8.7 — rota DELIBERADAMENTE fora da sidebar: a conferência é resposta a um
               sinal (o cartão de completude do diagnóstico / o "Conferir" de uma conta), não uma
               tarefa de rotina. Ver a docstring de ConferenciaPage.tsx antes de "consertar" isto. */}
-          <Route path="/financeiro/conferencia" element={<ConferenciaPage />} />
-          <Route path="/financeiro/plano-contas" element={<PlanoContasPage />} />
-          <Route path="/financeiro/centros-custo" element={<CentrosCustoPage />} />
-          <Route path="/financeiro/investimentos" element={<InvestimentosPage />} />
-          <Route path="/financeiro/dre" element={<DrePage />} />
-          <Route path="/financeiro/lucratividade" element={<LucratividadePage />} />
-          <Route path="/financeiro/projecao-caixa" element={<ProjecaoCaixaPage />} />
-          <Route path="/financeiro/fila-pagamentos" element={<FilaPagamentosPage />} />
-          <Route path="/financeiro/diagnostico" element={<DiagnosticoPage />} />
-          <Route path="/financeiro/contratos/:id/dre" element={<ContratoDrePage />} />
-          <Route path="/cobrancas" element={<CobrancasPage />} />
-          <Route path="/pagar" element={<PagarPage />} />
-          <Route path="/produtos" element={<ProdutosPage />} />
-          <Route path="/estoque" element={<EstoquePage />} />
-          <Route path="/config" element={<ConfiguracoesPage />} />
-          <Route path="/sites" element={<SitesPage />} />
-          <Route path="/sites/:id" element={<PageBuilderPage />} />
-          <Route path="/orcamentos" element={<OrcamentosPage />} />
-          <Route path="/orcamentos/novo" element={<QuoteBuilderPage />} />
-          <Route path="/orcamentos/:id" element={<QuoteBuilderPage />} />
-          <Route path="/contratos" element={<ContratosPage />} />
-          <Route path="/contratos/novo" element={<ContractBuilderPage />} />
-          <Route path="/contratos/:id" element={<ContractBuilderPage />} />
-          <Route path="/marketing" element={<MarketingPage />} />
-          <Route path="/marketing/novo" element={<CarrosselBuilderPage />} />
-          <Route path="/marketing/:id" element={<CarrosselBuilderPage />} />
-          <Route path="/juridico" element={<JuridicoPage />} />
-          <Route path="/juridico/novo" element={<JuridicoWizardPage />} />
-          <Route path="/juridico/:id" element={<JuridicoDocumentPage />} />
-          <Route path="/funis" element={<FunisPage />} />
-          <Route path="/funis/novo" element={<FunnelBuilderPage />} />
-          <Route path="/funis/:id" element={<FunnelBuilderPage />} />
+          <Route path="/financeiro/conferencia" element={<Modulo m="bank"><ConferenciaPage /></Modulo>} />
+          <Route path="/financeiro/plano-contas" element={<Modulo m="chart_of_accounts"><PlanoContasPage /></Modulo>} />
+          <Route path="/financeiro/centros-custo" element={<Modulo m="cost_centers"><CentrosCustoPage /></Modulo>} />
+          <Route path="/financeiro/investimentos" element={<Modulo m="investments"><InvestimentosPage /></Modulo>} />
+          <Route path="/financeiro/dre" element={<Modulo m="financial_intelligence"><DrePage /></Modulo>} />
+          <Route path="/financeiro/lucratividade" element={<Modulo m="financial_intelligence"><LucratividadePage /></Modulo>} />
+          <Route path="/financeiro/projecao-caixa" element={<Modulo m="financial_intelligence"><ProjecaoCaixaPage /></Modulo>} />
+          <Route path="/financeiro/fila-pagamentos" element={<Modulo m="payables"><FilaPagamentosPage /></Modulo>} />
+          <Route path="/financeiro/diagnostico" element={<Modulo m="financial_intelligence"><DiagnosticoPage /></Modulo>} />
+          <Route path="/financeiro/contratos/:id/dre" element={<Modulo m="financial_intelligence"><ContratoDrePage /></Modulo>} />
+          <Route path="/cobrancas" element={<Modulo m="receivables"><CobrancasPage /></Modulo>} />
+          <Route path="/pagar" element={<Modulo m="payables"><PagarPage /></Modulo>} />
+          <Route path="/produtos" element={<Modulo m="products"><ProdutosPage /></Modulo>} />
+          <Route path="/estoque" element={<Modulo m="stock"><EstoquePage /></Modulo>} />
+          <Route path="/config" element={<Modulo m="settings"><ConfiguracoesPage /></Modulo>} />
+          <Route path="/sites" element={<Modulo m="pages"><SitesPage /></Modulo>} />
+          <Route path="/sites/:id" element={<Modulo m="pages"><PageBuilderPage /></Modulo>} />
+          <Route path="/orcamentos" element={<Modulo m="quotes"><OrcamentosPage /></Modulo>} />
+          <Route path="/orcamentos/novo" element={<Modulo m="quotes"><QuoteBuilderPage /></Modulo>} />
+          <Route path="/orcamentos/:id" element={<Modulo m="quotes"><QuoteBuilderPage /></Modulo>} />
+          <Route path="/contratos" element={<Modulo m="contracts"><ContratosPage /></Modulo>} />
+          <Route path="/contratos/novo" element={<Modulo m="contracts"><ContractBuilderPage /></Modulo>} />
+          <Route path="/contratos/:id" element={<Modulo m="contracts"><ContractBuilderPage /></Modulo>} />
+          <Route path="/marketing" element={<Modulo m="marketing"><MarketingPage /></Modulo>} />
+          <Route path="/marketing/novo" element={<Modulo m="marketing"><CarrosselBuilderPage /></Modulo>} />
+          <Route path="/marketing/:id" element={<Modulo m="marketing"><CarrosselBuilderPage /></Modulo>} />
+          <Route path="/juridico" element={<Modulo m="juridico"><JuridicoPage /></Modulo>} />
+          <Route path="/juridico/novo" element={<Modulo m="juridico"><JuridicoWizardPage /></Modulo>} />
+          <Route path="/juridico/:id" element={<Modulo m="juridico"><JuridicoDocumentPage /></Modulo>} />
+          <Route path="/funis" element={<Modulo m="funnels"><FunisPage /></Modulo>} />
+          <Route path="/funis/novo" element={<Modulo m="funnels"><FunnelBuilderPage /></Modulo>} />
+          <Route path="/funis/:id" element={<Modulo m="funnels"><FunnelBuilderPage /></Modulo>} />
           <Route path="/admin" element={<AdminOnly />} />
           <Route path="*" element={<ComingSoon />} />
         </Route>
@@ -223,6 +224,28 @@ function AdminOnly() {
   const { user } = useAuth();
   if (!user?.is_platform_admin) return <Navigate to="/" replace />;
   return <AdminDashboard />;
+}
+
+/**
+ * Guarda de módulo por ROTA: espelha `require_module` do backend (mesmo nome de módulo) e
+ * impede a página de sequer MONTAR — logo de nunca disparar a requisição que voltaria 403.
+ *
+ * Antes disto a sidebar mostrava todo item a todo usuário (ver `navigation.ts`) e cada página
+ * tentava buscar seus dados de qualquer forma; um sub-usuário sem o módulo via a tela travar em
+ * "Carregando..." para sempre (o 403 vira promise rejeitada sem `.catch`, em vez de erro
+ * tratado). Complementa `visibleNavSections` — aquele esconde o item do menu, este protege
+ * contra link direto, favorito ou digitação da URL.
+ */
+export function Modulo({ m, children }: { m: string; children: ReactElement }) {
+  const { user } = useAuth();
+  if (!hasModule(user, m)) {
+    return (
+      <div className="flex h-full items-center justify-center text-center text-neutral-400">
+        Você não tem acesso a este módulo. Fale com o administrador da sua conta se precisar dele.
+      </div>
+    );
+  }
+  return children;
 }
 
 function ComingSoon() {

--- a/apps/web/src/app/AppShell.test.tsx
+++ b/apps/web/src/app/AppShell.test.tsx
@@ -12,8 +12,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("../lib/api", () => ({
   api: { get: vi.fn().mockResolvedValue({ data: {} }) },
 }));
+// `user` precisa ser um dono de verdade (não `null`): a Sidebar filtra os itens por
+// `hasModule(user, item.module)` (RBAC), e a Sidebar só é montada DEPOIS do gate de autenticação
+// — `user: null` aqui não é um caso real, e faria a sidebar aparecer VAZIA nestes testes
+// (que existem para cobrir responsividade, não permissão).
 vi.mock("../store/auth", () => ({
-  useAuth: () => ({ logout: vi.fn(), user: null, tenant: null }),
+  useAuth: () => ({
+    logout: vi.fn(),
+    user: { role: "owner", allowed_modules: [] },
+    tenant: null,
+  }),
 }));
 vi.mock("../store/pageActions", () => ({
   usePageActions: () => ({ action: null }),

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -5,10 +5,11 @@ import { type ReactNode, useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import BuscaGlobal from "../features/busca/BuscaGlobal";
 import { api } from "../lib/api";
+import { hasModule } from "../lib/access";
 import { applyBrandTheme } from "../lib/theme";
 import { useAuth } from "../store/auth";
 import { usePageActions } from "../store/pageActions";
-import { navSections } from "./navigation";
+import { visibleNavSections } from "./navigation";
 
 /** Largura a partir da qual a sidebar cabe ao lado do conteúdo (= breakpoint `md` do Tailwind). */
 const DESKTOP_MIN_WIDTH = 768;
@@ -74,6 +75,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
   const closeIfMobile = () => {
     if (!isDesktopWidth()) onClose();
   };
+  const navSections = visibleNavSections((module) => hasModule(user, module));
   return (
     <aside
       className="fixed inset-y-0 left-0 z-40 flex h-screen w-64 shrink-0 flex-col overflow-y-auto bg-primary-500 py-6 pl-4 text-white md:sticky md:top-0 md:z-auto md:self-start"

--- a/apps/web/src/app/navigation.test.ts
+++ b/apps/web/src/app/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type NavItem, navSections } from "./navigation";
+import { type NavItem, navSections, visibleNavSections } from "./navigation";
 
 const itens: NavItem[] = navSections.flatMap((s) => s.items);
 
@@ -85,5 +85,49 @@ describe("IV2 — a navegação existente continua inteira", () => {
   it("nenhuma rota duplicada no menu", () => {
     const rotas = itens.map((i) => i.to);
     expect(new Set(rotas).size).toBe(rotas.length);
+  });
+});
+
+/**
+ * `visibleNavSections` — o recorte da sidebar por RBAC (`allowed_modules`). Antes desta função a
+ * sidebar mostrava todo item a todo usuário, e um sub-usuário sem um módulo clicava numa tela que
+ * só sabia travar em "Carregando...". Ver `Modulo` em `app/App.tsx` para a segunda metade (o
+ * guard de ROTA, contra link direto/URL digitada).
+ */
+describe("visibleNavSections", () => {
+  it("dono (hasModule sempre true) vê a lista INTEIRA, mesma forma de navSections", () => {
+    const visiveis = visibleNavSections(() => true).flatMap((s) => s.items);
+    expect(visiveis).toEqual(itens);
+  });
+
+  it("sub-usuário sem nenhum módulo não vê NENHUM item com `module` — a seção some inteira", () => {
+    const secoes = visibleNavSections(() => false);
+    const visiveis = secoes.flatMap((s) => s.items);
+    // O que sobra é só o que nunca teve `module` (hoje, nada — todo item de negócio tem um).
+    expect(visiveis.every((i) => !i.module)).toBe(true);
+  });
+
+  it("um item sem `module` nunca é escondido, mesmo com hasModule sempre false", () => {
+    const semModulo = itens.filter((i) => !i.module);
+    const visiveis = visibleNavSections(() => false).flatMap((s) => s.items);
+    for (const item of semModulo) expect(visiveis).toContainEqual(item);
+  });
+
+  it("sub-usuário restrito (o caso relatado — sem 'juridico' e 'funnels') não vê Jurídico nem Funil de Vendas, mas o resto continua", () => {
+    const modulosPermitidos = new Set(["crm", "cockpit", "agenda", "receivables", "contracts"]);
+    const secoes = visibleNavSections((m) => modulosPermitidos.has(m));
+    const rotas = secoes.flatMap((s) => s.items).map((i) => i.to);
+
+    expect(rotas).not.toContain("/juridico");
+    expect(rotas).not.toContain("/funis");
+    expect(rotas).toContain("/crm");
+    expect(rotas).toContain("/cobrancas");
+    expect(rotas).toContain("/contratos");
+  });
+
+  it("seção que fica sem item nenhum some inteira (não sobra título/divisor vazio)", () => {
+    // "Análise & Configuração Financeira" é só módulos que este usuário não tem — a seção some.
+    const secoes = visibleNavSections((m) => m === "crm");
+    expect(secoes.some((s) => s.title === "Análise & Configuração Financeira")).toBe(false);
   });
 });

--- a/apps/web/src/app/navigation.ts
+++ b/apps/web/src/app/navigation.ts
@@ -36,6 +36,14 @@ export interface NavItem {
   /** Casamento EXATO da rota ativa (evita acender junto com sub-rotas, ex.: /financeiro x
    * /financeiro/plano-contas). Sem isto, o NavLink usa match por prefixo. */
   exact?: boolean;
+  /**
+   * O mesmo nome que `require_module` usa no backend (`app/core/tenancy.py`) para a rota que
+   * este item abre. Um sub-usuário sem este módulo em `allowed_modules` não vê o item — antes
+   * disto a sidebar mostrava tudo a todo mundo, e quem clicasse num módulo sem permissão via a
+   * tela travar em "Carregando..." (a API 403 e nenhuma página tratava isso). Ausente = item sem
+   * módulo próprio de negócio (não deve ser escondido por RBAC).
+   */
+  module?: string;
 }
 
 export interface NavSection {
@@ -86,10 +94,11 @@ export const navSections: NavSection[] = [
   {
     // Núcleo: o que se abre todo dia.
     items: [
-      { label: "Dashboard", to: "/", icon: LayoutDashboard, ready: true },
-      { label: "Agenda", to: "/agenda", icon: CalendarDays, ready: true },
-      { label: "CRM & Kanban", to: "/crm", icon: Users, ready: true },
-      { label: "Conversas", to: "/conversas", icon: MessageCircle, ready: true },
+      { label: "Dashboard", to: "/", icon: LayoutDashboard, ready: true, module: "cockpit" },
+      { label: "Agenda", to: "/agenda", icon: CalendarDays, ready: true, module: "agenda" },
+      { label: "CRM & Kanban", to: "/crm", icon: Users, ready: true, module: "crm" },
+      // `whatsapp_inbox` usa o mesmo guard de `crm` no backend (mesma dona dos dados).
+      { label: "Conversas", to: "/conversas", icon: MessageCircle, ready: true, module: "crm" },
     ],
   },
   {
@@ -97,7 +106,7 @@ export const navSections: NavSection[] = [
     // primeiro porque é onde entra o lançamento de recebimento do dia a dia ("Registrar venda").
     title: "Financeiro",
     items: [
-      { label: "Financeiro", to: "/financeiro", icon: Wallet, ready: true, exact: true },
+      { label: "Financeiro", to: "/financeiro", icon: Wallet, ready: true, exact: true, module: "wallet" },
       // Story 8.7 — ao lado da Carteira de propósito: o rótulo é "onde está o meu dinheiro", e a
       // vizinhança reforça a distinção dos planos ("na plataforma" × conta bancária). Fica FORA
       // de "Análise & Configuração Financeira" para não ser lido como relatório contábil.
@@ -105,10 +114,10 @@ export const navSections: NavSection[] = [
       // "Conciliação bancária" comunicaria "software de contabilidade" a todo usuário — inclusive
       // a quem nunca abre a tela — e viraria a conferência numa obrigação periódica. Ela é resposta
       // a um sinal. Coberto por teste em `navigation.test.ts`.
-      { label: "Contas & Saldos", to: "/financeiro/contas", icon: Landmark, ready: true },
-      { label: "Cobranças", to: "/cobrancas", icon: Receipt, ready: true },
-      { label: "Contas a Pagar", to: "/pagar", icon: CreditCard, ready: true },
-      { label: "Fila de pagamentos", to: "/financeiro/fila-pagamentos", icon: ListChecks, ready: true },
+      { label: "Contas & Saldos", to: "/financeiro/contas", icon: Landmark, ready: true, module: "bank" },
+      { label: "Cobranças", to: "/cobrancas", icon: Receipt, ready: true, module: "receivables" },
+      { label: "Contas a Pagar", to: "/pagar", icon: CreditCard, ready: true, module: "payables" },
+      { label: "Fila de pagamentos", to: "/financeiro/fila-pagamentos", icon: ListChecks, ready: true, module: "payables" },
     ],
   },
   {
@@ -118,32 +127,56 @@ export const navSections: NavSection[] = [
     // cadastros.
     title: "Análise & Configuração Financeira",
     items: [
-      { label: "DRE", to: "/financeiro/dre", icon: PieChart, ready: true },
-      { label: "Lucratividade", to: "/financeiro/lucratividade", icon: Trophy, ready: true },
-      { label: "Projeção de caixa", to: "/financeiro/projecao-caixa", icon: LineChart, ready: true },
-      { label: "Diagnóstico", to: "/financeiro/diagnostico", icon: Activity, ready: true },
-      { label: "Investimentos", to: "/financeiro/investimentos", icon: TrendingUp, ready: true },
-      { label: "Plano de contas", to: "/financeiro/plano-contas", icon: ListTree, ready: true },
-      { label: "Centros de custo", to: "/financeiro/centros-custo", icon: Layers, ready: true },
+      { label: "DRE", to: "/financeiro/dre", icon: PieChart, ready: true, module: "financial_intelligence" },
+      { label: "Lucratividade", to: "/financeiro/lucratividade", icon: Trophy, ready: true, module: "financial_intelligence" },
+      { label: "Projeção de caixa", to: "/financeiro/projecao-caixa", icon: LineChart, ready: true, module: "financial_intelligence" },
+      { label: "Diagnóstico", to: "/financeiro/diagnostico", icon: Activity, ready: true, module: "financial_intelligence" },
+      { label: "Investimentos", to: "/financeiro/investimentos", icon: TrendingUp, ready: true, module: "investments" },
+      { label: "Plano de contas", to: "/financeiro/plano-contas", icon: ListTree, ready: true, module: "chart_of_accounts" },
+      { label: "Centros de custo", to: "/financeiro/centros-custo", icon: Layers, ready: true, module: "cost_centers" },
     ],
   },
   {
     title: "Ferramentas de Produtividade",
     items: [
-      { label: "Orçamentos", to: "/orcamentos", icon: FileText, ready: true },
-      { label: "Contratos", to: "/contratos", icon: FileSignature, ready: true },
-      { label: "Produtos", to: "/produtos", icon: ShoppingBag, ready: true },
-      { label: "Estoque", to: "/estoque", icon: Package, ready: true },
-      { label: "Marketing", to: "/marketing", icon: Megaphone, ready: true },
-      { label: "Funil de Vendas", to: "/funis", icon: Workflow, ready: true },
-      { label: "Sites", to: "/sites", icon: Globe, ready: true },
-      { label: "Jurídico", to: "/juridico", icon: Scale, ready: true },
+      { label: "Orçamentos", to: "/orcamentos", icon: FileText, ready: true, module: "quotes" },
+      { label: "Contratos", to: "/contratos", icon: FileSignature, ready: true, module: "contracts" },
+      { label: "Produtos", to: "/produtos", icon: ShoppingBag, ready: true, module: "products" },
+      { label: "Estoque", to: "/estoque", icon: Package, ready: true, module: "stock" },
+      { label: "Marketing", to: "/marketing", icon: Megaphone, ready: true, module: "marketing" },
+      { label: "Funil de Vendas", to: "/funis", icon: Workflow, ready: true, module: "funnels" },
+      { label: "Sites", to: "/sites", icon: Globe, ready: true, module: "pages" },
+      { label: "Jurídico", to: "/juridico", icon: Scale, ready: true, module: "juridico" },
     ],
   },
   {
     // Raramente aberto — fica isolado no fim, longe do que se usa todo dia.
-    items: [{ label: "Configurações", to: "/config", icon: Settings, ready: true }],
+    items: [{ label: "Configurações", to: "/config", icon: Settings, ready: true, module: "settings" }],
   },
 ];
 
 // Stryker restore all
+
+/**
+ * `navSections` recortado para o que ESTE usuário pode abrir (`hasModule`). Item sem `module`
+ * nunca é escondido (não é módulo de negócio próprio). Seção que fica sem item nenhum some
+ * inteira — senão restaria só o título/divisor, uma seção vazia na tela.
+ *
+ * `navSections` em si permanece a lista COMPLETA e estática (é o que `navigation.test.ts` já
+ * afirma) — o recorte por permissão é uma função pura à parte, para não misturar "o menu que
+ * existe" com "o menu que este usuário vê".
+ *
+ * FORA do bloco `Stryker disable` acima de propósito (issue #191): esta função TEM lógica
+ * (`ConditionalExpression`/`LogicalOperator`) — é exatamente o caso que o comentário daquele
+ * bloco previu ("função nova nasce fora dele e volta a ser medida").
+ */
+export function visibleNavSections(
+  hasModule: (module: string) => boolean,
+): NavSection[] {
+  return navSections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => !item.module || hasModule(item.module)),
+    }))
+    .filter((section) => section.items.length > 0);
+}

--- a/apps/web/src/features/config/ConfiguracoesPage.test.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.test.tsx
@@ -161,6 +161,25 @@ describe("ConfiguracoesPage — áreas", () => {
   });
 });
 
+describe("ConfiguracoesPage — carregamento (RBAC)", () => {
+  it("erro ao carregar o perfil mostra a mensagem em vez de travar em 'Carregando...' para sempre", async () => {
+    // A rota já barra quem não tem o módulo `settings` antes de montar esta página (`Modulo` em
+    // `app/App.tsx`), mas a tela não pode confiar só nisso: qualquer outra falha de `load()`
+    // (rede, 500, sessão expirando) tinha o MESMO sintoma do defeito relatado — `p` nunca saía de
+    // `null` e a tela ficava presa em "Carregando..." para sempre.
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/settings/profile") {
+        return Promise.reject({ response: { data: { detail: "Sem acesso ao módulo 'settings'" } } });
+      }
+      return Promise.resolve({ data: [] } as never);
+    });
+    render(<ConfiguracoesPage />);
+
+    expect(await screen.findByText("Sem acesso ao módulo 'settings'")).toBeInTheDocument();
+    expect(screen.queryByText("Carregando...")).toBeNull();
+  });
+});
+
 describe("ConfiguracoesPage — aba Integrações", () => {
   it("troca pra aba Integrações e lista as chaves", async () => {
     const user = userEvent.setup();

--- a/apps/web/src/features/config/ConfiguracoesPage.tsx
+++ b/apps/web/src/features/config/ConfiguracoesPage.tsx
@@ -36,16 +36,28 @@ export default function ConfiguracoesPage() {
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // A rota já barra quem não tem o módulo `settings` (ver `Modulo` em `app/App.tsx`), então este
+  // 403 não deveria disparar mais — mas nenhuma tela deve ficar presa em "Carregando..." para
+  // sempre por causa de UM erro não tratado (rede caindo, 500, sessão expirando no meio). Sem
+  // isto, `load()` rejeitava em silêncio e `p` nunca saía de `null`.
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
-    const { data } = await api.get<TenantProfile>("/settings/profile");
-    setP(data);
+    try {
+      const { data } = await api.get<TenantProfile>("/settings/profile");
+      setP(data);
+    } catch (err) {
+      setLoadError(apiErrorMessage(err));
+    }
   }, []);
 
   useEffect(() => {
     load();
   }, [load]);
 
+  if (loadError) {
+    return <div className="p-8 text-sm text-danger">{loadError}</div>;
+  }
   if (!p) return <div className="p-8 text-sm text-neutral-400">Carregando...</div>;
 
   const set = (patch: Partial<TenantProfile>) => setP({ ...p, ...patch });

--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -34,7 +34,20 @@ let fusoDoTenant = "America/Sao_Paulo";
 /** Tóquio (UTC+9, sem horário de verão) está 12h à frente do runner: os dois discordam do DIA. */
 const FUSO_DISTANTE = "Asia/Tokyo";
 
-vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
+/**
+ * O usuário logado — dono por padrão, então `allowed_modules` vazio não restringe NADA e as 32
+ * asserções pré-existentes (escritas antes desta permissão existir) continuam vendo as seis
+ * seções da ficha. Só os testes que falam de RBAC trocam para um sub-usuário restrito.
+ */
+let usuarioLogado: { role: "owner" | "sub_user"; allowed_modules: string[] } = {
+  role: "owner",
+  allowed_modules: [],
+};
+
+vi.mock("../../store/auth", () => ({
+  useFuso: () => fusoDoTenant,
+  useAuth: () => ({ user: usuarioLogado }),
+}));
 
 // ── O instante congelado ────────────────────────────────────────────────────
 //
@@ -229,6 +242,8 @@ afterEach(() => {
   vi.useRealTimers();
   // Volta ao fuso "coincidente" para não contaminar os testes que não falam de fuso.
   fusoDoTenant = "America/Sao_Paulo";
+  // Volta ao dono (sem restrição) para não contaminar os testes que não falam de RBAC.
+  usuarioLogado = { role: "owner", allowed_modules: [] };
 });
 
 /** Destino de navegação que ECOA o `:id` recebido — ver a nota nas rotas abaixo. */
@@ -1053,5 +1068,87 @@ describe("ClientDetailPage — para onde a ficha leva (issue #145)", () => {
     expect(screen.getByText("Enviado")).toBeInTheDocument(); // orçamento `sent`
     expect(screen.getByText("Rascunho")).toBeInTheDocument(); // documento `draft`
     expect(screen.getByText("running")).toBeInTheDocument(); // jornada — fora do mapa, sai crua
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// 10. RBAC — um sub-usuário sem TODOS os módulos que a ficha agrega não pode travar em
+//     "Carregando ficha..." para sempre
+//
+// O defeito relatado: um sub-usuário sem Jurídico/Funis via a ficha travada em "Carregando
+// ficha..." porque o `Promise.all` da montagem rejeitava o LOTE INTEIRO na primeira leitura que
+// voltasse 403 — mesmo os dados que ele TINHA permissão de ver nunca apareciam.
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+
+describe("ClientDetailPage — RBAC (sub-usuário sem todos os módulos agregados)", () => {
+  it("abre normalmente, sem pedir os módulos ausentes, e esconde só as seções deles", async () => {
+    usuarioLogado = { role: "sub_user", allowed_modules: ["crm", "receivables", "contracts", "quotes"] };
+    // `urlsPedidas()` lê `mock.calls`, que ACUMULA desde o primeiro teste do arquivo (nenhum
+    // `beforeEach` chama `mockClear()` em `api.get` — só `mockImplementation`). Sem limpar aqui,
+    // a asserção `.not.toContain` abaixo veria as chamadas de dezenas de testes ANTERIORES (o
+    // dono default vendo os seis módulos) e falharia por acúmulo, não pelo próprio `load()`.
+    vi.mocked(api.get).mockClear();
+    renderFicha();
+
+    // A ficha ABRE — não fica presa em "Carregando ficha..." como no defeito relatado.
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.queryByText("Carregando ficha...")).toBeNull();
+
+    // Os dados PERMITIDOS aparecem.
+    expect(screen.getByText("Cobranças (6)")).toBeInTheDocument();
+    expect(screen.getByText("Contratos (1)")).toBeInTheDocument();
+    expect(screen.getByText("Orçamentos (1)")).toBeInTheDocument();
+
+    // As seções dos módulos AUSENTES somem inteiras — não aparecem como "0" nem como lista vazia.
+    expect(screen.queryByText(/Documentos jurídicos/)).toBeNull();
+    expect(screen.queryByText(/Jornadas no funil/)).toBeNull();
+
+    // E o ponto central do defeito: a tela nem PEDE os módulos que sabe de antemão que não tem.
+    expect(urlsPedidas()).not.toContain("/juridico/documents?client_id=cli-1");
+    expect(urlsPedidas()).not.toContain("/funnels/runs?client_id=cli-1");
+  });
+
+  it("dono (`allowed_modules` vazio) continua vendo as seis leituras — sem restrição nenhuma", async () => {
+    usuarioLogado = { role: "owner", allowed_modules: [] };
+    renderFicha();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    for (const url of URLS_DA_MONTAGEM) {
+      expect(urlsPedidas()).toContain(url);
+    }
+    expect(screen.getByText(/Documentos jurídicos/)).toBeInTheDocument();
+    expect(screen.getByText(/Jornadas no funil/)).toBeInTheDocument();
+  });
+
+  it("sem o módulo `receivables`, o resumo financeiro também some — não mostra R$ 0,00 de mentira", async () => {
+    usuarioLogado = { role: "sub_user", allowed_modules: ["crm", "contracts"] };
+    renderFicha();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.queryByText("A receber (a vencer)")).toBeNull();
+    expect(screen.queryByText("Vencido")).toBeNull();
+    expect(screen.queryByText("Recebido")).toBeNull();
+  });
+
+  it("uma leitura PERMITIDA que falha por outro motivo (não 403) não trava as demais seções", async () => {
+    // Defesa em profundidade: mesmo com o módulo liberado, uma falha de rede/500 na leitura de
+    // contratos não pode derrubar cobranças/orçamentos, que já chegaram.
+    usuarioLogado = { role: "owner", allowed_modules: [] };
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/contracts?client_id=cli-1") return Promise.reject(new Error("500"));
+      if (url === "/crm/clients/cli-1") return Promise.resolve({ data: ficha.cliente } as never);
+      if (url === "/receivables/charges?client_id=cli-1") return Promise.resolve({ data: ficha.charges } as never);
+      if (url === "/quotes?client_id=cli-1") return Promise.resolve({ data: ficha.quotes } as never);
+      if (url === "/juridico/documents?client_id=cli-1") return Promise.resolve({ data: ficha.legalDocs } as never);
+      if (url === "/funnels/runs?client_id=cli-1") return Promise.resolve({ data: ficha.journeys } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderFicha();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.queryByText("Carregando ficha...")).toBeNull();
+    expect(screen.getByText("Cobranças (6)")).toBeInTheDocument();
+    // Contratos sobrevive à falha degradando para a lista vazia, não travando a página inteira.
+    expect(screen.getByText("Contratos (0)")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -13,8 +13,9 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
+import { hasModule } from "../../lib/access";
 import { formatDate, formatDay } from "../../lib/datetime";
-import { useFuso } from "../../store/auth";
+import { useAuth, useFuso } from "../../store/auth";
 import { rotaDaCobranca } from "../cobrancas/rota";
 import { AGENDADO_ENTRADA_LABEL } from "../financeiro/contas";
 import BlocoDaAgenda from "./BlocoDaAgenda";
@@ -29,6 +30,7 @@ const dt = (s: string, tz: string) => (s.length === 10 ? formatDay(s) : formatDa
 
 export default function ClientDetailPage() {
   const fuso = useFuso();
+  const { user } = useAuth();
   const { id = "" } = useParams();
   const navigate = useNavigate();
   const [client, setClient] = useState<Client | null>(null);
@@ -41,14 +43,42 @@ export default function ClientDetailPage() {
   // [8.15] A cobrança para a qual o dono está declarando "recebi direto na conta".
   const [recebendo, setRecebendo] = useState<Charge | null>(null);
 
+  // A ficha pertence ao CRM, mas AGREGA cinco módulos que podem não pertencer ao usuário — um
+  // sub-usuário sem Jurídico/Funis (por exemplo) tem `allowed_modules` sem eles. Antes desta
+  // correção o `load()` disparava as SEIS leituras num `Promise.all` só: a PRIMEIRA a voltar 403
+  // rejeitava o lote inteiro, `client` nunca saía de `null`, e a ficha ficava presa em
+  // "Carregando ficha..." mesmo para os dados que o usuário TINHA permissão de ver.
+  const podeCobrancas = hasModule(user, "receivables");
+  const podeContratos = hasModule(user, "contracts");
+  const podeOrcamentos = hasModule(user, "quotes");
+  const podeJuridico = hasModule(user, "juridico");
+  const podeFunis = hasModule(user, "funnels");
+
   const load = useCallback(async () => {
+    // Cada leitura secundária: (1) nem dispara se o módulo não é permitido — não há por que
+    // pedir o que se sabe de antemão que vai vir 403; (2) tem `.catch` próprio para qualquer
+    // outra falha (rede, 500) não derrubar as outras seções. `client` (o único dado sem o qual a
+    // ficha não faz sentido nenhum) continua fora dessa rede: se ele falhar, a falha aparece —
+    // não há "ficha parcial" sem cliente.
     const [c, ch, co, qu, ld, jr] = await Promise.all([
       api.get<Client>(`/crm/clients/${id}`),
-      api.get<Charge[]>(`/receivables/charges?client_id=${id}`),
-      api.get<Contract[]>(`/contracts?client_id=${id}`),
-      api.get<Quote[]>(`/quotes?client_id=${id}`),
-      api.get<LegalDocumentSummary[]>(`/juridico/documents?client_id=${id}`),
-      api.get<FunnelRunSummary[]>(`/funnels/runs?client_id=${id}`),
+      podeCobrancas
+        ? api.get<Charge[]>(`/receivables/charges?client_id=${id}`).catch(() => ({ data: [] as Charge[] }))
+        : Promise.resolve({ data: [] as Charge[] }),
+      podeContratos
+        ? api.get<Contract[]>(`/contracts?client_id=${id}`).catch(() => ({ data: [] as Contract[] }))
+        : Promise.resolve({ data: [] as Contract[] }),
+      podeOrcamentos
+        ? api.get<Quote[]>(`/quotes?client_id=${id}`).catch(() => ({ data: [] as Quote[] }))
+        : Promise.resolve({ data: [] as Quote[] }),
+      podeJuridico
+        ? api
+            .get<LegalDocumentSummary[]>(`/juridico/documents?client_id=${id}`)
+            .catch(() => ({ data: [] as LegalDocumentSummary[] }))
+        : Promise.resolve({ data: [] as LegalDocumentSummary[] }),
+      podeFunis
+        ? api.get<FunnelRunSummary[]>(`/funnels/runs?client_id=${id}`).catch(() => ({ data: [] as FunnelRunSummary[] }))
+        : Promise.resolve({ data: [] as FunnelRunSummary[] }),
     ]);
     setClient(c.data);
     setCharges(ch.data);
@@ -56,7 +86,7 @@ export default function ClientDetailPage() {
     setQuotes(qu.data);
     setLegalDocs(ld.data);
     setJourneys(jr.data);
-  }, [id]);
+  }, [id, podeCobrancas, podeContratos, podeOrcamentos, podeJuridico, podeFunis]);
 
   useEffect(() => {
     load();
@@ -116,24 +146,28 @@ export default function ClientDetailPage() {
         {client.notes && <p className="mt-3 whitespace-pre-line rounded-lg bg-neutral-50 p-3 text-sm text-neutral-600">{client.notes}</p>}
       </div>
 
-      {/* Resumo financeiro */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Stat label="A receber (a vencer)" value={brl(openSum)} tone="text-neutral-700" />
-        <Stat label="Vencido" value={brl(overdueSum)} tone="text-danger" />
-        <Stat label="Recebido" value={brl(paidSum)} tone="text-accent-700" />
-        {/* [issue #154] Espelho EXATO do quarto cartão da `CobrancasPage` (Story 8.15): mesmo
-            rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
-            Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
-            ação de dinheiro, e uma terceira convenção para o mesmo estado seria a assimetria que
-            esta issue existe para fechar.
-            ⚠️ [#186] É por isso que o rótulo é IMPORTADO de `financeiro/contas.ts` em vez de
-            escrito solto: "vem de lá" precisava continuar valendo quando alguém o renomear. O
-            import atravessa feature de propósito e não inventa convenção — é a mesma forma do
-            `VOCAB_ENTRADA` (`pagar/baixa.ts`) que esta tela já importa acima. */}
-        {scheduledSum > 0 && (
-          <Stat label={AGENDADO_ENTRADA_LABEL} value={brl(scheduledSum)} tone="text-amber-700" />
-        )}
-      </div>
+      {/* Resumo financeiro — some inteiro sem o módulo Cobranças (`receivables`): mostrar três
+          cartões zerados para quem não tem acesso ao dinheiro do cliente seria uma afirmação
+          ("nada a receber") que ninguém verificou, não um resumo. */}
+      {podeCobrancas && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Stat label="A receber (a vencer)" value={brl(openSum)} tone="text-neutral-700" />
+          <Stat label="Vencido" value={brl(overdueSum)} tone="text-danger" />
+          <Stat label="Recebido" value={brl(paidSum)} tone="text-accent-700" />
+          {/* [issue #154] Espelho EXATO do quarto cartão da `CobrancasPage` (Story 8.15): mesmo
+              rótulo, mesmo tom âmbar e **some quando é zero**, pela mesma disciplina anti-ruído.
+              Rótulo e semântica vêm de lá de propósito — a ficha e a tela de cobranças são a MESMA
+              ação de dinheiro, e uma terceira convenção para o mesmo estado seria a assimetria que
+              esta issue existe para fechar.
+              ⚠️ [#186] É por isso que o rótulo é IMPORTADO de `financeiro/contas.ts` em vez de
+              escrito solto: "vem de lá" precisava continuar valendo quando alguém o renomear. O
+              import atravessa feature de propósito e não inventa convenção — é a mesma forma do
+              `VOCAB_ENTRADA` (`pagar/baixa.ts`) que esta tela já importa acima. */}
+          {scheduledSum > 0 && (
+            <Stat label={AGENDADO_ENTRADA_LABEL} value={brl(scheduledSum)} tone="text-amber-700" />
+          )}
+        </div>
+      )}
 
       {/* Histórico — primeiro bloco de propósito: é a história que dá sentido às seções
           operacionais abaixo (Cobranças, Contratos, Orçamentos). */}
@@ -166,7 +200,8 @@ export default function ClientDetailPage() {
         <BlocoDaAgenda clientId={id} nome={client.name} />
       </Section>
 
-      {/* Cobranças */}
+      {/* Cobranças — some inteiro sem o módulo `receivables` (ver comentário do resumo acima). */}
+      {podeCobrancas && (
       <Section icon={<Receipt size={16} />} title={`Cobranças (${charges.length})`}>
         {charges.length === 0 ? (
           <Empty text="Nenhuma cobrança para este cliente." />
@@ -184,8 +219,10 @@ export default function ClientDetailPage() {
           </ul>
         )}
       </Section>
+      )}
 
-      {/* Contratos */}
+      {/* Contratos — some inteiro sem o módulo `contracts`. */}
+      {podeContratos && (
       <Section icon={<FileSignature size={16} />} title={`Contratos (${contracts.length})`}>
         {contracts.length === 0 ? (
           <Empty text="Nenhum contrato." />
@@ -203,8 +240,10 @@ export default function ClientDetailPage() {
           </ul>
         )}
       </Section>
+      )}
 
-      {/* Orçamentos */}
+      {/* Orçamentos — some inteiro sem o módulo `quotes`. */}
+      {podeOrcamentos && (
       <Section icon={<FileText size={16} />} title={`Orçamentos (${quotes.length})`}>
         {quotes.length === 0 ? (
           <Empty text="Nenhum orçamento." />
@@ -222,8 +261,11 @@ export default function ClientDetailPage() {
           </ul>
         )}
       </Section>
+      )}
 
-      {/* Documentos jurídicos */}
+      {/* Documentos jurídicos — some inteiro sem o módulo `juridico` (segredo de justiça: nem a
+          CONTAGEM de documentos deve vazar para quem não tem o módulo). */}
+      {podeJuridico && (
       <Section icon={<Gavel size={16} />} title={`Documentos jurídicos (${legalDocs.length})`}>
         {legalDocs.length === 0 ? (
           <Empty text="Nenhum documento jurídico vinculado." />
@@ -241,8 +283,10 @@ export default function ClientDetailPage() {
           </ul>
         )}
       </Section>
+      )}
 
-      {/* Jornadas no funil (automação) */}
+      {/* Jornadas no funil (automação) — some inteiro sem o módulo `funnels`. */}
+      {podeFunis && (
       <Section icon={<Workflow size={16} />} title={`Jornadas no funil (${journeys.length})`}>
         {journeys.length === 0 ? (
           <Empty text="Este contato não está em nenhum funil." />
@@ -260,6 +304,7 @@ export default function ClientDetailPage() {
           </ul>
         )}
       </Section>
+      )}
 
       {/* [8.15] A MESMA porta da tela de Cobranças, no MESMO componente — a Ficha 360° não ganha
           um segundo fluxo de registro. */}

--- a/apps/web/src/lib/access.test.ts
+++ b/apps/web/src/lib/access.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { hasModule } from "./access";
+
+/**
+ * Espelha, um a um, os ramos de `require_module` em `app/core/tenancy.py`:
+ * `user.role == "owner" or not user.allowed_modules or module in user.allowed_modules`.
+ */
+describe("hasModule", () => {
+  it("nenhum usuário logado nunca tem acesso", () => {
+    expect(hasModule(null, "juridico")).toBe(false);
+  });
+
+  it("dono (role=owner) tem acesso a qualquer módulo, mesmo com allowed_modules restrito", () => {
+    expect(hasModule({ role: "owner", allowed_modules: ["crm"] }, "juridico")).toBe(true);
+  });
+
+  it("allowed_modules VAZIO é 'sem restrição' — não 'sem módulo nenhum'", () => {
+    expect(hasModule({ role: "sub_user", allowed_modules: [] }, "juridico")).toBe(true);
+  });
+
+  it("sub-usuário com o módulo na lista tem acesso", () => {
+    expect(hasModule({ role: "sub_user", allowed_modules: ["crm", "juridico"] }, "juridico")).toBe(true);
+  });
+
+  it("sub-usuário sem o módulo na lista NÃO tem acesso — o caso que travava a tela", () => {
+    expect(hasModule({ role: "sub_user", allowed_modules: ["crm"] }, "juridico")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/access.ts
+++ b/apps/web/src/lib/access.ts
@@ -1,0 +1,18 @@
+import type { User } from "@e1p/shared-types";
+
+/**
+ * Espelha `require_module` de `app/core/tenancy.py`: dono ou lista vazia não têm restrição;
+ * senão, o módulo precisa estar em `allowed_modules`.
+ *
+ * ⚠️ **É a ÚNICA porta desta regra no frontend.** Antes deste módulo, nada aqui consultava
+ * `allowed_modules` — a sidebar mostrava todo item a todo usuário e nenhuma tela sabia dizer
+ * "você não tem este módulo" antes de disparar a requisição. O sintoma era a tela travar em
+ * "Carregando..." para sempre quando a API respondia 403 (issue: ficha do cliente e
+ * Configurações travadas para um sub-usuário sem Jurídico/Funis/Configurações).
+ */
+export function hasModule(user: Pick<User, "role" | "allowed_modules"> | null | undefined, module: string): boolean {
+  if (!user) return false;
+  if (user.role === "owner") return true;
+  if (user.allowed_modules.length === 0) return true;
+  return user.allowed_modules.includes(module);
+}


### PR DESCRIPTION
## Resumo

O fundador reportou: um sub-usuário sem Jurídico/Funis (Leonardo) abria a **ficha do cliente** e ela travava em "Carregando ficha..." para sempre. Ao investigar, o mesmo aconteceu em **Configurações**.

**Causas:**
- `ClientDetailPage.load()` juntava as 6 leituras (cliente/cobranças/contratos/orçamentos/jurídico/funis) num `Promise.all` só — a primeira a voltar 403 rejeitava o lote inteiro, e nem os dados **permitidos** apareciam.
- `ConfiguracoesPage.load()` não tinha `.catch` — o 403 de `/settings/profile` (exige o módulo `settings`) tinha o mesmo efeito.
- **Raiz comum:** o frontend nunca consultava `allowed_modules` em lugar nenhum — a sidebar mostrava todo item a todo usuário, e nenhuma rota sabia recusar antes de a página tentar buscar dados que voltariam 403.

## O que mudou

- `lib/access.ts` — `hasModule(user, module)`, espelho exato do `require_module` do backend.
- `navigation.ts` — cada item de menu ganha `module`; `visibleNavSections()` recorta a sidebar por permissão (seção vazia some inteira).
- `App.tsx` — `<Modulo m="...">` guarda cada rota de módulo de negócio, protegendo contra link direto/favorito/URL digitada (não só o clique no menu).
- `ClientDetailPage.tsx` — pula a leitura de módulo não permitido (nunca dispara a requisição) + `.catch` defensivo nas demais (rede/500 não trava as outras seções); seções e resumo financeiro somem inteiros quando o módulo falta.
- `ConfiguracoesPage.tsx` — `load()` ganha `try/catch`, nunca mais trava sem explicação.
- `CLAUDE.md` — entrada documentando a causa raiz e a decisão de arquitetura (RBAC de UI é conveniência; o backend continua sendo o fail-closed real).

## Test plan

- [x] `pnpm typecheck` limpo
- [x] `pnpm lint` (`eslint --max-warnings 0`) limpo
- [x] Suíte completa do frontend: 871/873 (as 2 falhas são timeout pré-existente e documentado de `PlatformUsers.test.tsx` sob concorrência de suíte completa — 7/7 passam isolado, arquivo não tocado por este PR)
- [x] Testes novos cobrindo o cenário exato relatado: sub-usuário sem Jurídico/Funis abre a ficha normalmente, sem pedir os módulos ausentes (`ClientDetailPage.test.tsx`); guard de rota (`App.test.tsx`); recorte da sidebar (`navigation.test.ts`); `hasModule` (`access.test.ts`)
- [ ] e2e Playwright não rodado (fixture de sessão já usa `role: owner, allowed_modules: []`, comportamento idêntico ao anterior — baixo risco, não medido)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)