### PR TITLE
fix: google_event_id era curto demais para eventos de calendário externo

### DIFF
--- a/apps/api/app/modules/agenda/models.py
+++ b/apps/api/app/modules/agenda/models.py
@@ -68,10 +68,17 @@ class AgendaEvent(Base, TenantMixin, TimestampMixin):
     location: Mapped[str] = mapped_column(String(255), default="", nullable=False)
     meeting_url: Mapped[str | None] = mapped_column(String(512), nullable=True)  # link Meet/Zoom
     guests: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)  # e-mails
-    # Id do evento espelhado no Google Calendar (quando o Meet foi gerado via OAuth Google).
-    # Usado para sincronizar reschedule/cancel de volta pro Google (ver agenda/service.py +
+    # Id do evento espelhado no Google Calendar (quando o Meet foi gerado via OAuth Google, ou
+    # quando o evento foi puxado de lá pelo sync — google_calendar/sync.py). Usado para
+    # sincronizar reschedule/cancel de volta pro Google (ver agenda/service.py +
     # google_calendar/service.py::patch_meet_event/delete_meet_event).
-    google_event_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    #
+    # 1024, não 128: o próprio Google Calendar gera ids de ~26 chars, mas eventos IMPORTADOS de
+    # calendários externos (Outlook/Exchange via interop do Workspace) chegam com ids de até
+    # ~180+ chars — medido ao vivo em produção (2026-08-27), 3 ocorrências reais causando
+    # `StringDataRightTruncation` e derrubando o lote de sync inteiro daquele tenant. 1024 é o
+    # máximo documentado pela Google para o campo `id` do evento.
+    google_event_id: Mapped[str | None] = mapped_column(String(1024), nullable=True)
 
     # Dinheiro SEMPRE em centavos inteiros (evita erro de float). Opcional (cobranças).
     amount_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/apps/api/migrations/versions/0082_widen_google_event_id.py
