### PR TITLE
fix: aplicar campos-tocaveis em /orcamentos/novo (#227)

### DIFF
--- a/apps/web/e2e/campo-modal-360.spec.ts
+++ b/apps/web/e2e/campo-modal-360.spec.ts
@@ -255,3 +255,51 @@ test("os campos do WIZARD JURÍDICO são tocáveis com o polegar", async ({ page
   expect(await camposBaixos(page, "main"), "jurídico — campos abaixo de 44px").toEqual([]);
   expect((await medirPagina(page)).larguraDaPagina).toBe(360);
 });
+
+// ── `/orcamentos/novo` ──────────────────────────────────────────────────────────────
+// Issue #227: o CASO LIMITE que a issue separou dos outros 4 "construtores densos". A tabela da
+// issue media 90 campos abaixo de 44px fora de modal, em 5 telas de editor — mas só esta usa a
+// MESMA classe do `Field` (`inputCls` deste arquivo é `px-3 py-2 text-sm`, 38px medidos): não é
+// densidade de UI nova pedindo decisão de produto, é a mesma inconsistência de estilo que
+// `campos-tocaveis` já fecha em 16 outras telas, só que fora de modal. As outras 4 construtoras
+// da issue (`/marketing/m1` 30, `/sites/s1` 15, `/marketing/novo` 12, `/contratos/novo` 4) usam
+// `px-2 py-1.5 text-xs` — editores densos de propósito — e ficam de fora por decisão de produto,
+// com issue de acompanhamento própria.
+test("os campos do ORÇAMENTO (/orcamentos/novo) são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {
+    "/crm/clients": [{ id: "c1", name: "Maria Silva" }],
+    "/settings/profile": {
+      logo_url: "",
+      primary_color: "#5D44F8",
+      bg_color: "#FFFFFF",
+      text_color: "#1F2937",
+      accent_color: "#3DD68C",
+    },
+  });
+  await page.goto("/orcamentos/novo");
+  // A tela não tem `heading`: a `marca` é o rótulo "Orçamentos" do link de voltar
+  // (`QuoteBuilderPage.tsx`) — sem ele, "zero campos baixos" poderia significar "não montou".
+  await expect(page.getByText("Orçamentos").first()).toBeVisible();
+
+  // Aba "Serviços" (a inicial): título + campo da IA + 1 serviço (descrição/subtítulo/qtd/valor)
+  // + desconto — os 7 campos que a issue #227 mediu a 38px.
+  expect(await contarCampos(page, "main"), "orçamento (Serviços): campos").toBeGreaterThanOrEqual(7);
+  expect(
+    await camposBaixos(page, "main"),
+    "orçamento (Serviços) — campos abaixo de 44px",
+  ).toEqual([]);
+
+  // A aba "Dados" tem outro conjunto de campos na MESMA classe (select de cliente, nome,
+  // WhatsApp, senha do link, condições de pagamento) — o `campos-tocaveis` foi aplicado no
+  // container que envolve as 6 abas, não só a que a issue mediu.
+  await page.getByRole("button", { name: "Dados" }).click();
+  await expect(page.getByText("Cliente do CRM (opcional — gera a cobrança ao aprovar)")).toBeVisible();
+  expect(await contarCampos(page, "main"), "orçamento (Dados): campos").toBeGreaterThanOrEqual(5);
+  expect(
+    await camposBaixos(page, "main"),
+    "orçamento (Dados) — campos abaixo de 44px",
+  ).toEqual([]);
+
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});

--- a/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
+++ b/apps/web/src/features/orcamentos/QuoteBuilderPage.tsx
@@ -293,7 +293,11 @@ export default function QuoteBuilderPage() {
               </button>
             ))}
           </div>
-          <div className={`flex-1 space-y-3 overflow-auto p-4 ${readonly ? "pointer-events-none opacity-60" : ""}`}>
+          {/* `campos-tocaveis` (issue #227): o `inputCls` deste arquivo é a MESMA classe do `Field`
+              de `components/Modal.tsx` (`px-3 py-2 text-sm`, 38px medidos) — só que fora de modal.
+              Não é uma decisão de densidade nova, é a mesma inconsistência de estilo que a classe
+              já fecha em 16 telas; o container único cobre as 6 abas, não só a que a issue mediu. */}
+          <div className={`campos-tocaveis flex-1 space-y-3 overflow-auto p-4 ${readonly ? "pointer-events-none opacity-60" : ""}`}>
             {tab === "Serviços" && (
               <ServicesTab
                 services={services}


### PR DESCRIPTION
## O que é

Correção ESCOPADA da issue #227, por decisão do dono do produto: dos 5 "construtores densos" com ~90 campos abaixo de 44px, só `/orcamentos/novo` entra agora. Era o caso limite — usa a MESMA classe do `Field` de `components/Modal.tsx` (`px-3 py-2 text-sm`, 38px, 34px no campo de IA) só que fora de modal, então é inconsistência de estilo, não decisão de densidade de UI nova.

As outras 4 telas (`/marketing/m1` ~30 campos, `/sites/s1` ~15, `/marketing/novo` ~12, `/contratos/novo` ~4) são construtores densos de propósito e ficam para decisão de produto por tela em issue separada: #249.

## Medição

7 campos em `/orcamentos/novo` (aba Serviços): Título da proposta, campo da IA (brief), Descrição do serviço, Subtítulo do serviço, Qtd, Valor unitário (R$), Desconto (R$) — todos entre 34-38px, agora ≥44px via `.campos-tocaveis`.

## Verificação independente

- Reconferi eu mesmo: `git rev-parse --show-toplevel` / `git branch --show-current` batem com a worktree/branch esperadas antes do commit.
- Rodei `pnpm lint` e `pnpm typecheck` com minhas mãos — ambos limpos.
- Rodei `e2e/campo-modal-360.spec.ts -g "ORÇAMENTO"` — 1 passed.
- Refiz a prova por mutação eu mesmo (44px → 43px em `styles/index.css`, via cópia de backup, não `git checkout`): o teste morre listando os 7 campos a 43px, restaurei o arquivo depois. `git status` voltou limpo.

## Gates

- `pnpm lint` — limpo
- `pnpm typecheck` — limpo
- `e2e/campo-modal-360.spec.ts` (suíte completa) — 17 passed

## Fora deste PR

- As 4 telas restantes: #249.
- A "dívida menor" da issue #227 (checkboxes de `/agenda` e `/financeiro/plano-contas`) já tinha sido corrigida por PR #246, anterior a este trabalho — nada a fazer aqui.

Closes #227
