### PR TITLE
fix(api): TODAY lido no import discordava do relogio do servico na virada da meia-noite [#232]

### DIFF
--- a/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
+++ b/apps/api/tests/test_financial_intelligence_diagnostics_completude.py
@@ -14,6 +14,19 @@ os estados degradados que existem hoje em produção:
 - **sem `ANTHROPIC_API_KEY`** — os sinais são os mesmos; só a narrativa cai para template.
 
 Nada aqui escreve nada além do seed: o diagnóstico é read-only (IV3) e a conferência também.
+
+⚠️ **issue #232.** `TODAY` era `tenant_today(...)` lido no IMPORT do módulo — mesma classe de defeito
+do `test_financial_intelligence_projection.py` (#84/#90/#101). O comentário original argumentava que
+"data ancorada em HOJE real" era necessário porque o endpoint não injeta `today` e as guardas de
+"data futura" (`_validate_opening_date`, checkpoint) ancoram no relógio; um período FIXO no passado
+"deixaria de conter os dados conforme o tempo passa". Isso é verdade só enquanto o relógio for o
+verdadeiro — a correção é a mesma dos outros arquivos: `TODAY`/`START`/`END`/`REF` vêm de
+`tenant_today(..., now=FIXED_NOW)` (instante fixo, não o relógio) e
+`_hoje_travado_no_instante_fixo` tranca `hoje_do_tenant` no MESMO `FIXED_NOW` para toda chamada do
+serviço durante o teste — inclusive as guardas de "data futura", que também passam a comparar
+contra `FIXED_NOW`. `START`/`END`/`REF`
+continuam válidas para SEMPRE (não só até a próxima virada de dia), porque a guarda que antes corria
+risco de as invalidar agora usa a MESMA âncora fixa.
 """
 from __future__ import annotations
 
@@ -28,6 +41,7 @@ from app.modules.financial_intelligence import ai_narrator, diagnostics, engine
 from app.modules.payables import service as payables_service
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import Charge
+from app.modules.settings import service as settings_service
 
 REGISTER = {
     "legal_name": "Completude ME",
@@ -38,13 +52,37 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-# Datas ancoradas em HOJE (e não em constantes fixas) porque o endpoint não injeta `today`: as
-# guardas de "data futura" de conta/checkpoint/movimento ancoram no relógio real, e um período fixo
-# no passado deixaria de conter os dados conforme o tempo passa.
-TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
+# Instante FIXO — nunca o relógio da máquina/CI (issue #232). Meio-dia UTC, longe de qualquer
+# virada de fuso (inclusive a do tenant, UTC−3).
+FIXED_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE, now=FIXED_NOW)
 START = TODAY - timedelta(days=20)
 END = TODAY
 REF = TODAY - timedelta(days=2)
+
+# A implementação REAL de `hoje_do_tenant`, capturada ANTES de qualquer monkeypatch.
+_HOJE_DO_TENANT_REAL = settings_service.hoje_do_tenant
+
+
+@pytest.fixture(autouse=True)
+def _hoje_travado_no_instante_fixo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tranca o "hoje" que o SERVIÇO enxerga no MESMO instante fixo de `TODAY` (issue #232).
+
+    `hoje_do_tenant` é sempre alcançado por import tardio (`bank.service._today`,
+    `payables.service._today`, `financial_intelligence.projection._hoje_do_tenant`, entre outros) —
+    todos fazem `from app.modules.settings.service import hoje_do_tenant` DENTRO da função, então o
+    patch no atributo do módulo é visto por toda chamada nova.
+    `compute_signals`/`collect_engine_input` chamam `cash_projection(db)` e
+    `_completeness(..., today=None)` SEM `today=` explícito (o router
+    de `/diagnostics` não aceita esse parâmetro) — sem este patch, elas leriam o relógio real e
+    poderiam divergir de `TODAY`/`START`/`END`/`REF` se a meia-noite do tenant passasse no meio do
+    teste, o mecanismo exato da issue #232.
+    """
+    monkeypatch.setattr(
+        settings_service,
+        "hoje_do_tenant",
+        lambda db, *, now=None: _HOJE_DO_TENANT_REAL(db, now=FIXED_NOW),
+    )
 
 
 @pytest.fixture()

--- a/apps/api/tests/test_financial_intelligence_projection.py
+++ b/apps/api/tests/test_financial_intelligence_projection.py
@@ -23,10 +23,21 @@ o `saldo_projetado_cents` negativo continua asserido — suprime-se a afirmaçã
 RLS/isolamento cross-tenant é validado à parte no Postgres real
 (test_financial_intelligence_projection_rls.py, marcado `rls_e2e`) — aqui a suíte roda em SQLite e a
 RLS não é exercida (ver conftest).
+
+⚠️ **issue #232 (3ª rodada do mesmo defeito — #84, #90, #101).** `TODAY` era `tenant_today(...)` lido
+no IMPORT do módulo (relógio real). As fixtures (`_d(0)`, `amanha`, `ABERTURA_BANCO`...) ancoravam
+nesse valor, mas o ENDPOINT (`GET /financial-intelligence/projection`, `mark_paid`,
+`settle-externally`) chama `hoje_do_tenant(db)` de novo, na hora da REQUISIÇÃO — sem `today=`
+injetável na rota. Se a meia-noite do tenant virasse entre as duas leituras, fixture e serviço
+discordavam de um dia e a asserção quebrava. `TODAY` agora vem de
+`tenant_today(..., now=FIXED_NOW)` — um instante FIXO, não o relógio — e a fixture
+`_hoje_travado_no_instante_fixo` abaixo tranca `hoje_do_tenant` no MESMO `FIXED_NOW` para toda
+chamada feita pelo serviço durante o teste. Fixture e serviço passam a concordar por CONSTRUÇÃO,
+nunca por coincidência de horário.
 """
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -39,6 +50,7 @@ from app.modules.financial_intelligence import diagnostics as diagnostics_servic
 from app.modules.financial_intelligence import projection as projection_service
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import Charge
+from app.modules.settings import service as settings_service
 from app.modules.wallet.models import Transaction
 
 REGISTER = {
@@ -50,12 +62,39 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
+# Instante FIXO — nunca o relógio da máquina/CI. Meio-dia UTC cai bem longe de qualquer virada de
+# fuso (inclusive a do tenant, UTC−3), então não há ambiguidade de "qual dia" mesmo se alguém mudar
+# o fuso padrão amanhã.
+FIXED_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE, now=FIXED_NOW)
+
+# A implementação REAL de `hoje_do_tenant`, capturada ANTES de qualquer monkeypatch — é o que a
+# fixture abaixo chama por baixo, só que com `now=FIXED_NOW` amarrado. Preserva o comportamento de
+# resolver o fuso do tenant (`tenant_timezone(db)`); só o RELÓGIO deixa de ser o real.
+_HOJE_DO_TENANT_REAL = settings_service.hoje_do_tenant
 
 
 def _d(days: int) -> str:
-    """Data ISO de hoje + `days` (âncora UTC, a mesma que o serviço usa)."""
+    """Data ISO de hoje + `days` (âncora fixa, a mesma que o serviço usa via o patch abaixo)."""
     return (TODAY + timedelta(days=days)).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _hoje_travado_no_instante_fixo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tranca o "hoje" que o SERVIÇO enxerga no MESMO instante fixo da fixture `TODAY` (issue #232).
+
+    `hoje_do_tenant` é sempre alcançado por import tardio (`projection._hoje_do_tenant`,
+    `payables.service._today`, `receivables.service._today`) — todos fazem
+    `from app.modules.settings.service import hoje_do_tenant` DENTRO da função, então o patch no
+    atributo do módulo é visto por toda chamada nova, mesmo as que já estavam "importadas" antes
+    deste teste rodar. Sem isto, travar só `TODAY` não bastaria: o endpoint (que não recebe
+    `today=`) continuaria lendo o relógio real e podia discordar da fixture de novo.
+    """
+    monkeypatch.setattr(
+        settings_service,
+        "hoje_do_tenant",
+        lambda db, *, now=None: _HOJE_DO_TENANT_REAL(db, now=FIXED_NOW),
+    )
 
 
 @pytest.fixture()

--- a/apps/api/tests/test_hoje_fixo_no_import_dos_testes.py
+++ b/apps/api/tests/test_hoje_fixo_no_import_dos_testes.py
@@ -1,0 +1,202 @@
+"""Gate: nenhum `TODAY`/`HOJE` de teste lê o relógio real no IMPORT do módulo (issue #232 —
+3ª rodada do mesmo defeito: #84 corrigiu, #90 e #101 voltaram por outras frestas).
+
+**O mecanismo, provado em `test_financial_intelligence_projection.py` antes desta correção:**
+`TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)` era lido UMA VEZ, no import do módulo de teste —
+mas o SERVIÇO sob teste (o endpoint HTTP, que não injeta `today=`) recalcula "hoje" de novo, na
+hora da REQUISIÇÃO. Se a meia-noite do tenant virasse entre as duas leituras, fixture e serviço
+discordavam de um dia e a asserção quebrava — raro, não-determinístico e, por isso mesmo, já
+"corrigido" duas vezes sem a classe de defeito morrer (#90, #101).
+
+**A correção estrutural**, aplicada nos 3 arquivos exercitáveis desta issue (ver o comentário no
+topo de cada um): `TODAY`/`HOJE` passa a vir de um instante FIXO (`tenant_today(DEFAULT_TENANT_
+TIMEZONE, now=FIXED_NOW)`) — nunca do relógio — e, onde o SERVIÇO também precisa concordar
+(endpoints que não aceitam `today=`), uma fixture `autouse` tranca `hoje_do_tenant` no MESMO
+`FIXED_NOW`. O outro padrão igualmente válido, usado em 6 arquivos mais antigos (`test_vima_
+absences.py`, `test_dna_cadencia.py`, `test_bank_reconciliation_report.py`, `test_admin_nao_expoe_
+recebimento_fora_do_trilho.py`, `test_bank_ciclos.py`, `test_vima_trends.py`), é uma data LITERAL
+(`date(2026, 8, 6)`) — mais simples quando o endpoint sob teste aceita `today`/`start`/`end`
+injetáveis e não há guarda de "data futura" a coordenar.
+
+**Este gate é o complemento de
+`test_fuso_do_processo.py::test_o_app_NAO_ganhou_relogio_de_maquina_novo`** — aquele varre `app/`
+(relógio da MÁQUINA num caminho de negócio); este varre `tests/` (relógio lido para ANCORAR uma
+fixture de teste no import do módulo). São eixos diferentes e complementares, não duplicados: um
+`TODAY` fixo por `date(2026, 8, 6)` nunca aciona nenhum dos dois; um `date.today()` dentro de
+`app/modules/x/service.py` aciona só aquele; um `TODAY = tenant_today(...)` sem `now=` no import de
+um teste aciona só este.
+
+**Por que só o nível de MÓDULO** (e não qualquer `tenant_today(...)` em `tests/`): ler o relógio
+DENTRO do corpo de uma função de teste, na hora em que a asserção roda, não é o defeito — é a
+leitura do fixture ficar CONGELADA no import e o serviço ler de novo depois que é a fresta. Uma
+varredura
+que reprovasse todo `tenant_today()` sem `now=` em `tests/` pegaria ~10 usos legítimos (`hoje =
+tenant_today(...)` dentro do corpo de um teste, em `test_agenda_por_contato.py`, `test_investments.
+py`, `test_payables_reactivate.py` etc.) e o gate seria ruído — ruído é gate que alguém apaga.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# Os dois nomes que a suíte usa, por convenção, para "a data que ancora as fixtures do arquivo".
+NOMES_DE_ANCORA = {"TODAY", "HOJE"}
+
+# Chamadas que resolvem "hoje" a partir do relógio quando `now=`/instante fixo NÃO é passado.
+NOMES_DE_HOJE_INJETAVEL = {"tenant_today", "hoje_do_tenant"}
+
+# Leituras diretas do relógio da máquina/processo (mesmo vocabulário do gate de `app/`).
+ATRIBUTOS_DE_RELOGIO = {"today", "utcnow", "now"}
+
+
+def _le_relogio(expressao: ast.AST) -> bool:
+    """A subárvore de uma expressão (o lado direito de `TODAY = ...`) lê o relógio real?
+
+    Cobre tanto a chamada direta (`TODAY = tenant_today(TZ)`) quanto uma expressão que a contém
+    (`TODAY = tenant_today(TZ) - timedelta(days=1)`, `TODAY = date.today()` etc.) — o `ast.walk`
+    percorre a árvore inteira da expressão, não só o nó de topo.
+    """
+    for no in ast.walk(expressao):
+        if not isinstance(no, ast.Call):
+            continue
+        func = no.func
+        if isinstance(func, ast.Name) and func.id in NOMES_DE_HOJE_INJETAVEL:
+            tem_now = any(kw.arg == "now" for kw in no.keywords)
+            if not tem_now:
+                return True
+        elif isinstance(func, ast.Attribute) and func.attr in ATRIBUTOS_DE_RELOGIO:
+            return True
+    return False
+
+
+def _ancoras_de_relogio_no_import(fonte: str) -> list[tuple[str, int]]:
+    """`TODAY`/`HOJE` atribuídos no CORPO do módulo (nunca dentro de função/fixture) a partir do
+    relógio real — direto ou por trás de `tenant_today`/`hoje_do_tenant` sem `now=`."""
+    achados: list[tuple[str, int]] = []
+    arvore = ast.parse(fonte)
+    for no in arvore.body:  # só o nível do MÓDULO — ler dentro de uma função é outra história
+        if not isinstance(no, ast.Assign):
+            continue
+        alvos = [t.id for t in no.targets if isinstance(t, ast.Name)]
+        alvos_de_ancora = [nome for nome in alvos if nome in NOMES_DE_ANCORA]
+        if not alvos_de_ancora:
+            continue
+        if _le_relogio(no.value):
+            achados.append((", ".join(alvos_de_ancora), no.lineno))
+    return achados
+
+
+# Exceções FECHADAS — cada uma com o motivo, no molde de `RELOGIO_DE_MAQUINA_DECLARADO` do gate de
+# `app/`. A issue #232 corrigiu os 3 arquivos exercitáveis em SQLite; estes dois pedem Postgres/RLS
+# real (marcados `rls_e2e`) e não são exercitáveis neste ambiente (sem Docker disponível) — ficam
+# como dívida DECLARADA, não silenciosa.
+TODAY_PENDENTE_DE_POSTGRES = {
+    "test_financial_intelligence_projection_rls.py": (
+        "mesma classe de defeito do arquivo principal (issue #232), mas o cenário sob teste exige "
+        "Postgres/RLS real (marcado `rls_e2e`) — não foi possível medir a mutação (envelhecer "
+        "TODAY em 1 dia) nem aplicar/validar a correção sem Docker neste ambiente. Aplicar o "
+        "mesmo padrão de `FIXED_NOW` + fixture autouse de `test_financial_intelligence_"
+        "projection.py` quando houver Postgres disponível."
+    ),
+    "test_payment_queue_rls.py": (
+        "mesmo motivo do arquivo acima — RLS real, sem Docker neste ambiente."
+    ),
+}
+
+
+def test_nenhum_TODAY_HOJE_novo_le_o_relogio_no_import() -> None:
+    """Gate: em `tests/`, `TODAY`/`HOJE` de módulo não pode vir do relógio real — e a lista de
+    exceções é FECHADA (mesmo desenho do gate de `app/`, ver `test_fuso_do_processo.py`)."""
+    novos: dict[str, list[tuple[str, int]]] = {}
+    for arquivo in sorted(TESTS_DIR.glob("*.py")):
+        if arquivo.name == Path(__file__).name:
+            continue  # este próprio arquivo não define TODAY/HOJE — cita os nomes em dados/texto
+        achados = _ancoras_de_relogio_no_import(arquivo.read_text(encoding="utf-8"))
+        if achados and arquivo.name not in TODAY_PENDENTE_DE_POSTGRES:
+            novos[arquivo.name] = achados
+
+    assert not novos, (
+        "TODAY/HOJE novo lido do RELÓGIO no import de um módulo de teste (issue #232 — a mesma "
+        "classe de defeito que já voltou 2x, #90 e #101): "
+        + "; ".join(f"{f}:{ls}" for f, ls in sorted(novos.items()))
+        + ". Use uma data FIXA (`date(2026, 8, 6)`, o padrão de `test_vima_absences.py`) ou, se o "
+        "endpoint sob teste também precisa concordar (não aceita `today=`), `tenant_today(..., "
+        "now=FIXED_NOW)` + a fixture autouse que tranca `hoje_do_tenant` no mesmo instante (o "
+        "padrão de `test_financial_intelligence_projection.py`, pós issue #232). Se a leitura for "
+        "mesmo necessária, declare em TODAY_PENDENTE_DE_POSTGRES com o motivo, como as duas RLS."
+    )
+
+    # CONTROLE: as exceções declaradas ainda existem E ainda têm o padrão — sem isto o gate viraria
+    # vácuo no dia em que os RLS forem corrigidos e ninguém tirar a entrada da lista (o mesmo
+    # controle que `test_o_app_NAO_ganhou_relogio_de_maquina_novo` faz para `app/`).
+    ainda_pendentes = {
+        nome
+        for nome in TODAY_PENDENTE_DE_POSTGRES
+        if (TESTS_DIR / nome).exists()
+        and _ancoras_de_relogio_no_import((TESTS_DIR / nome).read_text(encoding="utf-8"))
+    }
+    assert ainda_pendentes == set(TODAY_PENDENTE_DE_POSTGRES), (
+        "arquivo declarado em TODAY_PENDENTE_DE_POSTGRES que sumiu ou já foi corrigido: tire-o da "
+        f"lista. declarados={sorted(TODAY_PENDENTE_DE_POSTGRES)} "
+        f"ainda_pendentes={sorted(ainda_pendentes)}"
+    )
+
+
+def test_controle_positivo_o_gate_ACUSA_TODAY_novo_lido_do_relogio() -> None:
+    """Controle positivo (issue #232, AC da story): fabrica um arquivo de teste TEMPORÁRIO dentro
+    de `tests/` com `TODAY` lido do relógio sem `now=`, mostra o gate REPROVANDO e nomeando esse
+    arquivo, e remove o arquivo em seguida — a prova de que a regra dispara de verdade, não só de
+    que a lista de exceções está vazia (o mesmo controle que `test_o_guarda_esta_LIGADO_no_import_
+    do_conftest` faz para o gate irmão)."""
+    nome = "test_ZZZ_fabricado_para_o_controle_positivo_232.py"
+    caminho = TESTS_DIR / nome
+    assert not caminho.exists(), f"limpeza de uma corrida anterior falhou: {caminho} já existe"
+    caminho.write_text(
+        "from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today\n"
+        "\n"
+        "TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)  # fabricado: sem now=, lê o relogio\n",
+        encoding="utf-8",
+    )
+    try:
+        # 1) a unidade que decide "isto é uma leitura de relógio" acusa o caso fabricado:
+        achados = _ancoras_de_relogio_no_import(caminho.read_text(encoding="utf-8"))
+        assert achados, "o gate não acusou um TODAY fabricado lido do relógio — regra vazia"
+        assert achados[0][0] == "TODAY"
+
+        # 2) e a varredura de nível de SUÍTE nomeia justamente ESTE arquivo entre os novos:
+        novos: dict[str, list[tuple[str, int]]] = {}
+        for arquivo in sorted(TESTS_DIR.glob("*.py")):
+            if arquivo.name == Path(__file__).name:
+                continue
+            ach = _ancoras_de_relogio_no_import(arquivo.read_text(encoding="utf-8"))
+            if ach and arquivo.name not in TODAY_PENDENTE_DE_POSTGRES:
+                novos[arquivo.name] = ach
+        assert nome in novos, f"o gate não nomeou o arquivo fabricado: {sorted(novos)}"
+    finally:
+        caminho.unlink(missing_ok=True)
+    assert not caminho.exists(), "o arquivo fabricado do controle positivo não foi limpo"
+
+
+def test_controle_negativo_data_literal_e_now_explicito_nao_disparam_o_gate() -> None:
+    """Controle negativo: os dois padrões CORRETOS (data literal e `now=` explícito) não acionam a
+    regra — sem isto, um gate que reprovasse qualquer `TODAY = ...` seria ruído, não sinal."""
+    literal = "from datetime import date\nTODAY = date(2026, 8, 6)\n"
+    assert _ancoras_de_relogio_no_import(literal) == []
+
+    com_now = (
+        "from datetime import UTC, datetime\n"
+        "from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today\n"
+        "FIXED_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)\n"
+        "TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE, now=FIXED_NOW)\n"
+    )
+    assert _ancoras_de_relogio_no_import(com_now) == []
+
+    dentro_de_funcao = (
+        "from app.core.tz import DEFAULT_TENANT_TIMEZONE, tenant_today\n"
+        "def test_algo():\n"
+        "    hoje = tenant_today(DEFAULT_TENANT_TIMEZONE)\n"
+        "    assert hoje\n"
+    )
+    assert _ancoras_de_relogio_no_import(dentro_de_funcao) == []

--- a/apps/api/tests/test_projection_saldo_misto.py
+++ b/apps/api/tests/test_projection_saldo_misto.py
@@ -25,12 +25,21 @@ comentário lá.
 RLS/isolamento cross-tenant é validado à parte no Postgres real
 (`test_financial_intelligence_projection_rls.py`, marcado `rls_e2e`) — aqui a suíte roda em SQLite
 e a RLS não é exercida (ver `conftest.py`).
+
+⚠️ **issue #232.** `TODAY` era `tenant_today(...)` lido no IMPORT do módulo — mesma classe de
+defeito de `test_financial_intelligence_projection.py` (#84/#90/#101): o endpoint
+`/financial-intelligence/projection` (e as guardas `posted_at > opening_date`, `opening_date > hoje`
+do `bank.service`) não recebem `today=` e leem `hoje_do_tenant(db)` de novo, na hora da
+REQUISIÇÃO — se a meia-noite do tenant virasse entre o import e a chamada, fixture e serviço
+discordavam de um dia. `TODAY` agora vem de `tenant_today(..., now=FIXED_NOW)` (instante fixo) e
+`_hoje_travado_no_instante_fixo` tranca `hoje_do_tenant` no MESMO `FIXED_NOW` para toda chamada do
+serviço durante o teste.
 """
 from __future__ import annotations
 
 import re
 from dataclasses import asdict
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -60,6 +69,7 @@ from app.modules.financial_intelligence import dre as dre_service
 from app.modules.financial_intelligence import projection as projection_service
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import Charge
+from app.modules.settings import service as settings_service
 from app.modules.wallet import service as wallet_service
 from app.modules.wallet.models import Transaction
 
@@ -72,15 +82,38 @@ REGISTER = {
     "password": "uma-senha-bem-grande",
 }
 
-TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)
+# Instante FIXO — nunca o relógio da máquina/CI (issue #232). Meio-dia UTC, longe de qualquer
+# virada de fuso (inclusive a do tenant, UTC−3).
+FIXED_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE, now=FIXED_NOW)
 # Abertura bem no passado: dá espaço para lançar movimento em qualquer data recente sem esbarrar na
 # guarda `posted_at > opening_date` do service (Story 8.3).
 OPENING = (TODAY - timedelta(days=60)).isoformat()
 
+# A implementação REAL de `hoje_do_tenant`, capturada ANTES de qualquer monkeypatch.
+_HOJE_DO_TENANT_REAL = settings_service.hoje_do_tenant
+
 
 def _d(days: int) -> str:
-    """Data ISO de hoje + `days` (âncora UTC, a mesma que o serviço usa)."""
+    """Data ISO de hoje + `days` (âncora fixa, a mesma que o serviço usa via o patch abaixo)."""
     return (TODAY + timedelta(days=days)).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _hoje_travado_no_instante_fixo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tranca o "hoje" que o SERVIÇO enxerga no MESMO instante fixo de `TODAY` (issue #232).
+
+    `hoje_do_tenant` é sempre alcançado por import tardio (`bank.service._today`,
+    `payables.service._today`, `financial_intelligence.projection._hoje_do_tenant`, entre outros) —
+    todos fazem `from app.modules.settings.service import hoje_do_tenant` DENTRO da função, então o
+    patch no atributo do módulo é visto por toda chamada nova, inclusive as guardas de "data
+    futura" (`_validate_opening_date`) que este arquivo exercita ao cadastrar conta/movimento.
+    """
+    monkeypatch.setattr(
+        settings_service,
+        "hoje_do_tenant",
+        lambda db, *, now=None: _HOJE_DO_TENANT_REAL(db, now=FIXED_NOW),
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## O que é

3ª rodada do mesmo defeito (#84 corrigiu, #90 e #101 voltaram por outras frestas): a suíte Python quebra ao atravessar a meia-noite de São Paulo. `TODAY = tenant_today(DEFAULT_TENANT_TIMEZONE)` era lido no IMPORT do módulo de teste (relógio real), mas o serviço sob teste recalcula "hoje" na hora da requisição via `hoje_do_tenant(db)`, sem `today=` injetável nos endpoints. Se a meia-noite do tenant virasse entre as duas leituras, fixture e serviço discordavam de um dia.

## Correção

Nos 3 arquivos exercitáveis em SQLite (`test_financial_intelligence_projection.py`, `test_financial_intelligence_diagnostics_completude.py`, `test_projection_saldo_misto.py`): `TODAY` agora vem de `tenant_today(DEFAULT_TENANT_TIMEZONE, now=FIXED_NOW)` — instante fixo — e uma fixture `autouse` tranca `hoje_do_tenant` no mesmo `FIXED_NOW` para toda chamada do serviço durante o teste (necessário porque os endpoints não aceitam `today=` injetável). Os 2 arquivos que pedem Postgres/RLS ficam declarados como dívida pendente no gate novo (não silenciosa).

## Gate novo

`test_hoje_fixo_no_import_dos_testes.py` reprova qualquer `TODAY`/`HOJE` de nível de módulo lido do relógio real em `apps/api/tests`, com lista de exceções fechada e controle positivo provando que a regra dispara de verdade. Complementar ao gate de `app/` (`test_fuso_do_processo.py`, issue #210) — eixos diferentes, não duplicados.

## Verificação independente

- Reproduzi o bug original eu mesmo: aplicando o código pré-fix e envelhecendo `TODAY` em 1 dia, os mesmos 4 testes falham com os mesmos nomes documentados na issue.
- Rodei os 3 arquivos corrigidos + o gate novo: 93 passed.
- **Achado na verificação**: o relatório do implementador não rodou `ruff check` — havia 4 violações `E501` (linha > 100 caracteres) nos comentários novos. Corrigi e revalidei antes de commitar.

## Gates

- `ruff check .` — limpo (após correção)
- `pytest tests/test_hoje_fixo_no_import_dos_testes.py tests/test_financial_intelligence_projection.py tests/test_financial_intelligence_diagnostics_completude.py tests/test_projection_saldo_misto.py` — 93 passed

Closes #232
