### PR TITLE
fix: campos tocáveis (44px) em /marketing (m1+novo) e /sites/s1 (#249)

### DIFF
--- a/apps/web/e2e/marketing-carrossel-360.spec.ts
+++ b/apps/web/e2e/marketing-carrossel-360.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { camposBaixos, medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+import { CARROSSEL } from "./support/rotas";
+
+/**
+ * `/marketing/m1` e `/marketing/novo` — a fatia da issue #249 do CARROSSEL. As duas rotas
+ * renderizam o MESMO componente (`CarrosselBuilderPage.tsx`): `/marketing/:id` hidrata via
+ * `hydrate()` a partir de `GET /marketing/carousels/:id`; `/marketing/novo` nasce com
+ * `slides: []`. Um único fix no arquivo cobre as duas.
+ *
+ * `main` é o escopo (`AppShell.tsx:65`, `overflow-x-hidden p-6`): página inteira, sem
+ * `components/Modal.tsx`.
+ *
+ * ⚠️ **Os números medidos aqui DIVERGEM dos números pré-calculados na issue.** A pesquisa prévia
+ * (baseada no catálogo de `#227`) previa 30 campos ABAIXO de 44px em `/marketing/m1`. Medido ao
+ * vivo, ANTES do fix, contra este `main`: **26**, não 30. A diferença de 4 é real e explicada:
+ * `topic` e `caption` (`<textarea rows={2}>`/`rows={3}`) e os campos `secondary` dos slides
+ * `editorial`/`accent` (também `<textarea rows={2}>`) já nascem com >=44px de altura por terem
+ * DUAS OU MAIS LINHAS — só o `<textarea>` de UMA linha equivalente (`rows=1` de fato, ou os
+ * `<input>`/`<select>`) fica abaixo do alvo. `30` continua correto como CONTAGEM TOTAL de campos
+ * de digitação (a régua `contarCampos` abaixo, que não filtra por altura) — é esse o número que a
+ * issue original media, não "abaixo de 44px". Mesmo raciocínio para `/marketing/novo`: total
+ * medido = 10 (a issue previa 12 — 2 a menos, mesma causa: sem slides, restam só os 10 campos
+ * fixos), campos abaixo de 44px = 8 (`topic`/`caption` já tocáveis).
+ */
+async function contarCampos(page: import("@playwright/test").Page, raiz: string): Promise<number> {
+  const naoDigitaveis =
+    '[type="hidden"],[type="checkbox"],[type="radio"],[type="file"],[type="color"],[type="range"]';
+  return page.locator(`${raiz} input:not(${naoDigitaveis}), ${raiz} select, ${raiz} textarea`).count();
+}
+
+test("os campos do CARROSSEL salvo (/marketing/m1) são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/marketing/carousels/templates": [], "/marketing/carousels": CARROSSEL });
+  await page.goto("/marketing/m1");
+  // A `marca`: o rótulo da prévia só existe depois de `hydrate()` ter rodado — sem ele, "zero
+  // campos baixos" poderia significar "a rota nunca hidratou".
+  await expect(page.getByText("Pré-visualização (Instagram 4:5) — baixe em PNG").first()).toBeVisible();
+
+  // 10 campos fixos (tema, perfil, nº de slides, 4 cores, fonte, legenda, hashtags) + 5 por slide
+  // (tipo, título, secundário/subtítulo, destaque, foto) × 4 slides do mock — a CONTAGEM TOTAL
+  // que a issue #227 media em 30, confirmada ao vivo.
+  expect(await contarCampos(page, "main"), "carrossel m1: total de campos de digitação").toBeGreaterThanOrEqual(30);
+  expect(await camposBaixos(page, "main"), "carrossel m1 — campos abaixo de 44px").toEqual([]);
+
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});
+
+test("os campos do CARROSSEL novo (/marketing/novo) são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/marketing/carousels/templates": [] });
+  await page.goto("/marketing/novo");
+  // Sem `id`, a tela nasce com `slides: []` — a `marca` é o rótulo do bloco "Gerar com IA", que
+  // não depende de nenhum GET além de `/marketing/carousels/templates` (mockado vazio).
+  await expect(page.getByText("Tema do carrossel").first()).toBeVisible();
+
+  // Só os 10 campos fixos — nasce sem slide algum. Medido ao vivo: 10 (a issue #227 previa 12).
+  expect(await contarCampos(page, "main"), "carrossel novo: total de campos de digitação").toBeGreaterThanOrEqual(10);
+  expect(await camposBaixos(page, "main"), "carrossel novo — campos abaixo de 44px").toEqual([]);
+
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});

