### PR TITLE
fix: guarda payload cru em CentrosCusto/Conferencia/Diagnostico/ProjecaoCaixa/ContratoDre/FilaPagamentos (#247)

### DIFF
--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -590,3 +590,62 @@ describe("CobrancasPage — clientes/contratos fora de forma não derrubam o mod
     expect(screen.getByText("Consultoria")).toBeInTheDocument();
   });
 });
+
+// ── `GET /receivables/summary` fora de forma (issue #247) ──────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.open_cents`/`overdue_count`/etc. são lidos
+// direto nos três cartões do topo, sem `?.` — uma raiz fora de forma (array, string, corpo vazio)
+// faz `null.open_cents` estourar (ou pior, um setter de função como no ClientTimeline). A guarda é
+// por TIPO da raiz (objeto simples, não array, não nulo) — os campos em si são todos escalares, e
+// um objeto com a forma errada mas ainda um OBJETO (ex.: envelope de erro `{detail: ...}`) passa
+// pela guarda de tipo e degrada para `R$ NaN` sem estourar; não é o caso que esta guarda evita.
+describe("CobrancasPage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ open_cents: 100 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/receivables/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/receivables/charges") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contas a Receber")).toBeInTheDocument();
+    expect(screen.getAllByText("R$ 0,00").length).toBeGreaterThan(0);
+  });
+
+  // Um OBJETO com a forma errada (não array, não nulo) não é o caso que a guarda de TIPO cobre —
+  // ela não valida campo a campo. A tela não estoura (nenhum `TypeError`), mas os cartões
+  // degradam para `R$ NaN`/`undefined`: um resultado feio, e não o crash que a guarda existe para
+  // evitar. Documentado aqui para não ser confundido com uma regressão.
+  it("envelope de erro devolvido com 200: não crasha, mas os cartões degradam (fora do que a guarda cobre)", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/receivables/summary")
+        return Promise.resolve({ data: { detail: "algo deu errado" } } as never);
+      if (url === "/receivables/charges") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contas a Receber")).toBeInTheDocument();
+  });
+
+  it("contra-teste: resumo de verdade continua aparecendo nos cartões", async () => {
+    mockCobrancas([], [CONTA_BANCARIA], {
+      open_cents: 12345,
+      overdue_cents: 0,
+      paid_cents: 0,
+      open_count: 1,
+      overdue_count: 0,
+      scheduled_cents: 0,
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("R$ 123,45")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -44,16 +44,17 @@ function statusInfo(c: Charge): { label: string; cls: string } {
   return { label: "A vencer", cls: "bg-blue-50 text-blue-700" };
 }
 
+const EMPTY_SUMMARY: ChargesSummary = {
+  open_cents: 0,
+  overdue_cents: 0,
+  paid_cents: 0,
+  open_count: 0,
+  overdue_count: 0,
+  scheduled_cents: 0,
+};
+
 export default function CobrancasPage() {
-  const empty: ChargesSummary = {
-    open_cents: 0,
-    overdue_cents: 0,
-    paid_cents: 0,
-    open_count: 0,
-    overdue_count: 0,
-    scheduled_cents: 0,
-  };
-  const [summary, setSummary] = useState<ChargesSummary>(empty);
+  const [summary, setSummary] = useState<ChargesSummary>(EMPTY_SUMMARY);
   const [charges, setCharges] = useState<Charge[]>([]);
   const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
   const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
@@ -75,7 +76,14 @@ export default function CobrancasPage() {
       api.get<ChargesSummary>("/receivables/summary"),
       api.get<Charge[]>("/receivables/charges"),
     ]);
-    setSummary(s.data);
+    // Guarda de FORMA (issue #247): `summary.open_cents`/`overdue_count`/etc. são lidos direto no
+    // render (cartões acima da tabela) sem `?.`. Um payload fora de forma — envelope de erro
+    // devolvido com 200, array em vez de objeto, corpo vazio — não pode quebrar os TRÊS cartões
+    // por causa de uma resposta malformada; degrada para o resumo zerado (`EMPTY_SUMMARY`), o mesmo
+    // que já é o estado inicial.
+    setSummary(
+      s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+    );
     setCharges(c.data);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de cobranças continua funcionando normalmente.

--- a/apps/web/src/features/contratos/ContratosPage.test.tsx
+++ b/apps/web/src/features/contratos/ContratosPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import ContratosPage from "./ContratosPage";
+
+// Rede sempre mockada (IV2): nenhum teste bate em /contracts real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+vi.mock("../../store/auth", () => ({ useFuso: () => "America/Sao_Paulo" }));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PageActionsProvider>
+        <ContratosPage />
+      </PageActionsProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/contracts/summary")
+      return Promise.resolve({
+        data: { draft_count: 0, sent_count: 0, signed_count: 0 },
+      } as never);
+    if (url === "/contracts") return Promise.resolve({ data: [] } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+});
+
+// ── `GET /contracts/summary` fora de forma (issue #247) ─────────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.draft_count`/`sent_count`/`signed_count`
+// são lidos direto nos três cartões, sem `?.` — uma raiz fora de forma (array, string, corpo
+// vazio) faz `null.draft_count` estourar. A guarda é por TIPO da raiz.
+describe("ContratosPage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ draft_count: 3 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/contracts/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/contracts") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contratos")).toBeInTheDocument();
+    expect(screen.getByText("Rascunhos")).toBeInTheDocument();
+    expect(screen.getAllByText("0").length).toBeGreaterThan(0);
+  });
+
+  it("contra-teste: resumo de verdade continua aparecendo nos cartões", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/contracts/summary")
+        return Promise.resolve({
+          data: { draft_count: 4, sent_count: 2, signed_count: 9 },
+        } as never);
+      if (url === "/contracts") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("4")).toBeInTheDocument();
+    expect(screen.getByText("9")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/contratos/ContratosPage.tsx
+++ b/apps/web/src/features/contratos/ContratosPage.tsx
@@ -13,11 +13,12 @@ const statusInfo: Record<Contract["status"], { label: string; cls: string }> = {
   cancelled: { label: "Cancelado", cls: "bg-red-50 text-danger" },
 };
 
+const EMPTY_SUMMARY: ContractsSummary = { draft_count: 0, sent_count: 0, signed_count: 0 };
+
 export default function ContratosPage() {
   const fuso = useFuso();
   const navigate = useNavigate();
-  const empty: ContractsSummary = { draft_count: 0, sent_count: 0, signed_count: 0 };
-  const [summary, setSummary] = useState<ContractsSummary>(empty);
+  const [summary, setSummary] = useState<ContractsSummary>(EMPTY_SUMMARY);
   const [contracts, setContracts] = useState<Contract[]>([]);
 
   const load = useCallback(async () => {
@@ -25,7 +26,11 @@ export default function ContratosPage() {
       api.get<ContractsSummary>("/contracts/summary"),
       api.get<Contract[]>("/contracts"),
     ]);
-    setSummary(s.data);
+    // Guarda de FORMA (issue #247): `summary.draft_count`/`sent_count`/`signed_count` são lidos
+    // direto no render, sem `?.`. Uma raiz fora de forma faz `null.draft_count` estourar.
+    setSummary(
+      s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+    );
     setContracts(c.data);
   }, []);
 

--- a/apps/web/src/features/contratos/PublicContractPage.test.tsx
+++ b/apps/web/src/features/contratos/PublicContractPage.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { publicApi } from "../../lib/api";
+import PublicContractPage from "./PublicContractPage";
+
+// Rota PÚBLICA (sem sessão) — rede sempre mockada (IV2): nenhum teste bate em /public/contracts
+// real.
+vi.mock("../../lib/api", () => ({
+  publicApi: { get: vi.fn(), post: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+beforeEach(() => {
+  vi.mocked(publicApi.get).mockReset();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/assinar/abc123"]}>
+      <Routes>
+        <Route path="/assinar/:slug" element={<PublicContractPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ── `GET /public/contracts/{slug}` fora de forma (issue #247) ───────────────────────────
+//
+// `setContract(data)` recebia o payload CRU numa rota PÚBLICA (sem sessão, sem tenant): quem abre
+// um link de contrato não pode ver a tela quebrar. `contract.clauses.map` roda direto no render,
+// sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). Guarda por CAMPO, reusando o
+// estado "Contrato indisponível." que a página já tem para o instante ANTES da resposta chegar.
+describe("PublicContractPage — contrato fora de forma não derruba a assinatura (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave clauses", { title: "Contrato", company_name: "e1p", status: "sent", signer_name: "", signed_at: null }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ title: "x" }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a página não estoura (mostra 'Contrato indisponível')", async (_rotulo, payload) => {
+    vi.mocked(publicApi.get).mockResolvedValue({ data: payload } as never);
+
+    renderPage();
+    await waitFor(() => expect(publicApi.get).toHaveBeenCalled());
+
+    expect(await screen.findByText("Contrato indisponível.")).toBeInTheDocument();
+  });
+
+  it("contra-teste: contrato de verdade continua mostrando as cláusulas", async () => {
+    vi.mocked(publicApi.get).mockResolvedValue({
+      data: {
+        title: "Prestação de serviços",
+        company_name: "e1p",
+        clauses: [{ title: "Objeto", text: "Descrição do serviço." }],
+        status: "sent",
+        signer_name: "",
+        signed_at: null,
+      },
+    } as never);
+
+    renderPage();
+
+    expect(await screen.findByText("Prestação de serviços")).toBeInTheDocument();
+    expect(screen.getByText("Descrição do serviço.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/contratos/PublicContractPage.tsx
+++ b/apps/web/src/features/contratos/PublicContractPage.tsx
@@ -23,8 +23,17 @@ export default function PublicContractPage() {
     setLoading(true);
     try {
       const { data } = await publicApi.get<PublicContract>(`/public/contracts/${slug}`);
-      setContract(data);
-      setSignedAt(data.signed_at);
+      // Guarda de FORMA (issue #247): `contract.clauses.map` roda direto no render, sem `?.` —
+      // `Array.isArray`, no molde de `CrmPage.tsx` (#225). Esta é uma rota PÚBLICA (sem sessão,
+      // sem tenant) — quem abre um link de contrato não pode ver a tela quebrar por um payload
+      // fora de forma. `null` reusa o estado "Contrato indisponível." que a página já tem para o
+      // instante ANTES da resposta chegar.
+      const valido =
+        data && typeof data === "object" && !Array.isArray(data) && Array.isArray(data.clauses)
+          ? data
+          : null;
+      setContract(valido);
+      setSignedAt(valido?.signed_at ?? null);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {

--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes, useParams } from "react-router-dom";
 import { api } from "../../lib/api";
+import { assentar } from "../../test/assentar";
 import ClientDetailPage from "./ClientDetailPage";
 
 // Issue #145 — a ficha do cliente NÃO é tela de leitura: ela dispara
@@ -1150,5 +1151,53 @@ describe("ClientDetailPage — RBAC (sub-usuário sem todos os módulos agregado
     expect(screen.getByText("Cobranças (6)")).toBeInTheDocument();
     // Contratos sobrevive à falha degradando para a lista vazia, não travando a página inteira.
     expect(screen.getByText("Contratos (0)")).toBeInTheDocument();
+  });
+});
+
+// ── `GET /crm/clients/{id}` fora de forma (issue #247) ──────────────────────────────────
+//
+// `setClient(c.data)` recebia o payload CRU. `client.tags.length`/`.map` (cabeçalho) rodam direto
+// no render, sem `?.` — `Array.isArray`, no molde de `ClientTimeline.tsx`/`CrmPage.tsx` (#225).
+describe("ClientDetailPage — cliente fora de forma não derruba a ficha (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ id: "cli-1" }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a ficha não estoura (fica em 'Carregando ficha...')", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/crm/clients/cli-1") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderFicha();
+    await assentar();
+
+    // `client` fica `null` (o guard não inventa uma ficha) — a página já tinha esse estado de
+    // espera para o instante ANTES da resposta chegar; aqui ele persiste em vez de estourar.
+    expect(screen.getByText("Carregando ficha...")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["campo tags ausente", { ...CLIENTE, tags: undefined }],
+    ["campo tags não é array (objeto)", { ...CLIENTE, tags: { vip: true } }],
+    ["campo tags não é array (string)", { ...CLIENTE, tags: "vip" }],
+  ])("%s → a ficha monta sem tags, sem estourar", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/crm/clients/cli-1") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.queryByText("vip")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: cliente de verdade continua mostrando as tags", async () => {
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("vip")).toBeInTheDocument();
+    expect(screen.getByText("recorrente")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -80,7 +80,16 @@ export default function ClientDetailPage() {
         ? api.get<FunnelRunSummary[]>(`/funnels/runs?client_id=${id}`).catch(() => ({ data: [] as FunnelRunSummary[] }))
         : Promise.resolve({ data: [] as FunnelRunSummary[] }),
     ]);
-    setClient(c.data);
+    // Guarda de FORMA (issue #247): `client.tags.length`/`.map` (cabeçalho) rodam direto no
+    // render, sem `?.`. `Array.isArray`, no molde de `crm/ClientTimeline.tsx`/`CrmPage.tsx`
+    // (#225): um payload cujo campo `tags` não é array (ou que não é objeto — string, array na
+    // raiz) faz `client.tags.length` estourar. Guarda por CAMPO — o resto da ficha (`name`,
+    // `notes`, etc.) já é lido com fallback (`||`) ou aceita `undefined` sem quebrar.
+    setClient(
+      c.data && typeof c.data === "object" && !Array.isArray(c.data)
+        ? { ...c.data, tags: Array.isArray(c.data.tags) ? c.data.tags : [] }
+        : null,
+    );
     setCharges(ch.data);
     setContracts(co.data);
     setQuotes(qu.data);

--- a/apps/web/src/features/estoque/EstoquePage.test.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.test.tsx
@@ -156,3 +156,44 @@ describe("EstoquePage — produtos fora de forma não derrubam o modal Novo item
     expect(await screen.findByText("Camiseta P")).toBeInTheDocument();
   });
 });
+
+// ── `GET /stock/summary` fora de forma (issue #247) ─────────────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.item_count`/`total_value_cents`/
+// `low_stock_count` são lidos direto nos três cartões do topo, sem `?.` — uma raiz fora de forma
+// (array, string, corpo vazio) faz `null.item_count` estourar. A guarda é por TIPO da raiz.
+describe("EstoquePage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ item_count: 3 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/stock/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/stock/items") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Controle de Estoque")).toBeInTheDocument();
+    expect(screen.getByText("Itens ativos")).toBeInTheDocument();
+    expect(screen.getAllByText("0").length).toBeGreaterThan(0);
+  });
+
+  it("contra-teste: resumo de verdade continua aparecendo nos cartões", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/stock/summary")
+        return Promise.resolve({
+          data: { item_count: 7, total_value_cents: 12345, low_stock_count: 2 },
+        } as never);
+      if (url === "/stock/items") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("7")).toBeInTheDocument();
+    expect(screen.getByText("R$ 123,45")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/estoque/EstoquePage.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.tsx
@@ -7,9 +7,10 @@ import { usePrimaryAction } from "../../store/pageActions";
 import { parseCentsBRL } from "../financeiro/contas";
 import { formatBRL } from "../financeiro/dre";
 
+const EMPTY_SUMMARY: StockSummary = { item_count: 0, total_value_cents: 0, low_stock_count: 0 };
+
 export default function EstoquePage() {
-  const empty: StockSummary = { item_count: 0, total_value_cents: 0, low_stock_count: 0 };
-  const [summary, setSummary] = useState<StockSummary>(empty);
+  const [summary, setSummary] = useState<StockSummary>(EMPTY_SUMMARY);
   const [items, setItems] = useState<StockItem[]>([]);
   const [newOpen, setNewOpen] = useState(false);
   const [adjust, setAdjust] = useState<StockItem | null>(null);
@@ -19,7 +20,12 @@ export default function EstoquePage() {
       api.get<StockSummary>("/stock/summary"),
       api.get<StockItem[]>("/stock/items"),
     ]);
-    setSummary(s.data);
+    // Guarda de FORMA (issue #247): `summary.item_count`/`total_value_cents`/`low_stock_count` são
+    // lidos direto no render, sem `?.`. Uma raiz fora de forma (array, string, corpo vazio) faz
+    // `null.item_count` estourar — degrada para o resumo zerado, igual ao estado inicial.
+    setSummary(
+      s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+    );
     setItems(i.data);
   }, []);
 

--- a/apps/web/src/features/financeiro/CentrosCustoPage.test.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
+import CentrosCustoPage from "./CentrosCustoPage";
+
+// Rede sempre mockada (IV2): nenhum teste bate em /cost-centers real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+function renderPage() {
+  return render(
+    <PageActionsProvider>
+      <CentrosCustoPage />
+    </PageActionsProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+    if (url === "/financial-intelligence/by-cost-center")
+      return Promise.resolve({
+        data: { start: "2026-08-01", end: "2026-08-31", buckets: [], notes: [] },
+      } as never);
+    return Promise.resolve({ data: [] } as never);
+  });
+});
+
+// ── `GET /financial-intelligence/by-cost-center` fora de forma (issue #247) ─────────────
+//
+// `setReport(r.data)` recebia o payload CRU. `report.buckets.length`/`.map` (dentro de
+// `ComparativeCard`) rodam sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). A guarda
+// é por CAMPO, com `null` de fallback: a mesma render já checa `report && report.buckets...`.
+describe("CentrosCustoPage — comparativo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave buckets", { start: "2026-08-01", end: "2026-08-31" }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ name: "x" }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, sem o comparativo", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+      if (url === "/financial-intelligence/by-cost-center")
+        return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Centros de custo")).toBeInTheDocument();
+    expect(screen.queryByTestId("comparativo-centros")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: comparativo de verdade continua aparecendo", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+      if (url === "/financial-intelligence/by-cost-center")
+        return Promise.resolve({
+          data: {
+            start: "2026-08-01",
+            end: "2026-08-31",
+            buckets: [
+              {
+                cost_center_id: "cc-1",
+                name: "Sócio A",
+                kind: "socio",
+                receita_cents: 100000,
+                resultado_cents: 50000,
+                lancamentos: 3,
+              },
+            ],
+            notes: [],
+          },
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByTestId("comparativo-centros")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/CentrosCustoPage.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.tsx
@@ -49,7 +49,11 @@ export default function CentrosCustoPage() {
         }),
       ]);
       setCenters(c.data);
-      setReport(r.data);
+      // Guarda de FORMA (issue #247): `report.buckets.length`/`.map` rodam direto no render, sem
+      // `?.`. `Array.isArray`, no molde de `CrmPage.tsx` (#225): guarda por CAMPO, com `null`
+      // quando o campo não é array — a render já checa `report && report.buckets...`, então
+      // `null` é o mesmo estado seguro que existe ANTES da resposta chegar.
+      setReport(Array.isArray(r.data?.buckets) ? r.data : null);
     } catch (err) {
       setError(apiErrorMessage(err));
     }

--- a/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
+++ b/apps/web/src/features/financeiro/ConferenciaPage.test.tsx
@@ -774,3 +774,39 @@ describe("o ciclo da conferência", () => {
     }
   });
 });
