### PR TITLE
fix: "+N mais" da Agenda leva à visão Dia, não abre "Novo evento"

### DIFF
--- a/apps/web/src/features/agenda/AgendaPage.test.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.test.tsx
@@ -342,3 +342,36 @@ describe("AgendaPage — histórico de mensagens fora de forma não derruba o mo
     expect(await screen.findByText("Mensagem real")).toBeInTheDocument();
   });
 });
+
+// ── "+N mais" leva à visão Dia, não abre "Novo evento" ───────────────────────
+//
+// A célula do dia tem um <button> "Novo evento" absoluto por baixo de todo o conteúdo (ver o
+// comentário grande em MonthGrid sobre o #183): antes desta mudança, "+N mais" era um <div> sem
+// clique próprio, e tocar nele caía nesse botão de fundo. O controle "não abriu Novo evento" é o
+// que prova que o clique ficou contido no botão do "+N mais", e não escorregou para a célula.
+describe("AgendaPage — \"+N mais\" abre a visão Dia (issue relatada pelo usuário)", () => {
+  it("clicar em \"+1 mais\" muda para a visão Dia do dia clicado, sem abrir o cadastro de novo evento", async () => {
+    const user = userEvent.setup();
+    const hoje = new Date();
+    const ymd = `${hoje.getFullYear()}-${String(hoje.getMonth() + 1).padStart(2, "0")}-${String(
+      hoje.getDate(),
+    ).padStart(2, "0")}`;
+    const at = (h: number) =>
+      new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate(), h, 0, 0).toISOString();
+    mockEvents([
+      agendaEvent({ id: "e-1", title: "Reunião A", starts_at: at(9), ends_at: at(10) }),
+      agendaEvent({ id: "e-2", title: "Reunião B", starts_at: at(11), ends_at: at(12) }),
+      agendaEvent({ id: "e-3", title: "Reunião C", starts_at: at(13), ends_at: at(14) }),
+      agendaEvent({ id: "e-4", title: "Reunião D", starts_at: at(15), ends_at: at(16) }),
+    ]);
+    renderPage();
+
+    await user.click(await screen.findByTestId(`mais-eventos-${ymd}`));
+
+    // Não caiu no botão de fundo da célula (que abriria o cadastro).
+    expect(screen.queryByRole("heading", { name: "Novo evento" })).not.toBeInTheDocument();
+    // Foi para a visão Dia: os 4 eventos aparecem em lista — no mês, só os 3 primeiros + "+1 mais".
+    expect(await screen.findByText("Reunião A")).toBeInTheDocument();
+    expect(screen.getByText("Reunião D")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/agenda/AgendaPage.tsx
+++ b/apps/web/src/features/agenda/AgendaPage.tsx
@@ -131,6 +131,10 @@ export default function AgendaPage() {
           events={events}
           onDayClick={openOnDay}
           onEventClick={setSelected}
+          onMoreClick={(d) => {
+            setAnchor(d);
+            setView("day");
+          }}
         />
       )}
       {view === "week" && (
@@ -184,12 +188,14 @@ function MonthGrid({
   events,
   onDayClick,
   onEventClick,
+  onMoreClick,
 }: {
   days: Date[];
   anchor: Date;
   events: AgendaEvent[];
   onDayClick: (d: Date) => void;
   onEventClick: (e: AgendaEvent) => void;
+  onMoreClick: (d: Date) => void;
 }) {
   const fuso = useFuso();
   const today = hojeDoTenant(fuso);
@@ -264,7 +270,13 @@ function MonthGrid({
                     </button>
                   ))}
                   {dayEvents.length > 3 && (
-                    <div className="text-[10px] text-neutral-400">+{dayEvents.length - 3} mais</div>
+                    <button
+                      data-testid={`mais-eventos-${localYmd(d)}`}
+                      onClick={() => onMoreClick(d)}
+                      className="pointer-events-auto block text-[10px] text-neutral-400 hover:text-primary-600 hover:underline"
+                    >
+                      +{dayEvents.length - 3} mais
+                    </button>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Resumo

Na visão de **Mês** da Agenda, tocar em "+N mais" (o indicador de estouro dos dias com mais de 3 eventos) abria o formulário de **"Novo evento"** em vez de mostrar os compromissos daquele dia.

**Causa:** "+N mais" era um `<div>` sem clique próprio. A célula do dia tem um `<button>` "Novo evento" posicionado `absolute inset-0` **atrás** de todo o conteúdo, e o conteúdo é `pointer-events-none` com os alvos clicáveis reabilitados individualmente via `pointer-events-auto`. Como o "+N mais" nunca recebeu esse tratamento, o clique atravessava e caía na camada de "Novo evento".

É a **mesma classe de perigo** já documentada no bloco de comentários do `AgendaPage.tsx` (~linha 211) para os chips de evento — aninhamento de alvos clicáveis com destinos diferentes, linhagem da issue #183. O comentário lá já registra a regra: o parentesco é que resolve, e cada alvo clicável do conteúdo precisa reabilitar `pointer-events`.

**Correção:** "+N mais" virou botão próprio com `pointer-events-auto` (mesmo padrão dos chips) que troca a página para a visão **"Dia"** já existente, ancorada na data clicada.

Expandir a célula da grade para caber os eventos escondidos foi **descartado**: a geometria das 42 células (44,3×92 em 360px) é medida e travada pelos e2e do #183/#249, e crescer uma célula quebraria o alinhamento da linha inteira. Reusar a visão de Dia entrega o mesmo resultado (ver todos os eventos do dia) sem mexer no layout.

## O que mudou

- `apps/web/src/features/agenda/AgendaPage.tsx` — `MonthGrid` ganha a prop `onMoreClick`; o `<div>` do "+N mais" vira `<button>` com `data-testid={mais-eventos-<ymd>}`; o handler em `AgendaPage` faz `setAnchor(d)` + `setView("day")`.
- `apps/web/src/features/agenda/AgendaPage.test.tsx` — 1 teste novo cobrindo o comportamento.

## Test plan

Rodados no checkout de origem, **sobre este diff exato** (byte-idêntico ao commit deste PR), antes de ele ser movido para o worktree:

- [x] `tsc --noEmit` — limpo
- [x] `eslint` nos arquivos tocados — limpo
- [x] `vitest run src/features/agenda/AgendaPage.test.tsx` — **15/15 passando** (inclui o teste novo)
- [x] Playwright `e2e/agenda-chip-aninhamento-360.spec.ts` + `e2e/agenda-evento-360.spec.ts` — **10 testes**, cobrindo justamente o perigo de clique aninhado célula/chip e o layout de 360px — sem regressão

## Ressalva de transparência

Estes gates foram **verificados no checkout de origem, e não foram re-executados dentro do worktree** de onde este PR sai: o `pnpm install` do worktree foi bloqueado por um classificador de permissão, então não há `node_modules` aqui para rodar a suíte de novo. O diff commitado é byte-idêntico ao que passou nos gates acima, mas o CI deste PR é a primeira execução independente — vale conferir os checks antes do merge.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)
