### PR TITLE
feat: permite iniciar conversa de WhatsApp no transporte Evolution

### DIFF
--- a/apps/api/app/modules/whatsapp_inbox/router.py
+++ b/apps/api/app/modules/whatsapp_inbox/router.py
@@ -12,7 +12,11 @@ from app.core import whatsapp
 from app.core.tenancy import CurrentUser, get_tenant_db, require_module
 from app.db.session import get_db, get_tenant_session_factory
 from app.modules.whatsapp_inbox import service
-from app.modules.whatsapp_inbox.schemas import SendTemplateRequest, SendTextRequest
+from app.modules.whatsapp_inbox.schemas import (
+    SendTemplateRequest,
+    SendTextRequest,
+    StartConversationRequest,
+)
 from app.modules.whatsapp_session import service as whatsapp_session_service
 from app.modules.whatsapp_templates import service as whatsapp_templates_service
 
@@ -240,6 +244,21 @@ def _msg_out(msg) -> dict:
         "id": msg.id, "direction": msg.direction, "kind": msg.kind,
         "text_body": msg.text_body, "status": msg.status, "created_at": msg.created_at,
     }
+
+
+@router.post("/start")
+def start_conversation(
+    data: StartConversationRequest,
+    user: CurrentUser = Depends(_guard), db: Session = Depends(get_tenant_db),
+) -> dict:
+    try:
+        msg = service.start_conversation(
+            db, tenant_id=user.tenant_id, actor=user.user_id,
+            client_id=data.client_id, text=data.text,
+        )
+    except service.WhatsappInboxError as e:
+        raise _err(e) from e
+    return {**_msg_out(msg), "chat_id": msg.chat_id}
 
 
 @router.post("/{chat_id}/messages/text")

--- a/apps/api/app/modules/whatsapp_inbox/schemas.py
+++ b/apps/api/app/modules/whatsapp_inbox/schemas.py
@@ -38,6 +38,11 @@ class SendTextRequest(BaseModel):
     text: str
 
 
+class StartConversationRequest(BaseModel):
+    client_id: str
+    text: str
+
+
 class SendTemplateRequest(BaseModel):
     template_id: str
     variables: list[str] = []

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -28,6 +28,7 @@ from app.modules.notifications.models import Notification
 from app.modules.settings import service as settings_service
 from app.modules.vima import scheduler as vima_scheduler
 from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
     CHAT_KIND_GROUP,
     DIRECTION_IN,
     DIRECTION_OUT,
@@ -857,6 +858,46 @@ def _destination(db: Session, chat: WhatsappChat) -> str:
             "Responda pelo contato no CRM.", 422,
         )
     return chat.chat_jid