+
+// ── `GET /bank/reconciliation-report` fora de forma (issue #247) ────────────────────────
+//
+// `setReport(res.data)` recebia o payload CRU. `ordenarContas(report.contas)` faz `.filter` sobre
+// o campo sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). Guarda por CAMPO, com
+// `null` de fallback (a própria render checa `report && report.contas...`).
+describe("ConferenciaPage — relatório fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave contas", { start: "2026-01-01", end: "2026-12-31" }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ bank_account_id: "x" }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, sem a lista de contas", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+
+    renderPage();
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+
+    expect(screen.getByText("Conferência de saldos")).toBeInTheDocument();
+    expect(screen.queryByTestId("frase-conta")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Você ainda não tem conta bancária cadastrada — não há o que conferir."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: conta de verdade continua aparecendo na lista de frases", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: report([conta()]),
+    } as never);
+
+    renderPage();
+
+    expect(await screen.findByTestId("frase-conta")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/ConferenciaPage.tsx
+++ b/apps/web/src/features/financeiro/ConferenciaPage.tsx
@@ -67,7 +67,10 @@ export default function ConferenciaPage() {
           ...(accountId ? { bank_account_id: accountId } : {}),
         },
       });
-      setReport(res.data);
+      // Guarda de FORMA (issue #247): `ordenarContas(report.contas)` faz `.filter` sobre o campo
+      // sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). `null` é o mesmo estado
+      // seguro que a tela já tem ANTES da resposta chegar (`useMemo`s abaixo checam `report ?`).
+      setReport(Array.isArray(res.data?.contas) ? res.data : null);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {

--- a/apps/web/src/features/financeiro/ContratoDrePage.test.tsx
+++ b/apps/web/src/features/financeiro/ContratoDrePage.test.tsx
@@ -65,3 +65,70 @@ describe("ContratoDrePage — centros de custo fora de forma não derrubam a pá
     expect(screen.getByText("Sócio João")).toBeInTheDocument();
   });
 });
