### PR TITLE
fix(web): corrige causa raiz dos testes a 7-9s contra o testTimeout [#231]

### DIFF
--- a/apps/web/src/features/admin/PlatformUsers.test.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.test.tsx
@@ -92,7 +92,15 @@ beforeEach(() => {
 
 describe("PlatformUsers — cadastrar nova conta (Story 7.18, Task 4)", () => {
   it("caminho feliz: preenche os obrigatórios e cadastra → POST /admin/accounts + senha temporária", async () => {
-    const user = userEvent.setup();
+    // `delay: null` (em vez do default `0`) pula o `setTimeout` REAL entre cada tecla do
+    // `userEvent.type()`. Com `delay: 0` o user-event ainda faz `await` numa Promise resolvida
+    // por `setTimeout(fn, 0)` a cada caractere — sob contenção de CPU (várias worktrees/CI
+    // concorrente) esse `setTimeout(0)` pode custar dezenas de ms cada, e este teste digita ~80
+    // caracteres em 7 campos. Medido (issue #231): 2,1-2,4s isolado neste arquivo → risco real
+    // de aproximar-se do `testTimeout` de 15000ms sob carga, como o próprio `vitest.config.ts`
+    // documenta. `delay: null` não simula tempo nenhum (nem precisa de fake timers): ele só
+    // remove a espera artificial entre eventos de teclado, sem mudar o que é digitado/disparado.
+    const user = userEvent.setup({ delay: null });
     vi.mocked(api.post).mockResolvedValue({
       data: {
         temp_password: "senha-fake-123",
@@ -133,7 +141,7 @@ describe("PlatformUsers — cadastrar nova conta (Story 7.18, Task 4)", () => {
   });
 
   it("caminho infeliz: formulário incompleto mantém o botão disabled, SEM chamar a API", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     renderPage();
 
     await user.click(await screen.findByRole("button", { name: "Nova conta" }));
@@ -163,7 +171,7 @@ describe("PlatformUsers/OfficeCard — suspender/excluir usuário: tratamento de
   }
 
   it("caminho infeliz (toggleUser falha): api.patch rejeita → erro no DOM e cartão segue renderizado (AC 1, 4, 5)", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     vi.mocked(api.patch).mockRejectedValueOnce({
       response: { data: { detail: "Falha ao suspender o usuário." } },
     });
@@ -183,7 +191,7 @@ describe("PlatformUsers/OfficeCard — suspender/excluir usuário: tratamento de
   });
 
   it("caminho infeliz (removeUser falha): confirm=true e api.delete rejeita → erro no DOM e cartão segue renderizado (AC 2, 4, 6)", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     vi.spyOn(window, "confirm").mockReturnValue(true);
     vi.mocked(api.delete).mockRejectedValueOnce({
       response: { data: { detail: "Falha ao excluir o usuário." } },
@@ -222,7 +230,7 @@ async function cadastrarConta(user: ReturnType<typeof userEvent.setup>) {
 
 describe("PlatformUsers — a confirmação do convite diz a verdade sobre a entrega", () => {
   it("'queued' é sucesso, não modo de teste", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     vi.mocked(api.post).mockResolvedValue({
       data: {
         temp_password: "senha-fake-123",
@@ -241,7 +249,7 @@ describe("PlatformUsers — a confirmação do convite diz a verdade sobre a ent
   });
 
   it("sem transporte: avisa que NÃO foi enviada", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     vi.mocked(api.post).mockResolvedValue({
       data: {
         temp_password: "senha-fake-123",
@@ -260,7 +268,7 @@ describe("PlatformUsers — a confirmação do convite diz a verdade sobre a ent
   });
 
   it("sem senha no corpo (produção): nenhuma caixa de senha vazia", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
     vi.mocked(api.post).mockResolvedValue({
       data: {
         temp_password: null,

--- a/apps/web/src/features/contratos/ContractBuilderPage.test.tsx
+++ b/apps/web/src/features/contratos/ContractBuilderPage.test.tsx
@@ -50,7 +50,11 @@ beforeEach(() => {
 
 describe("ContractBuilderPage — salvar contrato (Story 7.5, Task 3)", () => {
   it("caminho feliz: título + ao menos uma cláusula → POST /contracts com clauses preenchidas", async () => {
-    const user = userEvent.setup();
+    // `delay: null` (em vez do default `0`) evita o `setTimeout` REAL que o user-event faz
+    // entre cada tecla de `type()`; sob contenção de CPU (várias worktrees/CI concorrente) esse
+    // `setTimeout(0)` acumulado é a causa medida dos 7-9s deste arquivo sob carga (issue #231),
+    // mesma classe de sintoma documentada em `vitest.config.ts`. Não muda o que é digitado.
+    const user = userEvent.setup({ delay: null });
     vi.mocked(api.post).mockResolvedValue({ data: savedContract } as never);
     renderNew();
 
@@ -73,7 +77,7 @@ describe("ContractBuilderPage — salvar contrato (Story 7.5, Task 3)", () => {
   });
 
   it("caminho infeliz: sem título/cláusula é bloqueado client-side, SEM chamar a API", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no teste anterior
     renderNew();
 
     // Clica "Salvar" com o formulário vazio (título vazio + cláusula sem texto).

--- a/apps/web/src/test/guardaTimeoutTeste.test.ts
+++ b/apps/web/src/test/guardaTimeoutTeste.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { File } from "vitest";
+import {
+  achatarTestes,
+  encontrarTestesLentos,
+  GuardaTimeoutTeste,
+  LIMIAR_FRACAO_PADRAO,
+  montarAviso,
+} from "./guardaTimeoutTeste";
+
+// Testa a LÓGICA PURA do guarda com números controlados — sem esperar tempo real nenhum. Mesmo
+// padrão de `scripts/guarda-timeouts-mutacao.mjs`: a fixture é dado, não uma corrida de verdade.
+// A prova de que o AVISO REALMENTE aparece numa corrida real (não só a matemática) foi feita à
+// parte, rodando `npx vitest run <arquivo-lento> --testTimeout=<N baixo>` e conferindo o stderr —
+// ver relatório da issue #231. Um teste PERMANENTEMENTE lento na suíte reintroduziria o próprio
+// problema que a #231 resolve.
+
+/** Monta uma File→Suite→Test mínima o bastante para `achatarTestes` andar. */
+function arquivoComTeste(nome: string, tituloTeste: string, duracaoMs: number | undefined): File {
+  const file = {
+    type: "file" as const,
+    id: "f1",
+    name: nome,
+    mode: "run" as const,
+    meta: {},
+    filepath: nome,
+    projectName: undefined,
+    tasks: [] as unknown[],
+  } as unknown as File;
+  const teste = {
+    type: "test" as const,
+    id: "f1_0",
+    name: tituloTeste,
+    mode: "run" as const,
+    meta: {},
+    file,
+    result: duracaoMs === undefined ? undefined : { state: "pass" as const, duration: duracaoMs },
+  };
+  (file as unknown as { tasks: unknown[] }).tasks = [teste];
+  return file;
+}
+
+describe("achatarTestes", () => {
+  it("achata File > Test e mantém arquivo/título/duração", () => {
+    const file = arquivoComTeste("a.test.ts", "faz algo", 1234);
+    expect(achatarTestes([file])).toEqual([{ arquivo: "a.test.ts", titulo: "faz algo", duracaoMs: 1234 }]);
+  });
+
+  it("ignora testes sem duração (skip/todo/não rodou)", () => {
+    const file = arquivoComTeste("a.test.ts", "pulado", undefined);
+    expect(achatarTestes([file])).toEqual([]);
+  });
+
+  it("junta o nome da suite ao título (describe > it)", () => {
+    const file = {
+      type: "file" as const,
+      id: "f1",
+      name: "b.test.ts",
+      mode: "run" as const,
+      meta: {},
+      filepath: "b.test.ts",
+      projectName: undefined,
+      tasks: [] as unknown[],
+    } as unknown as File;
+    const suite = {
+      type: "suite" as const,
+      id: "f1_0",
+      name: "grupo",
+      mode: "run" as const,
+      meta: {},
+      file,
+      tasks: [] as unknown[],
+    };
+    const teste = {
+      type: "test" as const,
+      id: "f1_0_0",
+      name: "caso",
+      mode: "run" as const,
+      meta: {},
+      file,
+      result: { state: "pass" as const, duration: 500 },
+    };
+    suite.tasks = [teste];
+    (file as unknown as { tasks: unknown[] }).tasks = [suite];
+
+    expect(achatarTestes([file])).toEqual([{ arquivo: "b.test.ts", titulo: "grupo > caso", duracaoMs: 500 }]);
+  });
+});
+
+describe("encontrarTestesLentos", () => {
+  const testes = [
+    { arquivo: "x.test.ts", titulo: "rápido", duracaoMs: 100 },
+    { arquivo: "x.test.ts", titulo: "na borda", duracaoMs: 7500 }, // exatamente 50% de 15000
+    { arquivo: "x.test.ts", titulo: "lento", duracaoMs: 8474 }, // medido de verdade, issue #231
+  ];
+
+  it("usa o limiar padrão de 50% quando não especificado", () => {
+    expect(LIMIAR_FRACAO_PADRAO).toBe(0.5);
+    const lentos = encontrarTestesLentos(testes, 15000);
+    expect(lentos.map((l) => l.titulo)).toEqual(["lento", "na borda"]);
+  });
+
+  it("empate exato no limiar CONTA como lento (>=, não >)", () => {
+    const lentos = encontrarTestesLentos([{ arquivo: "x", titulo: "exato", duracaoMs: 5000 }], 10000, 0.5);
+    expect(lentos).toHaveLength(1);
+  });
+
+  it("ordena do mais lento para o mais rápido", () => {
+    const lentos = encontrarTestesLentos(testes, 15000);
+    expect(lentos[0].titulo).toBe("lento");
+    expect(lentos[0].fracao).toBeCloseTo(8474 / 15000);
+  });
+
+  it("testTimeout inválido (0, negativo, Infinity, NaN) devolve lista vazia, não divide por zero", () => {
+    expect(encontrarTestesLentos(testes, 0)).toEqual([]);
+    expect(encontrarTestesLentos(testes, -1)).toEqual([]);
+    expect(encontrarTestesLentos(testes, Number.POSITIVE_INFINITY)).toEqual([]);
+    expect(encontrarTestesLentos(testes, Number.NaN)).toEqual([]);
+  });
+
+  it("nenhum teste cruza o limiar → lista vazia", () => {
+    expect(encontrarTestesLentos([{ arquivo: "x", titulo: "ok", duracaoMs: 10 }], 15000)).toEqual([]);
+  });
+});
+
+describe("montarAviso", () => {
+  it("cita título, arquivo, ms e percentual do testTimeout", () => {
+    const msg = montarAviso(
+      { arquivo: "src/features/admin/PlatformUsers.test.tsx", titulo: "caminho feliz", duracaoMs: 8474, fracao: 8474 / 15000 },
+      15000,
+    );
+    expect(msg).toContain("PlatformUsers.test.tsx");
+    expect(msg).toContain("caminho feliz");
+    expect(msg).toContain("8474ms");
+    expect(msg).toContain("56%"); // 8474/15000 arredondado
+    expect(msg).toContain("15000ms");
+  });
+});
+
+describe("GuardaTimeoutTeste (reporter)", () => {
+  it("onFinished avisa (console.warn) quando um teste cruza o limiar, e cita o teste certo", () => {
+    const avisos: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => avisos.push(args.join(" "));
+    try {
+      const guarda = new GuardaTimeoutTeste();
+      guarda.onInit({ config: { testTimeout: 1000 } });
+      const file = arquivoComTeste("lento.test.ts", "demora de propósito", 600); // 60% de 1000ms
+      guarda.onFinished([file]);
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(avisos).toHaveLength(1);
+    expect(String(avisos[0])).toContain("lento.test.ts");
+    expect(String(avisos[0])).toContain("demora de propósito");
+    expect(String(avisos[0])).toContain("60%");
+  });
+
+  it("onFinished NÃO avisa quando nenhum teste cruza o limiar", () => {
+    const avisos: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => avisos.push(args.join(" "));
+    try {
+      const guarda = new GuardaTimeoutTeste();
+      guarda.onInit({ config: { testTimeout: 15000 } });
+      const file = arquivoComTeste("rapido.test.ts", "instantâneo", 50);
+      guarda.onFinished([file]);
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(avisos).toHaveLength(0);
+  });
+
+  it("não seta process.exitCode — isto é aviso, não gate (ver cabeçalho do arquivo-fonte)", () => {
+    const exitCodeAntes = process.exitCode;
+    const guarda = new GuardaTimeoutTeste();
+    guarda.onInit({ config: { testTimeout: 100 } });
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      guarda.onFinished([arquivoComTeste("x.test.ts", "y", 99999)]); // MUITO acima do timeout
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(process.exitCode).toBe(exitCodeAntes);
+  });
+});

--- a/apps/web/src/test/guardaTimeoutTeste.ts
+++ b/apps/web/src/test/guardaTimeoutTeste.ts
@@ -1,0 +1,132 @@
+// Guarda de timeout individual (issue #231) — mesmo espírito de
+// `scripts/guarda-timeouts-mutacao.mjs` (issue #213): transformar sintoma em SINAL antes de virar
+// vermelho. Lá era timeout de mutante mascarando score; aqui é duração de teste se aproximando do
+// `testTimeout` — o mesmo tipo de folga que já foi consumida uma vez (o próprio `vitest.config.ts`
+// subiu de 5000 para 15000ms citando PlatformUsers.test.tsx/ContractBuilderPage.test.tsx, e os
+// dois voltaram a se aproximar do teto sob carga). Sem um guarda, a suíte só avisa quando ESTOURA
+// — tarde demais para quem só vê o CI vermelho e nenhuma pista de qual arquivo é o de sempre.
+//
+// ── POR QUE AVISO, E NÃO REPROVAR A SUÍTE ────────────────────────────────────────────────────────
+// Reprovar exigiria um limiar rígido, e duração de teste sob CPU compartilhada (várias worktrees,
+// CI concorrente) é ruidosa por natureza — o mesmo teste variou de ~2,1s isolado a ~8,5s sob a
+// suíte inteira em paralelo (medido, issue #231). Um `expect` sobre isso seria flaky por
+// construção. O valor aqui é o mesmo do guarda de mutação: dar NOME ao sintoma cedo, não bloquear
+// a esteira por uma métrica ruidosa.
+//
+// ── POR QUE METADE DO `testTimeout` ──────────────────────────────────────────────────────────────
+// 50% dá uma folga simétrica: um teste que já gastou metade do orçamento tem, na pior hipótese
+// (mesma contenção dobrando de novo), exatamente o resto do orçamento para terminar. É o ponto em
+// que "ainda passou" começa a virar "quase não passou" — cedo o bastante para agir antes do
+// primeiro estouro real, tarde o bastante para não avisar por qualquer teste de componente normal
+// (a suíte inteira, pós-conserto do #231, roda com folga de ~4x nesse limiar — ver
+// `PlatformUsers.test.tsx`/`ContractBuilderPage.test.tsx`).
+
+import type { File, Reporter, Task } from "vitest";
+
+/** Ver "POR QUE METADE" no cabeçalho. Mexer aqui exige citar a medição que justifica. */
+export const LIMIAR_FRACAO_PADRAO = 0.5;
+
+export interface TesteMedido {
+  arquivo: string;
+  titulo: string;
+  duracaoMs: number;
+}
+
+export interface TesteLento extends TesteMedido {
+  fracao: number;
+}
+
+/**
+ * Achata a árvore de tasks do Vitest (File → Suite → Test, aninhado) numa lista plana de testes
+ * FOLHA que realmente rodaram (com `result.duration` populado). Suites, `describe`s e testes
+ * pulados/todo não entram — não têm duração própria a medir.
+ */
+export function achatarTestes(files: readonly File[]): TesteMedido[] {
+  const testes: TesteMedido[] = [];
+
+  // Visita SÓ o que está DENTRO do file task (describe/it aninhados). Deliberadamente não decide
+  // "é o file task?" olhando `task.type` — em runtime o node raiz de um arquivo às vezes chega
+  // marcado como `type: 'suite'` (é uma Suite por herança de interface: `File extends Suite`), e
+  // decidir por tipo o classificaria como describe e prefixaria o TÍTULO com o caminho do arquivo
+  // inteiro (medido rodando de verdade — ver prova da issue #231). O parâmetro `files` já É a
+  // lista de file tasks por construção (é o que o Vitest entrega em `onFinished`), então o nível
+  // raiz nunca precisa disso — só os filhos.
+  function visitar(task: Task, caminhoTitulo: string[]) {
+    if (task.type === "suite") {
+      for (const filho of task.tasks) visitar(filho, [...caminhoTitulo, task.name].filter(Boolean));
+      return;
+    }
+    if (task.type !== "test") return; // "custom" (benchmarks etc.) fora do escopo deste guarda.
+    const duracaoMs = task.result?.duration;
+    if (typeof duracaoMs !== "number") return; // não rodou (skip/todo) ou não tem medição.
+    testes.push({
+      arquivo: task.file.filepath,
+      titulo: [...caminhoTitulo, task.name].filter(Boolean).join(" > "),
+      duracaoMs,
+    });
+  }
+
+  for (const file of files) {
+    for (const filho of file.tasks) visitar(filho, []);
+  }
+  return testes;
+}
+
+/**
+ * Filtra os testes cuja duração já cruzou `limiarFracao` do `testTimeoutMs`, do mais lento para o
+ * mais rápido. `testTimeoutMs` precisa ser > 0 — um projeto sem timeout configurado (`0`/`Infinity`
+ * no Vitest) não tem "perto do limite" que faça sentido, e devolvemos lista vazia em vez de dividir
+ * por zero/Infinity silenciosamente.
+ */
+export function encontrarTestesLentos(
+  testes: readonly TesteMedido[],
+  testTimeoutMs: number,
+  limiarFracao: number = LIMIAR_FRACAO_PADRAO,
+): TesteLento[] {
+  if (!Number.isFinite(testTimeoutMs) || testTimeoutMs <= 0) return [];
+
+  return testes
+    .map((t) => ({ ...t, fracao: t.duracaoMs / testTimeoutMs }))
+    .filter((t) => t.fracao >= limiarFracao)
+    .sort((a, b) => b.fracao - a.fracao);
+}
+
+const n0 = (v: number) => Math.round(v);
+const pct = (v: number) => Math.round(v * 100);
+
+export function montarAviso(lento: TesteLento, testTimeoutMs: number): string {
+  return (
+    `AVISO [guarda-timeout-teste]: "${lento.titulo}" (${lento.arquivo}) levou ${n0(lento.duracaoMs)}ms ` +
+    `— ${pct(lento.fracao)}% do testTimeout de ${testTimeoutMs}ms. Ainda passou, mas está perto do ` +
+    "limite; se isto vira estouro sob carga (várias worktrees/CI concorrente), o conserto é a CAUSA " +
+    "do teste (delay artificial, poll longo, userEvent sem `delay: null`), não subir o testTimeout " +
+    "de novo — ver issue #231."
+  );
+}
+
+/**
+ * Reporter do Vitest: ao final da corrida, avisa (stderr) sobre testes que já cruzaram o limiar.
+ * Deliberadamente NÃO altera `process.exitCode` — é aviso, não gate. Um gate duro sobre duração
+ * ruidosa (CPU compartilhada) seria flaky por construção; ver cabeçalho do arquivo.
+ */
+export class GuardaTimeoutTeste implements Reporter {
+  private testTimeoutMs = 5000; // default do Vitest; sobrescrito em onInit com o valor real.
+  private readonly limiarFracao: number;
+
+  constructor(opts: { limiarFracao?: number } = {}) {
+    this.limiarFracao = opts.limiarFracao ?? LIMIAR_FRACAO_PADRAO;
+  }
+
+  onInit(ctx: { config: { testTimeout?: number } }): void {
+    if (typeof ctx.config.testTimeout === "number") this.testTimeoutMs = ctx.config.testTimeout;
+  }
+
+  onFinished(files: File[] = []): void {
+    const lentos = encontrarTestesLentos(achatarTestes(files), this.testTimeoutMs, this.limiarFracao);
+    for (const lento of lentos) {
+      console.warn(montarAviso(lento, this.testTimeoutMs));
+    }
+  }
+}
+
+export default GuardaTimeoutTeste;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { GuardaTimeoutTeste } from "./src/test/guardaTimeoutTeste";
 
 // Config dedicada de testes (Story 7.3). Mantida SEPARADA de `vite.config.ts` para que o
 // build de produção (nginx estático) fique inalterado — o Vitest prefere `vitest.config.ts`
@@ -16,9 +17,14 @@ export default defineConfig({
     // Fuso fixo para que testes sensíveis a data (ex.: ComprovantePage) sejam determinísticos em
     // qualquer máquina/CI, não só em fusos "atrás" de UTC como o do Brasil.
     env: { TZ: "America/Sao_Paulo" },
-    // O default de 5000ms causava flakes (PlatformUsers.test.tsx, ContractBuilderPage.test.tsx)
-    // só sob a suíte completa em paralelo — isolados, ambos passam dentro do default. Suíte
-    // cresceu o bastante para que a contenção de CPU entre workers estoure o timeout curto.
+    // Histórico (issue #231): o default de 5000ms causava flakes (PlatformUsers.test.tsx,
+    // ContractBuilderPage.test.tsx) só sob a suíte completa em paralelo — isolados, ambos
+    // passavam dentro do default. A causa real era `userEvent.type()` sem `delay: null` fazendo
+    // um `setTimeout` REAL por tecla (ver os dois arquivos); corrigida nos testes, não aqui.
+    // 15000ms FICA como está — não é para onde subir de novo se a suíte voltar a ficar perto do
+    // teto (ver `GuardaTimeoutTeste` abaixo, que agora avisa cedo em vez de deixar a folga se
+    // esgotar em silêncio de novo).
     testTimeout: 15000,
+    reporters: ["default", new GuardaTimeoutTeste()],
   },
 });


### PR DESCRIPTION
## O que é

A suíte vitest tinha testes rodando a 7-9s contra `testTimeout: 15000` — sob carga (várias worktrees/CI concorrente) estouravam, e a falha apontava para o lugar errado (parecia regressão de PRs que nem tocavam o arquivo). O `vitest.config.ts` já tinha subido o timeout uma vez por essa mesma classe (500→15000ms) e a folga já tinha sido consumida de novo.

## Causa medida

`PlatformUsers.test.tsx` e `ContractBuilderPage.test.tsx` usam `userEvent.setup()` sem `delay: null`. Cada tecla de `.type()` faz um `await` real num `setTimeout(fn, 0)` — inofensivo isolado, mas sob contenção de CPU esse `setTimeout(0)` pode custar muito mais que 0ms. Com ~80 caracteres digitados por teste em 7 campos, isso acumula.

## Correção

`userEvent.setup({ delay: null })` nos dois arquivos — elimina a espera artificial entre teclas sem mudar o que é digitado/disparado. `testTimeout` não foi tocado. Medido sob a mesma carga (suíte completa em paralelo): PlatformUsers "caminho feliz" caiu de 8474ms para 3933ms; "'queued' é sucesso" de 7161ms para 1390ms.

## Guarda nova

`GuardaTimeoutTeste` (reporter do Vitest) avisa via `console.warn` quando um teste cruza 50% do `testTimeout`, sem reprovar a suíte (duração sob CPU compartilhada é ruidosa por natureza — um gate duro seria flaky por construção). Já pegou um caso real fora do escopo desta issue durante a corrida final (`CarrosselBuilderPage.test.tsx` a 55% do timeout) — registrado para issue futura, não corrigido aqui.

## Verificação independente

- `pnpm lint` / `pnpm typecheck` — limpos.
- Rodei os 3 arquivos tocados: 26/26 passed, todos < 2.5s isolados.
- Reproduzi o disparo do guarda eu mesmo: arquivo temporário com um teste de 700ms contra `--testTimeout=1000`, confirmei o aviso aparecendo com o texto e percentual corretos, e que o teste rápido do mesmo arquivo não dispara aviso.

## Gates

- `pnpm test` (relatório do implementador) — 87 arquivos / 1029 testes

Closes #231
