### PR TITLE
fix: alvo tocavel de 2 checkboxes de convencao ja estabelecida (#227)

### DIFF
--- a/apps/web/e2e/toque-360.spec.ts
+++ b/apps/web/e2e/toque-360.spec.ts
@@ -322,3 +322,58 @@ test("as ações do centro de custo são tocáveis com o polegar", async ({ page
   expect(larguraDaPagina).toBe(360);
   await expect(page.getByTestId("comparativo-centros")).toBeVisible();
 });
+
+// ── `/agenda`, modal "Novo evento" — checkbox "Dia inteiro" ────────────────────────────────────
+// A forma LITERAL do PR #56 (issue #227, item "Dívida menor"): o alvo era um checkbox de 13×13
+// sem `min-h-[44px]` na LINHA do rótulo — e a consequência medida daquele PR foi uma conta real
+// marcada como paga sem o dono conseguir ver. Aqui o controle troca "conta paga" por "evento de
+// dia inteiro", mas o mecanismo do defeito é o mesmo dedo errando o mesmo alvo pequeno.
+//
+// Escopo deliberadamente pequeno: só a LINHA do rótulo ganha `min-h-[44px]` — mesma convenção do
+// `ContasSaldosPage.tsx:208` e do teste de `/financeiro/centros-custo` acima. O `<input>` em si
+// não muda de tamanho (a issue #227 é explícita: o alvo de toque é a linha inteira, não a
+// caixinha).
+test("o checkbox 'Dia inteiro' do modal de evento (/agenda) é tocável com o polegar", async ({
+  page,
+}) => {
+  // Relógio congelado: `/agenda` abre no mês corrente e o modal de evento nasce com a data de
+  // hoje. Sem isto o teste mede uma tela diferente a cada dia — mesma nota do bloco de
+  // `campo-modal-360.spec.ts` para esta mesma rota.
+  await page.clock.setFixedTime(new Date("2026-08-18T12:00:00Z"));
+  await semearSessao(page);
+  await mockarApi(page, {});
+  await page.goto("/agenda");
+
+  await page.getByRole("button", { name: "Novo evento" }).first().click();
+  await expect(page.getByRole("heading", { name: "Novo evento" })).toBeVisible();
+
+  const overlay = page.locator(".fixed.inset-0.z-50");
+  const caixaCheckbox = await overlay.getByText("Dia inteiro").boundingBox();
+  expect(caixaCheckbox, "Dia inteiro").not.toBeNull();
+  expect(caixaCheckbox!.height, "Dia inteiro").toBeGreaterThanOrEqual(44);
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+});
+
+// ── `/financeiro/plano-contas` — checkbox "Mostrar arquivadas" ─────────────────────────────────
+// Mesma dívida menor da issue #227: checkbox de 13×13 sem a classe `h-5 w-5` que é a convenção do
+// repo para o quadrado do checkbox (20×20 — ver `ContasSaldosPage.tsx:208` e
+// `CentrosCustoPage.tsx:86`). O `<label>` já cumpria os 44px? Não: também faltava `min-h-[44px]`
+// na linha, então as duas metades da convenção (caixinha 20×20 + linha 44px) foram aplicadas
+// juntas, exatamente como nas outras três telas de `/financeiro` que já seguem o padrão.
+test("o checkbox 'Mostrar arquivadas' de /financeiro/plano-contas é tocável com o polegar", async ({
+  page,
+}) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/chart-of-accounts": [] });
+  await page.goto("/financeiro/plano-contas");
+  await expect(page.getByRole("heading", { name: "Plano de contas" })).toBeVisible();
+
+  const caixaCheckbox = await page.getByText("Mostrar arquivadas").boundingBox();
+  expect(caixaCheckbox, "Mostrar arquivadas").not.toBeNull();
+  expect(caixaCheckbox!.height, "Mostrar arquivadas").toBeGreaterThanOrEqual(44);
+
+  const { larguraDaPagina } = await medirPagina(page);
+  expect(larguraDaPagina).toBe(360);
+});

--- a/apps/web/src/features/agenda/NewEventModal.tsx
+++ b/apps/web/src/features/agenda/NewEventModal.tsx
@@ -150,7 +150,7 @@ export default function NewEventModal({
               ))}
             </select>
           </label>
-          <label className="flex items-center gap-2 pb-2 text-sm text-neutral-600">
+          <label className="flex min-h-[44px] items-center gap-2 text-sm text-neutral-600">
             <input type="checkbox" checked={allDay} onChange={(e) => setAllDay(e.target.checked)} />
             Dia inteiro
           </label>

--- a/apps/web/src/features/financeiro/PlanoContasPage.tsx
+++ b/apps/web/src/features/financeiro/PlanoContasPage.tsx
@@ -75,9 +75,10 @@ export default function PlanoContasPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <label className="flex items-center gap-2 text-sm text-neutral-600">
+          <label className="flex min-h-[44px] items-center gap-3 text-sm text-neutral-600">
             <input
               type="checkbox"
+              className="h-5 w-5 shrink-0"
               checked={includeArchived}
               onChange={(e) => setIncludeArchived(e.target.checked)}
             />


### PR DESCRIPTION
## O que é

Correção PARCIAL, deliberadamente escopada, da issue #227. A issue completa pede uma decisão de produto por tela (quais dos 5 "construtores densos" — `/marketing/m1`, `/sites/s1`, `/marketing/novo`, `/orcamentos/novo`, `/contratos/novo` — devem engordar ~90 campos para 44px). Essa decisão fica em aberto — não é deste PR.

Este PR corrige só a "dívida menor" que a própria issue já registrava como violação de CONVENÇÃO JÁ ESTABELECIDA (não decisão de produto nova):

- `/agenda`, modal "Novo evento": checkbox "Dia inteiro" com 13x13, sem `min-h-[44px]` na linha do label — a forma literal do PR #56 (conta marcada como paga sem o dono ver).
- `/financeiro/plano-contas`: checkbox "Mostrar arquivadas" sem `h-5 w-5`, a convenção já usada em `ContasSaldosPage.tsx`/`CentrosCustoPage.tsx`.

O terceiro item citado na issue (`/sites/s1`) foi investigado e descartado: os únicos checkboxes da rota pertencem ao editor de blocos do construtor denso — corrigi-los invadiria o escopo do produto adiado, então ficaram intocados.

## Verificação independente

- Rodei os 2 testes e2e novos: 2/2 passed.
- Reproduzi a mutação eu mesmo: revertendo a classe de `NewEventModal.tsx`, o teste "Dia inteiro" morre com `Received: 28` vs `Expected: >= 44` — reproduz exatamente a medição da issue.

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `pnpm exec playwright test e2e/toque-360.spec.ts -g "Dia inteiro|arquivadas"` — 2/2 passed

## Fora deste PR

Os ~90 campos dos 5 construtores densos permanecem em aberto — decisão de produto, não desenvolvida aqui. A issue #227 continua aberta para essa parte.
