### PR TITLE
fix: occurred_at do fato de WhatsApp usa o messageTimestamp real, não o now()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2999,9 +2999,15 @@ cabeça. **`facts` é a memória narrativa do negócio inteiro**, e o briefing �
   - Gate em `tests/test_fuso_do_tenant.py`: varredura AST sobre `app/modules/vima/` separando
     carimbar um INSTANTE (legítimo) de derivar QUE DIA É HOJE (regressão). `absences`,
     `composer` e `permissions` são puros e não podem ler o relógio nem para instante.
-- **Dívida:** `occurred_at` das mensagens de WhatsApp cai no default em vez do `messageTimestamp`
-  real (`InboundMessage` não carrega o campo) — janela de erro de segundos na virada do dia;
-  expurgo dos sujeitos polimórficos (LGPD) não tem rotina, só `client_id` cascateia;
+- ~~**Dívida:** `occurred_at` das mensagens de WhatsApp cai no default em vez do
+  `messageTimestamp` real (`InboundMessage` não carrega o campo) — janela de erro de segundos na
+  virada do dia.~~ **FECHADA em 2026-08-28.** `InboundMessage` ganhou `occurred_at`
+  (`app/core/whatsapp/inbound.py`), preenchido pelos dois parsers via `parse_epoch_seconds` —
+  `messageTimestamp` (irmão de `key`/`message` em `data`) na Evolution, `timestamp` **por
+  MENSAGEM** na Meta — e propagado a `facts.record(..., occurred_at=msg.occurred_at)` em
+  `whatsapp_inbox/service.py`. `None` (carimbo ausente no payload) continua caindo no `now()` de
+  sempre — não é regressão, é o mesmo fallback que `facts.record` sempre teve.
+- **Dívida:** expurgo dos sujeitos polimórficos (LGPD) não tem rotina, só `client_id` cascateia;
   `comercial.topo.sem_lead` é a única Ausência que lê o log, então enquanto o registro for novo
   ela dispara por falta de histórico e não por falta de lead; o anonimizador não mascara nomes
   apesar da docstring dizer que sim (pré-existente, o briefing herda).

--- a/apps/api/app/core/whatsapp/inbound.py
+++ b/apps/api/app/core/whatsapp/inbound.py
@@ -11,6 +11,23 @@ NÃO de `app.core.whatsapp.providers.*` — há gate estrutural que barra
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+def parse_epoch_seconds(value: object) -> datetime | None:
+    """Converte o carimbo de tempo cru de um provider (segundos desde epoch, `int` ou `str`)
+    no INSTANTE em que a mensagem aconteceu de verdade — não o instante em que a processamos.
+
+    Usado pelos dois parsers (`messageTimestamp` da Evolution, `timestamp` da Meta): a forma é a
+    mesma nos dois, só o nome do campo no payload muda. `None` para qualquer valor ausente ou
+    ilegível — o chamador cai no `datetime.now(UTC)` de sempre (`facts.record`), nunca aqui.
+    """
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), tz=UTC)
+    except (TypeError, ValueError, OSError):
+        return None
 
 
 @dataclass(frozen=True)
@@ -55,6 +72,12 @@ class InboundMessage:
     # está ligado) — ingest cria o Attachment na hora, sem depender do worker.
     media_mime_type: str | None = None
     media_filename: str | None = None
+    # QUANDO a mensagem aconteceu de verdade, segundo o PRÓPRIO WhatsApp — não o instante em que
+    # o webhook chegou nem o instante em que o ingest processou. Alimenta `facts.record(...,
+    # occurred_at=...)`: sem isto, uma mensagem recebida às 23h59 e processada à 00h01 entrava no
+    # briefing do dia seguinte em vez do dia dela. `None` quando o provider não entregou o
+    # carimbo (nunca acontece em payload real; `facts.record` cai no `now()` de sempre nesse caso).
+    occurred_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/apps/api/app/core/whatsapp/providers/evolution.py
+++ b/apps/api/app/core/whatsapp/providers/evolution.py
@@ -15,7 +15,7 @@ import logging
 import httpx
 
 from app.config import settings
