### PR TITLE
feat: Vima Q&A ganha Jurídico, Marketing e Estoque

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2964,6 +2964,18 @@ os dados reais de Financeiro, Agenda e CRM.
   Toda falha de ferramenta vira `{"erro": ...}` em vez de subir crua: o loop de tool-use precisa
   de um `tool_result` sempre, e a Claude é instruída a dizer que não conseguiu, nunca a inventar
   (Artigo IV, No Invention).
+- [x] **`vima/tools.py` — Jurídico/Marketing/Estoque (2026-08-28, extensão)** — mais quatro
+  ferramentas, mesmo formato de wrapper fino: `consultar_documentos_juridicos`
+  (`juridico.list_documents`, com filtro opcional por cliente — resolvido via
+  `crm.list_clients` — e por janela de dias sobre `created_at`, filtrados aqui em Python porque
+  o serviço não tinha esses parâmetros), `consultar_campanhas_marketing`
+  (`marketing.list_carousels`, mesmo filtro de dias) e duas de `stock`:
+  `consultar_estoque_baixo` (`stock.low_stock`) e `consultar_item_estoque` (`stock.list_items`
+  filtrado por nome parcial em Python — o serviço não tem busca por nome). Datas comparadas com
+  o mesmo cuidado já usado em `vima/service.py` para `Briefing.created_at`: SQLite devolve
+  datetime sem fuso, então a comparação sempre normaliza para UTC antes (helper `_aware()` em
+  `tools.py`) — comparar naive com aware estoura `TypeError`, que o `try/except` de `executar()`
+  engoliria como `{"erro": ...}` em vez de filtrar corretamente.
 - [x] **`vima/pergunta.py`** — mascara a pergunta + histórico reenviado pelo front via
   `core/anonymizer` antes de mandar (Regra de Ouro nº 2), roda o loop, desmascara a resposta
   final, grava `vima.pergunta.respondida` no audit quando a IA de fato respondeu. Sem

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -22,9 +22,12 @@ from app.modules.agenda import service as agenda_service
 from app.modules.crm import service as crm_service
 from app.modules.crm import timeline as crm_timeline
 from app.modules.financial_intelligence import projection as projection_service
+from app.modules.juridico import service as juridico_service
+from app.modules.marketing import service as marketing_service
 from app.modules.payables import service as payables_service
 from app.modules.receivables import service as receivables_service
 from app.modules.settings.service import tenant_timezone
+from app.modules.stock import service as stock_service
 from app.modules.vima.permissions import pode_ver
 
 
@@ -83,6 +86,91 @@ def _consultar_cliente(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
             ),
         })
     return {"clientes": resultado}