+++ b/apps/api/migrations/versions/0082_widen_google_event_id.py
@@ -1,0 +1,52 @@
+"""agenda_events.google_event_id: VARCHAR(128) -> VARCHAR(1024)
+
+Revision ID: 0082
+Revises: 0081
+Create Date: 2026-08-27
+
+Incidente de produção (2026-08-27, algumas horas após o deploy da 0081): eventos importados de
+calendários externos (Outlook/Exchange via interop do Google Workspace) chegam com `id` de até
+181 caracteres — medido ao vivo, 3 ocorrências reais na conta conectada. `google_event_id` era
+`String(128)`: o INSERT do sync (google_calendar/sync.py::pull_changes) falhava com
+`StringDataRightTruncation`, e como o `pull_changes` grava o lote inteiro numa única transação,
+UM evento comprido derrubava a sincronização de TODOS os outros eventos daquele tenant naquela
+rodada — sintoma relatado pelo dono como "nada do celular volta pro sistema".
+
+1024 é o máximo documentado pela Google Calendar API para o campo `id` do evento — não é um
+número arredondado, é o teto real do domínio.
+
+DDL puro (`ALTER COLUMN TYPE`, VARCHAR→VARCHAR maior): sem UPDATE, sem backfill, a armadilha do
+FORCE RLS não se aplica. O índice único `ix_agenda_events_tenant_google_event_id` (migration
+0081) não precisa ser recriado — VARCHAR(1024) cabe folgado no limite de ~2704 bytes por entrada
+de índice btree do Postgres (tenant_id é 36 chars fixos + até 1024 do google_event_id, bem abaixo
+do teto).
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0082"
+down_revision: str | None = "0081"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "agenda_events",
+        "google_event_id",
+        existing_type=sa.String(128),
+        type_=sa.String(1024),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "agenda_events",
+        "google_event_id",
+        existing_type=sa.String(1024),
+        type_=sa.String(128),
+        existing_nullable=True,
+    )

--- a/apps/api/tests/test_google_calendar_sync.py
+++ b/apps/api/tests/test_google_calendar_sync.py
@@ -219,3 +219,20 @@ def test_network_failure_returns_zero_and_keeps_token(db: Session, monkeypatch):
     assert sync.pull_changes(db, tenant_id=TENANT) == 0
     db.refresh(cred)
     assert cred.sync_token == "token-v1"  # não corrompe o cursor numa falha
+
+
+# ── Incidente de produção (2026-08-27): google_event_id > 128 chars ──────────
+#
+# Confirmado em produção: eventos importados de calendários externos (Outlook/Exchange via
+# interop do Google Workspace) têm `id` de até 181 caracteres — bem além dos 26 chars do
+# formato próprio do Google. `google_event_id` era `String(128)`: o INSERT falhava com
+# `StringDataRightTruncation`, a transação inteira dava rollback, e NENHUM evento daquele
+# tenant sincronizava (não só o comprido — o `pull_changes` processa o lote inteiro numa
+# única transação). Google documenta até 1024 chars para `id` de evento.
+def test_google_event_id_column_accepts_external_calendar_ids():
+    """Regressão rápida (sem Postgres): a coluna precisa ser larga o bastante para IDs
+    importados de calendários externos. SQLite não aplica limite de VARCHAR (por isso este
+    teste confere o TAMANHO DECLARADO da coluna, não insere e deixa passar por acidente) —
+    a prova de que o banco REAL aceita mora em test_google_calendar_sync_rls.py."""
+    column = AgendaEvent.__table__.c.google_event_id
+    assert column.type.length is not None and column.type.length >= 1024

--- a/apps/api/tests/test_google_calendar_sync_rls.py
+++ b/apps/api/tests/test_google_calendar_sync_rls.py
@@ -122,3 +122,54 @@ def test_google_event_id_unique_index_enforced_on_real_postgres() -> None:
             with pytest.raises(IntegrityError):
                 session.commit()
             session.rollback()
+
+
+def test_google_event_id_accepts_external_calendar_length() -> None:
+    """Incidente de produção (2026-08-27): eventos importados de calendários externos
+    (Outlook/Exchange via interop do Google Workspace) chegam com `id` de até 181 caracteres —
+    medido ao vivo em produção, 3 ocorrências reais na conta conectada. `google_event_id` era
+    `String(128)`: o INSERT falhava com `StringDataRightTruncation` e derrubava o lote inteiro
+    (a transação de `pull_changes` é única — um evento comprido cancelava a sincronização de
+    TODOS os outros do mesmo tenant naquela rodada). Prova aqui é contra Postgres real: SQLite
+    não aplica limite de VARCHAR e deixaria este defeito passar em silêncio."""
+    from app.modules.agenda.models import AgendaEvent
+
+    # O id real mais comprido observado em produção (181 chars) — formato de evento importado.
+    long_id = (
+        "_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g6sq44c9h88qjad1k68"
+        "ok8h1g64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g652j8e9g6ko30c1j74p32dpk8csj0e226gsj8"
+        "c1m8cp4ad9m8d10"
+    )
+    assert len(long_id) == 181
+
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        with _tenant_session(app_url, tenant_a) as session:
+            session.add(
+                AgendaEvent(
+                    tenant_id=tenant_a,
+                    title="Canopy/Solus + AGSI",
+                    kind="google",
+                    starts_at=datetime(2026, 9, 10, 10, 0, tzinfo=UTC),
+                    ends_at=datetime(2026, 9, 10, 11, 0, tzinfo=UTC),
+                    google_event_id=long_id,
+                )
+            )
+            session.commit()  # não pode levantar StringDataRightTruncation
+
+            saved = session.query(AgendaEvent).filter_by(google_event_id=long_id).one()
+            assert saved.google_event_id == long_id


### PR DESCRIPTION
## Resumo

Incidente de produção, descoberto minutos após o deploy do PR #257 (sync bidirecional do Google Calendar). O dono relatou: "a agenda que fiz no sistema foi para o celular, agora o que fiz no celular, não voltou aqui para o CRM".

## Investigação (systematic-debugging)

1. Confirmei que a produção AWS tinha sido rebuildada com o código do #257 (imagens novas, `alembic current` = `0081`, `/api/health` = 200).
2. `docker logs infra-worker-1` mostrou que a Etapa 7 RODAVA e a chamada à API do Google TINHA sucesso (200 OK, 44 itens), mas o `INSERT` em `agenda_events` falhava com `sqlalchemy.exc.DataError: (psycopg.errors.StringDataRightTruncation) value too long for type character varying(128)`.
3. Reproduzi ao vivo, read-only, chamando o mesmo código de fetch do app dentro do container `infra-api-1`: **3 eventos reais na conta conectada têm `id` de 181 caracteres** — formato de evento importado de calendário externo (Outlook/Exchange via interop do Google Workspace), bem diferente do formato próprio do Google (~26 chars).

**Causa raiz:** `agenda_events.google_event_id` era `VARCHAR(128)`. Como `pull_changes` grava o lote inteiro numa única transação, o INSERT do evento comprido fazia rollback de TODOS os outros eventos daquele tenant na mesma rodada — não só o comprido não entrava, nada entrava.

## Fix

- `google_event_id` alargado para `VARCHAR(1024)` — o teto documentado pela própria Google Calendar API para o campo `id`, não um número arredondado.
- Migration `0082` (`ALTER COLUMN TYPE`, DDL puro, sem backfill).
- Teste unitário rápido (tamanho da coluna) + teste `rls_e2e` que reproduz o erro exato contra Postgres real usando o id de 181 chars medido em produção, prova que falha ANTES do fix e passa DEPOIS.

## Gates

- `pytest -q` — **2317 passed, 1 skipped, 0 failed**
- `pytest -m rls_e2e` (novo teste + o índice único da 0081, ambos contra Postgres real) — **passed**
- `ruff check .` — limpo

🤖 Gerado com [Claude Code](https://claude.com/claude-code)