+
+/** DRE de contrato válido, com os TRÊS campos array que a página lê sem `?.`. */
+function dreValido() {
+  return {
+    contract_id: "ct-1",
+    start: "2026-08-01",
+    end: "2026-08-31",
+    receita: { grupo_dre: "RECEITA", total_cents: 500000, categorias: [] },
+    custo_direto: { grupo_dre: "CUSTO_DIRETO", total_cents: 100000, categorias: [] },
+    receita_cents: 500000,
+    custo_direto_cents: 100000,
+    margem_contribuicao_cents: 400000,
+    margem_contribuicao_pct: 0.8,
+    outros_resultado_cents: 0,
+    resultado_cents: 400000,
+    fixed_costs_allocated_cents: 0,
+    overhead_allocated_cents: 0,
+    break_even_reachable: true,
+    notes: [],
+  };
+}
+
+// ── `GET /financial-intelligence/contracts/{id}/dre` fora de forma (issue #247) ─────────
+//
+// `setDre(data)` recebia o payload CRU. `GroupRow` faz `group.categorias.reduce` sem `?.`, e o
+// render faz `view.notes.length` sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225), nos
+// TRÊS campos array aninhados (`notes`, `receita.categorias`, `custo_direto.categorias`).
+describe("ContratoDrePage — DRE fora de forma não derruba a página (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave notes", { ...dreValido(), notes: undefined }],
+    ["receita sem categorias", { ...dreValido(), receita: { grupo_dre: "RECEITA", total_cents: 0 } }],
+    [
+      "custo_direto.categorias não é array",
+      { ...dreValido(), custo_direto: { ...dreValido().custo_direto, categorias: "x" } },
+    ],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ contract_id: "ct-1" }]],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a página segue montada, sem as métricas", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+      if (url === "/contracts/ct-1") return Promise.resolve({ data: null } as never);
+      if (url === "/financial-intelligence/contracts/ct-1/dre")
+        return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: null } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Página / Contratos / DRE")).toBeInTheDocument();
+    expect(screen.queryByText("Margem de contribuição")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: DRE de verdade continua mostrando as métricas", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers") return Promise.resolve({ data: [] } as never);
+      if (url === "/contracts/ct-1") return Promise.resolve({ data: null } as never);
+      if (url === "/financial-intelligence/contracts/ct-1/dre")
+        return Promise.resolve({ data: dreValido() } as never);
+      return Promise.resolve({ data: null } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Margem de contribuição")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/ContratoDrePage.tsx
+++ b/apps/web/src/features/financeiro/ContratoDrePage.tsx
@@ -78,7 +78,18 @@ export default function ContratoDrePage() {
         `/financial-intelligence/contracts/${id}/dre`,
         { params },
       );
-      setDre(data);
+      // Guarda de FORMA (issue #247): `buildContractDreView` alimenta `GroupRow` — que faz
+      // `group.categorias.reduce` sem `?.` — e `view.notes.length` no render, ambos sem `?.`.
+      // `Array.isArray`, no molde de `CrmPage.tsx` (#225), nos TRÊS campos array aninhados;
+      // `null` é o mesmo estado seguro que a tela já tem ANTES da resposta chegar (a render checa
+      // `{view && (...)}`, via `dre ? buildContractDreView(dre) : null`).
+      setDre(
+        Array.isArray(data?.notes) &&
+          Array.isArray(data?.receita?.categorias) &&
+          Array.isArray(data?.custo_direto?.categorias)
+          ? data
+          : null,
+      );
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {

--- a/apps/web/src/features/financeiro/DiagnosticoPage.test.tsx
+++ b/apps/web/src/features/financeiro/DiagnosticoPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../lib/api";
+import DiagnosticoPage from "./DiagnosticoPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DiagnosticoPage />
+    </MemoryRouter>,
+  );
+}
+
+// Rede sempre mockada (IV2): nenhum teste bate em /financial-intelligence real.
+vi.mock("../../lib/api", () => ({
+  api: { get: vi.fn() },
+  apiErrorMessage: (err: unknown) =>
+    (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+      ?.detail ??
+    (err as { message?: string })?.message ??
+    "Erro inesperado",
+}));
+
+beforeEach(() => {
+  vi.mocked(api.get).mockReset();
+});
+
+// ── `GET /financial-intelligence/diagnostics` fora de forma (issue #247) ────────────────
+//
+// `setData(res.data)` recebia o payload CRU. `countByLevel(data.signals)` faz `for (const s of
+// signals)` sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). Guarda por CAMPO, com
+// `null` de fallback (a própria render checa `{data && (...)}`).
+describe("DiagnosticoPage — diagnóstico fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave signals", { start: "2026-08-01", end: "2026-08-31" }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ level: "vermelho" }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, sem os sinais", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+
+    renderPage();
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+
+    expect(screen.getByText("Diagnóstico financeiro")).toBeInTheDocument();
+    expect(screen.queryByText("Sinais determinísticos")).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: diagnóstico de verdade continua mostrando os sinais", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: {
+        start: "2026-08-01",
+        end: "2026-08-31",
+        signals: [
+          {
+            level: "verde",
+            title: "Tudo em dia",
+            explanation: "Nenhuma divergência relevante.",
+            source: "completude",
+          },
+        ],
+        narrative: "Está tudo bem.",
+        narrative_source: "template",
+      },
+    } as never);
+
+    renderPage();
+
+    expect(await screen.findByText("Sinais determinísticos")).toBeInTheDocument();
+    expect(screen.getByText("Tudo em dia")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/DiagnosticoPage.tsx
+++ b/apps/web/src/features/financeiro/DiagnosticoPage.tsx
@@ -40,7 +40,11 @@ export default function DiagnosticoPage() {
       const res = await api.get<Diagnostics>("/financial-intelligence/diagnostics", {
         params: { start, end },
       });
-      setData(res.data);
+      // Guarda de FORMA (issue #247): `countByLevel`/`completudeCaveat`/`completudeLevel` fazem
+      // `for (const s of signals)`/`.filter` sobre o campo sem `?.` — `Array.isArray`, no molde de
+      // `CrmPage.tsx` (#225). `null` é o mesmo estado seguro que a tela já tem ANTES da resposta
+      // chegar (a render checa `{data && (...)}`).
+      setData(Array.isArray(res.data?.signals) ? res.data : null);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {

--- a/apps/web/src/features/financeiro/FilaPagamentosPage.test.tsx
+++ b/apps/web/src/features/financeiro/FilaPagamentosPage.test.tsx
@@ -266,3 +266,46 @@ describe("Story 8.14 — a conta agendada não some da Fila", () => {
     expect(within(total).queryByText(/5\.300/)).toBeNull();
   });
 });
+
+// ── `GET /payables/queue` fora de forma (issue #247) ─────────────────────────────────────
+//
+// `setQueue({ ...EMPTY, ...data })` só cobre um CAMPO AUSENTE — o spread de `data` não sobrescreve
+// a chave que falta. Mas um campo PRESENTE com o tipo errado (`atrasados: null`, `summary: null`,
+// um balde que não é array) SOBRESCREVE o default do `EMPTY`, e `queue.atrasados.length` (linha
+// ~128) ou `s.atrasados_cents` (linha ~124, via `queue.summary`) estouram no render. `Array.isArray`
+// por campo, no molde de `CrmPage.tsx` (#225).
+describe("FilaPagamentosPage — fila fora de forma não derruba a tela (#247)", () => {
+  it("campo atrasados presente e não-array (null) não derruba a fila", async () => {
+    mockApi([CONTA], { ...FILA, atrasados: null });
+    render(<FilaPagamentosPage />);
+
+    expect(await screen.findByText("Página / Financeiro / Fila de pagamentos")).toBeInTheDocument();
+    // Sem a atrasada de verdade sobrando em nenhum balde, a fila fica vazia.
+    expect(await screen.findByText(/Nada a pagar nos próximos 30 dias/)).toBeInTheDocument();
+  });
+
+  it("campo summary presente e não-objeto (null) não derruba os cartões", async () => {
+    mockApi([CONTA], { ...FILA, summary: null });
+    render(<FilaPagamentosPage />);
+
+    expect(await screen.findByText("Página / Financeiro / Fila de pagamentos")).toBeInTheDocument();
+    expect(screen.getAllByText("R$ 0,00").length).toBeGreaterThan(0);
+  });
+
+  it("balde presente e não-array (string) não derruba o balde", async () => {
+    mockApi([CONTA], { ...FILA, proximos_7_dias: "não é json" });
+    render(<FilaPagamentosPage />);
+
+    expect(await screen.findByText("Página / Financeiro / Fila de pagamentos")).toBeInTheDocument();
+    // A atrasada de verdade continua aparecendo — só o balde fora de forma degrada para vazio.
+    expect(await screen.findByText("Energia")).toBeInTheDocument();
+  });
+
+  it("contra-teste: fila de verdade continua mostrando o balde de atrasados", async () => {
+    mockApi([CONTA], FILA);
+    render(<FilaPagamentosPage />);
+
+    expect(await screen.findByText("Atrasados")).toBeInTheDocument();
+    expect(await screen.findByText("Energia")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
+++ b/apps/web/src/features/financeiro/FilaPagamentosPage.tsx
@@ -70,7 +70,29 @@ export default function FilaPagamentosPage() {
     setLoading(true);
     try {
       const { data } = await api.get<PaymentQueue>("/payables/queue");
-      setQueue({ ...EMPTY, ...data });
+      // Guarda de FORMA (issue #247): `{...EMPTY, ...data}` só cobre um CAMPO AUSENTE (o spread de
+      // `data` não sobrescreve a chave que falta) — mas um campo PRESENTE com o tipo errado (ex.:
+      // `atrasados: null`, ou um objeto sem `.length`) SOBRESCREVE o default do `EMPTY` e
+      // `queue.atrasados.length` (linha ~106) estoura no render. `Array.isArray` por campo, no
+      // molde de `CrmPage.tsx` (#225), fecha essa segunda metade; `summary` usa o mesmo TIPO de
+      // guarda das telas de resumo escalar (`EMPTY.summary` como fallback).
+      setQueue({
+        ...EMPTY,
+        ...data,
+        atrasados: Array.isArray(data?.atrasados) ? data.atrasados : EMPTY.atrasados,
+        hoje: Array.isArray(data?.hoje) ? data.hoje : EMPTY.hoje,
+        proximos_7_dias: Array.isArray(data?.proximos_7_dias)
+          ? data.proximos_7_dias
+          : EMPTY.proximos_7_dias,
+        proximos_30_dias: Array.isArray(data?.proximos_30_dias)
+          ? data.proximos_30_dias
+          : EMPTY.proximos_30_dias,
+        agendadas: Array.isArray(data?.agendadas) ? data.agendadas : EMPTY.agendadas,
+        summary:
+          data?.summary && typeof data.summary === "object" && !Array.isArray(data.summary)
+            ? { ...EMPTY.summary, ...data.summary }
+            : EMPTY.summary,
+      });
       setError(null);
     } catch (err) {
       setError(apiErrorMessage(err));

--- a/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import FinanceiroPage from "./FinanceiroPage";
 
 // Rede sempre mockada (IV2): nenhum teste bate em /wallet real.
@@ -77,5 +78,52 @@ describe("FinanceiroPage — separador de milhar (#224)", () => {
       "/wallet/transactions",
       expect.objectContaining({ gross_cents: 123456 }),
     );
+  });
+});
+
+// ── `GET /wallet/summary` fora de forma (issue #247) ────────────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.available_cents`/etc. são lidos direto nos
+// cartões e no botão "Sacar" (`summary.available_cents > 0`), sem `?.` — uma raiz fora de forma
+// (array, string, corpo vazio) faz `null.available_cents` estourar.
+describe("FinanceiroPage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ available_cents: 100 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/wallet/transactions") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Carteira")).toBeInTheDocument();
+    expect(screen.getAllByText("R$ 0,00").length).toBeGreaterThan(0);
+    // O botão só aparece quando `available_cents > 0` — com o resumo zerado, ele some.
+    expect(screen.queryByRole("button", { name: /Sacar/ })).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: resumo de verdade continua aparecendo nos cartões", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary")
+        return Promise.resolve({
+          data: {
+            available_cents: 50000,
+            pending_cents: 0,
+            withdrawn_cents: 0,
+            gross_total_cents: 50000,
+            fees_total_cents: 0,
+          },
+        } as never);
+      if (url === "/wallet/transactions") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("R$ 500,00")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -33,15 +33,16 @@ const statusLabel: Record<Transaction["status"], string> = {
   refunded: "Estornado",
 };
 
+const EMPTY_SUMMARY: WalletSummary = {
+  available_cents: 0,
+  pending_cents: 0,
+  withdrawn_cents: 0,
+  gross_total_cents: 0,
+  fees_total_cents: 0,
+};
+
 export default function FinanceiroPage() {
-  const empty: WalletSummary = {
-    available_cents: 0,
-    pending_cents: 0,
-    withdrawn_cents: 0,
-    gross_total_cents: 0,
-    fees_total_cents: 0,
-  };
-  const [summary, setSummary] = useState<WalletSummary>(empty);
+  const [summary, setSummary] = useState<WalletSummary>(EMPTY_SUMMARY);
   const [txs, setTxs] = useState<Transaction[]>([]);
   const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
   const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
@@ -57,7 +58,12 @@ export default function FinanceiroPage() {
       api.get<WalletSummary>("/wallet/summary"),
       api.get<Transaction[]>("/wallet/transactions"),
     ]);
-    setSummary(s.data);
+    // Guarda de FORMA (issue #247): `summary.available_cents`/etc. são lidos direto no render
+    // (cartões + botão "Sacar"), sem `?.`. Uma raiz fora de forma faz `null.available_cents`
+    // estourar.
+    setSummary(
+      s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+    );
     setTxs(t.data);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de transações continua funcionando normalmente.

--- a/apps/web/src/features/financeiro/ProjecaoCaixaPage.test.tsx
+++ b/apps/web/src/features/financeiro/ProjecaoCaixaPage.test.tsx
@@ -228,3 +228,35 @@ describe("ProjecaoCaixaPage — Story 8.8 (AC5): a soma entre planos nunca apare
     expect(screen.getByText(/^R\$\s*0,00$/)).toBeInTheDocument();
   });
 });
+
+// ── `GET /financial-intelligence/projection` fora de forma (issue #247) ─────────────────
+//
+// `setProjection(r.data)` recebia o payload CRU. `projection.windows.map` e
+// `projection.notes.length` rodam direto no render, sem `?.` — `Array.isArray`, no molde de
+// `CrmPage.tsx` (#225). Guarda pelos DOIS campos, com `null` de fallback (a própria render checa
+// `{projection && (...)}`).
+describe("ProjecaoCaixaPage — projeção fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem as chaves windows/notes", { today: "2026-08-01" }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ days: 30 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, sem os cartões de janela", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+
+    render(<ProjecaoCaixaPage />);
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+
+    expect(screen.getByText("Projeção de fluxo de caixa")).toBeInTheDocument();
+    expect(screen.queryByText(/Em \d+ dias/)).not.toBeInTheDocument();
+  });
+
+  it("contra-teste: projeção de verdade continua mostrando os cartões de janela", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: projecaoSuprimida } as never);
+
+    render(<ProjecaoCaixaPage />);
+
+    expect(await screen.findByText("Em 30 dias")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/ProjecaoCaixaPage.tsx
+++ b/apps/web/src/features/financeiro/ProjecaoCaixaPage.tsx
@@ -40,7 +40,14 @@ export default function ProjecaoCaixaPage() {
     setLoading(true);
     api
       .get<Projection>("/financial-intelligence/projection")
-      .then((r) => setProjection(r.data))
+      // Guarda de FORMA (issue #247): `projection.windows.map`/`.notes.length` rodam direto no
+      // render, sem `?.` — `Array.isArray`, no molde de `CrmPage.tsx` (#225). Guarda por CAMPO,
+      // com `null` de fallback (a própria render checa `{projection && (...)}`).
+      .then((r) =>
+        setProjection(
+          Array.isArray(r.data?.windows) && Array.isArray(r.data?.notes) ? r.data : null,
+        ),
+      )
       .catch((err) => setError(apiErrorMessage(err)))
       .finally(() => setLoading(false));
   }, []);