--- a/apps/web/e2e/sites-pagebuilder-360.spec.ts
+++ b/apps/web/e2e/sites-pagebuilder-360.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { mockarApi } from "./support/api";
+import { camposBaixos, medirPagina } from "./support/medidas";
+import { semearSessao } from "./support/sessao";
+import { PAGINA } from "./support/rotas";
+
+/**
+ * `/sites/s1` — a fatia da issue #249 do CONSTRUTOR DE PÁGINAS. Dois arquivos, não um:
+ * `PageBuilderPage.tsx` (editor + barra de ações) e `PageBlocks.tsx` (compartilhado, renderiza o
+ * `LeadForm` de verdade — inputs reais, não preview estático — tanto na prévia dentro do editor
+ * quanto na página pública `/p/:slug`, `PublicPage.tsx`, FORA do escopo desta issue).
+ *
+ * ⚠️ **`PublicPage.tsx`/`/p/:slug` herda esta correção automaticamente**, por usar o MESMO
+ * `PageBlocks.tsx`. Não é escopo desta issue, mas é efeito colateral esperado e correto — o
+ * `LeadForm` é literalmente o mesmo componente nos dois lugares, e não há como corrigir um sem
+ * corrigir o outro.
+ *
+ * `main` é o escopo (`AppShell.tsx:65`, `overflow-x-hidden p-6`): página inteira, sem
+ * `components/Modal.tsx`. O mock `PAGINA` do catálogo (`e2e/support/rotas.ts:43-55`) já inclui um
+ * bloco `form` com `extraFields: []` — é o que faz o `LeadForm` de fato renderizar na prévia.
+ *
+ * ⚠️ **Os números medidos aqui DIVERGEM dos pré-calculados na issue #227 (15).** Medido ao vivo:
+ * TOTAL de campos de digitação = 13 (10 no editor: título da barra de ações, fonte, URL do logo,
+ * título/texto do bloco heading/text, label/URL do botão, texto do botão/ajuda do
+ * WhatsApp/aviso do formulário; + 3 na prévia: nome/WhatsApp/e-mail do `LeadForm`) — 2 a menos que
+ * os 15 da issue, mesma classe de causa das outras fatias (algum campo saiu do fluxo desde a
+ * medição original). Campos ABAIXO de 44px, antes do fix: **10**, não 13 nem 15 — os `<textarea
+ * rows={2}>`/`rows={3}` de heading/text/aviso do formulário já nascem com altura suficiente por
+ * terem várias linhas; só sobra abaixo do alvo o que é de fato uma linha (inputs, selects, e o
+ * `LeadForm` inteiro, que não tem textarea nenhum).
+ */
+async function contarCampos(page: import("@playwright/test").Page, raiz: string): Promise<number> {
+  const naoDigitaveis =
+    '[type="hidden"],[type="checkbox"],[type="radio"],[type="file"],[type="color"],[type="range"]';
+  return page.locator(`${raiz} input:not(${naoDigitaveis}), ${raiz} select, ${raiz} textarea`).count();
+}
+
+test("os campos do CONSTRUTOR DE PÁGINAS (/sites/s1), editor E prévia com LeadForm, são tocáveis com o polegar", async ({ page }) => {
+  await semearSessao(page);
+  await mockarApi(page, { "/pages": PAGINA });
+  await page.goto("/sites/s1");
+  // A `marca`: o rótulo da prévia só existe depois do `GET /pages/s1` ter resolvido — sem ele,
+  // "zero campos baixos" poderia significar "a tela ficou em 'Carregando...'".
+  await expect(page.getByText("Pré-visualização").first()).toBeVisible();
+  // O LeadForm só renderiza depois que o bloco `form` do mock monta — confirmamos que ele está
+  // de fato na prévia (não só no editor) antes de medir.
+  await expect(page.getByText("Seu WhatsApp").first()).toBeVisible();
+
+  expect(await contarCampos(page, "main"), "sites s1: total de campos de digitação").toBeGreaterThanOrEqual(13);
+  expect(await camposBaixos(page, "main"), "sites s1 — campos abaixo de 44px (editor + prévia/LeadForm)").toEqual([]);
+
+  expect((await medirPagina(page)).larguraDaPagina).toBe(360);
+});

--- a/apps/web/e2e/support/rotas.ts
+++ b/apps/web/e2e/support/rotas.ts
@@ -40,7 +40,7 @@ export const DRE_MATRIX = {
   notes: [],
 };
 
