### PR TITLE
fix: Agenda (Dia/Mês) perdia evento perto da borda do dia local

### DIFF
--- a/apps/web/src/features/agenda/EscolherHorario.test.tsx
+++ b/apps/web/src/features/agenda/EscolherHorario.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../lib/api";
 import { localYmd } from "../../lib/datetime";
 import EscolherHorario from "./EscolherHorario";
-import { gradeDoMes } from "./grade";
+import { gradeDoMes, paramsDaGrade } from "./grade";
 import { agendaEvent } from "../../test/fixtures/agenda";
 
 vi.mock("../../lib/api", () => ({
@@ -143,7 +143,7 @@ describe("EscolherHorario", () => {
       expect(vi.mocked(api.get)).toHaveBeenLastCalledWith(
         "/agenda/events",
         expect.objectContaining({
-          params: expect.objectContaining({ start: `${localYmd(novembro.start)}T00:00:00.000Z` }),
+          params: expect.objectContaining({ start: paramsDaGrade(novembro.start, novembro.end).start }),
         }),
       ),
     );

--- a/apps/web/src/features/agenda/grade.test.ts
+++ b/apps/web/src/features/agenda/grade.test.ts
@@ -484,15 +484,31 @@ describe("gradeDoMes", () => {
 });
 
 describe("paramsDaGrade", () => {
-  it("pede o range em meia-noite UTC da DATA do grid", () => {
+  it("pede o range em meia-noite UTC da DATA do grid, com 1 dia de margem de cada lado", () => {
     const { start, end, days } = gradeDoMes(new Date(2026, 9, 20));
 
     expect(paramsDaGrade(start, end)).toEqual({
-      start: "2026-09-27T00:00:00.000Z",
-      end: "2026-11-08T00:00:00.000Z",
+      start: "2026-09-26T00:00:00.000Z",
+      end: "2026-11-09T00:00:00.000Z",
       limit: 500,
     });
     expect(days).toHaveLength(42);
+  });
+
+  it("a margem cobre um evento às 22h num tenant em UTC-3, que a fronteira exata perdia", () => {
+    // Bug real em produção (2026-08-27): "Bora" (sync do Google) às 22h de 27/08 no fuso do
+    // tenant (America/Sao_Paulo, UTC-3) é armazenado como 2026-08-28T01:00:00Z. A visão de Dia
+    // pedia exatamente [2026-08-27T00:00Z, 2026-08-28T00:00Z) — a fronteira UTC-date do rótulo
+    // "27/08", sem compensar o offset do tenant. O evento ficava DEPOIS do fim dessa janela e
+    // nunca era sequer devolvido pela API: sumia da visão de Dia (e, na de Mês, sobrevivia só
+    // escondido atrás de "+1 mais", porque a janela de 42 dias está longe da borda). A margem de
+    // 1 dia cobre qualquer offset real de fuso (UTC-12 a UTC+14, bem abaixo de 24h).
+    const dia = new Date(2026, 7, 27); // 27/08/2026, meia-noite local
+    const params = paramsDaGrade(dia, addDays(dia, 1));
+
+    const bora = new Date("2026-08-28T01:00:00.000Z").getTime();
+    expect(new Date(params.start).getTime()).toBeLessThanOrEqual(bora);
+    expect(new Date(params.end).getTime()).toBeGreaterThan(bora);
   });
 });
 

--- a/apps/web/src/features/agenda/grade.ts
+++ b/apps/web/src/features/agenda/grade.ts
@@ -138,10 +138,22 @@ export function densidadePorDia(eventos: AgendaEvent[], fuso: string): Map<strin
  * dois calendários — a tela de Agenda e o seletor da ficha — pedem o mesmo mês, e a regra vivia
  * num comentário copiado nos dois arquivos. Regra que mora em comentário duplicado é regra que
  * deriva.
+ *
+ * **A margem de 1 dia de cada lado, e por que sem ela a visão de Dia perde evento de verdade**
+ * (bug real, 2026-08-27): a fronteira UTC-date do rótulo "27/08" é `2026-08-27T00:00Z`, mas a
+ * meia-noite LOCAL do tenant cai em outro instante — em UTC−3, três horas DEPOIS
+ * (`2026-08-27T03:00Z`); em fuso positivo, mais cedo. Sem margem, um evento no fim (fuso
+ * negativo) ou no início (fuso positivo) do dia local simplesmente não entra na busca — não é
+ * filtrado depois, nunca chega ao array de eventos. Foi assim que um evento sincronizado do
+ * Google às 22h (BRT) sumiu da visão de Dia (e ficou escondido atrás de "+1 mais" na de Mês, cuja
+ * janela de 42 dias está longe da borda). 1 dia cobre qualquer offset real (UTC−12 a UTC+14).
+ * Evento de dia inteiro segue dentro da margem em qualquer direção — a folga não quebra o caso
+ * que a fronteira exata protegia. O agrupamento por célula (`eventsOfDay`/`eventYmd`) já filtra
+ * de volta pelo dia certo; a margem só evita que o SERVIDOR descarte cedo demais.
  */
 export const paramsDaGrade = (start: Date, end: Date) => ({
-  start: `${localYmd(start)}T00:00:00.000Z`,
-  end: `${localYmd(end)}T00:00:00.000Z`,
+  start: `${localYmd(addDays(start, -1))}T00:00:00.000Z`,
+  end: `${localYmd(addDays(end, 1))}T00:00:00.000Z`,
   limit: 500,
 });
 


### PR DESCRIPTION
## Resumo

- Corrige um bug real de produção: um evento sincronizado do Google Calendar ("Bora", 22h no fuso do tenant/BRT) não aparecia nas visões de **Dia** e **Mês** da Agenda, mas aparecia corretamente na de **Semana**. Confirmado pelo dono, inclusive em aba anônima (não era cache).
- **Causa raiz** (investigada via `systematic-debugging`, não é suposição): `paramsDaGrade` (`apps/web/src/features/agenda/grade.ts`) convertia a fronteira do grid (meia-noite LOCAL do tenant) para uma string UTC-date literal, sem compensar o offset do fuso (`America/Sao_Paulo` = UTC−3). A visão de Dia de "27/08" pedia `[2026-08-27T00:00Z, 2026-08-28T00:00Z)`, mas a meia-noite local real cai 3h depois. O evento (`starts_at = 2026-08-28T01:00:00Z`) ficava fora dessa janela — **a API nunca o devolvia**, não era um bug de exibição/agrupamento. A visão de Semana (janela de 7 dias) e a de Mês (janela de 42 dias, mas aí o evento ficava só escondido atrás de "+1 mais" no limite de 3 itens por célula) não são afetadas da mesma forma porque suas janelas estão longe dessa borda.
- **Correção:** margem de 1 dia em cada lado da janela de busca — cobre qualquer offset real de fuso (UTC−12 a UTC+14). O agrupamento por célula no cliente (`eventsOfDay`/`eventYmd`) já era fuso-correto e filtra de volta para o dia certo, então a folga extra não introduz nenhum evento no dia errado.

## O que mudou

- `apps/web/src/features/agenda/grade.ts` — o fix + docstring explicando a causa raiz (consumido também por `EscolherHorario.tsx`, então o conserto vale nos dois lugares).
- `apps/web/src/features/agenda/grade.test.ts` — teste que reproduz o bug real com os valores exatos de produção (TDD: escrito e confirmado vermelho antes do fix), e o teste existente atualizado para a nova janela com margem.
- `apps/web/src/features/agenda/EscolherHorario.test.tsx` — um teste que fixava o valor exato antigo da fronteira; agora deriva de `paramsDaGrade` em vez de duplicar a lógica de janela.

## Gates rodados nesta sessão

- `pnpm vitest run` (apps/web): **1221 passed**, 0 failed
- `tsc --noEmit`: limpo
- `eslint` nos arquivos alterados: limpo

## Pendências (não rodadas nesta sessão)

- Playwright e2e (`pnpm --filter @e1p/web e2e`) — a mudança mexe em lógica de data usada pelas telas de calendário; vale rodar antes do merge.
- Suíte do backend (`pytest`) — não é necessária, a mudança é 100% frontend e não toca `apps/api`.
- Os 3 subagentes de QA do §5 do CLAUDE.md (regression-tester/bug-hunter/dedup-checker) não foram executados nesta sessão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)