--- a/apps/web/src/features/orcamentos/OrcamentosPage.test.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import OrcamentosPage from "./OrcamentosPage";
 
 // Story 7.5 — Task 4 (aprovação). Rede sempre mockada (IV2): nenhum teste bate em /quotes real.
@@ -75,5 +76,44 @@ describe("OrcamentosPage — aprovar orçamento (Story 7.5, Task 4)", () => {
     expect(vi.mocked(api.post)).not.toHaveBeenCalled();
     // A tela continua funcional: o orçamento segue na lista.
     expect(screen.getByText("Consultoria tributária")).toBeInTheDocument();
+  });
+});
+
+// ── `GET /quotes/summary` fora de forma (issue #247) ────────────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.draft_count`/`sent_cents`/etc. são lidos
+// direto nos três cartões, sem `?.` — uma raiz fora de forma faz `null.draft_count` estourar.
+describe("OrcamentosPage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ draft_count: 3 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/quotes/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/quotes") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Orçamentos")).toBeInTheDocument();
+    expect(screen.getByText("Rascunhos")).toBeInTheDocument();
+    expect(screen.getAllByText("R$ 0,00").length).toBeGreaterThan(0);
+  });
+
+  it("contra-teste: resumo de verdade continua aparecendo nos cartões", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/quotes/summary")
+        return Promise.resolve({
+          data: { draft_count: 2, sent_cents: 30000, approved_cents: 0, approved_count: 0 },
+        } as never);
+      if (url === "/quotes") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("R$ 300,00")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/orcamentos/OrcamentosPage.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.tsx
@@ -13,10 +13,16 @@ const statusInfo: Record<Quote["status"], { label: string; cls: string }> = {
   rejected: { label: "Recusado", cls: "bg-red-50 text-danger" },
 };
 
+const EMPTY_SUMMARY: QuotesSummary = {
+  draft_count: 0,
+  sent_cents: 0,
+  approved_cents: 0,
+  approved_count: 0,
+};
+
 export default function OrcamentosPage() {
   const navigate = useNavigate();
-  const empty: QuotesSummary = { draft_count: 0, sent_cents: 0, approved_cents: 0, approved_count: 0 };
-  const [summary, setSummary] = useState<QuotesSummary>(empty);
+  const [summary, setSummary] = useState<QuotesSummary>(EMPTY_SUMMARY);
   const [quotes, setQuotes] = useState<Quote[]>([]);
 
   const load = useCallback(async () => {
@@ -24,7 +30,11 @@ export default function OrcamentosPage() {
       api.get<QuotesSummary>("/quotes/summary"),
       api.get<Quote[]>("/quotes"),
     ]);
-    setSummary(s.data);
+    // Guarda de FORMA (issue #247): `summary.draft_count`/etc. são lidos direto no render, sem
+    // `?.`. Uma raiz fora de forma faz `null.draft_count` estourar.
+    setSummary(
+      s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+    );
     setQuotes(q.data);
   }, []);
 

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -889,3 +889,76 @@ describe("PagarPage — contratos fora de forma não derrubam o modal Nova conta
     expect(await screen.findByText("Consultoria")).toBeInTheDocument();
   });
 });
