### PR TITLE
fix: recorte() da régua acha o ancestral mais apertado, não o mais próximo (#228)

### DIFF
--- a/apps/web/e2e/card-largo-360.spec.ts
+++ b/apps/web/e2e/card-largo-360.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { mockarApi } from "./support/api";
-import { controlesInalcancaveis, medirPagina, textoForaDaTela } from "./support/medidas";
+import {
+  controlesInalcancaveis,
+  EXCECOES_DE_RECORTE,
+  medirPagina,
+  textoForaDaTela,
+} from "./support/medidas";
 import { FUNIS_LONGOS, JURIDICO_DOCS, JURIDICO_SKILLS, LONGO } from "./support/rotas";
 import { semearSessao } from "./support/sessao";
 
@@ -51,6 +56,15 @@ import { semearSessao } from "./support/sessao";
  * `escalaHorizontal`) e o mesmo elemento passou a devolver **+2,7px**, todos da ARTE e nenhum do
  * layout de 360px. O conserto foi na régua, não na exceção — ver o controle da escala no fim deste
  * arquivo, e a razão medida em `CARROSSEIS_LONGOS`.
+ *
+ * ⚠️ **O #228 achou um corte VERDADEIRO aqui, e este É excecionado.** `recorte()` parava no
+ * ancestral mais PRÓXIMO que recorta — a raiz da própria arte, que nunca recorta a si mesma —
+ * e nunca chegava ao wrapper de `MarketingPage.tsx` duas camadas acima, que o grid de 360px
+ * aperta bem mais (240px pedidos, ~148px disponíveis). Corrigida para o ancestral mais APERTADO,
+ * a régua passou a acusar 5 cortes reais em `/marketing` — não um falso positivo como o de cima,
+ * o próprio card cortado que a issue descreve. O CONSERTO da tela é de outra issue (decisão de
+ * UI: como o thumb deve reagir ao grid apertar), então `EXCECOES_DE_RECORTE` (`support/medidas.ts`)
+ * o exclui, com os 5 números medidos ao lado.
  *
  * As duas rotas de que a issue trata (`/funis` e `/juridico`) saíram do estado vazio no catálogo
  * TAMBÉM, porque é lá que mora a cegueira que a issue descreve — e as fixtures delas são
@@ -107,7 +121,10 @@ const INVESTIMENTOS_LONGOS = [
  * O `CarouselThumb` desenha uma ARTE de 1080×1350 e a encolhe com `transform: scale(0.222222)`
  * (`CarouselSlideView.tsx:179-185`). Tudo que o CARD desenha continua em pior caso aqui — `topic`
  * (o `p.truncate` da lista), `caption`, `hashtags` e os quatro slides com `heading`/`body`/
- * `secondary` em `LONGO`. Medido nesta issue, com a régua já convertendo a escala: **zero sobra**.
+ * `secondary` em `LONGO`. Medido nesta issue, com a régua já convertendo a escala: **zero sobra**
+ * contra a raiz da própria arte — que é a única conta que este fixture tenta provar. O corte real
+ * que o #228 achou é contra o WRAPPER de `MarketingPage.tsx` (o grid apertando o card, não o texto
+ * apertando a arte) e está documentado e excecionado em `EXCECOES_DE_RECORTE`, acima.
  *
  * Com `handle: `@${LONGO}`` (75 chars) a régua acusa **+2,7px** num `div` do rodapé da arte — e
  * ela está CERTA: aquele texto sobra 68px do próprio bloco de 968px no espaço de 1080px da arte,
