### PR TITLE
feat: guarda contra diretiva 'Stryker disable next-line' deslocada [#229]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,19 @@ jobs:
       # uma razão de RELÓGIO: ela é o que decide se a medição noturna vale, e um guarda verificado
       # só de madrugada é um guarda que se descobre quebrado depois de já ter deixado passar uma
       # noite. Aqui ela roda a cada PR, como os outros gates de ferramental.
-      - name: Gates de infra/ (Caddyfile, guarda do deploy.sh e guarda de timeouts da mutação)
+      # A guarda de diretiva `Stryker disable next-line` deslocada (issue #229) entrou pela MESMA
+      # razão de checkout completo (varre `apps/web/src`, que `test-in-prod-image` não tem) — e
+      # não no job `frontend`, porque ali ela testaria uma REIMPLEMENTAÇÃO em vez do script de
+      # verdade; aqui ela roda via subprocess contra `scripts/guarda-stryker-disable-deslocado.mjs`,
+      # a mesma escolha da guarda de timeouts.
+      - name: Gates de infra/ (Caddyfile, guarda do deploy.sh, guarda de timeouts da mutação e guarda de diretiva Stryker deslocada)
         run: |
           set -uo pipefail
           cd apps/api
-          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py tests/test_guarda_timeouts_mutacao.py --junitxml=infra-gates.xml
+          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py tests/test_guarda_timeouts_mutacao.py tests/test_guarda_stryker_disable_deslocado.py --junitxml=infra-gates.xml
           rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=24; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 24 executados: 7 do Caddyfile + 4 da guarda do deploy.sh + 13 da guarda de timeouts da mutacao). Eles dependem de infra/, scripts/, bash, git e node alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS, o de timeouts e a issue #213."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=34; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 34 executados: 7 do Caddyfile + 4 da guarda do deploy.sh + 13 da guarda de timeouts da mutacao + 10 da guarda de diretiva Stryker deslocada). Eles dependem de infra/, scripts/, bash, git e node alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS, o de timeouts e a issue #213, o da diretiva deslocada e a issue #229."); sys.exit(0 if ok else 1)'
 
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem

