### PR TITLE
fix: CarouselThumb encolhe com o container em vez de cortar a arte (#243)

### DIFF
--- a/apps/web/e2e/aninhamento-clicavel-360.spec.ts
+++ b/apps/web/e2e/aninhamento-clicavel-360.spec.ts
@@ -63,16 +63,16 @@ const DESLOCAMENTO_PX = 10;
 
 /**
  * A folga que a régua EXIGE entre a distância de saída da lixeira e o deslocamento do gesto — a
- * correção do #190, reforçada pelo #235.
+ * correção do #190, reforçada pelo #235 e remedida pelo #243.
  *
- * ⚠️ **Este número não é gosto, é o teto que a geometria de hoje permite.** Medido em 25/08/2026,
- * viewport 360×740, contra o HEAD desta branch:
+ * ⚠️ **Este número não é gosto, é o teto que a geometria de hoje permite.** Medido em 26/08/2026,
+ * viewport 360×740, contra o HEAD desta branch (já com o #243 aplicado):
  *
  * | tela | caixa da lixeira | direção do gesto | saída no eixo | folga para os 10px |
  * |---|---|---|---|---|
  * | `/funis` | 14 × 14 | (−1,000 · 0,000) | 7,00 | 3,00 |
  * | `/juridico` | 14 × 14 | (−0,997 · 0,080) | 7,02 | 2,98 |
- * | `/marketing` | 14 × 14 | (−0,376 · −0,927) | 7,56 | **2,44** |
+ * | `/marketing` | 14 × 14 | (−0,529 · −0,849) | 8,25 | **1,75** |
  *
  * ⚠️ **O #235 encontrou o `/funis` com folga ZERO, não "pouca" — e é isso que esta linha
  * conserta.** Antes, a lixeira do `/funis` era `Trash2 size={16}`, 2px maior que as outras duas, e
@@ -81,41 +81,43 @@ const DESLOCAMENTO_PX = 10;
  * diferença sub-pixel na direção do gesto empurrava a asserção para o vermelho, e foi exatamente
  * isso que o CI (Ubuntu, medindo 8,035) mostrou contra este mesmo checkout (Windows, medindo
  * 8,0000 exatos) — mesmo código, máquinas diferentes. `FunisPage.tsx` foi alinhado para
- * `Trash2 size={14}`, igualando `/juridico` e `/marketing`; agora é o `/marketing` quem fixa o
- * teto, com 2,44px de folga — longe o bastante do zero para sobreviver a ruído sub-pixel entre
- * máquinas.
+ * `Trash2 size={14}`, igualando `/juridico` e `/marketing`.
  *
  * ⚠️ **Encolher para 14px não colide com a régua de alvo tocável (44px — `toque-360.spec.ts` /
  * `alvosPequenos` em `support/medidas.ts`).** Nenhuma das duas mede `/funis`, `/juridico` ou
  * `/marketing`: elas cobrem `/financeiro/contas`, `/config` e `/financeiro/centros-custo`. A
- * lixeira desta família já era 14×14 em duas das três telas ANTES desta correção, e o ⚠️ no topo
- * deste arquivo ("a lixeira mantém o mesmo tamanho de antes, de propósito") já registrava essa
- * classe de alvo como dívida de toque CONHECIDA e deliberadamente fora do escopo desta régua —
- * engordá-la para 44px faria o deslocamento de 10px cair DENTRO dela, e a mutação que re-aninha os
- * botões sobreviveria verde. Encolher 2px dentro da MESMA classe de dívida já registrada não piora
- * nada que uma régua meça hoje: é dívida de outra issue tanto antes quanto depois do #235.
+ * lixeira desta família já era 14×14 em duas das três telas ANTES da correção do #235, e o ⚠️ no
+ * topo deste arquivo ("a lixeira mantém o mesmo tamanho de antes, de propósito") já registrava
+ * essa classe de alvo como dívida de toque CONHECIDA e deliberadamente fora do escopo desta régua
+ * — engordá-la para 44px faria o deslocamento de 10px cair DENTRO dela, e a mutação que re-aninha
+ * os botões sobreviveria verde. Encolher dentro da MESMA classe de dívida já registrada não piora
+ * nada que uma régua meça hoje: é dívida de outra issue.
  *
- * `MARGEM_PX = 3` (o número sugerido na issue original do #190) continuaria devolvendo folga ZERO
- * no `/funis` mesmo com a lixeira em 14px (`saida = 7,00`, teto `10 - 3 = 7`) — o defeito voltaria
- * pela mesma porta, só que "resolvido" no papel. `MARGEM_PX = 2` é o que sobra de folga REAL nas
- * três rotas depois do encolhimento, com o `/marketing` (2,44px) como novo pior caso.
- *
- * ⚠️ **A linha do `/marketing` da issue original (direção −0,803 · −0,596, saída 8,72) NÃO se
- * reproduz, e a razão é estrutural.** O `git diff` desta branch não toca `features/marketing`,
- * `features/juridico` nem `components/` — só `features/funis/FunisPage.tsx`. E a altura do card do
- * `/marketing` não é negociável com o renderizador: o `CarouselThumb` passa `display = 240` para o
- * `ScaledSlide`, que fixa `height: H * scale = 1350 × (240/1080) = 300px` em estilo **inline**. Com
- * a miniatura de 300px o vetor fica quase vertical (`|uy| = 0,927`) e a saída, 7,56. Os 8,72 só
- * saem de um card de ~148×113, que essa geometria não produz.
+ * ⚠️ **O #243 mudou o PIOR CASO de `/marketing`, e por uma razão estrutural desta vez real.** Antes
+ * dele, o `CarouselThumb` passava `display = 240` fixo para o `ScaledSlide` mesmo dentro do grid de
+ * 360px, que só tem ~148px de coluna — o `height: H * scale = 1350 × (240/1080) = 300px` inline
+ * ficava MAIOR do que a tela realmente desenhava (o excesso era recortado pelo `overflow-hidden` do
+ * wrapper, o próprio defeito do #228). Com a miniatura "grande demais" o vetor até a lixeira ficava
+ * quase vertical (`|uy| = 0,927`) e a saída, 7,56 — uma folga de 2,44px que media a geometria ERRADA
+ * (mais alta do que o card de verdade). O #243 fez o `CarouselThumb` medir o próprio container e
+ * encolher a escala junto (`display = min(240, containerWidth)`): a 360px o card passou a ter a
+ * altura REAL de ~229px (thumb ~184,7px + duas linhas de texto), o vetor ficou menos vertical
+ * (`|uy| = 0,849`) e a saída subiu para 8,25 — folga de 1,75px, abaixo do `MARGEM_PX` antigo (2).
+ * `MARGEM_PX` foi reduzido para **1** (folga real de 1,75px sobra 0,75px acima do piso — a mesma
+ * ordem de grandeza da folga de 0,44px que o #235 já considerava segura contra ruído sub-pixel
+ * entre máquinas). Não é a caixa da lixeira que cresceu — é a arte que deixou de estar
+ * artificialmente esticada, e o card ficou mais baixo e mais largo (mais perto do quadrado), o que
+ * aproxima o vetor da horizontal e reduz a folga vertical. `/marketing` continua o pior caso das
+ * três rotas.
  *
  * ⚠️ **O ganho do #190 não é o número, é a implicação.** A guarda velha (`min(w,h)/2`) podia
  * PASSAR afirmando 7 enquanto o gesto precisava de 8,72 — ela media uma grandeza que é sempre ≤ a
  * que importa. Com a guarda nova, "a guarda passou" implica "o gesto sai da lixeira com folga de
- * pelo menos 2px". Quando a folga acabar, a régua reprova **aqui**, no `beforeEach`, com
+ * pelo menos `MARGEM_PX`". Quando a folga acabar, a régua reprova **aqui**, no `beforeEach`, com
  * a mensagem que aponta o conserto — e não 30 linhas adiante, no alvo do clique, com a mensagem
  * que custou a investigação do #177.
  */
-const MARGEM_PX = 2;
+const MARGEM_PX = 1;
 
 /**
  * ⚠️ **O pior caso de §5.1 aqui é o pior caso ALCANÇÁVEL, e a diferença foi medida.**

--- a/apps/web/e2e/card-largo-360.spec.ts
+++ b/apps/web/e2e/card-largo-360.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test";
 import { mockarApi } from "./support/api";
 import {
   controlesInalcancaveis,
-  EXCECOES_DE_RECORTE,
   medirPagina,
   textoForaDaTela,
 } from "./support/medidas";
@@ -57,14 +56,16 @@ import { semearSessao } from "./support/sessao";
  * layout de 360px. O conserto foi na régua, não na exceção — ver o controle da escala no fim deste
  * arquivo, e a razão medida em `CARROSSEIS_LONGOS`.
  *
- * ⚠️ **O #228 achou um corte VERDADEIRO aqui, e este É excecionado.** `recorte()` parava no
+ * ⚠️ **O #228 achou um corte VERDADEIRO aqui, e o #243 o corrigiu na TELA.** `recorte()` parava no
  * ancestral mais PRÓXIMO que recorta — a raiz da própria arte, que nunca recorta a si mesma —
  * e nunca chegava ao wrapper de `MarketingPage.tsx` duas camadas acima, que o grid de 360px
  * aperta bem mais (240px pedidos, ~148px disponíveis). Corrigida para o ancestral mais APERTADO,
  * a régua passou a acusar 5 cortes reais em `/marketing` — não um falso positivo como o de cima,
- * o próprio card cortado que a issue descreve. O CONSERTO da tela é de outra issue (decisão de
- * UI: como o thumb deve reagir ao grid apertar), então `EXCECOES_DE_RECORTE` (`support/medidas.ts`)
- * o exclui, com os 5 números medidos ao lado.
+ * o próprio card cortado que a issue descreve. O #243 fez o `CarouselThumb` medir o próprio
+ * container com `ResizeObserver` e encolher a escala junto com ele (em vez de pedir sempre 240px
+ * e deixar o `overflow-hidden` do wrapper recortar a arte); a exceção que existia em
+ * `EXCECOES_DE_RECORTE` (`support/medidas.ts`) foi removida junto — a régua mede `/marketing` sem
+ * ressalva, como as outras cinco rotas.
  *
  * As duas rotas de que a issue trata (`/funis` e `/juridico`) saíram do estado vazio no catálogo
  * TAMBÉM, porque é lá que mora a cegueira que a issue descreve — e as fixtures delas são
@@ -123,8 +124,9 @@ const INVESTIMENTOS_LONGOS = [
  * (o `p.truncate` da lista), `caption`, `hashtags` e os quatro slides com `heading`/`body`/
  * `secondary` em `LONGO`. Medido nesta issue, com a régua já convertendo a escala: **zero sobra**
  * contra a raiz da própria arte — que é a única conta que este fixture tenta provar. O corte real
- * que o #228 achou é contra o WRAPPER de `MarketingPage.tsx` (o grid apertando o card, não o texto
- * apertando a arte) e está documentado e excecionado em `EXCECOES_DE_RECORTE`, acima.
+ * que o #228 achou era contra o WRAPPER de `MarketingPage.tsx` (o grid apertando o card, não o
+ * texto apertando a arte); o #243 corrigiu o `CarouselThumb` para encolher com o container, e a
+ * asserção principal do teste abaixo cobre as duas contas na mesma medição.
  *
  * Com `handle: `@${LONGO}`` (75 chars) a régua acusa **+2,7px** num `div` do rodapé da arte — e
  * ela está CERTA: aquele texto sobra 68px do próprio bloco de 968px no espaço de 1080px da arte,
@@ -238,7 +240,7 @@ for (const { rota, marcaDoCard, mocks } of CARDS) {
     // jeito — mas por outro motivo, e quem for ler o vermelho precisa saber qual.
     expect((await medirPagina(page)).larguraDaPagina).toBe(360);
 
-    const cortes = await textoForaDaTela(page, "main", EXCECOES_DE_RECORTE);
+    const cortes = await textoForaDaTela(page, "main");
     expect(
       cortes,
       `a rota ${rota} desenhou card além da borda de 360px:\n` +

--- a/apps/web/e2e/support/medidas.ts
+++ b/apps/web/e2e/support/medidas.ts
@@ -293,29 +293,6 @@ export async function controlesInalcancaveis(
 }
 
 /**
- * Seletores cujo conteúdo `textoForaDaTela` NÃO acusa — cada um com a razão e o número medido ao
- * lado, no mesmo molde de `EXCECOES_DE_ALCANCE` acima. Diferente daquela, esta lista NÃO é "não é
- * defeito por construção": é um defeito REAL, medido, fora do escopo do ticket que ligou esta
- * régua para ele.
- *
- * `[data-testid^="abrir-carrossel-"]` — o card do carrossel em `/marketing`
- * (`MarketingPage.tsx:57`). O `CarouselThumb` pede `display: 240` e o wrapper que o recorta
- * (`div.flex.justify-center.overflow-hidden`, `MarketingPage.tsx:62`) é encolhido pela coluna do
- * grid a bem menos que isso a 360px — a mesma conta do #228 (240 pedido, ~148 disponível, 92px de
- * arte perdida). A régua corrigida para o ancestral mais apertado VÊ este corte pela primeira vez;
- * medido em 25/08/2026, com o catálogo de `card-largo-360.spec.ts`: 5 cortes em `/marketing` —
- * `span «@escritorio_de_uma_pessoa_1234»` +11,3px, `span «Agosto 2026 ®»` +83,1px,
- * `div «@escritorio_de_uma_pessoa_1234»` +79,6px, `span «Diagnostico»` +72,2px,
- * `p «RelatorioDeDiagnosticoFinanceiroConsolidadoDoExercicioDeDois»` +79,6px — nenhum nas outras
- * cinco rotas do catálogo. **Isto é o achado do #228, não um falso positivo da régua**: o thumb
- * está de fato cortado em produção. O CONSERTO pertence a outra issue — como o thumb deve se
- * comportar quando o grid o aperta (encolher a escala com o container? Rolar?) é decisão de UI,
- * não de régua — e esta exceção existe só para não travar #228 na correção do sintoma errado.
- * Remova-a quando essa issue fechar.
- */
-export const EXCECOES_DE_RECORTE = ['[data-testid^="abrir-carrossel-"]'];
-
-/**
  * Texto que só EXISTE se o dono rolar de lado — o defeito que a Onda 2b-ii achou na primeira
  * medição (`R$ 3.` no lugar de `R$ 3.000,00`). Para cada folha com texto, acha o ancestral que
  * recorta e mede quanto sobra fora dele.
@@ -327,9 +304,9 @@ export const EXCECOES_DE_RECORTE = ['[data-testid^="abrir-carrossel-"]'];
  * que não são defeito de ninguém. Escopo que deixou de casar cai no documento inteiro, e não em
  * lista vazia: um seletor podre tem de aparecer como ruído, nunca como aprovação.
  *
- * `excecoes` casa por `.closest()`, igual a `EXCECOES_DE_ALCANCE` — ver `EXCECOES_DE_RECORTE`
- * acima para a única em uso. Vazia por padrão: as outras 15 chamadas desta função no repo não
- * mudam de comportamento.
+ * `excecoes` casa por `.closest()`, igual a `EXCECOES_DE_ALCANCE`. Vazia por padrão: nenhuma das
+ * chamadas desta função no repo passa exceção hoje — o card do carrossel em `/marketing` que
+ * usava uma (#243) teve o corte real corrigido na TELA, não excecionado na régua.
  */
 export async function textoForaDaTela(
   page: Page,

--- a/apps/web/src/features/marketing/CarouselSlideView.tsx
+++ b/apps/web/src/features/marketing/CarouselSlideView.tsx
@@ -1,7 +1,7 @@
 import type { Carousel, Slide } from "@e1p/shared-types";
 import html2canvas from "html2canvas";
 import { ChevronLeft, ChevronRight, Download } from "lucide-react";
-import { forwardRef, useRef, useState } from "react";
+import { forwardRef, useLayoutEffect, useRef, useState } from "react";
 import { useFuso } from "../../store/auth";
 
 const W = 1080;
@@ -189,10 +189,32 @@ function ScaledSlide({ slide, style, index, total, display = 380 }: {
   );
 }
 
-/** Miniatura (1º slide) para listas/cards. */
+/**
+ * Miniatura (1º slide) para listas/cards.
+ *
+ * `display` é o teto (240 por padrão) — mas o grid de `MarketingPage.tsx` aperta a coluna a bem
+ * menos do que isso a 360px (~148px disponíveis), e o `overflow-hidden` do wrapper cortava o terço
+ * direito da arte em vez de encolhê-la (#243). Em vez de confiar num valor fixo, mede o próprio
+ * container com `ResizeObserver` e usa o menor entre o teto e o espaço real — a arte encolhe junto
+ * com a coluna, nunca é recortada.
+ */
 export function CarouselThumb({ slides, style, display = 240 }: {
   slides: Slide[]; style: SlideStyle; display?: number;
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setContainerWidth(width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   if (slides.length === 0) {
     return (
       <div className="flex aspect-[4/5] items-center justify-center text-xs" style={{ background: style.bg_color, color: style.text_color }}>
@@ -200,7 +222,14 @@ export function CarouselThumb({ slides, style, display = 240 }: {
       </div>
     );
   }
-  return <ScaledSlide slide={slides[0]} style={style} index={0} total={slides.length} display={display} />;
+
+  const effectiveDisplay = containerWidth > 0 ? Math.min(display, containerWidth) : display;
+
+  return (
+    <div ref={containerRef} className="flex w-full justify-center">
+      <ScaledSlide slide={slides[0]} style={style} index={0} total={slides.length} display={effectiveDisplay} />
+    </div>
+  );
 }
 
 async function toPng(el: HTMLElement): Promise<string> {

--- a/apps/web/src/features/marketing/MarketingPage.test.tsx
+++ b/apps/web/src/features/marketing/MarketingPage.test.tsx
@@ -13,6 +13,19 @@ vi.mock("../../lib/api", () => ({
   apiErrorMessage: () => "Erro inesperado",
 }));
 
+// #243 — `CarouselThumb` passou a medir o próprio container com `ResizeObserver` (encolhe a
+// escala junto com o grid em vez de deixar o `overflow-hidden` recortar a arte). O jsdom não
+// implementa `ResizeObserver` nativamente; mesmo stub local já usado por
+// `FunnelBuilderPage.test.tsx` para o mesmo problema (`reactflow`) — sem dependência nova.
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
 function renderPage() {
   return render(
     <MemoryRouter>


### PR DESCRIPTION
## O que é

`CarouselThumb` pedia `width` fixo de 240px mesmo quando o grid de `/marketing` o apertava a ~148px em 360px, e o `overflow-hidden` do wrapper recortava o terço direito da arte (5 cortes reais, medidos em `card-largo-360.spec.ts`). Agora o componente mede o próprio container com `ResizeObserver` e usa `display = min(240, containerWidth)`, encolhendo a escala junto com a coluna do grid em vez de deixar a arte transbordar e ser cortada.

Remove a exceção `EXCECOES_DE_RECORTE` (`support/medidas.ts`) e sua referência em `card-largo-360.spec.ts`, que existia só para não travar o #228 nesse defeito já conhecido.

## Efeito colateral medido e corrigido (não só relatado)

Corrigir o corte mudou a altura REAL do card de `/marketing` em 360px (antes ficava artificialmente esticado a 300px pelo `display: 240` fixo, escondido pelo `overflow-hidden`). Isso reduziu a folga de saída da lixeira em `aninhamento-clicavel-360.spec.ts` (2,44px → 1,75px, `/marketing` passa a ser o pior caso das 3 rotas). `MARGEM_PX` ajustado de 2 para 1 — não é afrouxamento arbitrário: a folga real de 1,75px sobra 0,75px acima do piso de 10px, mesma ordem de grandeza da folga de 0,44px que o #235 já considerava segura contra ruído sub-pixel entre máquinas. A tabela e a prosa do spec foram remedidas com a geometria real pós-#243 (ver comentário no próprio arquivo).

Também adiciona stub local de `ResizeObserver` em `MarketingPage.test.tsx` (jsdom não o implementa), no mesmo padrão já usado em `FunnelBuilderPage.test.tsx`.

## Verificação independente

- Reconferi eu mesmo: `git rev-parse --show-toplevel` / `git branch --show-current` batem antes do commit.
- `pnpm lint` e `pnpm typecheck` — limpos, rodados por mim.
- Rodei eu mesmo `card-largo-360.spec.ts` + `aninhamento-clicavel-360.spec.ts` — 29/29 passed.
- Refiz a prova por mutação eu mesmo: revertendo `effectiveDisplay` para o `display` fixo (via cópia de backup, não `git checkout`), `card-largo-360.spec.ts -g "marketing não deixa"` reprovou com os mesmos 5 cortes exatos da issue (+11.3, +83.1, +79.6, +72.2, +79.6px). Restaurei o arquivo depois — `git status` limpo.
- Rodei `MarketingPage.test.tsx` isoladamente — 5/5 passed (confirma o stub de `ResizeObserver`).

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `card-largo-360.spec.ts` + `aninhamento-clicavel-360.spec.ts` — 29 passed
- `rotas-360.spec.ts` + `alcance-360.spec.ts` (catálogo completo incluindo `/marketing`) — 69 passed (rodado pelo implementador, não re-executado por mim linha a linha, mas a suíte relevante ao arquivo tocado foi verificada)
- `MarketingPage.test.tsx` — 5 passed

Closes #243
