### PR TITLE
fix: reordena Canais e move Celular para Integrações

### DIFF
--- a/apps/web/src/features/config/CanaisTab.tsx
+++ b/apps/web/src/features/config/CanaisTab.tsx
@@ -1,12 +1,10 @@
-import CelularSection from "./CelularSection";
 import WhatsappSection from "./WhatsappSection";
 
-/** Aba "Canais": por onde a mensagem entra e sai — WhatsApp e o celular do dono. */
+/** Aba "Canais": por onde a mensagem entra e sai — WhatsApp (Evolution ou Meta). */
 export default function CanaisTab() {
   return (
     <div className="space-y-6">
       <WhatsappSection />
-      <CelularSection />
     </div>
   );
 }

--- a/apps/web/src/features/config/IntegracoesTab.tsx
+++ b/apps/web/src/features/config/IntegracoesTab.tsx
@@ -7,6 +7,7 @@ import {
   getGoogleConnectUrl,
   getGoogleStatus,
 } from "../../lib/api";
+import CelularSection from "./CelularSection";
 import IntegrationsSection from "./IntegrationsSection";
 import { Card } from "./ui";
 
@@ -16,6 +17,7 @@ export default function IntegracoesTab() {
     <div className="space-y-6">
       <IntegrationsSection />
       <GoogleSection />
+      <CelularSection />
     </div>
   );
 }

--- a/apps/web/src/features/config/WhatsappSection.tsx
+++ b/apps/web/src/features/config/WhatsappSection.tsx
@@ -40,10 +40,15 @@ function countVariables(bodyText: string): number {
 export default function WhatsappSection() {
   return (
     <div className="space-y-6">
-      <CredentialsCard />
       <EvolutionQrCard />
-      <TemplatesCard />
-      <BindingsCard />
+      <div className="space-y-6 rounded-2xl border border-dashed border-neutral-200 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+          Meta Cloud API — credenciais e templates
+        </p>
+        <CredentialsCard />
+        <TemplatesCard />
+        <BindingsCard />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Em Configurações > Canais: Evolution (QR Code) passa a vir primeiro; WhatsApp Business (Meta), Templates de Mensagem e Vínculos de Template ficam agrupados numa caixa própria logo abaixo (os dois últimos só se aplicam à Meta).
- "Celular — anexar comprovante" sai da aba Canais e vai para Integrações, ao lado do Google Calendar.

## Test plan
- [x] `pnpm vitest run src/features/config/` — 43 testes passando
- [x] `tsc --noEmit` limpo
- [ ] Conferência visual manual da tela `/config` (Canais e Integrações)

🤖 Generated with [Claude Code](https://claude.com/claude-code)