### PR TITLE
fix(web): botão primário do briefing (Vima) ficava invisível

### DIFF
--- a/apps/web/src/features/vima/BriefingPage.tsx
+++ b/apps/web/src/features/vima/BriefingPage.tsx
@@ -135,7 +135,7 @@ function VoltarAoPainel() {
   return (
     <Link
       to="/"
-      className="mt-8 block w-full rounded-md bg-primary px-4 py-3 text-center text-base font-medium text-white"
+      className="mt-8 block w-full rounded-md bg-primary-500 px-4 py-3 text-center text-base font-medium text-white"
     >
       Ir para o painel
     </Link>

--- a/apps/web/src/features/vima/PreferenciasSection.tsx
+++ b/apps/web/src/features/vima/PreferenciasSection.tsx
@@ -106,7 +106,7 @@ export default function PreferenciasSection({
         type="button"
         onClick={salvar}
         disabled={busy}
-        className="mt-4 w-full rounded-md bg-primary px-4 py-2.5 text-base font-medium text-white disabled:opacity-60 sm:w-auto"
+        className="mt-4 w-full rounded-md bg-primary-500 px-4 py-2.5 text-base font-medium text-white disabled:opacity-60 sm:w-auto"
       >
         {busy ? "Salvando…" : "Salvar"}
       </button>


### PR DESCRIPTION
## Resumo

O botão "Ir para o painel" (porta de saída do briefing do Vima, `/vima`) e o botão "Salvar" das preferências de briefing ficavam **invisíveis em produção** — reportado com print pelo fundador: a área do botão aparecia como um texto fantasma cinza-claro sobre fundo branco, ilegível.

**Causa:** os dois usavam a classe `bg-primary` (sem número de tom). O preset do Tailwind do e1p (`packages/design-tokens/src/tailwind-preset.ts`) só define tons numerados (`primary-50` a `primary-900`), sem uma cor `DEFAULT` — então `bg-primary` não gera CSS nenhum, e o botão fica sem cor de fundo (transparente sobre a página) com texto branco por cima. Eram as únicas duas ocorrências desse padrão em todo o app; todo o resto do código já usa `bg-primary-500`/`-600`/etc.

## Mudança

- `bg-primary` → `bg-primary-500` em `BriefingPage.tsx` (botão "Ir para o painel") e `PreferenciasSection.tsx` (botão "Salvar")

## Test plan
- [x] `pnpm vitest run src/features/vima/BriefingPage.test.tsx` — 11 testes verdes
- [x] `pnpm eslint` nos dois arquivos — limpo
- [x] Conferido por grep que não há mais nenhuma ocorrência de `bg-primary` sem tom no restante do app

🤖 Generated with [Claude Code](https://claude.com/claude-code)