### PR TITLE
fix: guarda payload cru em 26 sites de ARRAY (#252)

### DIFF
--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -649,3 +649,54 @@ describe("CobrancasPage — resumo fora de forma não derruba a tela (#247)", ()
     expect(await screen.findByText("R$ 123,45")).toBeInTheDocument();
   });
 });
+
+// ── `GET /receivables/charges` e os três rótulos fora de forma (issue #252) ───────────────
+//
+// `setCharges(c.data)`/`setChartAccounts`/`setCostCenters`/`setBankAccounts` recebiam o payload
+// CRU. `charges.map` roda direto no render (a tabela); os três rótulos alimentam
+// `Object.fromEntries(x.map(...))` — um payload fora de forma faz `.map is not a function`
+// estourar em qualquer um dos quatro.
+describe("CobrancasPage — lista e rótulos fora de forma não derrubam a tela (#252)", () => {
+  it("charges fora de forma (envelope de erro com 200) → tela segue montada, estado vazio", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/receivables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/receivables/charges")
+        return Promise.resolve({ data: { detail: "algo deu errado" } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contas a Receber")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhuma cobrança. Clique em "Nova cobrança".'),
+    ).toBeInTheDocument();
+  });
+
+  it("chartAccounts/costCenters/bankAccounts fora de forma → rótulos degradam sem quebrar a linha", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/receivables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/receivables/charges")
+        return Promise.resolve({ data: [COBRANCA_ABERTA] } as never);
+      if (url === "/chart-of-accounts")
+        return Promise.resolve({ data: { detail: "erro" } } as never);
+      if (url === "/cost-centers") return Promise.resolve({ data: null } as never);
+      if (url === "/bank/accounts") return Promise.resolve({ data: "não é json" } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    // A linha continua montada — o rótulo cai no fallback "—" em vez de estourar.
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("contra-teste: cobrança/contas/centros de verdade continuam aparecendo", async () => {
+    mockCobrancas([COBRANCA_ABERTA]);
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Joana Ré")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -84,7 +84,10 @@ export default function CobrancasPage() {
     setSummary(
       s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
     );
-    setCharges(c.data);
+    // Guarda de FORMA (issue #252): `charges.map`/`.length` rodam direto no render, sem checar o
+    // payload. `Array.isArray`, no molde de `CrmPage.tsx`/`ClientTimeline.tsx` (#225): um payload
+    // fora de forma (envelope de erro devolvido com 200, corpo vazio) faz `charges.map` estourar.
+    setCharges(Array.isArray(c.data) ? c.data : []);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de cobranças continua funcionando normalmente.
     const [ca, cc, ba] = await Promise.all([
@@ -94,9 +97,11 @@ export default function CobrancasPage() {
       // conta no registro é do `DialogDeBaixa`, que carrega a própria lista.
       api.get<BankAccount[]>("/bank/accounts").catch(() => ({ data: [] as BankAccount[] })),
     ]);
-    setChartAccounts(ca.data);
-    setCostCenters(cc.data);
-    setBankAccounts(ba.data);
+    // Guarda de FORMA (issue #252): os três alimentam `.map`/objectFromEntries usados nos rótulos
+    // (accountLabel/costCenterLabel/nomeDaContaBancaria) sem checar o payload.
+    setChartAccounts(Array.isArray(ca.data) ? ca.data : []);
+    setCostCenters(Array.isArray(cc.data) ? cc.data : []);
+    setBankAccounts(Array.isArray(ba.data) ? ba.data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/contratos/ContratosPage.test.tsx
+++ b/apps/web/src/features/contratos/ContratosPage.test.tsx
@@ -79,3 +79,49 @@ describe("ContratosPage — resumo fora de forma não derruba a tela (#247)", ()
     expect(screen.getByText("9")).toBeInTheDocument();
   });
 });
+
+// ── `GET /contracts` fora de forma (issue #252) ──────────────────────────────────────────
+//
+// `setContracts(c.data)` recebia o payload CRU. `contracts.map` roda direto no render (a
+// tabela) sem `Array.isArray` — um payload fora de forma (envelope de erro devolvido com 200,
+// objeto em vez de array) faria `contracts.map is not a function` estourar.
+describe("ContratosPage — lista de contratos fora de forma não derruba a tela (#252)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com o estado vazio", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/contracts/summary")
+        return Promise.resolve({
+          data: { draft_count: 0, sent_count: 0, signed_count: 0 },
+        } as never);
+      if (url === "/contracts") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Contratos")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhum contrato. Clique em "Novo contrato".'),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: contratos de verdade continuam aparecendo na tabela", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/contracts/summary")
+        return Promise.resolve({
+          data: { draft_count: 0, sent_count: 0, signed_count: 0 },
+        } as never);
+      if (url === "/contracts")
+        return Promise.resolve({
+          data: [{ id: "ct-1", title: "Consultoria", status: "draft", client_name: "Maria" }],
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Consultoria")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/contratos/ContratosPage.tsx
+++ b/apps/web/src/features/contratos/ContratosPage.tsx
@@ -31,7 +31,9 @@ export default function ContratosPage() {
     setSummary(
       s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
     );
-    setContracts(c.data);
+    // Guarda de FORMA (issue #252): `contracts.map`/`.length` rodam direto no render, sem checar
+    // o payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+    setContracts(Array.isArray(c.data) ? c.data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/crm/ClientDetailPage.test.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.test.tsx
@@ -1201,3 +1201,72 @@ describe("ClientDetailPage — cliente fora de forma não derruba a ficha (#247)
     expect(screen.getByText("recorrente")).toBeInTheDocument();
   });
 });
+
+// ── As CINCO leituras secundárias fora de forma (issue #252) ─────────────────────────────
+//
+// `setCharges(ch.data)`/`setContracts(co.data)`/`setQuotes(qu.data)`/`setLegalDocs(ld.data)`/
+// `setJourneys(jr.data)` recebiam o payload CRU. Cada uma alimenta `.length` (no título da
+// seção) e `.map` (na lista) sem `Array.isArray` — um payload fora de forma faria
+// `charges.map is not a function` (ou o irmão de cada seção) estourar.
+describe("ClientDetailPage — as cinco listas secundárias fora de forma (#252)", () => {
+  it("charges fora de forma → seção de Cobranças degrada para vazia, sem estourar a ficha", async () => {
+    ficha.charges = { detail: "algo deu errado" } as unknown as unknown[];
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("Cobranças (0)")).toBeInTheDocument();
+    expect(screen.getByText("Nenhuma cobrança para este cliente.")).toBeInTheDocument();
+  });
+
+  it("contracts fora de forma → seção de Contratos degrada para vazia", async () => {
+    ficha.contracts = "não é json" as unknown as unknown[];
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("Contratos (0)")).toBeInTheDocument();
+    expect(screen.getByText("Nenhum contrato.")).toBeInTheDocument();
+  });
+
+  it("quotes fora de forma → seção de Orçamentos degrada para vazia", async () => {
+    ficha.quotes = null as unknown as unknown[];
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("Orçamentos (0)")).toBeInTheDocument();
+    expect(screen.getByText("Nenhum orçamento.")).toBeInTheDocument();
+  });
+
+  it("legalDocs fora de forma → seção de Documentos jurídicos degrada para vazia", async () => {
+    ficha.legalDocs = { detail: "erro" } as unknown as unknown[];
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("Documentos jurídicos (0)")).toBeInTheDocument();
+    expect(screen.getByText("Nenhum documento jurídico vinculado.")).toBeInTheDocument();
+  });
+
+  it("journeys fora de forma → seção de Jornadas no funil degrada para vazia", async () => {
+    ficha.journeys = "não é json" as unknown as unknown[];
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByRole("heading", { name: "Joana Ré" })).toBeInTheDocument();
+    expect(screen.getByText("Jornadas no funil (0)")).toBeInTheDocument();
+    expect(screen.getByText("Este contato não está em nenhum funil.")).toBeInTheDocument();
+  });
+
+  it("contra-teste: as cinco listas de verdade continuam contando e aparecendo", async () => {
+    renderFicha();
+    await assentar();
+
+    expect(await screen.findByText("Cobranças (6)")).toBeInTheDocument();
+    expect(screen.getByText("Contratos (1)")).toBeInTheDocument();
+    expect(screen.getByText("Orçamentos (1)")).toBeInTheDocument();
+    expect(screen.getByText("Documentos jurídicos (1)")).toBeInTheDocument();
+    expect(screen.getByText("Jornadas no funil (1)")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -90,11 +90,15 @@ export default function ClientDetailPage() {
         ? { ...c.data, tags: Array.isArray(c.data.tags) ? c.data.tags : [] }
         : null,
     );
-    setCharges(ch.data);
-    setContracts(co.data);
-    setQuotes(qu.data);
-    setLegalDocs(ld.data);
-    setJourneys(jr.data);
+    // Guarda de FORMA (issue #252): as cinco alimentam `.length`/`.map` direto no render (contagem
+    // do título da seção + listas), sem checar o payload. `Array.isArray`, no molde de
+    // `CrmPage.tsx` (#225) — um payload fora de forma (envelope de erro, corpo vazio) degrada
+    // para a lista vazia, o mesmo estado que já existe antes da resposta chegar.
+    setCharges(Array.isArray(ch.data) ? ch.data : []);
+    setContracts(Array.isArray(co.data) ? co.data : []);
+    setQuotes(Array.isArray(qu.data) ? qu.data : []);
+    setLegalDocs(Array.isArray(ld.data) ? ld.data : []);
+    setJourneys(Array.isArray(jr.data) ? jr.data : []);
   }, [id, podeCobrancas, podeContratos, podeOrcamentos, podeJuridico, podeFunis]);
 
   useEffect(() => {

--- a/apps/web/src/features/estoque/EstoquePage.test.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.test.tsx
@@ -197,3 +197,43 @@ describe("EstoquePage — resumo fora de forma não derruba a tela (#247)", () =
     expect(screen.getByText("R$ 123,45")).toBeInTheDocument();
   });
 });
+
+// ── `GET /stock/items` fora de forma (issue #252) ────────────────────────────────────────
+//
+// `setItems(i.data)` recebia o payload CRU. `items.map`/`.length` rodam direto no render (a
+// tabela) sem `Array.isArray` — um payload fora de forma faria `items.map is not a function`
+// estourar.
+describe("EstoquePage — lista de itens fora de forma não derruba a tela (#252)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com o estado vazio", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/stock/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/stock/items") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Controle de Estoque")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhum item. Clique em "Novo item".'),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: item de verdade continua aparecendo na tabela", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/stock/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/stock/items")
+        return Promise.resolve({
+          data: [{ id: "i-1", name: "Camiseta P", quantity: 10, unit: "un", unit_cost_cents: 100, value_cents: 1000, low: false, min_quantity: 0 }],
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Camiseta P")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/estoque/EstoquePage.tsx
+++ b/apps/web/src/features/estoque/EstoquePage.tsx
@@ -26,7 +26,9 @@ export default function EstoquePage() {
     setSummary(
       s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
     );
-    setItems(i.data);
+    // Guarda de FORMA (issue #252): `items.map`/`.length` rodam direto no render, sem checar o
+    // payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+    setItems(Array.isArray(i.data) ? i.data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/financeiro/CentrosCustoPage.test.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.test.tsx
@@ -89,3 +89,47 @@ describe("CentrosCustoPage — comparativo fora de forma não derruba a tela (#2
     expect(await screen.findByTestId("comparativo-centros")).toBeInTheDocument();
   });
 });
+
+// ── `GET /cost-centers` fora de forma (issue #252) ───────────────────────────────────────
+//
+// `setCenters(c.data)` recebia o payload CRU. `centers.map`/`.length` rodam direto no render
+// (a lista) sem `Array.isArray` — um payload fora de forma faria `centers.map is not a
+// function` estourar.
+describe("CentrosCustoPage — lista de centros fora de forma não derruba a tela (#252)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com o estado vazio", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers") return Promise.resolve({ data: payload } as never);
+      if (url === "/financial-intelligence/by-cost-center")
+        return Promise.resolve({
+          data: { start: "2026-08-01", end: "2026-08-31", buckets: [], notes: [] },
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Centros de custo")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhum centro de custo ainda. Clique em "Novo centro de custo".'),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: centro de verdade continua aparecendo na lista", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/cost-centers")
+        return Promise.resolve({ data: [{ id: "cc-1", name: "Sócio A", kind: "socio", archived_at: null }] } as never);
+      if (url === "/financial-intelligence/by-cost-center")
+        return Promise.resolve({
+          data: { start: "2026-08-01", end: "2026-08-31", buckets: [], notes: [] },
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Sócio A")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/CentrosCustoPage.tsx
+++ b/apps/web/src/features/financeiro/CentrosCustoPage.tsx
@@ -48,7 +48,9 @@ export default function CentrosCustoPage() {
           params: { start, end },
         }),
       ]);
-      setCenters(c.data);
+      // Guarda de FORMA (issue #252): `centers.map`/`.length` rodam direto no render, sem checar o
+      // payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+      setCenters(Array.isArray(c.data) ? c.data : []);
       // Guarda de FORMA (issue #247): `report.buckets.length`/`.map` rodam direto no render, sem
       // `?.`. `Array.isArray`, no molde de `CrmPage.tsx` (#225): guarda por CAMPO, com `null`
       // quando o campo não é array — a render já checa `report && report.buckets...`, então

--- a/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.test.tsx
@@ -1303,6 +1303,53 @@ describe("checkpoints fora de formato não viram saldo declarado", () => {
   });
 });
 
+// ── `txs`/`checkpoints` DENTRO de `AccountDetail` fora de forma (issue #252) ──────────────
+//
+// `setTxs(t.data)`/`setCheckpoints(c.data)` (o `Promise.all` de `AccountDetail.load()`, disparado
+// ao abrir "Ver movimentos") recebiam o payload CRU. `txs.map`/`.length` e `checkpoints.map`/
+// `.length` rodam direto no render da seção de movimentos, sem `Array.isArray` — distinto do
+// checkpoint-resumo do cartão (issue #179, já guardado por `cps.data[0] ?? null`).
+describe("ContasSaldosPage — movimentos/checkpoints da conta aberta fora de forma (#252)", () => {
+  async function abrirMovimentos() {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Ver movimentos")).toBeInTheDocument());
+    screen.getByText("Ver movimentos").click();
+    await waitFor(() => expect(screen.getByText(/Movimentos — Itaú PJ/)).toBeInTheDocument());
+  }
+
+  it("txs fora de forma → a seção de movimentos mostra o estado vazio, sem estourar", async () => {
+    mockApi([conta({ id: "a", name: "Itaú PJ" })], [], "não é json" as never);
+    await abrirMovimentos();
+
+    expect(
+      screen.getByText("Nenhum movimento nesta conta no período selecionado."),
+    ).toBeInTheDocument();
+  });
+
+  it("checkpoints fora de forma → 'Saldos declarados' mostra o estado vazio, sem estourar", async () => {
+    mockApi([conta({ id: "a", name: "Itaú PJ" })], { detail: "erro" } as never, []);
+    await abrirMovimentos();
+
+    expect(
+      screen.getByText(/Nenhum saldo declarado\. Sem ele o e1p não tem contra o que conferir/),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: movimento e checkpoint de verdade continuam aparecendo na seção aberta", async () => {
+    mockApi(
+      [conta({ id: "a", name: "Itaú PJ" })],
+      [checkpoint],
+      [movimento({ id: "tx-real", description: "Aluguel de agosto" })],
+    );
+    await abrirMovimentos();
+
+    expect(await screen.findByText("Aluguel de agosto")).toBeInTheDocument();
+    // A linha do checkpoint na seção "Saldos declarados" — o botão "Remover declaração" só existe
+    // quando `checkpoints.map` de fato correu sobre a lista de verdade.
+    expect(screen.getByRole("button", { name: /Remover declaração/ })).toBeInTheDocument();
+  });
+});
+
 // ── `GET /bank/accounts` fora de forma (issue #207) ───────────────────────────
 //
 // `setAccounts(res.data)` recebia o payload CRU, sem operador nenhum — é um dos dois exemplos que

--- a/apps/web/src/features/financeiro/ContasSaldosPage.tsx
+++ b/apps/web/src/features/financeiro/ContasSaldosPage.tsx
@@ -561,8 +561,10 @@ function AccountDetail({
           params: { limit: 12 },
         }),
       ]);
-      setTxs(t.data);
-      setCheckpoints(c.data);
+      // Guarda de FORMA (issue #252): `txs`/`checkpoints` alimentam `.map`/`.length` direto no
+      // render, sem checar o payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+      setTxs(Array.isArray(t.data) ? t.data : []);
+      setCheckpoints(Array.isArray(c.data) ? c.data : []);
     } catch (err) {
       setError(apiErrorMessage(err));
     }

--- a/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
@@ -127,3 +127,119 @@ describe("FinanceiroPage — resumo fora de forma não derruba a tela (#247)", (
     expect(await screen.findByText("R$ 500,00")).toBeInTheDocument();
   });
 });
