### PR TITLE
test: a ativação do núcleo ganha rls_e2e, no molde do investment_audit [Vima]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3332,9 +3332,18 @@ migration.
 - **Dívida:** `audit_entries` cresce — quatro eventos por tenant por passagem, mais um por resposta
   de gancho. Dezenas por tenant por ano; irrelevante hoje, anotado para não ser descoberto como
   surpresa.
-- **Dívida:** o script não tem teste `rls_e2e` (o `investment_audit.py` tem). A leitura por tenant é
-  coberta contra o SQLite dos testes, e o isolamento real depende do mesmo `tenant_session` que os
-  outros três scripts já usam em produção.
+- [x] **`test_nucleo_activation_rls.py` prova o isolamento real** (2026-08-28), no molde de
+  `test_investment_audit_rls.py`: dois tenants com roteiros DISTINTOS pelo núcleo (perguntas e
+  `exibidas` diferentes) — se a leitura trocasse A por B em vez de vazar as duas, o conteúdo
+  denunciaria. Sem GUC, `entradas_do_dna()` devolve zero linhas, o mesmo fail-closed do script
+  irmão.
+  - ⚠️ **A ordem NÃO é afirmada, e por um motivo que `investment_audit_rls` não tinha como expor:**
+    as três chamadas de `eventos.registrar` de uma passagem caem na MESMA transação, e
+    `AuditEntry.created_at` usa `server_default=func.now()` — em Postgres isso é o instante da
+    TRANSAÇÃO, não da linha. As três saem com o carimbo idêntico e o desempate cai no `id` (uuid),
+    arbitrário. A primeira versão deste teste afirmava lista e falhou na primeira execução; a
+    comparação é por conjunto, e é a MESMA lição que `test_entradas_do_dna_le_so_o_que_e_do_dna`
+    já registrava do lado do SQLite — aqui ela também vale no Postgres real.
 - **Dívida (a que NÃO fecha):** as 46 perguntas seguem nunca validadas com dono real. Não é
   instrumentável; é conversa com dono.
 