+
+
+def _aware(dt: datetime) -> datetime:
+    # SQLite devolve sem fuso; a comparação é sempre em UTC (mesma convenção de vima/service.py).
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def _consultar_documentos_juridicos(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+    client_id = None
+    if entrada.get("cliente"):
+        clientes = crm_service.list_clients(db, search=entrada["cliente"], limit=1)
+        if not clientes:
+            return {"documentos": []}
+        client_id = clientes[0].id
+    documentos = juridico_service.list_documents(db, client_id=client_id)
+    dias = entrada.get("dias")
+    if dias:
+        limite = datetime.now(UTC) - timedelta(days=int(dias))
+        documentos = [d for d in documentos if _aware(d.created_at) >= limite]
+    return {
+        "documentos": [
+            {
+                "titulo": d.title,
+                "skill": d.skill,
+                "categoria": d.category,
+                "cliente": juridico_service.client_name(db, d.client_id),
+                "gerado_em": d.created_at.isoformat(),
+                "status": d.status,
+            }
+            for d in documentos[:20]
+        ]
+    }
+
+
+def _consultar_campanhas_marketing(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+    campanhas = marketing_service.list_carousels(db)
+    dias = entrada.get("dias")
+    if dias:
+        limite = datetime.now(UTC) - timedelta(days=int(dias))
+        campanhas = [c for c in campanhas if _aware(c.created_at) >= limite]
+    return {
+        "campanhas": [
+            {
+                "tema": c.topic,
+                "plataforma": c.platform,
+                "status": c.status,
+                "gerado_em": c.created_at.isoformat(),
+            }
+            for c in campanhas[:20]
+        ]
+    }
+
+
+def _consultar_estoque_baixo(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+    itens = stock_service.low_stock(db)
+    return {
+        "itens": [
+            {
+                "nome": i.name,
+                "quantidade": i.quantity,
+                "minimo": i.min_quantity,
+                "unidade": i.unit,
+            }
+            for i in itens
+        ]
+    }
+
+
+def _consultar_item_estoque(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+    nome = entrada["nome"].strip().lower()
+    itens = [
+        i for i in stock_service.list_items(db, only_active=True) if nome in i.name.lower()
+    ]
+    return {
+        "itens": [
+            {
+                "nome": i.name,
+                "quantidade": i.quantity,
+                "minimo": i.min_quantity,
+                "unidade": i.unit,
+                "baixo": i.quantity <= i.min_quantity,
+            }
+            for i in itens
+        ]
+    }
 
 
 @dataclass
@@ -184,6 +272,94 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_consultar_cliente,
+    ),
+    Ferramenta(
+        nome="consultar_documentos_juridicos",
+        modulo="juridico",
+        definicao={
+            "name": "consultar_documentos_juridicos",
+            "description": (
+                "Lista documentos jurídicos já gerados (petições, contratos, pareceres etc.), "
+                "opcionalmente filtrados por cliente (nome ou parte dele) e/ou por quantos dias "
+                "atrás foram gerados. Use para perguntas como 'que documentos jurídicos eu já "
+                "gerei para o cliente X?' ou 'quais documentos foram gerados essa semana?'."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "cliente": {
+                        "type": "string",
+                        "description": "Nome ou parte do nome do cliente, se a busca for por ele.",
+                    },
+                    "dias": {
+                        "type": "integer",
+                        "description": (
+                            "Só considera documentos gerados nos últimos N dias. Omita para não "
+                            "filtrar por data."
+                        ),
+                    },
+                },
+            },
+        },
+        executar=_consultar_documentos_juridicos,
+    ),
+    Ferramenta(
+        nome="consultar_campanhas_marketing",
+        modulo="marketing",
+        definicao={
+            "name": "consultar_campanhas_marketing",
+            "description": (
+                "Lista carrosséis/campanhas de marketing já gerados (tema, plataforma, status), "
+                "opcionalmente só os dos últimos N dias. Use para perguntas sobre que campanhas "
+                "de marketing foram criadas recentemente e sobre qual tema."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "dias": {
+                        "type": "integer",
+                        "description": (
+                            "Só considera campanhas geradas nos últimos N dias. Omita para não "
+                            "filtrar por data."
+                        ),
+                    },
+                },
+            },
+        },
+        executar=_consultar_campanhas_marketing,
+    ),
+    Ferramenta(
+        nome="consultar_estoque_baixo",
+        modulo="stock",
+        definicao={
+            "name": "consultar_estoque_baixo",
+            "description": (
+                "Lista os itens de estoque cuja quantidade já caiu para o mínimo configurado ou "
+                "abaixo dele. Use para perguntas como 'o que está com estoque baixo?'."
+            ),
+            "input_schema": {"type": "object", "properties": {}},
+        },
+        executar=_consultar_estoque_baixo,
+    ),
+    Ferramenta(
+        nome="consultar_item_estoque",
+        modulo="stock",
+        definicao={
+            "name": "consultar_item_estoque",
+            "description": (
+                "Busca item(ns) de estoque pelo nome (ou parte dele) e devolve quantidade atual, "
+                "mínimo configurado e se está baixo. Use para perguntas sobre quanto tem em "
+                "estoque de um item específico."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "nome": {"type": "string", "description": "Nome ou parte do nome do item."},
+                },
+                "required": ["nome"],
+            },
+        },
+        executar=_consultar_item_estoque,
     ),
 ]
 

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -1,4 +1,4 @@
-"""As cinco ferramentas de leitura que a Vima oferece à Claude — permissão, delegação e o
+"""As nove ferramentas de leitura que a Vima oferece à Claude — permissão, delegação e o
 contrato "nunca deixa exceção subir crua" (o loop de tool-use precisa de um tool_result sempre).
 """
 import json
@@ -8,7 +8,10 @@ from sqlalchemy.orm import Session
 
 from app.core.tenancy import CurrentUser
 from app.modules.crm.models import Client
+from app.modules.juridico.models import LegalDocument
+from app.modules.marketing.models import Carousel
 from app.modules.receivables.models import METHOD_PIX, STATUS_OPEN, Charge
+from app.modules.stock.models import StockItem
 from app.modules.vima import tools
 from app.modules.wallet.models import KIND_SERVICE
 
@@ -25,12 +28,28 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_cinco_ferramentas():
+def test_owner_ve_as_nove_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
     }
+
+
+def test_sub_usuario_so_de_juridico_so_ve_a_ferramenta_de_documentos():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["juridico"]))}
+    assert nomes == {"consultar_documentos_juridicos"}
+
+
+def test_sub_usuario_so_de_marketing_so_ve_a_ferramenta_de_campanhas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["marketing"]))}
+    assert nomes == {"consultar_campanhas_marketing"}
+
+
+def test_sub_usuario_so_de_stock_ve_as_duas_ferramentas_de_estoque():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["stock"]))}
+    assert nomes == {"consultar_estoque_baixo", "consultar_item_estoque"}
 
 
 def test_sub_usuario_so_de_crm_so_ve_a_ferramenta_de_cliente():
@@ -123,6 +142,116 @@ def test_consultar_cliente_encontra_por_nome_parcial(db: Session):
 def test_consultar_cliente_sem_match_devolve_lista_vazia(db: Session):
     resultado = json.loads(tools.executar(db, _usuario(), "consultar_cliente", {"nome": "Ninguém"}))
     assert resultado["clientes"] == []
+
+
+# ── consultar_documentos_juridicos ──────────────────────────────────────────────────────────
+
+
+def test_consultar_documentos_juridicos_filtra_por_cliente(db: Session):
+    cliente = Client(tenant_id=TENANT, name="Maria Souza", phone="11988887777", source="manual")
+    db.add(cliente)
+    db.flush()
+    db.add(LegalDocument(
+        tenant_id=TENANT, skill="peticao_inicial", title="Petição — Maria Souza",
+        client_id=cliente.id,
+    ))
+    db.add(LegalDocument(tenant_id=TENANT, skill="contrato", title="Contrato — outro cliente"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_documentos_juridicos", {"cliente": "Maria"})
+    )
+    assert len(resultado["documentos"]) == 1
+    assert resultado["documentos"][0]["titulo"] == "Petição — Maria Souza"
+    assert resultado["documentos"][0]["cliente"] == "Maria Souza"
+
+
+def test_consultar_documentos_juridicos_sem_filtro_lista_tudo(db: Session):
+    db.add(LegalDocument(tenant_id=TENANT, skill="contrato", title="Contrato A"))
+    db.add(LegalDocument(tenant_id=TENANT, skill="parecer", title="Parecer B"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_documentos_juridicos", {})
+    )
+    assert len(resultado["documentos"]) == 2
+
+
+def test_consultar_documentos_juridicos_filtra_por_dias(db: Session):
+    db.add(LegalDocument(tenant_id=TENANT, skill="contrato", title="Contrato recente"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_documentos_juridicos", {"dias": 7})
+    )
+    assert len(resultado["documentos"]) == 1
+    resultado_antigo = json.loads(
+        tools.executar(db, _usuario(), "consultar_documentos_juridicos", {"dias": -1})
+    )
+    assert resultado_antigo["documentos"] == []
+
+
+def test_consultar_documentos_juridicos_cliente_sem_match_devolve_lista_vazia(db: Session):
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_documentos_juridicos", {"cliente": "Ninguém"})
+    )
+    assert resultado["documentos"] == []
+
+
+# ── consultar_campanhas_marketing ───────────────────────────────────────────────────────────
+
+
+def test_consultar_campanhas_marketing_lista_as_geradas(db: Session):
+    db.add(Carousel(tenant_id=TENANT, topic="5 erros de precificação", platform="instagram"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_campanhas_marketing", {})
+    )
+    assert len(resultado["campanhas"]) == 1
+    assert resultado["campanhas"][0]["tema"] == "5 erros de precificação"
+    assert resultado["campanhas"][0]["plataforma"] == "instagram"
+
+
+def test_consultar_campanhas_marketing_filtra_por_dias(db: Session):
+    db.add(Carousel(tenant_id=TENANT, topic="Tema antigo", platform="instagram"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_campanhas_marketing", {"dias": -1})
+    )
+    assert resultado["campanhas"] == []
+
+
+# ── consultar_estoque_baixo / consultar_item_estoque ────────────────────────────────────────
+
+
+def test_consultar_estoque_baixo_so_lista_item_no_ou_abaixo_do_minimo(db: Session):
+    db.add(StockItem(
+        tenant_id=TENANT, name="Caneca personalizada", quantity=2, min_quantity=5, unit="un",
+    ))
+    db.add(StockItem(
+        tenant_id=TENANT, name="Camiseta P", quantity=50, min_quantity=5, unit="un",
+    ))
+    db.commit()
+    resultado = json.loads(tools.executar(db, _usuario(), "consultar_estoque_baixo", {}))
+    assert len(resultado["itens"]) == 1
+    assert resultado["itens"][0]["nome"] == "Caneca personalizada"
+
+
+def test_consultar_item_estoque_busca_por_nome_parcial(db: Session):
+    db.add(StockItem(
+        tenant_id=TENANT, name="Caneca personalizada", quantity=2, min_quantity=5, unit="un",
+    ))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_item_estoque", {"nome": "caneca"})
+    )
+    assert len(resultado["itens"]) == 1
+    assert resultado["itens"][0]["quantidade"] == 2
+    assert resultado["itens"][0]["baixo"] is True
+
+
+def test_consultar_item_estoque_sem_match_devolve_lista_vazia(db: Session):
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_item_estoque", {"nome": "Ninguém"})
+    )
+    assert resultado["itens"] == []
 
 
 # ── Falha nunca sobe crua ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumo

Amplia o Q&A da Vima (PR #266) para três novos domínios, seguindo exatamente o mesmo padrão das
cinco ferramentas existentes — wrappers finos sobre serviços de leitura já existentes, nada de
lógica de negócio nova:

- **`consultar_documentos_juridicos`** (`juridico`) — lista documentos jurídicos gerados,
  opcionalmente filtrados por cliente e/ou janela de dias.
- **`consultar_campanhas_marketing`** (`marketing`) — lista carrosséis do Instagram gerados
  (tema, plataforma, status), opcionalmente por janela de dias.
- **`consultar_estoque_baixo`** (`stock`) — itens no ou abaixo do mínimo.
- **`consultar_item_estoque`** (`stock`) — busca item de estoque por nome parcial.

Nenhum domínio foi pulado — os três tinham um caminho de leitura limpo para embrulhar
(`list_documents`, `list_carousels`, `low_stock`/`list_items`).

Um detalhe de correção que vale registrar: os filtros de "últimos N dias" comparam `created_at`
contra um corte UTC-aware, mas o SQLite (suíte de testes) devolve datetime naive — um helper
`_aware()` (mesma convenção já usada em `vima/service.py`) evita o `TypeError` que isso geraria.

CLAUDE.md atualizado com a extensão.

## Test plan

- [x] `apps/api/tests/test_vima_tools.py`: 24 testes (eram 12), todos passando — cobrem caminho
      feliz, sem match, bordas do filtro de dias, e o gate de permissão por módulo de cada
      ferramenta nova
- [x] `ruff check .` limpo
- [x] Suíte completa (`pytest -q`): 2364 passed, 1 skipped — sem regressão

🤖 Gerado com [Claude Code](https://claude.com/claude-code)