--- a/apps/api/tests/test_guarda_stryker_disable_deslocado.py
+++ b/apps/api/tests/test_guarda_stryker_disable_deslocado.py
@@ -1,0 +1,239 @@
+"""A guarda de diretivas `Stryker disable next-line` deslocadas dispara com arquivo e linha corretos
+na mensagem (issue #229).
+
+⚠️ Este teste EXECUTA `scripts/guarda-stryker-disable-deslocado.mjs`, o arquivo de verdade — não uma
+reimplementação da regra escrita aqui. Uma cópia passaria a concordar consigo mesma no dia em que
+alguém editasse o script, a mesma família de teste que este repositório documenta como "passa e não
+prova nada" (§5.1). Mesma escolha do `test_guarda_timeouts_mutacao.py` e do
+`test_deploy_guarda_checkout_limpo.py`.
+
+O defeito que ele fecha: `// Stryker disable next-line <mutador>` só suprime a mutação da linha
+LITERAL seguinte. Achado na triagem do #214 (PR #222): `financeiro/ledger.ts` e
+`financeiro/dreMatrixEntries.ts` traziam a diretiva SETE LINHAS acima do alvo — a linha seguinte
+literal era outro comentário, então a supressão nunca existiu, e o mutante apareceu como `Survived`
+em dois relatórios de CI sem ninguém notar. Os dois casos foram consertados no PR #222; esta guarda
+fecha a reincidência.
+
+Por que um teste em Python para um script Node: é onde este repositório já testa ferramental que não
+é código de aplicação (o `Caddyfile`, o `deploy.sh` e a guarda de timeouts da mutação têm os seus
+aqui), e é o job `cross-tenant-rls` — required em `main` — que os roda, com a guarda anti-vacuidade
+que REPROVA o skip.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _acha_guarda() -> pathlib.Path | None:
+    """Sobe procurando o script — o mesmo motivo do gate do Caddyfile e do `deploy.sh`.
+
+    A suíte também roda DENTRO da imagem da API (`test-in-prod-image`), onde só `apps/api` foi
+    copiado: `scripts/` não existe lá. Resolver a raiz por índice fixo estoura `IndexError` na
+    COLETA e derruba o job inteiro por um teste que nem era sobre a API.
+    """
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "scripts" / "guarda-stryker-disable-deslocado.mjs"
+        if candidato.is_file():
+            return candidato
+    return None
+
+
+GUARDA = _acha_guarda()
+
+pytestmark = pytest.mark.skipif(
+    GUARDA is None or shutil.which("node") is None,
+    reason=(
+        "precisa de scripts/guarda-stryker-disable-deslocado.mjs e do node — o job "
+        "cross-tenant-rls tem os dois, e lá o SKIP é reprovado pela guarda anti-vacuidade"
+    ),
+)
+
+
+def _roda(*args: str) -> subprocess.CompletedProcess[str]:
+    assert GUARDA is not None
+    return subprocess.run(
+        ["node", str(GUARDA), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+
+
+def _escreve(tmp_path: pathlib.Path, nome: str, conteudo: str) -> pathlib.Path:
+    caminho = tmp_path / nome
+    caminho.parent.mkdir(parents=True, exist_ok=True)
+    caminho.write_text(textwrap.dedent(conteudo), encoding="utf-8")
+    return caminho
+
+
+# ── CASO POSITIVO (CONTROLE) — diretiva encostada no alvo ──────────────────────────────────────────
+
+
+def test_diretiva_encostada_no_alvo_passa(tmp_path: pathlib.Path) -> None:
+    """A mesma forma de `pagar/baixa.ts:197` — nada entre a diretiva e o código."""
+    _escreve(
+        tmp_path,
+        "ok.ts",
+        """\
+        // Explicação qualquer sobre o mutante equivalente.
+        // Stryker disable next-line ArithmeticOperator
+        export const X = 1 + 2;
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert r.stdout.startswith("OK: nenhuma diretiva")
+
+
+def test_os_quatro_arquivos_reais_do_e1p_passam_limpo() -> None:
+    """Controle contra a árvore REAL: roda a guarda direto em `apps/web/src`.
+
+    Os quatro pontos citados na issue #229 (grade.ts, dreMatrixEntries.ts, ledger.ts, baixa.ts) têm
+    de estar, hoje, com a diretiva encostada no alvo — senão este teste é o primeiro a acusar.
+    """
+    raiz = None
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "apps" / "web" / "src"
+        if candidato.is_dir():
+            raiz = candidato
+            break
+    if raiz is None:
+        pytest.skip("apps/web/src não está presente neste checkout (ex.: imagem da API)")
+
+    r = _roda(str(raiz))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert r.stdout.startswith("OK: nenhuma diretiva")
+
+
+# ── CASO NEGATIVO (REGRESSÃO) — diretiva deslocada ──────────────────────────────────────────────────
+
+
+def test_diretiva_seguida_de_comentario_reprova_com_arquivo_e_linha(tmp_path: pathlib.Path) -> None:
+    """O caso EXATO do #214/#222: a diretiva na linha 2, o alvo real sete linhas abaixo."""
+    _escreve(
+        tmp_path,
+        "features/financeiro/quebrado.ts",
+        """\
+        // 0 onde o original devolve 1, e o sort só observa o SINAL do comparador.
+        // Stryker disable next-line EqualityOperator
+        // Medido: 23.600 arranjos de 2 a 60 itens com datas repetidas, ZERO divergências.
+        // Não leva `disable` porque a directive é por MUTADOR, e desligar
+        // `ConditionalExpression` aqui apagaria junto o mutante `true`, que HOJE morre no
+        // teste de empate.
+        export function cmp(a: number, b: number): number {
+          return a < b ? 1 : a > b ? -1 : 0;
+        }
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "ERRO: 1 diretiva(s)" in r.stdout
+    assert "features/financeiro/quebrado.ts:2" in r.stdout
+    assert "linha seguinte não-branca (linha 3) é outro COMENTÁRIO" in r.stdout
+
+
+def test_diretiva_no_fim_do_arquivo_reprova(tmp_path: pathlib.Path) -> None:
+    """Sem linha nenhuma depois da diretiva não há o que suprimir — também é defeito."""
+    _escreve(
+        tmp_path,
+        "orfao.ts",
+        """\
+        export const Y = 1;
+        // Stryker disable next-line ArithmeticOperator
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "orfao.ts:2" in r.stdout
+    assert "ÚLTIMA linha do arquivo" in r.stdout
+
+
+def test_linha_em_branco_entre_diretiva_e_alvo_e_ignorada_na_busca(tmp_path: pathlib.Path) -> None:
+    """Linha em branco pura NÃO conta como "outra linha" — só comentário conta."""
+    _escreve(
+        tmp_path,
+        "com-branco.ts",
+        """\
+        // Stryker disable next-line ArithmeticOperator
+
+        export const Z = 1 + 1;
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_bloco_de_comentario_apos_a_diretiva_tambem_reprova(tmp_path: pathlib.Path) -> None:
+    """Não é só `//`: um `/* ... */` ou uma linha `*` de continuação também não é código."""
+    _escreve(
+        tmp_path,
+        "com-bloco.ts",
+        """\
+        // Stryker disable next-line ArithmeticOperator
+        /** JSDoc que por engano ficou entre a diretiva e o alvo. */
+        export const W = 3 + 4;
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "com-bloco.ts:1" in r.stdout
+
+
+def test_multiplas_diretivas_deslocadas_aparecem_todas(tmp_path: pathlib.Path) -> None:
+    _escreve(
+        tmp_path,
+        "a.ts",
+        """\
+        // Stryker disable next-line ArithmeticOperator
+        // comentário no meio
+        export const A = 1;
+        """,
+    )
+    _escreve(
+        tmp_path,
+        "b.ts",
+        """\
+        // Stryker disable next-line EqualityOperator
+        // outro comentário no meio
+        export const B = 2;
+        """,
+    )
+    r = _roda(str(tmp_path))
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "ERRO: 2 diretiva(s)" in r.stdout
+    assert "a.ts:1" in r.stdout
+    assert "b.ts:1" in r.stdout
+
+
+# ── FALHA-DURA ANTI-VACUIDADE ────────────────────────────────────────────────────────────────────
+
+
+def test_diretorio_inexistente_nao_e_aprovacao(tmp_path: pathlib.Path) -> None:
+    r = _roda(str(tmp_path / "nao-existe"))
+    assert r.returncode == 2
+    assert "NAO e aprovacao" in r.stderr
+
+
+def test_diretorio_sem_ts_nao_e_aprovacao(tmp_path: pathlib.Path) -> None:
+    """Nenhum `.ts`/`.tsx` encontrado — uma guarda que fica verde aqui não guardou nada."""
+    _escreve(tmp_path, "nao-e-typescript.py", "x = 1\n")
+    r = _roda(str(tmp_path))
+    assert r.returncode == 2
+    assert "NAO e aprovacao" in r.stderr
+
+
+# ── SEM ARGUMENTO, USA O ALVO PADRÃO (apps/web/src) ─────────────────────────────────────────────
+
+
+def test_sem_argumento_usa_apps_web_src_como_alvo_padrao() -> None:
+    """Sem argumento o script varre `apps/web/src` da raiz do repo — não falha por falta de alvo."""
+    r = _roda()
+    assert r.returncode in (0, 1), r.stdout + r.stderr
+    assert "apps/web/src" in r.stdout

--- a/apps/api/tests/test_guarda_stryker_disable_deslocado.py
+++ b/apps/api/tests/test_guarda_stryker_disable_deslocado.py
@@ -73,7 +73,7 @@ def _escreve(tmp_path: pathlib.Path, nome: str, conteudo: str) -> pathlib.Path:
     return caminho
 
 
-# ── CASO POSITIVO (CONTROLE) — diretiva encostada no alvo ──────────────────────────────────────────
+# ── CASO POSITIVO (CONTROLE) — diretiva encostada no alvo ────────────────────────────────────────
 
 
 def test_diretiva_encostada_no_alvo_passa(tmp_path: pathlib.Path) -> None:
@@ -112,7 +112,7 @@ def test_os_quatro_arquivos_reais_do_e1p_passam_limpo() -> None:
     assert r.stdout.startswith("OK: nenhuma diretiva")
 
 
-# ── CASO NEGATIVO (REGRESSÃO) — diretiva deslocada ──────────────────────────────────────────────────
+# ── CASO NEGATIVO (REGRESSÃO) — diretiva deslocada ──────────────────────────────────────────────
 
 
 def test_diretiva_seguida_de_comentario_reprova_com_arquivo_e_linha(tmp_path: pathlib.Path) -> None:

--- a/apps/web/src/features/agenda/grade.ts
+++ b/apps/web/src/features/agenda/grade.ts
@@ -281,13 +281,14 @@ export function faixasLivres(
 
   // −1 em qualquer outro dia: nada do passado a cortar.
   //
-  // Stryker disable next-line UnaryOperator: mutante EQUIVALENTE, e a issue #121 o cita pelo nome.
   // O −1 aqui é SENTINELA, não medida: o único uso de `corte` é `if (inicio <= corte) continue`,
   // e `inicio` começa em `HORA_ABERTURA * 60` = 480. Qualquer valor abaixo de 480 — −1, 0, +1 —
   // produz exatamente a mesma grade de faixas. Não existe teste capaz de distinguir os dois
   // programas, porque eles são o mesmo programa. Escrever um só fixaria o literal, e um teste
   // que fixa literal sem consequência observável é a família do `toContain("flex-wrap")` que o
   // CLAUDE.md §5.1 proíbe.
+  //
+  // Stryker disable next-line UnaryOperator: mutante EQUIVALENTE, e a issue #121 o cita pelo nome.
   const corte = today(fuso, agora) === ymd ? emMinutos(formatTime(agora.toISOString(), fuso)) : -1;
 
   const livres: Faixa[] = [];

--- a/scripts/guarda-stryker-disable-deslocado.mjs
+++ b/scripts/guarda-stryker-disable-deslocado.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// `Stryker disable next-line <mutador>` só suprime a mutação da linha LITERAL seguinte — e nada
+// detectava quando a diretiva estava deslocada do alvo (issue #229).
+//
+// ── O DEFEITO ────────────────────────────────────────────────────────────────────────────────────
+// Achado na triagem do #214 (PR #222): `financeiro/ledger.ts` e `financeiro/dreMatrixEntries.ts`
+// traziam
+//
+//     // Stryker disable next-line EqualityOperator
+//
+// SETE LINHAS ACIMA do alvo de verdade. A linha seguinte LITERAL não era o código que a diretiva
+// alegava suprimir — era outro comentário, parte do mesmo parágrafo explicativo. A supressão que o
+// parágrafo descrevia NUNCA EXISTIU: o Stryker não pula linha de comentário procurando código: ele
+// desativa o mutador só na linha imediatamente após a diretiva, comentário ou não.
+//
+// Provado pelo `mutation-report` da corrida 32557684625:
+//
+//     Arquivo                          | EqualityOperator | "Ignored using a comment" no arquivo
+//     ----------------------------------|-------------------|--------------------------------------
+//     financeiro/ledger.ts:42           | Survived          | 0
+//     financeiro/dreMatrixEntries.ts:28 | Survived          | 0
+//     pagar/baixa.ts:197 (encostada)    | —                 | 6
+//
+// O mecanismo funciona quando a diretiva encosta na linha, e falha em silêncio quando não encosta.
+// Passou por DOIS relatórios de CI sem ninguém notar: o mutante aparece como `Survived`, e isso é
+// indistinguível de dívida de teste comum — quem for triar depois gasta tempo tentando matar um
+// mutante que alguém já tinha decidido dispensar (ou escreve um teste que fixa literal sem
+// consequência observável, a família que o CLAUDE.md §5.1 proíbe).
+//
+// Os dois casos foram consertados no PR #222. Esta guarda fecha a REINCIDÊNCIA: nada, antes dela,
+// detectava uma diretiva deslocada — só a sorte de alguém abrir o `mutation-report` e comparar
+// número de `Ignored` contra o esperado.
+//
+// ── A REGRA ──────────────────────────────────────────────────────────────────────────────────────
+// Para cada linha que contém "Stryker disable next-line", a próxima linha NÃO-EM-BRANCO do arquivo
+// tem de ser código executável — nunca outro comentário. Só linhas totalmente em branco são
+// puladas na busca; qualquer OUTRA linha de comentário (`//`, `/*`, ou `*` de continuação de bloco)
+// reprova, porque é exatamente esse o caso que escapou: comentário-sobre-comentário.
+//
+// `pagar/baixa.ts:197` é a referência POSITIVA: a diretiva é a ÚLTIMA linha de comentário antes do
+// `export const ALTURA_DA_BARRA = ...`, sem nenhuma linha de explicação depois dela. É a posição
+// que toda diretiva tem de ocupar — explicar ANTES, diretiva por ÚLTIMO, encostada no alvo.
+//
+// ── O QUE FAZER QUANDO ELA DISPARA ───────────────────────────────────────────────────────────────
+// Mova a diretiva (e só ela — a explicação continua onde está) para a última linha de comentário
+// imediatamente acima do código que ela alega suprimir. Não é preciso reescrever a explicação: o
+// PR #222 só moveu a linha da diretiva, o resto do parágrafo ficou onde estava.
+//
+// ── COMO RODAR ───────────────────────────────────────────────────────────────────────────────────
+//   node scripts/guarda-stryker-disable-deslocado.mjs                    # varre apps/web/src
+//   node scripts/guarda-stryker-disable-deslocado.mjs caminho/qualquer   # varre outro diretório
+//
+// Saída: 0 = nenhuma diretiva deslocada · 1 = alguma diretiva deslocada (reprovar o gate) · 2 =
+// diretório inexistente ou sem nenhum `.ts`/`.tsx` para varrer. O 2 é deliberado: uma guarda que
+// fica verde quando não achou o que guardar é a mesma falha-mole que o `ci.yml` já reprova no
+// `rls_e2e` e nos gates de `infra/` — silêncio indistinguível de aprovação.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const RAIZ_REPO = resolve(__dirname, "..");
+export const ALVO_PADRAO = join(RAIZ_REPO, "apps", "web", "src");
+
+const EXTENSOES_VARRIDAS = new Set([".ts", ".tsx"]);
+const DIRETORIOS_IGNORADOS = new Set(["node_modules", "dist", "build", ".turbo", "coverage"]);
+const DIRETIVA = /Stryker disable next-line/;
+
+/** Lista, recursivamente, todo `.ts`/`.tsx` sob `dir` — ordem estável (facilita comparar saída). */
+export function listarArquivos(dir) {
+  const resultado = [];
+
+  function caminha(atual) {
+    let entradas;
+    try {
+      entradas = readdirSync(atual, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entrada of entradas) {
+      if (entrada.isDirectory()) {
+        if (DIRETORIOS_IGNORADOS.has(entrada.name)) continue;
+        caminha(join(atual, entrada.name));
+      } else if (entrada.isFile() && EXTENSOES_VARRIDAS.has(extname(entrada.name))) {
+        resultado.push(join(atual, entrada.name));
+      }
+    }
+  }
+
+  caminha(dir);
+  return resultado.sort();
+}
+
+/**
+ * Acha, no conteúdo de UM arquivo, toda diretiva `Stryker disable next-line` cuja linha seguinte
+ * não-branca é outro comentário (ou cuja diretiva é a última linha do arquivo). `caminhoRelativo`
+ * é só o que aparece na mensagem — a função não toca o sistema de arquivos.
+ */
+export function analisarConteudo(caminhoRelativo, conteudo) {
+  const linhas = conteudo.split(/\r?\n/);
+  const violacoes = [];
+
+  for (let i = 0; i < linhas.length; i++) {
+    if (!DIRETIVA.test(linhas[i])) continue;
+
+    // A busca pula SÓ linha em branco — nunca outra linha de comentário. É esse o ponto inteiro
+    // da guarda: comentário-sobre-comentário é o defeito, não uma exceção a ele.
+    let j = i + 1;
+    while (j < linhas.length && linhas[j].trim() === "") j++;
+
+    if (j >= linhas.length) {
+      violacoes.push({ caminho: caminhoRelativo, linha: i + 1, motivo: "fim-do-arquivo" });
+      continue;
+    }
+
+    const proxima = linhas[j].trim();
+    const ehComentario =
+      proxima.startsWith("//") || proxima.startsWith("/*") || proxima.startsWith("*");
+    if (ehComentario) {
+      violacoes.push({
+        caminho: caminhoRelativo,
+        linha: i + 1,
+        linhaSeguinte: j + 1,
+        motivo: "comentario",
+      });
+    }
+  }
+
+  return violacoes;
+}
+
+export function montarMensagem(violacoes, arquivosVarridos, alvoExibido) {
+  const linhas = [];
+
+  if (violacoes.length === 0) {
+    linhas.push(
+      `OK: nenhuma diretiva 'Stryker disable next-line' deslocada (${arquivosVarridos} arquivo(s) ` +
+        `.ts/.tsx em ${alvoExibido}).`,
+    );
+    return linhas.join("\n");
+  }
+
+  linhas.push(
+    `ERRO: ${violacoes.length} diretiva(s) 'Stryker disable next-line' DESLOCADA(S) do alvo ` +
+      `(${arquivosVarridos} arquivo(s) .ts/.tsx em ${alvoExibido}).`,
+    "",
+  );
+
+  for (const v of violacoes) {
+    if (v.motivo === "fim-do-arquivo") {
+      linhas.push(
+        `  - ${v.caminho}:${v.linha} — a diretiva é a ÚLTIMA linha do arquivo; não existe linha ` +
+          "seguinte para suprimir. A supressão não existe.",
+      );
+    } else {
+      linhas.push(
+        `  - ${v.caminho}:${v.linha} — a linha seguinte não-branca (linha ${v.linhaSeguinte}) é ` +
+          "outro COMENTÁRIO, não código executável. 'Stryker disable next-line' só suprime a linha " +
+          "LITERAL seguinte; aqui essa linha é comentário, e a supressão nunca existiu (issue #229).",
+      );
+    }
+  }
+
+  linhas.push(
+    "",
+    "Mova a diretiva (só ela — a explicação pode continuar onde está) para a ÚLTIMA linha de",
+    "comentário IMEDIATAMENTE ANTES do código que ela alega suprimir — a mesma posição de",
+    "'apps/web/src/features/pagar/baixa.ts:197', a referência positiva.",
+  );
+
+  return linhas.join("\n");
+}
+
+export function principal(argv) {
+  const alvo = resolve(argv[0] ?? ALVO_PADRAO);
+  const alvoExibido = relative(RAIZ_REPO, alvo).split("\\").join("/") || ".";
+
+  let alvoValido = false;
+  try {
+    alvoValido = statSync(alvo).isDirectory();
+  } catch {
+    alvoValido = false;
+  }
+
+  if (!alvoValido) {
+    process.stderr.write(
+      `ERRO: ${alvo} não existe ou não é um diretório legível. Nada a guardar — isto NAO e ` +
+        "aprovacao.\n",
+    );
+    return 2;
+  }
+
+  const arquivos = listarArquivos(alvo);
+  if (arquivos.length === 0) {
+    process.stderr.write(
+      `ERRO: nenhum arquivo .ts/.tsx encontrado em ${alvo}. Nada a guardar — isto NAO e ` +
+        "aprovacao.\n",
+    );
+    return 2;
+  }
+
+  const violacoes = [];
+  for (const arquivo of arquivos) {
+    const conteudo = readFileSync(arquivo, "utf-8");
+    const caminhoRelativo = relative(RAIZ_REPO, arquivo).split("\\").join("/");
+    violacoes.push(...analisarConteudo(caminhoRelativo, conteudo));
+  }
+
+  process.stdout.write(montarMensagem(violacoes, arquivos.length, alvoExibido) + "\n");
+  return violacoes.length > 0 ? 1 : 0;
+}
+
+// `import.meta.main` existe do Node 24 em diante — o mesmo Node do job. O fallback cobre quem
+// rodar numa versão anterior na mão.
+if (import.meta.main ?? process.argv[1]?.endsWith("guarda-stryker-disable-deslocado.mjs")) {
+  process.exit(principal(process.argv.slice(2)));
+}


### PR DESCRIPTION
## O que é

`Stryker disable next-line <mutador>` só suprime a mutação da linha LITERAL seguinte. Dois arquivos (`ledger.ts`, `dreMatrixEntries.ts`) tinham a diretiva 7 linhas acima do alvo real — a linha seguinte literal era outro comentário, então a supressão nunca existiu, e passou por 2 relatórios de CI sem ninguém notar (já corrigidos no PR #222). Faltava o guarda que impede a regressão.

## O que entra

- `scripts/guarda-stryker-disable-deslocado.mjs` — varre `apps/web/src` e reprova qualquer diretiva `Stryker disable next-line` cuja próxima linha não-branca seja outro comentário (ou cuja diretiva seja a última linha do arquivo). `baixa.ts:197` é a referência positiva.
- `apps/api/tests/test_guarda_stryker_disable_deslocado.py` — 10 testes contra o script real via subprocess (não uma reimplementação), no molde de `test_guarda_timeouts_mutacao.py`.
- Achado extra durante a implementação: `apps/web/src/features/agenda/grade.ts:284` tinha o MESMO defeito (não estava entre os dois casos citados na issue original, mas o `git blame` mostra o mesmo padrão) — corrigido movendo a diretiva para a última linha antes do código.
- Wiring no `.github/workflows/ci.yml`, job de gates de infra (mesmo lugar da guarda de timeouts de mutação, issue #213), com o contador de gates executados atualizado de `>=24` para `>=34`.

## Verificação independente

Reproduzi a prova por mutação eu mesmo: desloquei a diretiva em `baixa.ts` (referência positiva) por cópia de arquivo, confirmei que o guarda acusa com arquivo e linha corretos, e restaurei — `git diff` voltou vazio. Rodei o script contra a árvore real (`apps/web/src`, 214 arquivos) e confirmou zero violações hoje. Revi o CI wiring e o fix do `grade.ts`.

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `pytest tests/test_guarda_stryker_disable_deslocado.py` — 10 passed

Closes #229