-from app.core.whatsapp.inbound import InboundMessage
+from app.core.whatsapp.inbound import InboundMessage, parse_epoch_seconds
 
 logger = logging.getLogger("e1p.whatsapp.evolution")
 
@@ -291,6 +291,9 @@ def parse_inbound(payload: dict) -> list[InboundMessage]:
             "from_me": from_me, "chat_jid": chat_jid or None,
             "chat_kind": "group" if is_group else "direct",
             "sender_phone": sender_phone, "sender_name": push_name or None,
+            # `messageTimestamp` é irmão de `key`/`pushName`/`message` no MESMO nível de `data`
+            # (confirmado no payload real capturado 2026-08-04), em segundos desde epoch.
+            "occurred_at": parse_epoch_seconds(data.get("messageTimestamp")),
         }
 
         media_kind, media_obj = _extract_media(message)

--- a/apps/api/app/core/whatsapp/providers/meta.py
+++ b/apps/api/app/core/whatsapp/providers/meta.py
@@ -16,7 +16,7 @@ import logging
 import httpx
 
 from app.config import settings
-from app.core.whatsapp.inbound import InboundMessage, TemplateStatusEvent
+from app.core.whatsapp.inbound import InboundMessage, TemplateStatusEvent, parse_epoch_seconds
 
 logger = logging.getLogger("e1p.whatsapp")
 
@@ -379,6 +379,9 @@ def parse_inbound(payload: dict) -> list[InboundMessage]:
                         chat_jid=f"{from_phone}@s.whatsapp.net" if from_phone else None,
                         sender_phone=from_phone, sender_name=push_name or None,
                         button_payload=button_payload,
