### PR TITLE
fix: e-mail/whatsapp de funil usam campos do envio atual

### DIFF
--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -261,7 +261,8 @@ def create_client(db: Session, *, tenant_id: str, actor: str, data: ClientCreate
     # Gatilho de automação: outros módulos podem reagir (ex.: auto-enroll no funil de entrada
     # padrão do tenant, ver funnels/automation.py).
     events.emit(
-        EVENT_CLIENT_CREATED, tenant_id=tenant_id, client_id=client.id, source=client.source
+        EVENT_CLIENT_CREATED, tenant_id=tenant_id, client_id=client.id, source=client.source,
+        notes=data.notes,
     )
     return client
 
@@ -369,6 +370,9 @@ def absorb_lead(
         tenant_id=tenant_id,
         client_id=existente.id,
         source=data.source,
+        # `data.notes` (o envio ATUAL), não `corpo` (que mistura complementos tipo "telefone:
+        # X" — bom pro Histórico, ruim pra virar {{cliente.notas}} no e-mail de alerta).
+        notes=data.notes,
     )
     return existente, False
 

--- a/apps/api/app/modules/funnels/automation.py
+++ b/apps/api/app/modules/funnels/automation.py
@@ -28,7 +28,9 @@ logger = logging.getLogger("e1p.funnels.automation")
 AUTO_ENROLL_SOURCES = {"landing", "api"}
 
 
-def on_client_created(*, tenant_id: str, client_id: str, source: str, **_: object) -> None:
+def on_client_created(
+    *, tenant_id: str, client_id: str, source: str, notes: str = "", **_: object
+) -> None:
     if source not in AUTO_ENROLL_SOURCES:
         return
     with tenant_session(tenant_id) as db:
@@ -39,6 +41,7 @@ def on_client_created(*, tenant_id: str, client_id: str, source: str, **_: objec
             engine.enroll(
                 db, tenant_id=tenant_id, actor="sistema:auto-enroll",
                 funnel_id=profile.default_entry_funnel_id, client_id=client_id,
+                trigger_notes=notes,
             )
         except service.FunnelError:
             # Funil apagado/inválido/vazio: não pode propagar e derrubar o publicador do
@@ -61,7 +64,9 @@ def _ja_esta_andando(db, *, funnel_id: str, client_id: str) -> bool:
     ) is not None
 
 
-def on_client_returned(*, tenant_id: str, client_id: str, source: str, **_: object) -> None:
+def on_client_returned(
+    *, tenant_id: str, client_id: str, source: str, notes: str = "", **_: object
+) -> None:
     """Contato conhecido voltou pela captura: reinscreve, se a jornada anterior já acabou.
 
     A guarda de "já está andando" vive AQUI e não dentro de `engine.enroll`: inscrição manual
@@ -83,6 +88,7 @@ def on_client_returned(*, tenant_id: str, client_id: str, source: str, **_: obje
             engine.enroll(
                 db, tenant_id=tenant_id, actor="sistema:auto-enroll",
                 funnel_id=profile.default_entry_funnel_id, client_id=client_id,
+                trigger_notes=notes,
             )
         except service.FunnelError:
             logger.warning(

--- a/apps/api/app/modules/funnels/engine.py
+++ b/apps/api/app/modules/funnels/engine.py
@@ -245,6 +245,7 @@ def _drive(db: Session, *, tenant_id: str, actor: str, funnel: Funnel, run: Funn
                 result = service.run_node(
                     db, tenant_id=tenant_id, actor=actor, action=action,
                     client_id=run.client_id, params=_params(data),
+                    trigger_notes=run.trigger_notes,
                 )
                 _log(run, node, "ok", result.get("message", ""))
             except service.FunnelError as e:
@@ -264,7 +265,7 @@ def _drive(db: Session, *, tenant_id: str, actor: str, funnel: Funnel, run: Funn
 # ── API do motor ────────────────────────────────────────────────────────────
 def enroll(
     db: Session, *, tenant_id: str, actor: str, funnel_id: str,
-    client_id: str | None, start_node_id: str | None = None,
+    client_id: str | None, start_node_id: str | None = None, trigger_notes: str = "",
 ) -> FunnelRun:
     funnel = service.get_funnel(db, funnel_id)
     if not funnel.nodes:
@@ -277,7 +278,7 @@ def enroll(
 
     run = FunnelRun(
         tenant_id=tenant_id, funnel_id=funnel_id, client_id=client_id,
-        status=RUN_RUNNING, current_node_id=entry, steps=[],
+        status=RUN_RUNNING, current_node_id=entry, steps=[], trigger_notes=trigger_notes,
     )
     db.add(run)
     db.flush()

--- a/apps/api/app/modules/funnels/models.py
+++ b/apps/api/app/modules/funnels/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, String
+from sqlalchemy import JSON, DateTime, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base, TenantMixin, TimestampMixin, _uuid
@@ -48,3 +48,9 @@ class FunnelRun(Base, TenantMixin, TimestampMixin):
     # Log de execução: [{node_id, key, action, status, message, at}].
     steps: Mapped[list] = mapped_column(JSON, default=list, nullable=False)
     error: Mapped[str] = mapped_column(String(500), default="", nullable=False)
+    # Campos do formulário/gatilho QUE ORIGINOU esta jornada (ex.: respostas de uma página de
+    # captura). Existe porque `client.notes` só é preenchido na CRIAÇÃO do contato — quem
+    # retorna pelo mesmo canal (absorb_lead, crm/service.py) nunca sobrescreve `notes` pra não
+    # apagar edição manual do dono, o que travaria `{{cliente.notas}}` no primeiro envio pra
+    # sempre. `trigger_notes` é o snapshot DESTE envio, não o acumulado do contato.
+    trigger_notes: Mapped[str] = mapped_column(Text, default="", nullable=False)

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -184,35 +184,41 @@ class FunnelError(Exception):
 
 
 # ── WhatsApp/E-mail: resolução de placeholders ({{cliente.*}} ou texto literal) ──
+# Assinatura uniforme (client, trigger_notes) mesmo quando um resolver ignora o 2º argumento —
+# só `cliente.notas` usa, mas manter os dois na mesma forma evita um branch especial no
+# despacho abaixo.
 _CLIENT_KEYWORDS = {
-    "cliente.nome": lambda c: c.name,
-    "cliente.telefone": lambda c: c.phone or "(não informado)",
-    "cliente.email": lambda c: c.email or "(não informado)",
+    "cliente.nome": lambda c, tn: c.name,
+    "cliente.telefone": lambda c, tn: c.phone or "(não informado)",
+    "cliente.email": lambda c, tn: c.email or "(não informado)",
     # Bloco de Observações do lead — já traz as respostas de campos customizados de
     # formulários (Sites/Integrações), sem precisar de uma keyword por campo (que varia
-    # de página pra página). Vazio fica "" (não é um valor único tipo telefone/e-mail).
-    "cliente.notas": lambda c: c.notes or "",
+    # de página pra página). Prefere `trigger_notes` (o ENVIO que disparou esta jornada) a
+    # `client.notes` (que só é preenchido na criação do contato — quem retorna pelo mesmo
+    # canal nunca o atualiza, de propósito, pra não apagar edição manual do dono; ver
+    # `crm.service.absorb_lead`). Vazio fica "" (não é um valor único tipo telefone/e-mail).
+    "cliente.notas": lambda c, tn: tn or c.notes or "",
 }
 _KEYWORD_PATTERN = re.compile(r"\{\{\s*(cliente\.\w+)\s*\}\}")
 
 
-def _resolve_template_variable(raw: str, client) -> str:
+def _resolve_template_variable(raw: str, client, trigger_notes: str = "") -> str:
     if raw.startswith("{{") and raw.endswith("}}"):
         key = raw[2:-2].strip()
         resolver = _CLIENT_KEYWORDS.get(key)
         if resolver is not None:
-            return resolver(client) or ""
+            return resolver(client, trigger_notes) or ""
     return raw  # texto fixo, literal
 
 
-def _render_client_placeholders(text: str, client) -> str:
+def _render_client_placeholders(text: str, client, trigger_notes: str = "") -> str:
     """Substitui `{{cliente.*}}` NO MEIO de um texto livre (assunto/corpo de e-mail) — ao
     contrário de `_resolve_template_variable` (variável posicional inteira do WhatsApp), aqui
     o placeholder pode aparecer misturado com texto fixo."""
 
     def _sub(m: re.Match[str]) -> str:
         resolver = _CLIENT_KEYWORDS.get(m.group(1))
-        return (resolver(client) or "") if resolver else m.group(0)
+        return (resolver(client, trigger_notes) or "") if resolver else m.group(0)
 
     return _KEYWORD_PATTERN.sub(_sub, text)
 
@@ -338,7 +344,8 @@ def _valid_amount(params: dict) -> int:
 
 
 def run_node(
-    db: Session, *, tenant_id: str, actor: str, action: str, client_id: str | None, params: dict
+    db: Session, *, tenant_id: str, actor: str, action: str, client_id: str | None, params: dict,
+    trigger_notes: str = "",
 ) -> dict:
     from datetime import timedelta
 
@@ -440,8 +447,10 @@ def run_node(
             raise FunnelError("Escreva a mensagem (ou gere com IA) antes de enviar", 422)
         to_team = params.get("recipient") == "team"
         recipient = _team_email() if to_team else (c.email or c.name)
-        subject = _render_client_placeholders((params.get("subject") or "Mensagem").strip(), c)
-        msg = _render_client_placeholders(msg, c)
+        subject = _render_client_placeholders(
+            (params.get("subject") or "Mensagem").strip(), c, trigger_notes
+        )
+        msg = _render_client_placeholders(msg, c, trigger_notes)
         status = email.send_email(to=recipient, subject=subject, body=msg)
         db.add(Notification(
             tenant_id=tenant_id, channel="email", recipient=recipient,
@@ -471,7 +480,8 @@ def run_node(
                 raise FunnelError("Escreva a mensagem do WhatsApp no nó antes de executar", 422)
             notifications_service.enqueue(
                 db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient, client_id=c.id,
-                message=_render_client_placeholders(body, c), purpose=PURPOSE_FUNNEL_NODE,
+                message=_render_client_placeholders(body, c, trigger_notes),
+                purpose=PURPOSE_FUNNEL_NODE,
             )
         else:
             template_id = params.get("template_id")
@@ -481,7 +491,8 @@ def run_node(
             if tpl is None or tpl.status != STATUS_APPROVED:
                 raise FunnelError("Template não encontrado ou ainda não aprovado pela Meta", 422)
             resolved_vars = [
-                _resolve_template_variable(v, c) for v in (params.get("variables") or [])
+                _resolve_template_variable(v, c, trigger_notes)
+                for v in (params.get("variables") or [])
             ]
             notifications_service.enqueue(
                 db, tenant_id=tenant_id, channel="whatsapp", recipient=recipient, client_id=c.id,

--- a/apps/api/migrations/versions/0080_funnel_run_trigger_notes.py
+++ b/apps/api/migrations/versions/0080_funnel_run_trigger_notes.py
@@ -1,0 +1,34 @@
+"""funnel_runs.trigger_notes: snapshot dos campos do formulário QUE INSCREVEU esta jornada.
+
+Revision ID: 0080
+Revises: 0079
+Create Date: 2026-08-26
+
+`{{cliente.notas}}` (usado no nó de e-mail/WhatsApp) lia `client.notes` — mas `absorb_lead`
+(crm/service.py) só preenche `notes` na CRIAÇÃO do contato; quem retorna pelo mesmo canal
+(mesmo telefone/e-mail) nunca sobrescreve `notes`, de propósito, pra não apagar edição manual
+do dono. Resultado: o e-mail de alerta de um lead que já existia saía com os campos do
+PRIMEIRO envio (ou vazio, se o contato nasceu de outro jeito). `trigger_notes` é o snapshot do
+envio QUE DISPAROU esta jornada especificamente — `engine.enroll` grava, e os nós de
+comunicação passam a preferir isto a `client.notes`.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0080"
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "funnel_runs",
+        sa.Column("trigger_notes", sa.Text(), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("funnel_runs", "trigger_notes")

--- a/apps/api/tests/test_funnels.py
+++ b/apps/api/tests/test_funnels.py
@@ -433,6 +433,47 @@ def test_run_send_email_placeholder_shows_fallback_when_empty(client: TestClient
     assert notif["message"] == "E-mail: (não informado)\nWhatsApp: (não informado)"
 
 
+def test_run_send_email_prefers_trigger_notes_over_client_notes(
+    client: TestClient, headers, tenant_id, db
+):
+    # `{{cliente.notas}}` deve refletir o envio ATUAL do funil (trigger_notes), não o
+    # client.notes acumulado — `absorb_lead` (crm/service.py) só preenche `notes` na criação
+    # do contato; quem retorna pelo site não atualiza esse campo, então sem trigger_notes o
+    # e-mail de alerta ficaria travado nos dados do primeiro envio (ou vazio).
+    from app.modules.funnels import engine
+    from app.modules.funnels.models import Funnel
+
+    cl = client.post(
+        "/crm/clients",
+        json={"name": "Ana", "phone": "43999998888",
+              "notes": "Campos do formulário:\nOcasião: Casamento"},
+        headers=headers,
+    ).json()
+
+    funil = Funnel(
+        tenant_id=tenant_id, name="Alerta equipe",
+        nodes=[{"id": "n1", "data": {
+            "key": "enviar-email", "action": "send_email", "label": "Alertar",
+            "config": {"subject": "Novo lead", "body": "{{cliente.notas}}", "recipient": "team"},
+        }}],
+        edges=[],
+    )
+    db.add(funil)
+    db.commit()
+    db.refresh(funil)
+
+    engine.enroll(
+        db, tenant_id=tenant_id, actor="teste", funnel_id=funil.id, client_id=cl["id"],
+        trigger_notes="Campos do formulário:\nOcasião: Aniversário",
+    )
+    db.commit()
+
+    notifs = client.get("/notifications", headers=headers).json()
+    notif = next(n for n in notifs if n["client_id"] == cl["id"])
+    assert "Aniversário" in notif["message"]
+    assert "Casamento" not in notif["message"]
+
+
 def test_run_requires_client(client: TestClient, headers):
     resp = client.post(
         "/funnels/run-node",

--- a/apps/api/tests/test_lead_auto_enroll.py
+++ b/apps/api/tests/test_lead_auto_enroll.py
@@ -165,6 +165,55 @@ def test_retorno_nao_reinscreve_quem_ja_esta_andando(db: Session, _fake_session)
     assert len(runs) == 1
 
 
+def test_criacao_carrega_notes_do_evento_para_o_run(db: Session, _fake_session):
+    tenant = _seed_tenant(db, slug="auto7", document="00000000000107")
+    funnel = _seed_funnel(db, tenant.id)
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id=funnel.id))
+    client = Client(tenant_id=tenant.id, name="Lead Com Campos", source="landing")
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(
+        tenant_id=tenant.id, client_id=client.id, source="landing",
+        notes="Campos do formulário:\nQuando é a festa?: Dezembro",
+    )
+
+    run = _run_for(db, client.id)
+    assert run is not None
+    assert run.trigger_notes == "Campos do formulário:\nQuando é a festa?: Dezembro"
+
+
+def test_retorno_carrega_notes_do_envio_atual_nao_do_client_notes(db: Session, _fake_session):
+    """`client.notes` fica travado no primeiro envio (absorb_lead não sobrescreve pra não
+    apagar edição manual do dono) — o `trigger_notes` do run é o que garante que o e-mail de
+    alerta reflita o envio QUE ACABOU de chegar, não o primeiro."""
+    from app.modules.funnels.models import RUN_DONE
+
+    tenant = _seed_tenant(db, slug="auto8", document="00000000000108")
+    funnel = _seed_funnel(db, tenant.id)
+    db.add(TenantProfile(tenant_id=tenant.id, default_entry_funnel_id=funnel.id))
+    client = Client(
+        tenant_id=tenant.id, name="Lead Retorno", source="landing", notes="Primeiro envio"
+    )
+    db.add(client)
+    db.commit()
+
+    automation.on_client_created(tenant_id=tenant.id, client_id=client.id, source="landing")
+    primeira = _run_for(db, client.id)
+    primeira.status = RUN_DONE
+    db.commit()
+
+    automation.on_client_returned(
+        tenant_id=tenant.id, client_id=client.id, source="landing",
+        notes="Segundo envio: dados novos",
+    )
+
+    runs = list(db.scalars(select(FunnelRun).where(FunnelRun.client_id == client.id)).all())
+    assert len(runs) == 2
+    segunda = next(r for r in runs if r.id != primeira.id)
+    assert segunda.trigger_notes == "Segundo envio: dados novos"
+
+
 def test_retorno_de_source_manual_nao_inscreve(db: Session, _fake_session):
     tenant = _seed_tenant(db, slug="auto6", document="00000000000106")
     funnel = _seed_funnel(db, tenant.id)


### PR DESCRIPTION
## Resumo

- `client.notes` só é preenchido na criação do contato — `absorb_lead` (crm/service.py) nunca
  sobrescreve num retorno, de propósito, pra não apagar edição manual do dono do CRM.
- Isso travava `{{cliente.notas}}` (usado nos nós de e-mail/WhatsApp do funil) nos dados do
  PRIMEIRO envio de um contato — ou vazio, se o contato nasceu de outro jeito (manual, etc.).
- `FunnelRun.trigger_notes` (migração `0080`) guarda o snapshot do envio que disparou aquela
  jornada específica. Os eventos `crm.client.created`/`crm.client.returned` passam a carregar
  `notes`, até `engine.enroll` → `service.run_node`, e `{{cliente.notas}}` agora prefere
  `trigger_notes` a `client.notes` — sem alterar a proteção contra sobrescrever anotação manual.

## Test plan

- [x] 3 testes novos (auto-enroll grava `trigger_notes` na criação e no retorno; e-mail de
      funil usa `trigger_notes` em vez de `client.notes`) — RED confirmado antes da implementação
- [x] Suíte completa: 2302 passed, 1 skipped
- [x] `ruff check .` limpo
- [x] `alembic heads` → head único (`0080`), sem colisão de revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)