+
+// ── As CINCO leituras secundárias fora de forma (issue #252) ─────────────────────────────
+//
+// `setTxs(t.data)`/`setChartAccounts(ca.data)`/`setCostCenters(cc.data)`/`setPayouts(po.data)`/
+// `setContas(bc.data)` recebiam o payload CRU. `txs.map`/`.length` roda na tabela principal; os
+// outros quatro alimentam rótulos (`accountLabel`/`costCenterLabel`) e o `PayoutHistory` — um
+// payload fora de forma faria `.map is not a function` estourar em qualquer um dos cinco.
+describe("FinanceiroPage — as cinco leituras secundárias fora de forma (#252)", () => {
+  it("txs fora de forma → tabela principal degrada para o estado vazio", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/wallet/transactions")
+        return Promise.resolve({ data: { detail: "algo deu errado" } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Carteira")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhuma transação. Clique em "Registrar venda".'),
+    ).toBeInTheDocument();
+  });
+
+  it("chartAccounts/costCenters fora de forma → linha da transação não estoura, rótulo cai no '—'", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/wallet/transactions")
+        return Promise.resolve({
+          data: [
+            {
+              id: "t-1", kind: "service", method: "pix", description: "Consultoria",
+              chart_account_id: "ca-1", cost_center_id: "cc-1",
+              gross_cents: 10000, platform_fee_cents: 500, net_cents: 9500, status: "available",
+            },
+          ],
+        } as never);
+      if (url === "/chart-of-accounts") return Promise.resolve({ data: "não é json" } as never);
+      if (url === "/cost-centers") return Promise.resolve({ data: null } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Consultoria")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("payouts fora de forma → histórico de saques mostra o estado vazio", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/wallet/transactions") return Promise.resolve({ data: [] } as never);
+      if (url === "/wallet/payouts") return Promise.resolve({ data: { detail: "erro" } } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(
+      await screen.findByText("Nenhum saque ainda. O que você sacar aparece aqui e no extrato da sua conta."),
+    ).toBeInTheDocument();
+  });
+
+  it("contas (bank/accounts) fora de forma → nome da conta de destino não estoura", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/wallet/transactions") return Promise.resolve({ data: [] } as never);
+      if (url === "/wallet/payouts")
+        return Promise.resolve({
+          data: [{ id: "po-1", amount_cents: 5000, paid_on: "2026-08-01", bank_account_id: "acc-1", bank_transaction_id: "bt-1" }],
+        } as never);
+      if (url === "/bank/accounts") return Promise.resolve({ data: "não é json" } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    // Sem o nome resolvido (o `Object.fromEntries` ficou vazio), cai no fallback do próprio
+    // `PayoutHistory` — a tela não estoura.
+    expect(await screen.findByText("Conta removida")).toBeInTheDocument();
+  });
+
+  it("contra-teste: as cinco leituras de verdade continuam aparecendo", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/wallet/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/wallet/transactions")
+        return Promise.resolve({
+          data: [
+            {
+              id: "t-1", kind: "service", method: "pix", description: "Consultoria",
+              chart_account_id: "ca-1", cost_center_id: "cc-1",
+              gross_cents: 10000, platform_fee_cents: 500, net_cents: 9500, status: "available",
+            },
+          ],
+        } as never);
+      if (url === "/chart-of-accounts")
+        return Promise.resolve({ data: [{ id: "ca-1", categoria: "Serviços" }] } as never);
+      if (url === "/cost-centers")
+        return Promise.resolve({ data: [{ id: "cc-1", name: "Sócio A" }] } as never);
+      if (url === "/wallet/payouts")
+        return Promise.resolve({
+          data: [{ id: "po-1", amount_cents: 5000, paid_on: "2026-08-01", bank_account_id: "acc-1", bank_transaction_id: "bt-1" }],
+        } as never);
+      if (url === "/bank/accounts")
+        return Promise.resolve({ data: [{ id: "acc-1", name: "Itaú PJ" }] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Consultoria")).toBeInTheDocument();
+    expect(screen.getByText("Serviços")).toBeInTheDocument();
+    expect(screen.getByText("Sócio A")).toBeInTheDocument();
+    expect(screen.getByText("Itaú PJ")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -64,7 +64,9 @@ export default function FinanceiroPage() {
     setSummary(
       s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
     );
-    setTxs(t.data);
+    // Guarda de FORMA (issue #252): `txs.map`/`.length` rodam direto no render, sem checar o
+    // payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+    setTxs(Array.isArray(t.data) ? t.data : []);
     // Rótulos são só um complemento de exibição — se o usuário não tiver acesso a esses módulos
     // (require_module), a lista de transações continua funcionando normalmente.
     const [ca, cc, po, bc] = await Promise.all([
@@ -78,10 +80,12 @@ export default function FinanceiroPage() {
         .get<{ id: string; name: string }[]>("/bank/accounts")
         .catch(() => ({ data: [] as { id: string; name: string }[] })),
     ]);
-    setChartAccounts(ca.data);
-    setCostCenters(cc.data);
-    setPayouts(po.data);
-    setContas(bc.data);
+    // Guarda de FORMA (issue #252): os quatro alimentam `.map`/`.length` (rótulos, PayoutHistory,
+    // nome da conta de destino) sem checar o payload.
+    setChartAccounts(Array.isArray(ca.data) ? ca.data : []);
+    setCostCenters(Array.isArray(cc.data) ? cc.data : []);
+    setPayouts(Array.isArray(po.data) ? po.data : []);
+    setContas(Array.isArray(bc.data) ? bc.data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/orcamentos/OrcamentosPage.test.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.test.tsx
@@ -117,3 +117,35 @@ describe("OrcamentosPage — resumo fora de forma não derruba a tela (#247)", (
     expect(await screen.findByText("R$ 300,00")).toBeInTheDocument();
   });
 });
+
+// ── `GET /quotes` fora de forma (issue #252) ─────────────────────────────────────────────
+//
+// `setQuotes(q.data)` recebia o payload CRU. `quotes.map`/`.length` rodam direto no render (a
+// tabela) sem `Array.isArray` — um payload fora de forma faria `quotes.map is not a function`
+// estourar.
+describe("OrcamentosPage — lista de orçamentos fora de forma não derruba a tela (#252)", () => {
+  it.each([
+    ["envelope de erro devolvido com 200", { detail: "algo deu errado" }],
+    ["corpo vazio (204 / sem conteúdo)", null],
+  ])("%s → a tela segue montada, com o estado vazio", async (_rotulo, payload) => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/quotes/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/quotes") return Promise.resolve({ data: payload } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByText("Orçamentos")).toBeInTheDocument();
+    expect(
+      await screen.findByText('Nenhum orçamento. Clique em "Novo orçamento".'),
+    ).toBeInTheDocument();
+  });
+
+  it("contra-teste: orçamento de verdade continua aparecendo na tabela", async () => {
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Consultoria tributária")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orcamentos/OrcamentosPage.tsx
+++ b/apps/web/src/features/orcamentos/OrcamentosPage.tsx
@@ -35,7 +35,9 @@ export default function OrcamentosPage() {
     setSummary(
       s.data && typeof s.data === "object" && !Array.isArray(s.data) ? s.data : EMPTY_SUMMARY,
     );
-    setQuotes(q.data);
+    // Guarda de FORMA (issue #252): `quotes.map`/`.length` rodam direto no render, sem checar o
+    // payload. `Array.isArray`, no molde de `CrmPage.tsx` (#225).
+    setQuotes(Array.isArray(q.data) ? q.data : []);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -962,3 +962,79 @@ describe("PagarPage — página de contas fora de forma não derruba a lista (#2
     expect(await screen.findByText("Aluguel")).toBeInTheDocument();
   });
 });
+
+// ── chartAccounts/costCenters/inbox fora de forma (issue #252) ───────────────────────────
+//
+// `setChartAccounts(ca.data)`/`setCostCenters(cc.data)` alimentam `FiltrosDaLista` (`.map` direto,
+// sem `Array.isArray`), e `setInbox(pend.data)` alimenta o aviso da bandeja (`.length`/`[0].id`).
+// Um payload fora de forma faria `.map is not a function` (ou `.length` num objeto/string sem
+// sentido) estourar em qualquer um dos três.
+describe("PagarPage — filtros e bandeja fora de forma não derrubam a tela (#252)", () => {
+  it("chartAccounts/costCenters fora de forma → os filtros seguem montados, sem estourar", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [], total: 0 } } as never);
+      if (url === "/chart-of-accounts")
+        return Promise.resolve({ data: { detail: "erro" } } as never);
+      if (url === "/cost-centers") return Promise.resolve({ data: "não é json" } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    // `mockClear()` + `waitFor` na chamada real: sem isto o teste passaria mesmo com a guarda
+    // removida, porque nunca esperaria o debounce de 300ms (linha ~185) o bastante para o commit
+    // de `setChartAccounts`/`setCostCenters` realmente acontecer — a mesma falsa confiança que o
+    // docstring de `assentar.ts` descreve (medido: sem isto este mutante SOBREVIVE).
+    vi.mocked(api.get).mockClear();
+    renderPage();
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/chart-of-accounts"));
+    await assentar();
+
+    expect(screen.getByText("Todas as categorias")).toBeInTheDocument();
+    expect(screen.getByText("Todos os centros")).toBeInTheDocument();
+  });
+
+  it("inbox (comprovantes) fora de forma → sem aviso, sem estourar", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [], total: 0 } } as never);
+      // ⚠️ Um OBJETO (`{ detail: ... }`) não serve aqui: `inbox.length` sobre ele é `undefined`,
+      // `undefined > 0` é falso, e o aviso já nasce escondido pelo PRÓPRIO `inbox.length > 0` —
+      // o mutante (payload cru) sobrevive porque nunca chega a executar `inbox[0].id`. `null` é
+      // o payload que de fato força a leitura: `null.length` estoura sem a guarda.
+      if (url === "/payables/receipts") return Promise.resolve({ data: null } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    // Mesma razão do teste acima: espera a chamada real antes de assentar.
+    vi.mocked(api.get).mockClear();
+    renderPage();
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/payables/receipts"));
+    await assentar();
+
+    expect(screen.getByRole("button", { name: "Nova conta" })).toBeInTheDocument();
+    expect(screen.queryByText(/aguardando/i)).toBeNull();
+  });
+
+  it("contra-teste: categorias/centros/bandeja de verdade continuam aparecendo", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/payables/summary") return Promise.resolve({ data: emptySummary } as never);
+      if (url === "/payables/bills")
+        return Promise.resolve({ data: { items: [], total: 0 } } as never);
+      if (url === "/chart-of-accounts")
+        return Promise.resolve({ data: [{ id: "ca-1", categoria: "Estrutura" }] } as never);
+      if (url === "/cost-centers")
+        return Promise.resolve({ data: [{ id: "cc-1", name: "Sócio A" }] } as never);
+      if (url === "/payables/receipts")
+        return Promise.resolve({
+          data: [{ id: "r-1", filename: "a.pdf", content_type: "application/pdf", size: 1, created_at: "2026-07-28T10:00:00Z" }],
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Estrutura")).toBeInTheDocument();
+    expect(screen.getByText("Sócio A")).toBeInTheDocument();
+    expect(screen.getByText(/1 comprovante aguardando/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -168,13 +168,15 @@ export default function PagarPage() {
       api.get<ChartAccount[]>("/chart-of-accounts").catch(() => ({ data: [] as ChartAccount[] })),
       api.get<CostCenter[]>("/cost-centers").catch(() => ({ data: [] as CostCenter[] })),
     ]);
-    setChartAccounts(ca.data);
-    setCostCenters(cc.data);
+    // Guarda de FORMA (issue #252): as três alimentam `.map`/`.length` (rótulos + bandeja de
+    // comprovantes) sem checar o payload.
+    setChartAccounts(Array.isArray(ca.data) ? ca.data : []);
+    setCostCenters(Array.isArray(cc.data) ? cc.data : []);
     // .catch: a bandeja é um extra da tela; se falhar, Contas a Pagar continua funcionando.
     const pend = await api
       .get<{ id: string }[]>("/payables/receipts")
       .catch(() => ({ data: [] as { id: string }[] }));
-    setInbox(pend.data);
+    setInbox(Array.isArray(pend.data) ? pend.data : []);
   }, [filtro]);
 
   useEffect(() => {

--- a/apps/web/src/features/produtos/ProdutosPage.test.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
+import { assentar } from "../../test/assentar";
 import ProdutosPage from "./ProdutosPage";
 
 // Story 7.16 — Task 2. Rede sempre mockada (IV2): nenhum teste bate em /products real.
@@ -125,5 +126,84 @@ describe("ProdutosPage — separador de milhar (#224)", () => {
       "/products/coupons",
       expect.objectContaining({ discount_value: 123456 }),
     );
+  });
+});
+
+// ── `GET /products`, `/products/coupons`, `/products/enrollments` fora de forma (issue #252) ──
+//
+// `setProducts(p.data)`/`setCoupons(c.data)`/`setAlunos(e.data)` recebiam o payload CRU. Cada
+// uma alimenta `.map`/`.length` direto no render da aba correspondente (grade de produtos,
+// tabela de cupons, tabela de compradores), sem `Array.isArray` — um payload fora de forma
+// faria `.map is not a function` estourar em qualquer uma das três abas.
+describe("ProdutosPage — as três listas fora de forma não derrubam a tela (#252)", () => {
+  it("products fora de forma → a aba Produtos mostra o estado vazio", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/products") return Promise.resolve({ data: { detail: "algo deu errado" } } as never);
+      if (url === "/products/coupons") return Promise.resolve({ data: [] } as never);
+      if (url === "/products/enrollments") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(screen.getByRole("heading", { name: "Produtos" })).toBeInTheDocument();
+    expect(await screen.findByText("Nenhum produto ainda.")).toBeInTheDocument();
+  });
+
+  it("coupons fora de forma → a aba Cupons mostra o estado vazio", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/products") return Promise.resolve({ data: [] } as never);
+      if (url === "/products/coupons") return Promise.resolve({ data: "não é json" } as never);
+      if (url === "/products/enrollments") return Promise.resolve({ data: [] } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: "Cupons" }));
+    await assentar();
+
+    expect(await screen.findByText("Nenhum cupom.")).toBeInTheDocument();
+  });
+
+  it("alunos (compradores) fora de forma → a aba Compradores mostra o estado vazio", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/products") return Promise.resolve({ data: [] } as never);
+      if (url === "/products/coupons") return Promise.resolve({ data: [] } as never);
+      if (url === "/products/enrollments") return Promise.resolve({ data: null } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: "Compradores" }));
+    await assentar();
+
+    expect(await screen.findByText("Nenhum comprador ainda.")).toBeInTheDocument();
+  });
+
+  it("contra-teste: produto/cupom/comprador de verdade continuam aparecendo", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/products")
+        return Promise.resolve({
+          data: [{ id: "p-1", name: "Curso de React", kind: "digital", price_cents: 19700, active: true, students: 3, checkout_url: "https://x" }],
+        } as never);
+      if (url === "/products/coupons")
+        return Promise.resolve({
+          data: [{ id: "c-1", code: "PROMO10", discount_type: "percent", discount_value: 10, uses: 2, max_uses: null, active: true }],
+        } as never);
+      if (url === "/products/enrollments")
+        return Promise.resolve({
+          data: [{ id: "e-1", name: "Maria", email: "maria@x.com", product_name: "Curso de React", amount_cents: 19700, status: "active" }],
+        } as never);
+      return Promise.resolve({ data: [] } as never);
+    });
+    renderPage();
+    await assentar();
+
+    expect(await screen.findByText("Curso de React")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Cupons" }));
+    expect(await screen.findByText("PROMO10")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Compradores" }));
+    expect(await screen.findByText("Maria")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/produtos/ProdutosPage.tsx
+++ b/apps/web/src/features/produtos/ProdutosPage.tsx
@@ -36,9 +36,12 @@ export default function ProdutosPage() {
       api.get<Coupon[]>("/products/coupons"),
       api.get<Enrollment[]>("/products/enrollments"),
     ]);
-    setProducts(p.data);
-    setCoupons(c.data);
-    setAlunos(e.data);
+    // Guarda de FORMA (issue #252): as três alimentam `.map`/`.length` direto no render (grade de
+    // produtos, tabela de cupons, tabela de compradores) sem checar o payload. `Array.isArray`,
+    // no molde de `CrmPage.tsx` (#225).
+    setProducts(Array.isArray(p.data) ? p.data : []);
+    setCoupons(Array.isArray(c.data) ? c.data : []);
+    setAlunos(Array.isArray(e.data) ? e.data : []);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## O que é

4ª rodada da série "payload cru no setter" (#161→#176, #179→#197, #207→#216, #225→#248, #247→#253). O #247 tratou a fatia NÃO-array. Esta PR trata a fatia ARRAY: sites em que `setX(resposta.data)` alimenta um estado consumido direto como array (`.map`/`.length`/spread), sem `Array.isArray`.

Medição própria (não a contagem da issue): `grep -rn "set[A-Z]\w*([a-zA-Z0-9_]\+\.data)" apps/web/src --include=*.tsx`, cada resultado lido e classificado por consumo. O grep bruto deu 29 linhas — uma é comentário (`ConversasPage.tsx:273`, cita `setTimeline(tl.data)` como exemplo de outra issue, não é código) e duas já eram fora de escopo (ver abaixo). Sobraram **26 sites**, mesma contagem da issue.

## 26 sites consertados, cada um com teste + prova de mutação real

| Arquivo | Setter(s) |
|---|---|
| `CobrancasPage.tsx:87,97-99` | `setCharges`, `setChartAccounts`, `setCostCenters`, `setBankAccounts` |
| `ContratosPage.tsx:34` | `setContracts` |
| `ClientDetailPage.tsx:93-97` | `setCharges`, `setContracts`, `setQuotes`, `setLegalDocs`, `setJourneys` |
| `EstoquePage.tsx:29` | `setItems` |
| `CentrosCustoPage.tsx:51` | `setCenters` |
| `ContasSaldosPage.tsx:564-565` (`AccountDetail`) | `setTxs`, `setCheckpoints` |
| `FinanceiroPage.tsx:67,81-84` | `setTxs`, `setChartAccounts`, `setCostCenters`, `setPayouts`, `setContas` |
| `OrcamentosPage.tsx:38` | `setQuotes` |
| `PagarPage.tsx:171-172,177` | `setChartAccounts`, `setCostCenters`, `setInbox` |
| `ProdutosPage.tsx:39-41` | `setProducts`, `setCoupons`, `setAlunos` |

Guarda aplicada: `Array.isArray(x) ? x : []`, mesmo molde do #225/#247.

3 sites confirmados fora de escopo (objeto escalar ou objeto único, não array):
- `AccountModal.tsx:165` (`setPagasAntes`) — todo consumo é opcional/com fallback.
- `ContratoDrePage.tsx:52` (`setContract`) — objeto único, `.title` com fallback.
- `AdminDashboard.tsx:134` (`setE`) — objeto único, todo acesso via `?.`/`??`.

1 dívida vizinha, citada na issue, **não tocada aqui** por ser outro tipo de bug: `InvestimentosPage.tsx:52` (`contasDeAplicacao(bancarias)`) — falta `try/catch`, não falta `Array.isArray`.

## Verificação independente

- `git rev-parse --show-toplevel` / `git branch --show-current` conferidos antes de aceitar os 10 commits.
- `pnpm lint` e `pnpm typecheck` rodados por mim — limpos.
- `pnpm test` (suíte inteira) rodado por mim — **95 arquivos / 1215 testes, todos verdes**.
- Refiz a mutação em `PagarPage.tsx:179` (`setInbox`) eu mesmo: removi a guarda, o teste "inbox fora de forma" morreu com `TypeError: Cannot read properties of null (reading 'length')` — mesma mensagem do relatório. Restaurado por cópia de arquivo.
- Confirmei que os 4 arquivos fora de escopo (`AccountModal.tsx`, `ContratoDrePage.tsx`, `AdminDashboard.tsx`, `InvestimentosPage.tsx`) não aparecem no diff.

## Gates

- `pnpm lint` / `pnpm typecheck` — limpos
- `pnpm test` — 95 arquivos / 1215 testes passed

Closes #252