-const PAGINA = {
+export const PAGINA = {
   id: "s1", tenant_id: "t1", title: LONGO, model: "captura", status: "draft",
   public_slug: null, created_at: "2026-01-01T10:00:00Z",
   primary_color: "#123456", bg_color: "#ffffff", text_color: "#111111",
@@ -59,7 +59,7 @@ const slide = (kind: string) => ({
   highlight: "Diagnostico", photo_url: "", photo_position: "mid",
 });
 
-const CARROSSEL = {
+export const CARROSSEL = {
   id: "m1", tenant_id: "t1", topic: LONGO, platform: "instagram",
   slides: [slide("cover"), slide("editorial"), slide("accent"), slide("cta")],
   status: "draft", handle: `@${LONGO}`, caption: LONGO, hashtags: `#${LONGO}`,

--- a/apps/web/src/features/marketing/CarrosselBuilderPage.tsx
+++ b/apps/web/src/features/marketing/CarrosselBuilderPage.tsx
@@ -172,7 +172,12 @@ export default function CarrosselBuilderPage() {
 
       <div className="grid flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-2">
         {/* Editor */}
-        <div className="flex flex-col gap-4 overflow-auto rounded-2xl bg-white p-4 shadow-sm">
+        {/* `campos-tocaveis` (issue #249, fatia de /marketing/m1 e /marketing/novo): tema, perfil,
+            nº de slides, cores, fonte e todos os campos de cada slide usam `px-2/3 py-1.5/2 text-sm`
+            ou `text-xs` — 27-38px medidos, o mesmo padrão de editor denso já fechado em
+            `/orcamentos/novo` e `/contratos/novo`. O container único cobre o editor inteiro; a
+            prévia (`CarouselViewer`) não tem campo de digitação. */}
+        <div className="campos-tocaveis flex flex-col gap-4 overflow-auto rounded-2xl bg-white p-4 shadow-sm">
           {/* Gerar com IA */}
           <div className="rounded-xl bg-primary-50 p-3">
             <label className="mb-1 block text-xs font-medium text-primary-700">Tema do carrossel</label>

--- a/apps/web/src/features/sites/PageBlocks.tsx
+++ b/apps/web/src/features/sites/PageBlocks.tsx
@@ -27,8 +27,13 @@ export default function PageBlocks({
   onLead?: (lead: LeadPayload) => Promise<void>;
 }) {
   return (
+    // `campos-tocaveis` (issue #249, fatia de /sites/s1): o `LeadForm` do bloco `form` usa
+    // `inp = "...px-3 py-2.5 text-sm..."` (≈42px medidos), abaixo do alvo. Este componente é
+    // compartilhado com `PublicPage.tsx` (`/p/:slug`, fora do escopo desta issue): a prévia
+    // dentro do editor (`/sites/s1`) e a página pública herdam a correção juntas, de propósito —
+    // o `LeadForm` é o MESMO componente nos dois lugares.
     <div
-      className="mx-auto max-w-xl space-y-5 px-6 py-10"
+      className="campos-tocaveis mx-auto max-w-xl space-y-5 px-6 py-10"
       style={{ background: style.bg_color, color: style.text_color, fontFamily: style.font }}
     >
       {safeSrc(style.logo_url) && (

--- a/apps/web/src/features/sites/PageBuilderPage.tsx
+++ b/apps/web/src/features/sites/PageBuilderPage.tsx
@@ -130,7 +130,10 @@ export default function PageBuilderPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      {/* `campos-tocaveis` (issue #249, fatia de /sites/s1): o título da página vive fora do grid do
+          editor (é da barra de ações), com a mesma classe densa `px-3 py-1.5 text-sm` — 34px
+          medidos. Isolado aqui porque o resto da barra é só botão. */}
+      <div className="campos-tocaveis mb-3 flex flex-wrap items-center justify-between gap-2">
         <button onClick={() => navigate("/sites")} className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700">
           <ArrowLeft size={16} /> Sites
         </button>
@@ -161,7 +164,11 @@ export default function PageBuilderPage() {
 
       <div className="grid flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-2">
         {/* Editor */}
-        <div className="flex flex-col gap-3 overflow-auto rounded-2xl bg-white p-4 shadow-sm">
+        {/* `campos-tocaveis` (issue #249, fatia de /sites/s1): aparência (fonte, URL do logo) e
+            todos os campos de cada bloco (`BlockFields`/`FormBlockFields`) usam `px-2 py-1.5
+            text-sm` — 34-38px medidos. O container único cobre o editor inteiro, incluindo os
+            blocos dinâmicos; a prévia usa a mesma classe já aplicada em `PageBlocks.tsx`. */}
+        <div className="campos-tocaveis flex flex-col gap-3 overflow-auto rounded-2xl bg-white p-4 shadow-sm">
           {/* Aparência */}
           <div className="grid grid-cols-2 gap-2 rounded-xl bg-neutral-50 p-3">
             {([


### PR DESCRIPTION
## O que é

Fecha as 3 telas que ficaram sem decisão na #249 depois do #256 (`/contratos/novo`). Decisão do dono do produto nesta rodada: consertar as 3 (`/marketing/m1`, `/marketing/novo`, `/sites/s1`) — as 4 telas densas originais do #227/#215 ficam todas fechadas depois desta PR.

## O que mudou

- `CarrosselBuilderPage.tsx` (rotas `/marketing/m1` e `/marketing/novo` — MESMO componente, `hydrate()` distingue as duas): aplicada `.campos-tocaveis` no container único do editor.
- `PageBuilderPage.tsx` (rota `/sites/s1`): aplicada `.campos-tocaveis` em dois containers — a barra de ações (título da página) e o grid do editor (aparência + blocos dinâmicos).
- `PageBlocks.tsx` (compartilhado por `PageBuilderPage.tsx` e por `PublicPage.tsx`/`/p/:slug`, fora do escopo desta issue): aplicada `.campos-tocaveis` no container do `LeadForm`. **Efeito colateral esperado e correto**: a página pública `/p/:slug` herda a correção porque é literalmente o mesmo componente — não há como corrigir a prévia do editor sem corrigir a página pública junto.
- `e2e/marketing-carrossel-360.spec.ts` e `e2e/sites-pagebuilder-360.spec.ts` (novos): régua a 360×740 com `boundingBox()`, no molde de `campo-modal-360.spec.ts`/`contratos-novo-360.spec.ts`.
- `e2e/support/rotas.ts`: exporta `PAGINA`/`CARROSSEL` (já existiam, eram privados ao arquivo) para reuso nos specs novos.

## Contagem medida (não copiada da issue)

A issue #227 previa 30/12/15 campos "abaixo de 44px". Medindo ao vivo com Playwright, os números batem só parcialmente:

| Rota | Total de campos de digitação | Abaixo de 44px (pré-fix) | Issue #227 previa |
|---|---|---|---|
| `/marketing/m1` | 30 (bate exato) | 26 | "30 abaixo de 44px" |
| `/marketing/novo` | 10 | 8 | "12" |
| `/sites/s1` | 13 | 10 | "15" |

A divergência tem uma causa única e verificável: `<textarea rows={2}>`/`rows={3}` (tema/legenda do carrossel, secundário de slide, heading/text/aviso do formulário) já nascem com altura ≥44px por terem 2+ linhas — só o equivalente de uma linha (inputs, selects, textarea de 1 linha) fica abaixo do alvo. A issue original media o TOTAL de campos, não "abaixo de 44px" — os números totais (30/10/13) batem ou ficam a poucas unidades de distância explicada por drift de código desde a medição de #227.

## Régua

Antes do fix (vermelho): 26 + 8 + 10 = 44 campos reprovando nas duas telas.
Depois do fix (verde): `210 passed` — suíte e2e inteira, incluindo os 2 testes novos.

## Prova por mutação

Mutei `min-height: 2.75rem` (44px) → `2.6875rem` (43px) em `.campos-tocaveis` (styles/index.css, classe compartilhada). Os 2 testes novos morreram, com `altura: 43` medido em cada campo. Por ser classe global, a mutação também derrubou 19 testes de outras telas que já usam `.campos-tocaveis` (`campo-modal-360.spec.ts`, 17 telas; `contratos-novo-360.spec.ts`, 1 teste — não é regressão desta PR, é a mesma classe compartilhada sendo sensível ao pixel em toda a base). Total sob mutação: 21 failed / 189 passed, contra 210/210 sem ela. Revertido por cópia de arquivo.

## Verificação independente

- `issue-wt check 249`: toplevel confinado à worktree, branch certa, `origin/main` contida, árvore limpa.
- `issue-wt gates 249` rodado à mão: lint limpo, typecheck limpo, `1217 passed` (testes unitários), `210 passed` (e2e) — bate com o relatório do implementador.
- Refiz a mutação 44→43 eu mesmo (arquivo CSS inteiro, cópia de segurança antes) e rodei `marketing-carrossel-360.spec.ts` contra a mutação: os 2 testes morreram com a mensagem real de asserção (`altura: 43` em cada campo). Restaurei por cópia de arquivo — `git status` ficou vazio.
- `git diff --name-only origin/main..HEAD`: exatamente os 6 arquivos listados acima, nada de `/contratos/novo` (já mergeado no #256) ou de outra área do repo.

## Fora desta PR

Nenhuma — as 4 telas densas originais do #227/#215 ficam todas fechadas entre esta PR e o #256. A #249 pode ser fechada depois do merge.

Refs #249