--- a/apps/api/tests/test_nucleo_activation_rls.py
+++ b/apps/api/tests/test_nucleo_activation_rls.py
@@ -1,0 +1,188 @@
+"""O rastro de ativação do núcleo (Vima V2), no Postgres REAL e sob RLS.
+
+**Por que este teste existe, e por que não podia ser em SQLite.** `entradas_do_dna()` é a leitura
+que `nucleo_activation.py` usa para reconstruir as passagens pelo núcleo — e, como `auditar()` em
+`investment_audit.py`, ela lê uma tabela com `FORCE ROW LEVEL SECURITY` (`audit_entries`, via
+`TenantMixin`). Uma consulta ali **sem** a GUC de tenant devolve **zero linhas, sem erro**: foi
+assim que a sondagem de `phone_key` em produção quase virou um "está tudo limpo" falso, e a mesma
+armadilha vale aqui — um relatório de ativação vazio por falta de sessão de tenant seria
+indistinguível de "ninguém abriu o núcleo ainda".
+
+Os testes SQLite de `derivar()`/`respostas_por_origem()` (em `test_nucleo_activation.py`) provam a
+aritmética das passagens e nada mais — **RLS não é exercida lá** (ver `conftest.py`). O que se
+prova aqui é a outra metade:
+
+1. `entradas_do_dna()` dentro de `tenant_session` só vê a trilha **daquele** tenant;
+2. e **não** vê a do vizinho (se visse, um dono veria as passagens de outro pelo núcleo — pior do
+   que ficar calado);
+3. sem GUC, a leitura é **fail-closed** — zero linhas, o mesmo resultado que o `main()` do script
+   não pode confundir com "nenhum tenant varreu o núcleo ainda" (por isso ele imprime a contagem
+   de tenants).
+
+Módulo marcado `rls_e2e`: NÃO roda no `pytest -q` (suíte SQLite), só no job `cross-tenant-rls` do
+CI ou manualmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+
+_API_DIR = Path(__file__).resolve().parents[1]
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original_url
+
+
+def _seed(app_url: str, *, slug: str, exibidas: str, pergunta: str) -> str:
+    """Um tenant com uma passagem completa pelo núcleo: `open` → `save` → `abandon`.
+
+    `exibidas` e `pergunta` distinguem o conteúdo entre tenants — se a leitura trocasse A por B
+    (em vez de simplesmente vazar as duas), um teste que semeasse o MESMO roteiro nos dois não
+    pegaria a troca. Grava via `eventos.registrar`, a mesma porta que `service._gravar` e
+    `router.nucleo_evento` usam em produção — não `AuditEntry` direto, para o teste também provar
+    que o vocabulário fechado sobrevive a uma sessão com GUC de tenant fixada à mão. Devolve o
+    `tenant_id`.
+    """
+    from app.modules.auth.models import Tenant
+    from app.modules.dna import eventos
+
+    tenant_id = str(uuid4())
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()  # fixa a GUC (escopo de sessão) e encerra a txn — ver a nota do
+            # test_financial_intelligence_diagnostics_rls sobre o SAVEPOINT.
+            session = Session(bind=conn)
+            session.add(Tenant(id=tenant_id, slug=slug, legal_name=slug, document=f"{slug}-doc"))
+            session.flush()
+            eventos.registrar(
+                session,
+                tenant_id=tenant_id,
+                actor="u",
+                action=eventos.ACTION_OPEN,
+                target=exibidas,
+            )
+            eventos.registrar(
+                session,
+                tenant_id=tenant_id,
+                actor="u",
+                action=eventos.ACTION_SAVE,
+                target=eventos.alvo_da_resposta("nucleo", pergunta),
+            )
+            eventos.registrar(
+                session, tenant_id=tenant_id, actor="u", action=eventos.ACTION_ABANDON, target=""
+            )
+            session.commit()
+            session.close()
+    finally:
+        engine.dispose()
+    return tenant_id
+
+
+def _entradas_como(app_url: str, tenant_id: str | None) -> list[str]:
+    """Os `target`s da trilha do DNA vistos por esta sessão.
+
+    ⚠️ **Sem ordem prometida.** As três chamadas de `_seed` correm na MESMA transação, e
+    `AuditEntry.created_at` usa `server_default=func.now()` — em Postgres isso é o instante da
+    TRANSAÇÃO, não da linha: as três saem com o MESMO carimbo, e a query de `entradas_do_dna`
+    desempata por `id` (uuid), arbitrário. Afirmar a ordem aqui testaria o acaso (achado na
+    primeira execução deste teste); o chamador compara por CONJUNTO.
+    """
+    from app.scripts.nucleo_activation import entradas_do_dna
+
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            if tenant_id is not None:
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, false)"),
+                    {"tid": tenant_id},
+                )
+            session = Session(bind=conn)
+            entradas = entradas_do_dna(session)
+            session.close()
+            return [e.target for e in entradas]
+    finally:
+        engine.dispose()
+
+
+def test_a_ativacao_enxerga_a_propria_trilha_e_nao_a_do_vizinho() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        a = _seed(app_url, slug="tenant-a", exibidas="6", pergunta="oferta.o_que_vende")
+        b = _seed(app_url, slug="tenant-b", exibidas="5", pergunta="oferta.como_cobra")
+
+        # (1) e (2) — o tenant A vê as TRÊS entradas da própria passagem, e não a de B.
+        # Por conjunto, não por lista (ver a nota de `_entradas_como` sobre `func.now()`
+        # por transação — a mesma razão que `test_investment_audit_rls` não tem aqui, porque lá
+        # a ordem nunca era afirmada).
+        alvos_a = _entradas_como(app_url, a)
+        assert sorted(alvos_a) == sorted(["6", "nucleo:oferta.o_que_vende", ""])
+
+        # (3) — e não vê nada do vizinho. Se a leitura trocasse A por B (em vez de vazar as duas),
+        # o roteiro distinto de cada tenant denuncia: o relatório de ativação de A citaria a
+        # pergunta de B — o modo de falha que o épico chama de "pior do que ficar calado".
+        alvos_b = _entradas_como(app_url, b)
+        assert sorted(alvos_b) == sorted(["5", "nucleo:oferta.como_cobra", ""])
+        assert "nucleo:oferta.como_cobra" not in alvos_a
+        assert "nucleo:oferta.o_que_vende" not in alvos_b
+
+        # (4) — sem GUC: ZERO linhas, sem erro. É este silêncio que `main()` não pode confundir com
+        # "nenhum tenant abriu o núcleo ainda", e por isso o script imprime a contagem de tenants.
+        assert _entradas_como(app_url, None) == []


### PR DESCRIPTION
## A dívida

`apps/api/app/scripts/nucleo_activation.py` lê o rastro de passagem pelo núcleo do DNA via
`entradas_do_dna()` — uma consulta a `audit_entries`, tabela com `FORCE ROW LEVEL SECURITY` (via
`TenantMixin`). Até aqui, a cobertura dessa leitura era **só SQLite** (`test_nucleo_activation.py`,
que prova a aritmética de `derivar()`/`respostas_por_origem()` e nada mais — RLS não é exercida lá,
ver `conftest.py`).

O script irmão `investment_audit.py` já tinha o teste de isolamento real
(`test_investment_audit_rls.py`). Este PR fecha a mesma lacuna do lado do `nucleo_activation.py`, no
mesmo molde.

O modo de falha que isso cobre não é barulhento: uma consulta a `audit_entries` **sem** a GUC de
tenant devolve **zero linhas, sem erro**. Um relatório de ativação vazio por falta de sessão de
tenant seria indistinguível de "ninguém abriu o núcleo ainda" — a mesma armadilha que quase virou um
"está tudo limpo" falso na sondagem de `phone_key` em produção.

## O que o teste prova

`apps/api/tests/test_nucleo_activation_rls.py` sobe um Postgres real (testcontainers), cria o papel
`e1p_app` NOSUPERUSER, roda as migrations como esse papel e semeia **dois tenants com roteiros
distintos** pelo núcleo (`open` → `save` → `abandon`, com `exibidas` e pergunta diferentes em cada):

1. **Isolamento positivo** — dentro de `tenant_session`, `entradas_do_dna()` vê as três entradas da
   própria trilha;
2. **Isolamento negativo** — e não vê a do vizinho. Os roteiros são distintos de propósito: se a
   leitura *trocasse* A por B em vez de vazar as duas, um teste que semeasse o mesmo roteiro nos
   dois não pegaria a troca. Aqui o relatório de A citaria a pergunta de B — o modo de falha que o
   épico chama de "pior do que ficar calado";
3. **Fail-closed sem GUC** — sem `app.current_tenant_id`, a leitura devolve zero linhas e nenhum
   erro. É exatamente esse silêncio que o `main()` do script não pode confundir com "nenhum tenant
   varreu o núcleo ainda" (e por isso ele imprime a contagem de tenants).

A semeadura passa por `eventos.registrar` — a mesma porta que `service._gravar` e
`router.nucleo_evento` usam em produção, não `AuditEntry` direto — para que o teste também prove que
o vocabulário fechado sobrevive a uma sessão com GUC de tenant fixada à mão.

## A nota do `func.now()`: comparação por conjunto, não por lista

Vale registrar porque a primeira versão do teste **falhou na primeira execução** por causa disso, e
é uma armadilha que o `test_investment_audit_rls.py` não tinha como expor (lá a ordem nunca era
afirmada):

As três chamadas de `eventos.registrar` de uma passagem caem na **mesma transação**, e
`AuditEntry.created_at` usa `server_default=func.now()`. Em Postgres, `now()` é o instante da
**transação**, não da linha — as três entradas saem com o **carimbo idêntico**, e o desempate da
query de `entradas_do_dna()` cai no `id` (uuid), que é arbitrário.

Afirmar a ordem ali seria testar o acaso. A comparação é **por conjunto** (`sorted(...)`), com a
razão documentada no docstring de `_entradas_como` para não ser "consertada" de volta depois. É a
mesma lição que `test_entradas_do_dna_le_so_o_que_e_do_dna` já registrava do lado do SQLite — este
PR mostra que ela vale também no Postgres real.

## Onde roda

Módulo marcado `pytest.mark.rls_e2e`: **fora** do `pytest -q` padrão (suíte SQLite). Roda no job
`cross-tenant-rls` do CI, que filtra por propriedade (o marker), não por arquivo nomeado — então o
arquivo novo entra sozinho, sem alterar o workflow. Localmente: `pytest -m rls_e2e` (exige Docker).

## Arquivos

- `apps/api/tests/test_nucleo_activation_rls.py` (novo)
- `CLAUDE.md` — fecha a dívida na seção "Vima V2: o DNA da Empresa" e registra a nota do
  `func.now()`. A dívida que **não** fecha (as 46 perguntas nunca validadas com dono real) segue
  anotada — não é instrumentável, é conversa com dono.

## Verificação

- `pytest -m rls_e2e` contra Postgres real via testcontainers — passa
- `ruff check .` — limpo
- Suíte SQLite existente — intacta