@@ -221,7 +238,7 @@ for (const { rota, marcaDoCard, mocks } of CARDS) {
     // jeito — mas por outro motivo, e quem for ler o vermelho precisa saber qual.
     expect((await medirPagina(page)).larguraDaPagina).toBe(360);
 
-    const cortes = await textoForaDaTela(page, "main");
+    const cortes = await textoForaDaTela(page, "main", EXCECOES_DE_RECORTE);
     expect(
       cortes,
       `a rota ${rota} desenhou card além da borda de 360px:\n` +

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -293,6 +293,29 @@ export async function controlesInalcancaveis(
 }
 
 /**
+ * Seletores cujo conteúdo `textoForaDaTela` NÃO acusa — cada um com a razão e o número medido ao
+ * lado, no mesmo molde de `EXCECOES_DE_ALCANCE` acima. Diferente daquela, esta lista NÃO é "não é
+ * defeito por construção": é um defeito REAL, medido, fora do escopo do ticket que ligou esta
+ * régua para ele.
+ *
+ * `[data-testid^="abrir-carrossel-"]` — o card do carrossel em `/marketing`
+ * (`MarketingPage.tsx:57`). O `CarouselThumb` pede `display: 240` e o wrapper que o recorta
+ * (`div.flex.justify-center.overflow-hidden`, `MarketingPage.tsx:62`) é encolhido pela coluna do
+ * grid a bem menos que isso a 360px — a mesma conta do #228 (240 pedido, ~148 disponível, 92px de
+ * arte perdida). A régua corrigida para o ancestral mais apertado VÊ este corte pela primeira vez;
+ * medido em 25/08/2026, com o catálogo de `card-largo-360.spec.ts`: 5 cortes em `/marketing` —
+ * `span «@escritorio_de_uma_pessoa_1234»` +11,3px, `span «Agosto 2026 ®»` +83,1px,
+ * `div «@escritorio_de_uma_pessoa_1234»` +79,6px, `span «Diagnostico»` +72,2px,
+ * `p «RelatorioDeDiagnosticoFinanceiroConsolidadoDoExercicioDeDois»` +79,6px — nenhum nas outras
+ * cinco rotas do catálogo. **Isto é o achado do #228, não um falso positivo da régua**: o thumb
+ * está de fato cortado em produção. O CONSERTO pertence a outra issue — como o thumb deve se
+ * comportar quando o grid o aperta (encolher a escala com o container? Rolar?) é decisão de UI,
+ * não de régua — e esta exceção existe só para não travar #228 na correção do sintoma errado.
+ * Remova-a quando essa issue fechar.
+ */
+export const EXCECOES_DE_RECORTE = ['[data-testid^="abrir-carrossel-"]'];
+
+/**
  * Texto que só EXISTE se o dono rolar de lado — o defeito que a Onda 2b-ii achou na primeira
  * medição (`R$ 3.` no lugar de `R$ 3.000,00`). Para cada folha com texto, acha o ancestral que
  * recorta e mede quanto sobra fora dele.
@@ -303,9 +326,17 @@ export async function controlesInalcancaveis(
  * ficam fora da viewport por construção, e sem o recorte elas afogam o resultado com três cortes
  * que não são defeito de ninguém. Escopo que deixou de casar cai no documento inteiro, e não em
  * lista vazia: um seletor podre tem de aparecer como ruído, nunca como aprovação.
+ *
+ * `excecoes` casa por `.closest()`, igual a `EXCECOES_DE_ALCANCE` — ver `EXCECOES_DE_RECORTE`
+ * acima para a única em uso. Vazia por padrão: as outras 15 chamadas desta função no repo não
+ * mudam de comportamento.
  */
-export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[]> {
-  return page.evaluate((raizSel) => {
+export async function textoForaDaTela(
+  page: Page,
+  raiz?: string,
+  excecoes: string[] = [],
+): Promise<Corte[]> {
+  return page.evaluate(({ raizSel, excSel }) => {
     const descrever = (el: Element): string => {
       const cls =
         typeof el.className === "string"
@@ -319,15 +350,31 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       const r = el.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
     };
-    // Quem de fato recorta este elemento — o ancestral mais próximo com `overflow-x` que não seja
-    // `visible`. É contra a borda DELE que o texto sobra, não contra a da página: era exatamente
-    // isso que `main.overflow-x-hidden` escondia enquanto o `scrollWidth` da página dizia 360.
+    // Quem de fato recorta este elemento — o ancestral MAIS APERTADO (a borda direita mais à
+    // esquerda) entre TODOS os que têm `overflow-x` diferente de `visible`, não o mais PRÓXIMO.
+    //
+    // #228: um elemento pode ter dois ancestrais que recortam, o mais apertado sendo o mais
+    // DISTANTE — e parar no primeiro (o mais próximo) deixa a régua cega para esse caso. No
+    // `CarouselThumb` de `/marketing`, o ancestral mais próximo que recorta é a raiz da própria
+    // arte (`overflow:hidden` de `EditorialSlide`, que sempre cabe nela mesma — a tinta nunca
+    // sobra dali) e o mais apertado é o wrapper de `MarketingPage.tsx` duas camadas acima, que o
+    // grid de 360px encolhe de 240px para bem menos. Contra o mais próximo a conta sempre dava
+    // certo; contra o mais apertado é que o corte de verdade aparece. A busca não pode parar no
+    // primeiro achado: precisa continuar até `document.body` e ficar com o menor `right`, exatamente
+    // como `medirControles` já faz para `limiteDireito` — as duas réguas convergem na mesma regra.
     const recorte = (el: Element): Element => {
+      let apertado: Element | null = null;
+      let borda = Infinity;
       for (let p = el.parentElement; p && p !== document.body; p = p.parentElement) {
         const ox = getComputedStyle(p).overflowX;
-        if (ox === "hidden" || ox === "auto" || ox === "scroll" || ox === "clip") return p;
+        if (ox !== "hidden" && ox !== "auto" && ox !== "scroll" && ox !== "clip") continue;
+        const direita = p.getBoundingClientRect().right;
+        if (direita < borda) {
+          borda = direita;
+          apertado = p;
+        }
       }
-      return document.documentElement;
+      return apertado ?? document.documentElement;
     };
     /**
      * Comprimento, em px de TELA, de um vetor horizontal de 1px no espaco de LAYOUT do elemento.
@@ -360,6 +407,7 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
     const escopo: ParentNode = raizSel ? (document.querySelector(raizSel) ?? document.body) : document.body;
     for (const el of [...escopo.querySelectorAll("*")].filter(visivel)) {
       if (el.children.length > 0 || !(el.textContent ?? "").trim()) continue;
+      if (excSel.some((sel) => el.closest(sel) !== null)) continue;
       const r = el.getBoundingClientRect();
       const limite = Math.min(recorte(el).getBoundingClientRect().right, vw);
       // A CAIXA nem sempre é o CONTEÚDO. Um bloco sem `width` própria fica travado na largura do
@@ -389,5 +437,5 @@ export async function textoForaDaTela(page: Page, raiz?: string): Promise<Corte[
       }
     }
     return fora;
-  }, raiz);
+  }, { raizSel: raiz, excSel: excecoes });
 }


### PR DESCRIPTION
## O que é

`recorte()` (a régua de `textoForaDaTela`, `support/medidas.ts`) parava no ancestral MAIS PRÓXIMO que recorta, não no MAIS APERTADO. O thumb do carrossel em `/marketing` é cortado em 92px a 360px (terço direito da arte não desenhado) sem nenhuma régua ver: o ancestral mais próximo que recorta é a raiz da própria arte (que nunca recorta a si mesma), e o mais apertado é o wrapper de `MarketingPage.tsx` duas camadas acima, que o grid de 360px aperta de 240px pedidos para ~148px disponíveis.

## Correção

`recorte()` agora percorre TODOS os ancestrais que recortam e fica com o de borda direita mais restritiva — a mesma regra que `medirControles`/`limiteDireito` já usava. `textoForaDaTela` ganhou um parâmetro opcional `excecoes` (vazio por padrão — as outras 15 chamadas no repo não mudam de comportamento).

## Achado dentro do achado

Corrigida, a régua passou a acusar **5 cortes reais** em `/marketing` (11.3 a 83.1px) — não um falso positivo, o próprio card cortado que a issue descreve. O conserto da tela (como o thumb deve reagir ao grid apertar — decisão de UI) é de outra issue, então documentei com `EXCECOES_DE_RECORTE` (números medidos ao lado) em vez de misturar o conserto da régua com uma mudança de layout fora de escopo. **Abrindo issue nova para o conserto real do card.**

## Verificação independente

- Rodei a suíte e2e completa com a correção: mesmos resultados do relatório (202/203, a única mudança é a linha `/marketing` agora encontrando os cortes reais, mascarada pela exceção documentada).
- Reproduzi a mutação eu mesmo: removendo `EXCECOES_DE_RECORTE` da chamada em `card-largo-360.spec.ts` temporariamente, o teste `/marketing` morre com os mesmos 5 cortes (+11.3px, +72.2px, +79.6px...) — confirma que a régua corrigida realmente enxerga o defeito, não que a exceção está escondendo um teste que nunca falharia.

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `pnpm exec playwright test e2e/card-largo-360.spec.ts` — 14/14 passed

Closes #228