+
+
+def start_conversation(
+    db: Session, *, tenant_id: str, actor: str, client_id: str, text: str
+) -> WhatsappMessage:
+    """Abre a PRIMEIRA conversa com um cliente que nunca escreveu — sem chat prévio.
+
+    Só existe para o transporte Evolution: na Meta, abrir do zero exige template aprovado (a
+    janela de 24h nem entra em jogo, porque não há mensagem recebida nenhuma para contar a
+    partir dela). Ver app/core/whatsapp/capabilities.py e o `session_window` em
+    `is_within_session_window`."""
+    client = db.get(Client, client_id)
+    if client is None:
+        raise WhatsappInboxError("Cliente não encontrado", 404)
+    profile = settings_service.get_profile(db, tenant_id)
+    if whatsapp_capabilities.for_profile(profile).session_window:
+        raise WhatsappInboxError(
+            "Este WhatsApp exige contato prévio do cliente ou um template aprovado", 422
+        )
+    phone = normalize_br(client.phone)
+    if not phone:
+        raise WhatsappInboxError("Cliente sem telefone válido para WhatsApp", 422)
+
+    chat = _get_or_create_chat(
+        db, tenant_id=tenant_id, chat_jid=f"{phone}@s.whatsapp.net", kind=CHAT_KIND_DIRECT,
+        client=client, profile=profile,
+    )
+    status = whatsapp.send_text(to=phone, text=text, profile=profile)
+    msg = WhatsappMessage(
+        tenant_id=tenant_id, client_id=client.id, chat_id=chat.id,
+        direction=DIRECTION_OUT, kind=KIND_TEXT, text_body=text, status=status,
+    )
+    db.add(msg)
+    audit.record(
+        db, tenant_id=tenant_id, actor=actor, action="whatsapp_inbox.conversation.start",
+        target=chat.id,
+    )
+    db.commit()
+    db.refresh(msg)
+    return msg
 
 
 def send_reply_text(

--- a/apps/api/tests/test_whatsapp_inbox_reply.py
+++ b/apps/api/tests/test_whatsapp_inbox_reply.py
@@ -89,6 +89,40 @@ def test_reply_text_endpoint_success_within_window(client, db, monkeypatch, auth
     assert resp.json()["status"] == "sent"
 
 
+def test_start_conversation_endpoint_evolution_success(client, db, monkeypatch, auth):
+    headers, tenant_id = auth
+    profile = settings_service.get_profile(db, tenant_id)
+    profile.whatsapp_provider = "evolution"
+    db.commit()
+    c = Client(tenant_id=tenant_id, name="Cliente", phone="5511900000004", source="manual")
+    db.add(c)
+    db.commit()
+    monkeypatch.setattr(whatsapp, "send_text", lambda **_kw: "sent")
+    resp = client.post(
+        "/whatsapp-conversations/start",
+        json={"client_id": c.id, "text": "Oi! Bem-vindo."},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "sent"
+    assert body["chat_id"]
+
+
+def test_start_conversation_endpoint_rejects_meta(client, db, monkeypatch, auth):
+    headers, tenant_id = auth
+    _configure(db, tenant_id)
+    c = Client(tenant_id=tenant_id, name="Cliente", phone="5511900000005", source="manual")
+    db.add(c)
+    db.commit()
+    resp = client.post(
+        "/whatsapp-conversations/start",
+        json={"client_id": c.id, "text": "Oi!"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
 def test_reply_template_endpoint_success(client, db, monkeypatch, auth):
     headers, tenant_id = auth
     _configure(db, tenant_id)

--- a/apps/api/tests/test_whatsapp_inbox_service.py
+++ b/apps/api/tests/test_whatsapp_inbox_service.py
@@ -696,6 +696,61 @@ def test_send_reply_text_raises_outside_window(db):
         )
 
 
+def test_start_conversation_evolution_cria_chat_e_envia(db, monkeypatch: pytest.MonkeyPatch):
+    """Evolution não tem janela de 24h nem template — pode abrir conversa do zero (sem nenhuma
+    mensagem prévia do contato). Ver app/core/whatsapp/capabilities.py."""
+    profile = _configure_credentials(db)
+    profile.whatsapp_provider = "evolution"
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900009999", source="manual")
+    db.add(client)
+    db.commit()
+
+    captured = {}
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda **kw: (captured.update(kw), "sent")[1],
+    )
+    msg = inbox_service.start_conversation(
+        db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="Oi! Bem-vindo.",
+    )
+    assert msg.direction == DIRECTION_OUT
+    assert msg.status == "sent"
+    assert msg.text_body == "Oi! Bem-vindo."
+    assert captured["to"] == "5511900009999"
+
+    chat = db.scalar(select(WhatsappChat).where(WhatsappChat.id == msg.chat_id))
+    assert chat is not None
+    assert chat.chat_jid == "5511900009999@s.whatsapp.net"
+    assert chat.client_id == client.id
+
+
+def test_start_conversation_rejeita_transporte_meta(db):
+    """Na Meta abrir conversa do zero exige template aprovado — a mesma restrição que já
+    escondia o botão no frontend antes desta mudança."""
+    _configure_credentials(db)
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone="5511900001111", source="manual")
+    db.add(client)
+    db.commit()
+
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.start_conversation(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="Oi!",
+        )
+
+
+def test_start_conversation_rejeita_cliente_sem_telefone(db):
+    profile = _configure_credentials(db)
+    profile.whatsapp_provider = "evolution"
+    client = Client(tenant_id=TENANT_ID, name="Cliente", phone=None, source="manual")
+    db.add(client)
+    db.commit()
+
+    with pytest.raises(inbox_service.WhatsappInboxError):
+        inbox_service.start_conversation(
+            db, tenant_id=TENANT_ID, actor="user-1", client_id=client.id, text="Oi!",
+        )
+
+
 def test_send_reply_media_rejects_disallowed_mime_type_before_sending(
     db, monkeypatch: pytest.MonkeyPatch
 ):

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { api } from "../../lib/api";
@@ -39,20 +40,27 @@ const mensagens = [
   },
 ];
 
-function mockar(conversas: unknown[], timeline: unknown[] = mensagens) {
+function mockar(
+  conversas: unknown[],
+  timeline: unknown[] = mensagens,
+  whatsappProvider: string | null = null,
+) {
   vi.mocked(api.get).mockImplementation((url: string) => {
     if (url.startsWith("/whatsapp-conversations?")) {
       return Promise.resolve({ data: conversas } as never);
     }
     if (url.includes("/timeline")) return Promise.resolve({ data: timeline } as never);
+    if (url === "/settings/profile") {
+      return Promise.resolve({ data: { whatsapp_provider: whatsappProvider } } as never);
+    }
     return Promise.resolve({ data: [] } as never);
   });
 }
 
-const renderBloco = () =>
+const renderBloco = (clientPhone: string | null = "5511999998888") =>
   render(
     <MemoryRouter>
-      <BlocoDaConversa clientId="cli-1" />
+      <BlocoDaConversa clientId="cli-1" clientPhone={clientPhone} />
     </MemoryRouter>,
   );
 
@@ -109,11 +117,49 @@ describe("BlocoDaConversa", () => {
     expect(link).toHaveAttribute("href", "/conversas/chat-1");
   });
 
-  it("sem conversa, diz isso e NÃO oferece iniciar uma", async () => {
-    mockar([]);
+  it("sem conversa na Meta, diz isso e NÃO oferece iniciar uma", async () => {
+    // Meta exige template aprovado pra abrir do zero — sem isso, um botão que sempre falha é
+    // pior que nenhum (mesmo raciocínio de antes desta mudança, agora restrito ao transporte).
+    mockar([], mensagens, null);
     renderBloco();
     expect(await screen.findByText(/nenhuma conversa no whatsapp/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /iniciar/i })).not.toBeInTheDocument();
+  });
+
+  it("sem conversa na Evolution, oferece iniciar uma", async () => {
+    // Evolution (QR code) não tem janela de 24h nem template — abrir do zero é possível.
+    mockar([], mensagens, "evolution");
+    renderBloco();
+    expect(await screen.findByRole("button", { name: /iniciar conversa/i })).toBeInTheDocument();
+  });
+
+  it("sem conversa na Evolution mas sem telefone cadastrado, NÃO oferece iniciar", async () => {
+    mockar([], mensagens, "evolution");
+    renderBloco(null);
+    await screen.findByText(/nenhuma conversa no whatsapp/i);
+    expect(screen.queryByRole("button", { name: /iniciar conversa/i })).not.toBeInTheDocument();
+  });
+
+  it("envia a primeira mensagem e passa a mostrar a conversa criada", async () => {
+    mockar([], mensagens, "evolution");
+    vi.mocked(api.post).mockResolvedValue({ data: { chat_id: "chat-novo" } } as never);
+    renderBloco();
+
+    const user = userEvent.setup();
+    const botao = await screen.findByRole("button", { name: /iniciar conversa/i });
+    const campo = screen.getByRole("textbox");
+    await user.type(campo, "Oi! Bem-vindo.");
+
+    // A partir daqui a conversa já existe — a mesma lista que a tela buscaria de novo.
+    mockar([conversa("chat-novo", "Ju")], mensagens, "evolution");
+    await user.click(botao);
+
+    expect(api.post).toHaveBeenCalledWith("/whatsapp-conversations/start", {
+      client_id: "cli-1",
+      text: "Oi! Bem-vindo.",
+    });
+    expect(await screen.findByRole("link", { name: /abrir conversa/i }))
+      .toHaveAttribute("href", "/conversas/chat-novo");
   });
 
   it("com duas conversas, mostra a mais recente e avisa da outra", async () => {

--- a/apps/web/src/features/crm/BlocoDaConversa.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.tsx
@@ -1,8 +1,9 @@
-import type { ConversationSummary, TimelineEntry } from "@e1p/shared-types";
+import type { ConversationSummary, TenantProfile, TimelineEntry } from "@e1p/shared-types";
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../../lib/api";
 import { formatTime } from "../../lib/datetime";
+import { capabilitiesFor } from "../../lib/whatsappCapabilities";
 import { useFuso } from "../../store/auth";
 
 /** Quantas falas cabem sem a ficha virar uma segunda tela de Conversas. */
@@ -18,12 +19,20 @@ const ULTIMAS = 5;
  * Não confundir com o `ClientTimeline` logo acima na ficha: aquele é a NARRATIVA do
  * relacionamento (chegou, moveu, pagou, escreveu); este é o TEOR, o que foi dito.
  */
-export default function BlocoDaConversa({ clientId }: { clientId: string }) {
+export default function BlocoDaConversa(
+  { clientId, clientPhone }: { clientId: string; clientPhone?: string | null },
+) {
   const fuso = useFuso();
   const [conversas, setConversas] = useState<ConversationSummary[]>([]);
   const [mensagens, setMensagens] = useState<TimelineEntry[]>([]);
   const [erro, setErro] = useState(false);
   const [carregando, setCarregando] = useState(true);
+  // Só a Evolution (QR code) permite abrir conversa do zero — a Meta exige template aprovado
+  // (ver app/core/whatsapp/capabilities.py). Busca própria, à parte do `load()`: uma falha aqui
+  // só deve esconder o compositor, nunca derrubar o resto do bloco.
+  const [podeIniciar, setPodeIniciar] = useState(false);
+  const [mensagemNova, setMensagemNova] = useState("");
+  const [enviando, setEnviando] = useState(false);
 
   const load = useCallback(async () => {
     // Falha aqui NÃO pode derrubar a ficha — mesma postura do `ClientTimeline`, que degrada
@@ -60,6 +69,26 @@ export default function BlocoDaConversa({ clientId }: { clientId: string }) {
     load();
   }, [load]);
 
+  useEffect(() => {
+    api
+      .get<TenantProfile>("/settings/profile")
+      .then(({ data }) => setPodeIniciar(!capabilitiesFor(data.whatsapp_provider).sessionWindow))
+      .catch(() => setPodeIniciar(false));
+  }, []);
+
+  const iniciar = useCallback(async () => {
+    const texto = mensagemNova.trim();
+    if (!texto) return;
+    setEnviando(true);
+    try {
+      await api.post("/whatsapp-conversations/start", { client_id: clientId, text: texto });
+      setMensagemNova("");
+      await load();
+    } finally {
+      setEnviando(false);
+    }
+  }, [clientId, mensagemNova, load]);
+
   if (carregando) return <p className="py-4 text-sm text-neutral-400">Carregando conversa...</p>;
   if (erro) {
     return (
@@ -71,8 +100,30 @@ export default function BlocoDaConversa({ clientId }: { clientId: string }) {
 
   const recente = maisRecente(conversas);
   if (!recente) {
-    // Sem botão de "iniciar conversa": a janela de 24h da Meta não permite abrir conversa do
-    // nada, e um botão que sempre falha é pior que nenhum.
+    if (podeIniciar && clientPhone) {
+      return (
+        <div className="space-y-2">
+          <textarea
+            className="w-full resize-none rounded-lg border border-neutral-200 p-2 text-sm text-neutral-800 focus:border-primary-400 focus:outline-none"
+            rows={2}
+            placeholder="Escreva a primeira mensagem..."
+            value={mensagemNova}
+            onChange={(e) => setMensagemNova(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={iniciar}
+            disabled={!mensagemNova.trim() || enviando}
+            className="w-full rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+          >
+            {enviando ? "Enviando..." : "Iniciar conversa"}
+          </button>
+        </div>
+      );
+    }
+    // Meta exige template aprovado pra abrir conversa do zero (janela de 24h da Cloud API) — um
+    // botão que sempre falha é pior que nenhum. `capabilitiesFor` decide isso; ver o comentário
+    // no `useEffect` de `podeIniciar` acima.
     return <p className="py-4 text-center text-sm text-neutral-400">Nenhuma conversa no WhatsApp.</p>;
   }
 

--- a/apps/web/src/features/crm/ClientDetailPage.tsx
+++ b/apps/web/src/features/crm/ClientDetailPage.tsx
@@ -196,7 +196,7 @@ export default function ClientDetailPage() {
           `rounded-2xl bg-white p-5 shadow-sm` não distingue esta da de Cobranças ou Contratos,
           e a régua de 360px precisa de um recorte que aponte só para esta. */}
       <Section icon={<MessageCircle size={16} />} title="Conversa" testId="secao-conversa">
-        <BlocoDaConversa clientId={id} />
+        <BlocoDaConversa clientId={id} clientPhone={client.phone} />
       </Section>
 
       {/* Agenda vem depois da Conversa e antes do operacional: a ficha conta uma história — o


### PR DESCRIPTION
## Resumo

O botao "Iniciar conversa" na ficha do cliente estava escondido incondicionalmente porque o codigo assumia a janela de 24h da Meta Cloud API. Essa regra nao existe no transporte Evolution (WhatsApp por QR code) - ver `capabilities.py`, onde `EVOLUTION.session_window = False`.

- Backend: novo `POST /whatsapp-conversations/start` (`{client_id, text}`) + `start_conversation()` no `whatsapp_inbox/service.py`. Rejeita com 422 tenants na Meta e clientes sem telefone valido; na Evolution cria a conversa (reaproveitando `_get_or_create_chat`) e envia a primeira mensagem.
- Frontend: `BlocoDaConversa.tsx` busca a capacidade do tenant (`/settings/profile` + `capabilitiesFor`) e mostra um compositor de texto com o botao "Iniciar conversa" quando nao ha conversa, o transporte e Evolution e o cliente tem telefone. Na Meta mantem o texto estatico de antes.

## Test plan

- [x] Backend: `test_start_conversation_*` em `test_whatsapp_inbox_service.py` e `test_whatsapp_inbox_reply.py` (service + endpoint, Evolution sucesso / Meta rejeita / sem telefone rejeita)
- [x] Frontend: `BlocoDaConversa.test.tsx` (botao aparece so na Evolution com telefone, fluxo de envio completo, Meta continua sem botao)
- [x] `ruff check` nos modulos tocados
- [x] Suite completa do backend: `pytest -q` (2253 passed, 1 skipped - so o `rls_e2e`, fora do escopo desta mudanca)
- [x] `tsc --noEmit`, `eslint` nos arquivos tocados
- [x] Suite `crm` do frontend (111 testes)