### PR TITLE
docs: marca a VPS Hostinger como descomissionada

### DIFF
--- a/docs/HOSTINGER-DEPLOY.md
+++ b/docs/HOSTINGER-DEPLOY.md
@@ -1,5 +1,14 @@
 # Deploy em VPS Hostinger (KVM) — 1 servidor, Docker Compose
 
+> ⚠️ **DESCOMISSIONADO em 2026-08-30.** A instância real que este guia documentava
+> (`e1p.doroeventos.com.br`, VPS `187.127.21.213`) foi **totalmente removida**: containers,
+> volumes (Postgres, uploads, Evolution, uptime-kuma), imagens locais, `/opt/e1p` e
+> `/opt/e1p-backups`, cron jobs, o remote `rclone` e os registros DNS (`e1p` e `monitor.e1p`
+> em `doroeventos.com.br`). A produção é **só a AWS** (`docs/AWS-DEPLOYMENT.md`) desde
+> 2026-08-20 — ver `docs/decisions/`. Este arquivo fica só como referência histórica de COMO
+> um deploy em VPS Hostinger funcionava; **não siga os passos abaixo contra um host real sem
+> antes confirmar que ele ainda existe.**
+
 Alternativa mais barata ao plano AWS (`docs/AWS-DEPLOYMENT.md`): tudo num único VPS.
 Como a app já é 100% conteinerizada (12-factor), a topologia é quase idêntica ao
 `docker-compose.yml` de dev — só troca o alvo. Ver ADR 0001 (`docs/decisions/`) para o
@@ -130,8 +139,9 @@ pro IP da VPS (`dig +short app.seudominio.com`) e se a porta 80 está mesmo aces
 > nomear serviço** e **prova** o resultado (health, alembic, e o hash do bundle servido, que
 > precisa ter mudado se e somente se o diff tocou `apps/web`). `--dry-run` imprime o plano.
 >
-> **Esta VPS é dev/teste desde 2026-08-20**; a produção é a AWS (`docs/AWS-DEPLOYMENT.md`). O mesmo
-> script serve as duas — muda só o host. Em produção ele exige confirmação digitada.
+> **Esta VPS foi DESCOMISSIONADA em 2026-08-30** (era dev/teste desde 2026-08-20; a produção
+> é a AWS, `docs/AWS-DEPLOYMENT.md`). O host `187.127.21.213` não roda mais nenhum serviço do
+> e1p — o `deploy.sh` acima não tem mais alvo aqui. O mesmo script segue servindo a AWS.
 
 > **Antes de dar `git pull` + rebuild em produção, confirme que o CI está VERDE** no
 > commit/branch que será deployado (`.github/workflows/ci.yml` — jobs `test-in-prod-image`


### PR DESCRIPTION
## Resumo
- Adiciona um aviso de descomissionamento no topo de `docs/HOSTINGER-DEPLOY.md`.
- Atualiza a nota da seção 5 (que dizia "dev/teste desde 2026-08-20") para refletir a remoção completa em 2026-08-30.

## Contexto
A VPS Hostinger (`187.127.21.213`, compartilhada com axisgov/fiscalize/autoinfracao/doro-site/nexus-publica) teve todos os artefatos do e1p removidos: containers, volumes (Postgres, uploads, Evolution, uptime-kuma), imagens locais, `/opt/e1p`, `/opt/e1p-backups`, cron jobs (`e1p-backup`, `e1p-disk-monitor`), o remote rclone `e1p-offsite`, e os registros DNS `e1p`/`monitor.e1p` na zona Cloudflare de `doroeventos.com.br`. Nenhum outro projeto na VPS foi tocado. Produção continua só na AWS (desde 2026-08-20).

O runbook `.claude/agent-memory/aiox-devops/reference_prod_deployment.md` (gitignorado, local) também foi marcado como histórico — não faz parte deste PR por não ser versionado.

## Test plan
- [x] Documentação apenas — sem mudança de código/comportamento.