### PR TITLE
fix: CompartilharPage nao trava no spinner sob React.StrictMode (#226)

### DIFF
--- a/apps/web/src/features/pagar/CompartilharPage.test.tsx
+++ b/apps/web/src/features/pagar/CompartilharPage.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { useEffect, useRef } from "react";
+import { StrictMode, useEffect, useRef } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { MemoryRouter, Route, Routes, useNavigate, useNavigationType } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,9 +34,9 @@ function TestProbe({ onReady }: { onReady: (handle: ProbeHandle) => void }) {
   return null;
 }
 
-function renderAt(url: string, extraRoutes: JSX.Element[] = []) {
+function renderAt(url: string, extraRoutes: JSX.Element[] = [], strict = false) {
   let handle: ProbeHandle | null = null;
-  render(
+  const tree = (
     <MemoryRouter initialEntries={[url]}>
       <TestProbe onReady={(h) => (handle = h)} />
       <Routes>
@@ -44,8 +44,9 @@ function renderAt(url: string, extraRoutes: JSX.Element[] = []) {
         <Route path="/comprovante/:id" element={<p>tela do comprovante</p>} />
         {extraRoutes}
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
+  render(strict ? <StrictMode>{tree}</StrictMode> : tree);
   return {
     navigate: (to: string) => act(() => handle!.navigate(to)),
     getActionType: () => handle!.getActionType(),
@@ -151,5 +152,32 @@ describe("CompartilharPage", () => {
 
     await waitFor(() => expect(screen.queryByText("tela do comprovante")).toBeNull());
     expect(screen.getByText("outra tela")).toBeTruthy();
+  });
+
+  // Achado 5 (#226): sob React.StrictMode (produção real via main.tsx), a 2ª montagem do efeito
+  // via que `startedFor === token` e desistia SEM se inscrever no resultado. Quando a limpeza do
+  // StrictMode cancelava a 1ª montagem, ninguém vivo chamava setError/navigate e o spinner ficava
+  // preso em "Enviando comprovante..." para sempre. A 2ª montagem (a que sobrevive) precisa
+  // terminar — sucesso ou erro — mesmo reaproveitando a mesma requisição da 1ª.
+  it("sob StrictMode, a 2a montagem termina (sucesso) e nao trava em 'Enviando comprovante...'", async () => {
+    vi.mocked(takeSharedFile).mockResolvedValue(
+      new File(["x"], "comp.pdf", { type: "application/pdf" }),
+    );
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "r-strict" } } as never);
+
+    renderAt("/compartilhar?k=strict1", [], true);
+
+    await waitFor(() => screen.getByText("tela do comprovante"), { timeout: 2000 });
+    // dedup: mesmo com StrictMode montando duas vezes, a chave só é buscada uma vez.
+    expect(vi.mocked(takeSharedFile)).toHaveBeenCalledTimes(1);
+  });
+
+  it("sob StrictMode, a 2a montagem termina (erro) e nao trava em 'Enviando comprovante...'", async () => {
+    vi.mocked(takeSharedFile).mockResolvedValue(null);
+
+    renderAt("/compartilhar?k=strict2", [], true);
+
+    await waitFor(() => screen.getByText(/não encontramos o arquivo/i), { timeout: 2000 });
+    expect(screen.queryByText(/enviando comprovante/i)).toBeNull();
   });
 });

--- a/apps/web/src/features/pagar/CompartilharPage.tsx
+++ b/apps/web/src/features/pagar/CompartilharPage.tsx
@@ -3,6 +3,30 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
 import { takeSharedFile } from "../../lib/shareInbox";
 
+type Result = { ok: true; id: string } | { ok: false; message: string };
+
+/**
+ * Busca o arquivo no IndexedDB e sobe para a bandeja. Não toca estado do componente — devolve um
+ * `Result` para quem chamou decidir o que fazer (ver Achado 5 abaixo: mais de uma montagem do
+ * StrictMode pode se inscrever na mesma promessa).
+ */
+async function uploadSharedFile(key: string): Promise<Result> {
+  try {
+    const file = await takeSharedFile(key);
+    if (!file) {
+      return { ok: false, message: "Não encontramos o arquivo compartilhado. Ele pode já ter sido enviado." };
+    }
+    const fd = new FormData();
+    fd.append("file", file);
+    const { data } = await api.post<{ id: string }>("/payables/receipts", fd, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return { ok: true, id: data.id };
+  } catch (err) {
+    return { ok: false, message: apiErrorMessage(err) };
+  }
+}
+
 /**
  * Rota de trânsito do Web Share Target. Sem UI própria além do spinner: o service worker
  * redireciona para cá com `?k=<chave>`, nós pegamos o arquivo do IndexedDB, subimos para a
@@ -20,25 +44,29 @@ import { takeSharedFile } from "../../lib/shareInbox";
  *   processar o novo compartilhamento normalmente. Um `cancelled` de escopo por execução garante
  *   que uma promessa antiga (de uma chave/tela já abandonada) nunca chame `setError`/`navigate`
  *   depois que o efeito foi limpo.
+ *
+ * Achado 5 (#226): `startedFor` respondia DUAS perguntas diferentes com uma variável só — "já
+ * comecei a buscar essa chave?" (precisa sobreviver entre montagens, senão duplica o upload) e
+ * "esta execução do efeito foi cancelada?" (é por-execução). A 2ª montagem do StrictMode via que
+ * `startedFor` já batia com o token e retornava ANTES de sequer se inscrever para saber o
+ * resultado — então quando a 1ª montagem era cancelada pela limpeza do StrictMode, ninguém mais
+ * vivo chamava `setError`/navegava, e o spinner ficava preso para sempre. A correção: o token
+ * ainda deduplica a REQUISIÇÃO (`pendingFor`/`pending`), mas a promessa em voo fica guardada num
+ * ref e toda execução do efeito — mesmo a que não iniciou o fetch — se inscreve nela com o seu
+ * próprio `cancelled` local, então a montagem que sobrevive sempre resolve o estado.
  */
 export default function CompartilharPage() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
-  const startedFor = useRef<string | null>(null);
+  const pendingFor = useRef<string | null>(null);
+  const pending = useRef<Promise<Result> | null>(null);
 
   const key = params.get("k");
   const swError = params.get("erro");
 
   useEffect(() => {
     let cancelled = false;
-
-    // StrictMode monta duas vezes com os mesmos parâmetros — o token evita reprocessar o mesmo
-    // compartilhamento nessa segunda montagem. Mas se `key`/`swError` mudarem (SW navegando a
-    // mesma janela para uma chave nova, sem reload), o token muda e o efeito processa de novo.
-    const token = `k=${key ?? ""}|erro=${swError ?? ""}`;
-    if (startedFor.current === token) return;
-    startedFor.current = token;
 
     if (swError) {
       setError("Não conseguimos receber o arquivo compartilhado. Tente de novo.");
@@ -49,26 +77,27 @@ export default function CompartilharPage() {
       return;
     }
 
-    (async () => {
-      try {
-        const file = await takeSharedFile(key);
-        if (cancelled) return;
-        if (!file) {
-          setError("Não encontramos o arquivo compartilhado. Ele pode já ter sido enviado.");
-          return;
-        }
-        const fd = new FormData();
-        fd.append("file", file);
-        const { data } = await api.post<{ id: string }>("/payables/receipts", fd, {
-          headers: { "Content-Type": "multipart/form-data" },
-        });
-        if (cancelled) return;
-        navigate(`/comprovante/${data.id}`, { replace: true });
-      } catch (err) {
-        if (cancelled) return;
-        setError(apiErrorMessage(err));
+    // StrictMode monta duas vezes com os mesmos parâmetros — o token evita DUPLICAR o
+    // upload nessa segunda montagem, reaproveitando a promessa já em voo. Mas se `key`
+    // mudar (SW navegando a mesma janela para uma chave nova, sem reload), o token muda e
+    // um novo upload é iniciado.
+    const token = `k=${key}`;
+    if (pendingFor.current !== token || !pending.current) {
+      pendingFor.current = token;
+      pending.current = uploadSharedFile(key);
+    }
+
+    // Toda execução do efeito se inscreve no resultado — inclusive a que NÃO iniciou o
+    // upload — para que a montagem que sobrevive ao StrictMode sempre resolva o estado
+    // (setError ou navigate), mesmo quando a montagem que começou o fetch foi cancelada.
+    pending.current.then((result) => {
+      if (cancelled) return;
+      if (result.ok) {
+        navigate(`/comprovante/${result.id}`, { replace: true });
+      } else {
+        setError(result.message);
       }
-    })();
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## O que é

`/compartilhar?k=<chave>` travava em "Enviando comprovante..." para sempre sob `React.StrictMode` — o spinner nunca saía, nem para sucesso nem para erro.

## Causa

O guard `startedFor` respondia duas perguntas diferentes com uma única variável: "já comecei a buscar essa chave?" (precisa sobreviver entre montagens, para não duplicar o upload) e "esta execução do efeito foi cancelada?" (é por-execução). A 2ª montagem do StrictMode via que o token já batia e retornava **antes de se inscrever no resultado** — quando a limpeza do StrictMode cancelava a 1ª montagem, ninguém vivo chamava `setError`/`navigate`.

## Correção

Separei as duas perguntas: `pendingFor`/`pending` deduplicam a requisição entre montagens (guardando a promessa em voo), mas **toda execução do efeito** — inclusive a que não iniciou o fetch — se inscreve no resultado com seu próprio `cancelled` local. A montagem que sobrevive sempre resolve o estado (sucesso ou erro).

## Prova por mutação

Revertido o componente para o comportamento antigo, os dois testes novos de StrictMode morrem com o spinner preso em "Enviando comprovante...", reproduzindo o bug relatado. Verificação independente confirmou isso (não apenas o relatório do implementador).

## Gates

- `pnpm lint` — limpo
- `pnpm typecheck` — limpo
- `pnpm test` — 86 arquivos / 1019 testes, todos verdes (incluindo os 2 testes novos de StrictMode)

Closes #226