+
+// ── `GET /payables/summary` fora de forma (issue #247) ──────────────────────────────────
+//
+// `setSummary(s.data)` recebia o payload CRU. `summary.open_cents`/etc. são lidos direto nos
+// cartões, sem `?.` — uma raiz fora de forma faz `null.open_cents` estourar.
+describe("PagarPage — resumo fora de forma não derruba a tela (#247)", () => {
+  it.each([
+    ["array no lugar do objeto", [{ open_cents: 100 }]],
+    ["string no lugar do objeto", "não é json"],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com os cartões zerados", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: payload } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [], total: 0 } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    // `mockClear()`: sem isto, `toHaveBeenCalledWith` abaixo acha uma chamada de um teste ANTERIOR
+    // (o mock nunca é limpo entre testes, só reimplementado) e o `waitFor` resolve na hora — antes
+    // mesmo do debounce de 300ms (linha ~182) desta montagem disparar. Medido: sem o `mockClear`,
+    // o teste "passa" mesmo com a guarda removida, porque nunca espera o bastante para o commit
+    // real acontecer — falsa confiança do mesmo tipo que o docstring de `assentar.ts` descreve.
+    vi.mocked(api.get).mockClear();
+    renderPage();
+    // `waitFor` polla com relógio de VERDADE (timeout default ~1s) até `/payables/summary` ter
+    // sido chamado NESTA montagem — só então o debounce já disparou e o commit de `setSummary`
+    // aconteceu. `assentar()` sozinho não basta: ele só esvazia microtarefas, não temporizadores.
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/payables/summary"));
+    await assentar();
+
+    expect(screen.getByRole("button", { name: "Nova conta" })).toBeInTheDocument();
+    expect(screen.getAllByText("R$ 0,00").length).toBeGreaterThan(0);
+  });
+});
+
+// ── `GET /payables/bills` fora de forma (issue #247) ─────────────────────────────────────
+//
+// `setBills(b.data.items)`/`setTotal(b.data.total)` recebiam o CAMPO cru — `bills.map` roda no
+// render sem guarda, e `[...antes, ...b.data.items]` (página seguinte) estouraria num spread de
+// `undefined`. A guarda é por CAMPO (`Array.isArray(b.data?.items)`), não pela raiz.
+describe("PagarPage — página de contas fora de forma não derruba a lista (#247)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["objeto sem a chave items", { total: 3 }],
+    ["array no lugar do objeto (raiz certa, campo errado)", [{ id: "x" }]],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a lista segue montada, vazia", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    // `mockClear()` + `waitFor` na chamada real (não em "Nenhuma conta", que já está no DOM desde
+    // o estado inicial `bills = []` — a MESMA falsa confiança que o docstring de `assentar.ts`
+    // descreve): sem isto o teste passaria mesmo com a guarda removida, porque nunca esperaria o
+    // debounce de 300ms (linha ~182) o bastante para o commit de `setBills` realmente acontecer.
+    vi.mocked(api.get).mockClear();
+    renderPage();
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/payables/summary"));
+    await assentar();
+
+    expect(screen.getByRole("button", { name: "Nova conta" })).toBeInTheDocument();
+    expect(await screen.findByText(/Nenhuma conta/i)).toBeInTheDocument();
+  });
+
+  it("contra-teste: conta de verdade continua aparecendo na lista", async () => {
+    mockComConta([CONTA]);
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Aluguel")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -85,17 +85,18 @@ function statusInfo(p: Payable): { label: string; cls: string } {
   return { label: "A pagar", cls: "bg-amber-50 text-amber-700" };
 }
 
+const EMPTY_SUMMARY: PayablesSummary = {
+  open_cents: 0,
+  overdue_cents: 0,
+  week_cents: 0,
+  month_cents: 0,
+  paid_month_cents: 0,
+  // Story 8.14 — o resumo ganhou o campo; os cinco antigos não mudaram de definição.
+  scheduled_cents: 0,
+};
+
 export default function PagarPage() {
-  const empty: PayablesSummary = {
-    open_cents: 0,
-    overdue_cents: 0,
-    week_cents: 0,
-    month_cents: 0,
-    paid_month_cents: 0,
-    // Story 8.14 — o resumo ganhou o campo; os cinco antigos não mudaram de definição.
-    scheduled_cents: 0,
-  };
-  const [summary, setSummary] = useState<PayablesSummary>(empty);
+  const [summary, setSummary] = useState<PayablesSummary>(EMPTY_SUMMARY);
   const [bills, setBills] = useState<Payable[]>([]);
   const [chartAccounts, setChartAccounts] = useState<ChartAccount[]>([]);
   const [costCenters, setCostCenters] = useState<CostCenter[]>([]);
@@ -144,14 +145,22 @@ export default function PagarPage() {
         }),
       ]);
       b = pagina;
