### PR TITLE
fix: campos tocáveis (44px) em /contratos/novo (#249)

### DIFF
--- a/apps/web/e2e/contratos-novo-360.spec.ts
+++ b/apps/web/e2e/contratos-novo-360.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { camposBaixos, medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+
+/**
+ * `/contratos/novo` — a fatia da issue #249 que o dono do produto decidiu fechar agora.
+ *
+ * A issue #249 original listava 4 telas densas sem decisão de produto: `/marketing/m1` (30
+ * campos), `/sites/s1` (15), `/marketing/novo` (12), `/contratos/novo` (4). O dono escolheu só
+ * esta — é o caso mais próximo do já fechado `/orcamentos/novo` (#227): o `<input>`/`<select>` do
+ * TÍTULO e do CLIENTE em `ContractBuilderPage.tsx` usa a MESMA classe do `Field` de
+ * `components/Modal.tsx` (`px-3 py-2 text-sm`, 38px medidos), só que fora de modal. As outras 3
+ * telas ficam de fora — decisão de produto pendente, não procrastinação.
+ *
+ * `main` é o escopo (`AppShell.tsx:65`, `overflow-x-hidden p-6`): a tela não usa
+ * `components/Modal.tsx`, é conteúdo de página inteira.
+ */
+async function contarCampos(page: import("@playwright/test").Page, raiz: string): Promise<number> {
+  const naoDigitaveis =
+    '[type="hidden"],[type="checkbox"],[type="radio"],[type="file"],[type="color"],[type="range"]';
+  return page.locator(`${raiz} input:not(${naoDigitaveis}), ${raiz} select, ${raiz} textarea`).count();
+}
+
+test("os campos do CONTRATO (/contratos/novo) são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, {});
+  await page.goto("/contratos/novo");
+  // A tela não tem `heading`: a `marca` é o rótulo "Contratos" do link de voltar
+  // (`ContractBuilderPage.tsx:154`) — sem ele, "zero campos baixos" poderia significar "não montou".
+  await expect(page.getByText("Contratos").first()).toBeVisible();
+
+  // Título + cliente + template ("Usar template..." só existe em modo novo) + 1 cláusula
+  // (título + texto) — os campos que a issue #227 mediu em 4, fora de modal.
+  expect(await contarCampos(page, "main"), "contrato: campos de digitação").toBeGreaterThanOrEqual(4);
+  expect(await camposBaixos(page, "main"), "contrato — campos abaixo de 44px").toEqual([]);
+
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});

--- a/apps/web/src/features/contratos/ContractBuilderPage.tsx
+++ b/apps/web/src/features/contratos/ContractBuilderPage.tsx
@@ -186,7 +186,13 @@ export default function ContractBuilderPage() {
 
       <div className="grid flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-2">
         {/* Editor */}
-        <div className={`flex flex-col gap-3 overflow-auto rounded-2xl bg-white p-4 shadow-sm ${readonly ? "pointer-events-none opacity-60" : ""}`}>
+        {/* `campos-tocaveis` (issue #249, fatia de /contratos/novo): título, cliente/template e
+            título da cláusula usam a MESMA classe do `Field` de `components/Modal.tsx`
+            (`px-3 py-2 text-sm`) ou a variante `px-2 py-1.5 text-sm` — 34-39px medidos, fora de
+            modal. Mesma inconsistência de estilo que a classe já fecha em 17 telas (issue #227,
+            `/orcamentos/novo`), não densidade de UI nova. O container único cobre título, cliente,
+            template, variáveis e cláusulas — todo o formulário do editor. */}
+        <div className={`campos-tocaveis flex flex-col gap-3 overflow-auto rounded-2xl bg-white p-4 shadow-sm ${readonly ? "pointer-events-none opacity-60" : ""}`}>
           <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Título do contrato" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm font-medium outline-none focus:border-primary-400" />
 
           <div className="flex gap-2">


### PR DESCRIPTION
## O que é

Fatia da #249 (que por sua vez retoma as 4 telas densas deixadas de fora do #227/#215, já que o #215 fechou só `/orcamentos/novo`). As outras 3 telas (`/marketing/m1` 30 campos, `/sites/s1` 15, `/marketing/novo` 12) seguem **sem decisão de produto** e não entram aqui — decisão explícita do dono do produto nesta rodada: consertar só `/contratos/novo`, por ser o caso mais próximo do já aprovado `/orcamentos/novo` (mesma classe do `Field`, 38px, fora de modal).

## O que mudou

- `ContractBuilderPage.tsx` (rota `/contratos/novo`): aplicada a classe `.campos-tocaveis` (já existente em `styles/index.css`) nos 4 campos medidos abaixo de 44px — mesmo número histórico do #227 (título do contrato 38px, cliente 39px, template 39px, título da cláusula 34px). Sem drift de refactor desde a medição original.
- `e2e/contratos-novo-360.spec.ts` (novo): régua a 360×740 com `boundingBox()`, no molde de `campo-modal-360.spec.ts`.

## Régua

Antes do conserto (vermelho): 4 campos reprovando (38/39/39/34px).
Depois do conserto (verde): `207 passed`.

## Prova por mutação

Mutei `min-height: 2.75rem` (44px) → `2.6875rem` (43px) na classe `.campos-tocaveis` compartilhada. Como a classe é global, a mutação também derrubou 17 testes de OUTRAS telas que já usam `.campos-tocaveis` (não é regressão desta PR — é a mesma classe compartilhada sendo sensível ao pixel em toda a base). O teste novo (`contratos-novo-360.spec.ts`) morreu como esperado, distinguindo 44px (passa) de 43px (reprova). Revertido por cópia de arquivo.

## Verificação independente

- `git rev-parse --show-toplevel` / `git branch --show-current` conferidos antes do commit.
- `pnpm lint` e `pnpm typecheck` rodados por mim — limpos.
- `E2E_PORT` exclusivo desta worktree usado no e2e — `207 passed`, batendo com o relatório.
- Refiz a mutação 44→43 eu mesmo (arquivo CSS inteiro, não só o teste) — confirmei que o teste novo reprova e que o valor restaurado deixa a árvore limpa (`git status` vazio).
- Confirmei que nenhum arquivo de `features/marketing` ou `features/sites` está no diff.

## Fora desta PR

`/marketing/m1`, `/sites/s1`, `/marketing/novo` — decisão de produto pendente, ficam na #249 original até haver decisão tela por tela.

Refs #249 (fatia `/contratos/novo` apenas — a issue continua aberta: `/marketing/m1`, `/sites/s1` e `/marketing/novo` seguem sem decisão de produto)