+                        # `timestamp` é string de segundos desde epoch, por MENSAGEM (não por
+                        # lote) — documentado pela Meta no schema de webhook de mensagens.
+                        occurred_at=parse_epoch_seconds(msg.get("timestamp")),
                     ))
                 except (AttributeError, TypeError, KeyError):
                     continue  # isola só esta mensagem — ver docstring

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -370,12 +370,11 @@ def ingest_webhook_payload(
             # e a vinda do telefone de um usuário do tenant (`da_equipe` — ex.: o toque no
             # botão do briefing na Meta, Onda 4).
             #
-            # ⚠️ DÍVIDA: `occurred_at` cai no default (agora), não no instante real da
-            # mensagem — `InboundMessage` não carrega o `messageTimestamp` do payload, e
-            # propagá-lo é mudança na camada de provider (os dois parsers). O efeito é uma
-            # janela de segundos: uma mensagem recebida 23h59 e processada 00h01 entra no
-            # briefing do dia seguinte em vez do dia dela. Fecha adicionando o campo ao
-            # `InboundMessage` e preenchendo em `evolution.parse_inbound`/`meta`.
+            # `occurred_at=msg.occurred_at` (o `messageTimestamp`/`timestamp` do provider, já
+            # convertido por `parse_epoch_seconds`): sem isto o fato nasceria com `now()`, e uma
+            # mensagem recebida 23h59 e processada 00h01 entraria no briefing do dia seguinte em
+            # vez do dia dela. `None` (provider não entregou o carimbo) cai no `now()` de sempre,
+            # dentro de `facts.record`.
             if direction == DIRECTION_IN and not da_equipe:
                 quem = (msg.sender_name or msg.push_name or msg.from_phone
                         or "contato não identificado")
@@ -386,6 +385,7 @@ def ingest_webhook_payload(
                     client_id=client_id,
                     subject_type="whatsapp_chat",
                     subject_id=chat.id if chat is not None else None,
+                    occurred_at=msg.occurred_at,
                 )
 
             # O toque no botão do aviso do briefing (Vima, Onda 4). Fica DEPOIS do registro da

--- a/apps/api/tests/test_facts_whatsapp.py
+++ b/apps/api/tests/test_facts_whatsapp.py
@@ -4,6 +4,8 @@ O guard de telefone da equipe fecha um bug que já existe hoje (o dono que escre
 próprio número entra no funil de vendas) e que o opt-in do briefing por botão na Meta (Onda 4)
 tornaria diário.
 """
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
@@ -60,6 +62,42 @@ def test_mensagem_do_proprio_time_nao_vira_lead_nem_fato(client: TestClient, db,
 
     assert db.query(Client).count() == antes
     assert db.query(Fact).filter(Fact.kind == COM_MENSAGEM_RECEBIDA).count() == 0
+
+
+def test_fato_usa_o_instante_real_da_mensagem_nao_o_do_processamento(
+    client: TestClient, db, tenant_id
+):
+    """A dívida registrada em CLAUDE.md: sem `occurred_at` vindo do provider, o fato sempre
+    nascia com `now()` — uma mensagem de 23h59 processada à 00h01 entrava no briefing do dia
+    seguinte em vez do dia dela."""
+    instante_real = datetime(2026, 8, 27, 23, 59, 0, tzinfo=UTC)
+    inbox.ingest_webhook_payload(
+        db, tenant_id=tenant_id,
+        messages=[InboundMessage(
+            wa_message_id="MSG-TS", from_phone="5511999998888", kind="text",
+            text_body="boa noite", media_ref=None, push_name="Contato",
+            chat_jid="5511999998888@s.whatsapp.net", occurred_at=instante_real,
+        )],
+    )
+
+    # SQLite (a suíte inteira roda contra ele) não preserva tzinfo na volta do banco — o
+    # `DateTime(timezone=True)` da coluna é honrado só no Postgres real. `.replace(tzinfo=UTC)`
+    # reafirma o que a coluna já promete, não uma suposição nova.
+    fato = db.query(Fact).filter(Fact.kind == COM_MENSAGEM_RECEBIDA).one()
+    assert fato.occurred_at.replace(tzinfo=UTC) == instante_real
+
+
+def test_fato_sem_carimbo_do_provider_cai_no_agora(client: TestClient, db, tenant_id):
+    """`occurred_at=None` (provider não entregou) não é erro — `facts.record` cai no
+    `datetime.now(UTC)` de sempre. Controle: `_msg` (acima) não passa `occurred_at`."""
+    antes = datetime.now(UTC)
+    inbox.ingest_webhook_payload(
+        db, tenant_id=tenant_id, messages=[_msg("5511999998888", "oi")]
+    )
+    depois = datetime.now(UTC)
+
+    fato = db.query(Fact).filter(Fact.kind == COM_MENSAGEM_RECEBIDA).one()
+    assert antes <= fato.occurred_at.replace(tzinfo=UTC) <= depois
 
 
 def test_mensagem_espelhada_do_dono_nao_vira_fato(client: TestClient, db, tenant_id):

--- a/apps/api/tests/test_whatsapp_inbound_parsing.py
+++ b/apps/api/tests/test_whatsapp_inbound_parsing.py
@@ -3,10 +3,11 @@ Payloads de exemplo reais/realistas de cada provider."""
 from __future__ import annotations
 
 import base64
+from datetime import UTC, datetime
 
 import pytest
 
-from app.core.whatsapp.inbound import InboundMessage
+from app.core.whatsapp.inbound import InboundMessage, parse_epoch_seconds
 from app.core.whatsapp.providers import evolution, meta
 
 META_TEXT_PAYLOAD = {
@@ -400,3 +401,57 @@ def test_extract_waba_id_devolve_none_quando_nao_ha() -> None:
     assert meta.extract_waba_id({"entry": [{}]}) is None
     assert meta.extract_waba_id({"entry": "nao-e-lista"}) is None
     assert meta.extract_waba_id({"entry": [{"id": 123}]}) is None  # número não é WABA válido
+
+
+# ── `occurred_at` — o instante REAL da mensagem, não o instante em que a processamos ────────
+# (a dívida registrada em CLAUDE.md: sem isto, `facts.record` sempre caía no `now()`, e uma
+# mensagem recebida 23h59 entrava no briefing do dia seguinte).
+
+
+def test_parse_epoch_seconds_aceita_int_e_str() -> None:
+    esperado = datetime(2025, 8, 5, 13, 20, 0, tzinfo=UTC)  # 1754400000
+    assert parse_epoch_seconds(1754400000) == esperado
+    assert parse_epoch_seconds("1754400000") == esperado
+
+
+def test_parse_epoch_seconds_devolve_none_para_valor_ausente_ou_ilegivel() -> None:
+    assert parse_epoch_seconds(None) is None
+    assert parse_epoch_seconds("") is None
+    assert parse_epoch_seconds("não-é-número") is None
+
+
+def test_evolution_parse_inbound_le_o_messageTimestamp() -> None:
+    payload = {
+        "data": {
+            "key": {"id": "3EB0TS1", "remoteJid": "5511988887777@s.whatsapp.net"},
+            "pushName": "Maria Cliente",
+            "message": {"conversation": "oi"},
+            "messageTimestamp": 1754400000,
+        }
+    }
+    msg = evolution.parse_inbound(payload)[0]
+    assert msg.occurred_at == datetime(2025, 8, 5, 13, 20, 0, tzinfo=UTC)
+
+
+def test_evolution_parse_inbound_sem_messageTimestamp_devolve_none() -> None:
+    # EVOLUTION_TEXT_PAYLOAD (acima) não tem messageTimestamp — o caso comum de payload
+    # deliberadamente incompleto: occurred_at fica None, e quem grava o fato cai no `now()`.
+    assert evolution.parse_inbound(EVOLUTION_TEXT_PAYLOAD)[0].occurred_at is None
+
+
+def test_meta_parse_inbound_le_o_timestamp_da_mensagem() -> None:
+    payload = {
+        "entry": [{"changes": [{"value": {
+            "contacts": [{"profile": {"name": "Maria"}}],
+            "messages": [{
+                "id": "wamid.TS1", "from": "5511988887777", "type": "text",
+                "text": {"body": "oi"}, "timestamp": "1754400000",
+            }],
+        }}]}]
+    }
+    msg = meta.parse_inbound(payload)[0]
+    assert msg.occurred_at == datetime(2025, 8, 5, 13, 20, 0, tzinfo=UTC)
+
+
+def test_meta_parse_inbound_sem_timestamp_devolve_none() -> None:
+    assert meta.parse_inbound(META_TEXT_PAYLOAD)[0].occurred_at is None


### PR DESCRIPTION
## Resumo

- `InboundMessage` ganha `occurred_at`, com um helper compartilhado `parse_epoch_seconds` (`app/core/whatsapp/inbound.py`).
- Preenchido pelos dois parsers: `messageTimestamp` (irmão de `key`/`message` em `data`) na Evolution, `timestamp` **por mensagem** na Meta.
- Propagado a `facts.record(..., occurred_at=msg.occurred_at)` em `whatsapp_inbox/service.py`, fechando a dívida registrada no `CLAUDE.md`: sem isso o fato sempre nascia com `now()`, e uma mensagem recebida 23h59 e processada 00h01 entrava no briefing do dia seguinte em vez do dia dela.
- `None` (provider não entrega o carimbo) continua caindo no `now()` de sempre — mesmo fallback que `facts.record` sempre teve.

## Plan de teste

- [x] Testes de parser (`test_whatsapp_inbound_parsing.py`): `parse_epoch_seconds` aceita int/str, devolve `None` para ausente/ilegível; os dois providers leem o carimbo certo e caem em `None` quando o payload não o traz.
- [x] Teste de integração (`test_facts_whatsapp.py`): `Fact.occurred_at` reflete o instante real da mensagem, e o fallback para `now()` quando o provider não entrega carimbo.
- [x] `ruff check` limpo.
- [x] Suíte backend completa: 2330 passed (os 4 testes `rls_e2e` de `test_migration_0069_facts_rls.py` só falham por contenção de Docker quando rodados dentro do `pytest -q` inteiro — comportamento pré-existente do §5.5 do CLAUDE.md, reproduzido verde isoladamente com `-m rls_e2e`).

🤖 Gerado com [Claude Code](https://claude.com/claude-code)