-      setSummary(s.data);
+      // Guarda de FORMA (issue #247): `summary.open_cents`/etc. são lidos direto no render, sem
+      // `?.`. Uma raiz fora de forma faz `null.open_cents` estourar.
+      setSummary(
+        s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
+      );
     } finally {
       setCarregando(false);
     }
+    // Guarda de FORMA (issue #247, campo): `b.data.items` alimenta `bills.map` no render sem
+    // `?.`; um payload fora de forma (envelope de erro, `items` ausente) faria o spread
+    // `[...antes, ...undefined]` estourar (ou pior, `bills` virar `undefined` direto na página 1).
+    const itensDaPagina = Array.isArray(b.data?.items) ? b.data.items : [];
     // `proximoOffset > 0` é "carregar mais": ANEXA. Substituir aqui é o erro clássico de
     // paginação, e ele passa despercebido porque a primeira página sempre parece certa.
-    setBills((antes) => (proximoOffset === 0 ? b.data.items : [...antes, ...b.data.items]));
-    setTotal(b.data.total);
+    setBills((antes) => (proximoOffset === 0 ? itensDaPagina : [...antes, ...itensDaPagina]));
+    setTotal(typeof b.data?.total === "number" ? b.data.total : 0);
     setOffset(proximoOffset);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de contas a pagar continua funcionando normalmente.


