### PR TITLE
fix: usar parseCentsBRL nos 12 sites de conversao BRL->centavos (#224)

### DIFF
--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -497,3 +497,49 @@ describe("CobrancasPage — recebimento fora do trilho (Story 8.15)", () => {
     expect(screen.queryByText("Agendado para entrar")).toBeNull();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; estes testes fixam esse contrato nos dois sites de CobrancasPage.
+describe("CobrancasPage — separador de milhar (#224)", () => {
+  it("Nova cobrança: '1.234,56' vira 123456 centavos, não 123 (regressão do parseFloat cru)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova cobrança" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "1.234,56");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-09-10" } });
+    await user.click(screen.getByRole("button", { name: "Gerar cobrança" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/receivables/charges",
+      expect.objectContaining({ amount_cents: 123456 }),
+    );
+  });
+
+  it("Editar cobrança: '1.234,56' vira 123456 centavos, não 123", async () => {
+    const user = userEvent.setup();
+    mockCobrancas([COBRANCA_ABERTA]);
+    vi.mocked(api.patch).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Editar" }));
+    const valor = await screen.findByLabelText("Valor (R$)");
+    await user.clear(valor);
+    await user.type(valor, "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    await waitFor(() => expect(vi.mocked(api.patch)).toHaveBeenCalled());
+    expect(vi.mocked(api.patch)).toHaveBeenCalledWith(
+      "/receivables/charges/c-1",
+      expect.objectContaining({ amount_cents: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -8,7 +8,7 @@ import { pluralize } from "../../lib/pluralize";
 import GanchoDaVima from "../dna/GanchoDaVima";
 import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
-import { AGENDADO_ENTRADA_LABEL, type BankAccount } from "../financeiro/contas";
+import { AGENDADO_ENTRADA_LABEL, parseCentsBRL, type BankAccount } from "../financeiro/contas";
 import type { CostCenter } from "../financeiro/costCenters";
 import CostCenterSelect from "../financeiro/CostCenterSelect";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
@@ -376,7 +376,7 @@ function EditChargeModal({
         description,
         chart_account_id: chartAccountId,
         cost_center_id: costCenterId,
-        amount_cents: Math.round(parseFloat(value.replace(",", ".")) * 100),
+        amount_cents: parseCentsBRL(value),
         due_date: dueDate,
       });
       onSaved();
@@ -454,7 +454,7 @@ function NewChargeModal({
     setError(null);
     setSaving(true);
     try {
-      const amount_cents = Math.round(parseFloat(value.replace(",", ".")) * 100);
+      const amount_cents = parseCentsBRL(value);
       await api.post("/receivables/charges", {
         kind,
         method,

--- a/apps/web/src/features/estoque/EstoquePage.test.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.test.tsx
@@ -86,3 +86,30 @@ describe("EstoquePage — Novo item de estoque (Story 7.16, Task 1)", () => {
     expect(screen.getByRole("button", { name: "Criar item" })).toBeEnabled();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; este teste fixa esse contrato no único site de EstoquePage.
+describe("EstoquePage — separador de milhar (#224)", () => {
+  it("'1.234,56' vira unit_cost_cents 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Novo item" }));
+    await user.type(screen.getByLabelText("Nome"), "Notebook usado");
+    await user.type(screen.getByLabelText("Custo unitário (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Criar item" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/stock/items",
+      expect.objectContaining({ unit_cost_cents: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/estoque/EstoquePage.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
+import { parseCentsBRL } from "../financeiro/contas";
 import { formatBRL } from "../financeiro/dre";
 
 export default function EstoquePage() {
@@ -159,7 +160,7 @@ function NewItemModal({
         product_id: productId || null,
         quantity: parseInt(quantity, 10) || 0,
         min_quantity: parseInt(min, 10) || 0,
-        unit_cost_cents: Math.round(parseFloat(cost.replace(",", ".") || "0") * 100),
+        unit_cost_cents: parseCentsBRL(cost),
       });
       onCreated();
       onClose();

--- a/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider, usePageActions } from "../../store/pageActions";
+import FinanceiroPage from "./FinanceiroPage";
+
+// Rede sempre mockada (IV2): nenhum teste bate em /wallet real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  publicApi: { post: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+const emptySummary = {
+  available_cents: 0,
+  pending_cents: 0,
+  withdrawn_cents: 0,
+  gross_total_cents: 0,
+  fees_total_cents: 0,
+};
+
+// Estratégia (a): o botão "Registrar venda" vive na topbar (AppShell), fora do escopo da página.
+// Este componente local replica o contrato real da topbar — consome `usePageActions().action` —
+// sem importar o AppShell inteiro.
+function Topbar() {
+  const { action } = usePageActions();
+  return action ? <button onClick={action.onClick}>{action.label}</button> : null;
+}
+
+function renderPage() {
+  return render(
+    <PageActionsProvider>
+      <FinanceiroPage />
+      <Topbar />
+    </PageActionsProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+    if (url === "/wallet/transactions") return Promise.resolve({ data: [] } as never);
+    if (url === "/chart-of-accounts") return Promise.resolve({ data: [] } as never);
+    if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+    if (url === "/wallet/payouts") return Promise.resolve({ data: [] } as never);
+    if (url === "/bank/accounts") return Promise.resolve({ data: [] } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+  vi.mocked(api.post).mockReset();
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; este teste fixa esse contrato no único site de FinanceiroPage.
+describe("FinanceiroPage — separador de milhar (#224)", () => {
+  it("Registrar venda: '1.234,56' vira gross_cents 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Registrar venda" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Registrar" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/wallet/transactions",
+      expect.objectContaining({ gross_cents: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -8,6 +8,7 @@ import { PayoutHistory, type Payout } from "./PayoutHistory";
 import ChartAccountSelect from "./ChartAccountSelect";
 import type { CostCenter } from "./costCenters";
 import CostCenterSelect from "./CostCenterSelect";
+import { parseCentsBRL } from "./contas";
 import { type ChartAccount, GRUPOS_DRE } from "./planoContas";
 import { formatBRL } from "./dre";
 
@@ -273,7 +274,7 @@ function NewSaleModal({
     setError(null);
     setSaving(true);
     try {
-      const gross_cents = Math.round(parseFloat(value.replace(",", ".")) * 100);
+      const gross_cents = parseCentsBRL(value);
       await api.post("/wallet/transactions", {
         kind,
         method,

--- a/apps/web/src/features/financeiro/contas.ts
+++ b/apps/web/src/features/financeiro/contas.ts
@@ -663,13 +663,12 @@ export function resumoSaldos(accounts: BankAccount[]): ResumoSaldo[] {
  * "1.234,56" / "1234.56" / "1234" → centavos. Vazio ou inválido → `0`. Aceita sinal negativo
  * (saldo de abertura de conta no limite é legítimo).
  *
- * ⚠️ **Achado registrado, não corrigido aqui:** o repositório tem hoje ~8 conversões BRL→centavos
- * escritas inline (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) espalhadas por
- * `CobrancasPage`, `FinanceiroPage`, `InvestimentosPage`, `EstoquePage`, `FunnelBuilderPage` e
- * `QuoteBuilderPage`, mais um `toCents` local em `ComprovantePage`. Nenhuma delas trata o ponto de
- * milhar ("1.234,56" vira 1,23 em metade delas). Consolidar tudo num helper único ao lado de
- * `formatBRL` é a correção certa — e está **fora do escopo desta story** (tocaria 7 telas que a
- * IV1 manda deixar intactas). Esta é a única versão testada; ver Dev Agent Record.
+ * ✅ **Consolidada (#224).** As 12 conversões inline (`Math.round(parseFloat(v.replace(",", "."))
+ * * 100)`) espalhadas por `CobrancasPage`, `PagarPage`, `ProdutosPage`, `FunnelBuilderPage`,
+ * `EstoquePage`, `FinanceiroPage`, `FunnelAutomation` e o `toCents` local de `QuoteBuilderPage`
+ * agora chamam esta função — nenhuma delas tratava o ponto de milhar ("1.234,56" virava 1,23).
+ * `ComprovantePage.toCents` (que já trata milhar de outro jeito) ficou fora: não estava na lista
+ * de 12 sites da #224.
  */
 export function parseCentsBRL(raw: string): number {
   const s = raw.trim().replace(/\s/g, "");

--- a/apps/web/src/features/funis/FunnelAutomation.test.tsx
+++ b/apps/web/src/features/funis/FunnelAutomation.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationFields } from "./FunnelAutomation";
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(e.target.value.replace(",", ".") || "0") * 100)`)
+// só troca a PRIMEIRA vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira
+// "1.234.56", `parseFloat` para no segundo ponto e devolve 1.234 → 123 centavos, não 123456.
+// `parseCentsBRL` (contas.ts) trata o milhar corretamente.
+//
+// ⚠️ **Medido, não assumido:** este campo é um input CONTROLADO cujo `value` é sempre
+// `(cfg.amount_cents / 100).toString()` — recalculado a CADA `onChange`. Digitar caractere por
+// caractere (`user.type`) faz cada tecla de pontuação ("." ou ",") ser imediatamente descartada no
+// re-render seguinte, então o separador de milhar NUNCA sobrevive a uma digitação incremental
+// aqui — só chega inteiro via colar (`fireEvent.change` de uma vez, como um paste real do
+// clipboard). É por isso que o teste dispara UM `fireEvent.change` com a string completa, e não
+// `user.type`: é o único caminho realista pelo qual o bug de milhar é alcançável neste campo.
+describe("AutomationFields — separador de milhar (#224)", () => {
+  it("create_charge: colar '1.234,56' vira amount_cents 123456, não 123", () => {
+    const onChange = vi.fn();
+    render(
+      <AutomationFields
+        data={{ key: "gerar-cobranca", action: "create_charge", config: {} }}
+        onChange={onChange}
+      />,
+    );
+
+    const campo = screen.getByPlaceholderText("Valor (R$)");
+    fireEvent.change(campo, { target: { value: "1.234,56" } });
+
+    expect(onChange).toHaveBeenCalledWith({ amount_cents: 123456 });
+  });
+
+  it("create_quote: colar '1.234,56' vira amount_cents 123456, não 123", () => {
+    const onChange = vi.fn();
+    render(
+      <AutomationFields
+        data={{ key: "gerar-orcamento", action: "create_quote", config: {} }}
+        onChange={onChange}
+      />,
+    );
+
+    const campo = screen.getByPlaceholderText("Valor (R$)");
+    fireEvent.change(campo, { target: { value: "1.234,56" } });
+
+    expect(onChange).toHaveBeenCalledWith({ amount_cents: 123456 });
+  });
+});

--- a/apps/web/src/features/funis/FunnelAutomation.tsx
+++ b/apps/web/src/features/funis/FunnelAutomation.tsx
@@ -2,6 +2,7 @@ import type { Client, FunnelRun, FunnelRunSummary } from "@e1p/shared-types";
 import { Clock, Play, UserPlus, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { api, apiErrorMessage } from "../../lib/api";
+import { parseCentsBRL } from "../financeiro/contas";
 
 type Notify = (msg: string, type?: "ok" | "err") => void;
 
@@ -113,7 +114,7 @@ export function AutomationFields({
         <input
           inputMode="decimal" value={reais}
           onChange={(e) =>
-            onChange({ amount_cents: Math.round(parseFloat(e.target.value.replace(",", ".") || "0") * 100) })
+            onChange({ amount_cents: parseCentsBRL(e.target.value) })
           }
           placeholder="Valor (R$)"
           className="mb-2 w-full rounded-lg border border-neutral-200 px-2 py-1.5 text-sm outline-none"

--- a/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.test.tsx
@@ -267,3 +267,95 @@ describe("catálogo de componentes fora de forma não derruba o builder (#207)",
     expect(screen.getByText("Novo Lead")).toBeInTheDocument();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; estes testes fixam esse contrato nos dois sites de `RunNodeModal.run()`
+// (create_quote e create_charge), que digitam no mesmo campo "Valor (R$)" mas montam o payload em
+// dois `if` distintos (linhas 624 e 629 antes do #224).
+const catalogComAcoesDeDinheiro = [
+  {
+    category: "gatilhos",
+    label: "Gatilhos",
+    color: "#F59E0B",
+    items: [
+      {
+        key: "gerar-orcamento", label: "Gerar orçamento", description: "Cria um orçamento",
+        shape: "node", action: "create_quote",
+      },
+      {
+        key: "gerar-cobranca", label: "Gerar cobrança", description: "Cria uma cobrança",
+        shape: "node", action: "create_charge",
+      },
+    ],
+  },
+];
+
+describe("RunNodeModal — separador de milhar (#224)", () => {
+  function mockComAcoes() {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/funnels/components") return Promise.resolve({ data: catalogComAcoesDeDinheiro } as never);
+      if (url === "/settings/profile") return Promise.resolve({ data: profile(null) } as never);
+      if (url === "/crm/clients") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+  }
+
+  /** Adiciona o nó pelo item da paleta, seleciona-o no canvas e abre "Executar ação". */
+  async function abrirExecutarAcao(user: ReturnType<typeof userEvent.setup>, itemLabel: string) {
+    await user.click(await screen.findByText(itemLabel)); // item da paleta → cria o nó
+    fireEvent.click(screen.getAllByText(itemLabel).at(-1)!); // seleciona o nó recém-criado
+    await user.click(await screen.findByRole("button", { name: "Executar ação" }));
+  }
+
+  it("create_quote: '1.234,56' vira amount_cents 123456, não 123 (linha do params.amount_cents em create_quote)", async () => {
+    const user = userEvent.setup();
+    mockComAcoes();
+    vi.mocked(api.post).mockImplementation((url: string) => {
+      if (url === "/funnels/run-node") return Promise.resolve({ data: { message: "ok" } } as never);
+      return Promise.resolve({ data: {} } as never);
+    });
+    renderNew();
+
+    await abrirExecutarAcao(user, "Gerar orçamento");
+    await user.type(screen.getByLabelText("Valor (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Executar agora" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalledWith("/funnels/run-node", expect.anything()));
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/funnels/run-node",
+      expect.objectContaining({
+        action: "create_quote",
+        params: expect.objectContaining({ amount_cents: 123456 }),
+      }),
+    );
+  });
+
+  it("create_charge: '1.234,56' vira amount_cents 123456, não 123 (linha do params.amount_cents em create_charge)", async () => {
+    const user = userEvent.setup();
+    mockComAcoes();
+    vi.mocked(api.post).mockImplementation((url: string) => {
+      if (url === "/funnels/run-node") return Promise.resolve({ data: { message: "ok" } } as never);
+      return Promise.resolve({ data: {} } as never);
+    });
+    renderNew();
+
+    await abrirExecutarAcao(user, "Gerar cobrança");
+    await user.type(screen.getByLabelText("Valor (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Executar agora" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalledWith("/funnels/run-node", expect.anything()));
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/funnels/run-node",
+      expect.objectContaining({
+        action: "create_charge",
+        params: expect.objectContaining({ amount_cents: 123456 }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/features/funis/FunnelBuilderPage.tsx
+++ b/apps/web/src/features/funis/FunnelBuilderPage.tsx
@@ -29,6 +29,7 @@ import ReactFlow, {
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { api, apiErrorMessage } from "../../lib/api";
+import { parseCentsBRL } from "../financeiro/contas";
 import { capabilitiesFor } from "../../lib/whatsappCapabilities";
 
 type NodeConfig = {
@@ -621,12 +622,12 @@ function RunNodeModal({
     if (action === "add_tag") params.tag = tag;
     if (action === "create_quote") {
       params.title = title;
-      params.amount_cents = Math.round(parseFloat(amount.replace(",", ".") || "0") * 100);
+      params.amount_cents = parseCentsBRL(amount);
     }
     if (action === "create_charge") {
       params.method = method;
       params.description = description;
-      params.amount_cents = Math.round(parseFloat(amount.replace(",", ".") || "0") * 100);
+      params.amount_cents = parseCentsBRL(amount);
     }
     if (action === "send_email") {
       params.subject = subject;

--- a/apps/web/src/features/orcamentos/QuoteBuilderPage.test.tsx
+++ b/apps/web/src/features/orcamentos/QuoteBuilderPage.test.tsx
@@ -106,3 +106,53 @@ describe("QuoteBuilderPage — salvar orçamento (Story 7.5, Task 4)", () => {
     expect(vi.mocked(api.patch)).not.toHaveBeenCalled();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// O `toCents` local desta tela (`Math.round(parseFloat((s||"").replace(",",".")||"0") * 100)`) só
+// trocava a PRIMEIRA vírgula por ponto e nunca removia o ponto de milhar: "1.234,56" virava
+// "1.234.56", `parseFloat` parava no segundo ponto e devolvia 1.234 → 123 centavos, não 123456. A
+// #224 removeu o `toCents` local e trocou os 4 usos por `parseCentsBRL` (contas.ts), que trata o
+// milhar corretamente. Os dois testes abaixo cobrem os dois SITES que recebem entrada distinta do
+// usuário (preço do serviço e desconto — `subtotal`/`total`/`preview` derivam dos mesmos valores).
+describe("QuoteBuilderPage — separador de milhar (#224)", () => {
+  it("Valor unitário do serviço: '1.234,56' vira unit_price_cents 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: savedQuote } as never);
+    renderNew();
+
+    await user.type(screen.getByPlaceholderText("Proposta comercial"), "Proposta comercial");
+    await user.type(screen.getByPlaceholderText("Título exibido"), "Consultoria");
+    await user.type(screen.getByLabelText("Valor unitário (R$)"), "1.234,56");
+
+    await user.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/quotes",
+      expect.objectContaining({
+        items: [expect.objectContaining({ unit_price_cents: 123456 })],
+      }),
+    );
+  });
+
+  it("Desconto: '1.234,56' vira discount_cents 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: savedQuote } as never);
+    renderNew();
+
+    await user.type(screen.getByPlaceholderText("Proposta comercial"), "Proposta comercial");
+    await user.type(screen.getByPlaceholderText("Título exibido"), "Consultoria");
+    await user.type(screen.getByLabelText("Desconto (R$)"), "1.234,56");
+
+    await user.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/quotes",
+      expect.objectContaining({ discount_cents: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
+++ b/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
@@ -16,9 +16,9 @@ import { api, apiErrorMessage } from "../../lib/api";
 import ProposalView from "./ProposalView";
 import { formatTime } from "../../lib/datetime";
 import { useFuso } from "../../store/auth";
+import { parseCentsBRL } from "../financeiro/contas";
 import { formatBRL } from "../financeiro/dre";
 
-const toCents = (s: string) => Math.round(parseFloat((s || "").replace(",", ".") || "0") * 100);
 const fromCents = (c: number) => (c / 100).toFixed(2).replace(".", ",");
 
 type Service = { description: string; subtitle: string; quantity: number; price: string };
@@ -129,19 +129,19 @@ export default function QuoteBuilderPage() {
           description: s.description,
           subtitle: s.subtitle,
           quantity: Math.max(1, s.quantity || 1),
-          unit_price_cents: toCents(s.price),
+          unit_price_cents: parseCentsBRL(s.price),
         })),
     [services],
   );
   const subtotal = items.reduce((a, i) => a + i.quantity * i.unit_price_cents, 0);
-  const total = Math.max(0, subtotal - toCents(discount));
+  const total = Math.max(0, subtotal - parseCentsBRL(discount));
 
   const preview: PublicProposal = {
     title: title || "Sua proposta",
     client_name: clientName,
     items,
     subtotal_cents: subtotal,
-    discount_cents: toCents(discount),
+    discount_cents: parseCentsBRL(discount),
     total_cents: total,
     payment_terms: paymentTerms,
     show_gallery: showGallery,
@@ -164,7 +164,7 @@ export default function QuoteBuilderPage() {
       title,
       client_id: clientId || null,
       items,
-      discount_cents: toCents(discount),
+      discount_cents: parseCentsBRL(discount),
       client_name: clientName,
       client_whatsapp: clientWhatsapp,
       payment_terms: paymentTerms,

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -800,3 +800,49 @@ describe("reativar conta cancelada (spec 2026-08-18, §6)", () => {
     await waitFor(() => expect(api.post).toHaveBeenCalledWith("/payables/bills/b-9/reactivate"));
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; estes testes fixam esse contrato nos dois sites de PagarPage.
+describe("PagarPage — separador de milhar (#224)", () => {
+  it("Nova conta: '1.234,56' vira 123456 centavos, não 123 (regressão do parseFloat cru)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova conta" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "1.234,56");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-08-01" } });
+    await user.click(screen.getByRole("button", { name: "Adicionar conta" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/payables/bills",
+      expect.objectContaining({ amount_cents: 123456 }),
+    );
+  });
+
+  it("Editar conta: '1.234,56' vira 123456 centavos, não 123", async () => {
+    const user = userEvent.setup();
+    mockComConta([CONTA]);
+    vi.mocked(api.patch).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Editar" }));
+    const valor = await screen.findByLabelText("Valor (R$)");
+    await user.clear(valor);
+    await user.type(valor, "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    await waitFor(() => expect(vi.mocked(api.patch)).toHaveBeenCalled());
+    expect(vi.mocked(api.patch)).toHaveBeenCalledWith(
+      "/payables/bills/b-1",
+      expect.objectContaining({ amount_cents: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -10,6 +10,7 @@ import { usePrimaryAction } from "../../store/pageActions";
 import ChartAccountSelect from "../financeiro/ChartAccountSelect";
 import type { CostCenter } from "../financeiro/costCenters";
 import CostCenterSelect from "../financeiro/CostCenterSelect";
+import { parseCentsBRL } from "../financeiro/contas";
 import { type ChartAccount, GRUPOS_DRE } from "../financeiro/planoContas";
 import { DialogDeBaixa } from "./EscolhaDaBaixa";
 import FiltrosDaLista from "./FiltrosDaLista";
@@ -500,7 +501,7 @@ function EditBillModal({
         chart_account_id: chartAccountId,
         cost_center_id: costCenterId,
         supplier,
-        amount_cents: Math.round(parseFloat(value.replace(",", ".")) * 100),
+        amount_cents: parseCentsBRL(value),
         due_date: dueDate,
         recurrence,
       });
@@ -678,7 +679,7 @@ function NewBillModal({
     setError(null);
     setSaving(true);
     try {
-      const amount_cents = Math.round(parseFloat(value.replace(",", ".")) * 100);
+      const amount_cents = parseCentsBRL(value);
       await api.post("/payables/bills", {
         description,
         chart_account_id: chartAccountId || null,

--- a/apps/web/src/features/produtos/ProdutosPage.test.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.test.tsx
@@ -81,3 +81,49 @@ describe("ProdutosPage — Novo produto (Story 7.16, Task 2)", () => {
     expect(screen.getByRole("button", { name: "Criar produto" })).toBeEnabled();
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Issue #224 — separador de milhar no valor digitado (parseCentsBRL)
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// A conta manual antiga (`Math.round(parseFloat(v.replace(",", ".")) * 100)`) só troca a PRIMEIRA
+// vírgula por ponto e nunca remove o ponto de milhar: "1.234,56" vira "1.234.56", `parseFloat` para
+// no segundo ponto e devolve 1.234 → 123 centavos, não 123456. `parseCentsBRL` (contas.ts) trata o
+// milhar corretamente; estes testes fixam esse contrato nos dois sites de ProdutosPage.
+describe("ProdutosPage — separador de milhar (#224)", () => {
+  it("Novo produto: '1.234,56' vira price_cents 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Novo produto" }));
+    await user.type(screen.getByLabelText("Nome"), "Mentoria anual");
+    await user.type(screen.getByLabelText("Preço (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Criar produto" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/products",
+      expect.objectContaining({ price_cents: 123456 }),
+    );
+  });
+
+  it("Novo cupom (desconto fixo): '1.234,56' vira discount_value 123456, não 123", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: {} } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Cupons" }));
+    await user.click(await screen.findByRole("button", { name: "Novo cupom" }));
+    await user.type(screen.getByLabelText("Código"), "PROMO1234");
+    await user.selectOptions(screen.getByLabelText("Tipo"), "fixed");
+    await user.type(screen.getByLabelText("Desconto (R$)"), "1.234,56");
+    await user.click(screen.getByRole("button", { name: "Criar cupom" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/products/coupons",
+      expect.objectContaining({ discount_value: 123456 }),
+    );
+  });
+});

--- a/apps/web/src/features/produtos/ProdutosPage.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
+import { parseCentsBRL } from "../financeiro/contas";
 import { formatBRL } from "../financeiro/dre";
 
 type Tab = "produtos" | "cupons" | "compradores";
@@ -259,7 +260,7 @@ function ProductModal({
       await api.post("/products", {
         name,
         kind,
-        price_cents: Math.round(parseFloat(value.replace(",", ".")) * 100),
+        price_cents: parseCentsBRL(value),
         description,
       });
       onCreated();
@@ -322,7 +323,7 @@ function CouponModal({
       const discount_value =
         type === "percent"
           ? parseInt(value, 10)
-          : Math.round(parseFloat(value.replace(",", ".")) * 100);
+          : parseCentsBRL(value);
       await api.post("/products/coupons", {
         code,
         discount_type: type,


### PR DESCRIPTION
## O que é

O #209 unificou `brl` (saída de dinheiro). Faltava o lado da ENTRADA: a conversão de string BRL para centavos estava inline em 12 lugares / 8 arquivos, nenhuma tratando separador de milhar. Medido: `Math.round(parseFloat("1.234,56".replace(",", ".")) * 100)` dá **123** centavos em vez de **123456** — erro de 1000x em dinheiro digitado pelo dono.

## Correção

Todos os 12 sites trocados por `parseCentsBRL` (já existia, testada, em `financeiro/contas.ts`). Medido que os 12 são alcançáveis pelo usuário — 11 por digitação direta (sem máscara que bloqueie o milhar), 1 (`FunnelAutomation.tsx`) só por colar (vetor real: copiar valor de extrato/nota). `QuoteBuilderPage.tsx` teve seu `toCents` local removido em favor da função única.

## Verificação independente

- Rodei os 8 arquivos de teste tocados: 82/82 passed.
- Reproduzi uma mutação eu mesmo (`CobrancasPage.tsx`, edição de cobrança): revertendo para a conta manual antiga, o teste morre com `amount_cents: 123` recebido vs `123456` esperado — reproduz exatamente o erro de 1000x da issue. Restaurado por cópia de arquivo.
- O relatório do implementador documenta as 13 mutações restantes com a mesma metodologia (tabela mutação → teste morto → mensagem real).

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos

Closes #224