### PR DESCRIPTION
## O que é

3ª rodada da série "payload cru no setter" (#161→#176, #179→#197, #207→#216, #225→#248). O #225 tratou 19 sites de ARRAY (`.map`/`.length` direto). Esta PR trata a fatia NÃO-array: sites em que `setX(resposta.data)` alimenta um objeto ou objeto-com-campo-array, sem checar a forma.

Triagem própria (não a contagem da issue): li o CONSUMO de cada site candidato (render, `useEffect` derivado, prop para filho) e classifiquei por tipo antes de consertar qualquer coisa.

## 15 sites consertados, cada um com teste + prova de mutação real

| Arquivo:linha | Tipo de guarda |
|---|---|
| `CobrancasPage.tsx:84` | objeto escalar (raiz) |
| `EstoquePage.tsx:26` | objeto escalar (raiz) |
| `ContratosPage.tsx:31` | objeto escalar (raiz) |
| `ClientDetailPage.tsx:88` | por campo (`tags`) |
| `FinanceiroPage.tsx:64` | objeto escalar (raiz, summary) |
| `PagarPage.tsx:150` | objeto escalar (raiz, summary) |
| `PagarPage.tsx:159` | por campo (`items`/`total`) |
| `OrcamentosPage.tsx:35` | objeto escalar (raiz) |
| `CentrosCustoPage.tsx:56` | por campo (`buckets`) |
| `ConferenciaPage.tsx:73` | por campo (`contas`) |
| `DiagnosticoPage.tsx:47` | por campo (`signals`) |
| `ProjecaoCaixaPage.tsx:46-50` | por 2 campos (`windows`, `notes`) |
| `ContratoDrePage.tsx:86-92` | por 3 campos aninhados |
| `FilaPagamentosPage.tsx:79-95` | por 5 campos + summary |
| `PublicContractPage.tsx:31-36` | por campo (`clauses`) — **rota pública** |

3 sites avaliados e confirmados SEM necessidade de guarda (todo consumo já é opcional/com fallback): `ContratoDrePage.tsx:52` (`setContract`), `AccountModal.tsx:165` (`setPagasAntes`), `AdminDashboard.tsx:134` (`setE`).

## Verificação independente

- Reconferi eu mesmo: `git rev-parse --show-toplevel` / `git branch --show-current` batem antes de cada um dos 4 commits.
- `pnpm lint` e `pnpm typecheck` rodados por mim — limpos.
- `pnpm test` (suíte inteira) rodado por mim — **95 arquivos / 1179 testes, todos verdes**.
- Refiz DUAS mutações eu mesmo, escolhendo os casos mais centrais/arriscados:
  - `ClientDetailPage.tsx` (guarda por campo `tags`): removi a guarda, `client.tags.length` estourou com `TypeError: Cannot read properties of undefined (reading 'length')`, 4 testes morreram. Restaurado.
  - `ContratoDrePage.tsx` (guarda com 3 campos aninhados, a mais complexa): removi a guarda, `group.categorias.reduce` estourou com `TypeError: group.categorias.reduce is not a function`, 5 testes morreram. Restaurado.
- Confirmei que `InvestimentosPage.tsx` (dívida vizinha citada na issue, de outro tipo — falta de try/catch, não guarda de forma) **não foi tocado**: `contasDeAplicacao(bancarias)` ainda presente sem tratamento, como a issue original registrava.

## Fora desta PR

26 sites de ARRAY direto (mesmo padrão do #225), medidos e classificados durante esta triagem: #252.

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `pnpm test` — 95 arquivos / 1179 testes passed

Closes #247
