### PR TITLE
feat: contador de mensagens não lidas na tela de Conversas (estilo WhatsApp Web)

### DIFF
--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -691,9 +691,21 @@ def list_conversations(
     #
     # Esta ordenação e o laço "última iteração vence" abaixo NÃO mudam com o filtro — só QUAIS
     # linhas entram na consulta muda.
+    unread_counts: dict[str, int] = {}
     for msg in db.scalars(consulta_msgs).all():
         if msg.chat_id is not None:
             last_msgs[msg.chat_id] = msg  # a última iteração (ordem crescente) vence
+            # Reaproveita este MESMO laço (que já materializa toda mensagem candidata) para
+            # contar quantas ficaram para trás do `last_read_at` — o número que o badge da tela
+            # mostra (estilo WhatsApp Web). Sem isto seria uma segunda consulta agregada por
+            # chat, pagando de novo o custo que este laço já cobre.
+            chat = chats.get(msg.chat_id)
+            if (
+                chat is not None
+                and msg.direction == DIRECTION_IN
+                and (chat.last_read_at is None or msg.created_at > chat.last_read_at)
+            ):
+                unread_counts[msg.chat_id] = unread_counts.get(msg.chat_id, 0) + 1
 
     out = []
     for chat_id, last_msg in last_msgs.items():
@@ -714,7 +726,12 @@ def list_conversations(
             "client_id": chat.client_id,
             "last_message_at": last_msg.created_at,
             "last_message_preview": _preview(last_msg, chat),
+            # Mantido por compatibilidade (e pela paridade com `unread_client_ids`, ver nota
+            # acima) — não é derivado de `unread_count` de propósito: são duas leituras
+            # independentes que já coincidem hoje, e trocar por `unread_count > 0` arriscaria
+            # divergir da regra que o board usa sem nenhum teste avisando.
             "unread": unread,
+            "unread_count": unread_counts.get(chat_id, 0),
         })
     out.sort(key=lambda c: c["last_message_at"], reverse=True)
     return out

--- a/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
+++ b/apps/api/tests/test_whatsapp_inbox_nao_lidas.py
@@ -123,6 +123,26 @@ def test_list_conversations_filtra_por_client_id(db):
     assert {c["client_id"] for c in do_contato} == {"cli-5"}
 
 
+def test_list_conversations_unread_count_conta_mensagens_atras_do_last_read_at(db):
+    """`unread_count` é uma contagem de verdade (o número do badge estilo WhatsApp Web), não o
+    booleano `unread` — que só olha a ÚLTIMA mensagem da conversa. As duas podem divergir de
+    propósito: em c3 e c6 o dono respondeu por cima de uma mensagem do contato sem nunca marcar
+    a conversa como lida. `unread` diz "em dia" (a última mensagem é nossa), mas ainda existe 1
+    mensagem do contato nunca lida — e é isso que `unread_count` mostra, sem que isso quebre a
+    paridade de `unread` com `unread_client_ids` (não mexe nesse campo)."""
+    _cenario_completo(db)
+    por_jid = {
+        c["title"]: c["unread_count"] for c in inbox_service.list_conversations(db, TENANT_ID)
+    }
+    assert por_jid["5511900000001@s.whatsapp.net"] == 1  # c1: nunca lida
+    assert por_jid["5511900000002@s.whatsapp.net"] == 0  # c2: lida depois da mensagem
+    assert por_jid["5511900000003@s.whatsapp.net"] == 1  # c3: respondeu, mas nunca leu
+    assert por_jid["120363000000000000@g.us"] == 1  # grupo: mesma regra de `unread`, conta igual
+    assert por_jid["5511900000005@s.whatsapp.net"] == 0  # c5a: lida
+    assert por_jid["99995@lid"] == 1  # c5b: não lida
+    assert por_jid["5511900000006@s.whatsapp.net"] == 1  # c6: empate, mas a `in` ainda conta
+
+
 def test_list_conversations_sem_filtro_continua_trazendo_grupo(db):
     """O filtro é OPCIONAL e não pode mudar o comportamento da tela de Conversas."""
     _cenario_completo(db)

--- a/apps/web/src/features/conversas/ConversasPage.test.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.test.tsx
@@ -54,7 +54,7 @@ describe("ConversasPage", () => {
           data: [{
             chat_id: "c1", kind: "direct" as const, title: "Doro Eventos", phone: "5511999999999", client_id: "c1",
             last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "Oi, quero o cardápio",
-            unread: true,
+            unread: true, unread_count: 1,
           }],
         });
       }
@@ -85,6 +85,48 @@ describe("ConversasPage", () => {
     expect(screen.getByPlaceholderText(/mensagem/i)).toBeInTheDocument();
   });
 
+  it("mostra o badge com a contagem de não lidas, com cap em 99+, e deixa a prévia em negrito", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/whatsapp-conversations") {
+        return Promise.resolve({
+          data: [
+            {
+              chat_id: "c1", kind: "direct" as const, title: "Poucas não lidas",
+              phone: "5511999999999", client_id: "c1",
+              last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "oi",
+              unread: true, unread_count: 3,
+            },
+            {
+              chat_id: "c2", kind: "direct" as const, title: "Tudo lido",
+              phone: "5511977776666", client_id: "c2",
+              last_message_at: "2026-07-19T09:00:00Z", last_message_preview: "tudo certo",
+              unread: false, unread_count: 0,
+            },
+            {
+              chat_id: "c3", kind: "direct" as const, title: "Muitíssimas não lidas",
+              phone: "5511966665555", client_id: "c3",
+              last_message_at: "2026-07-19T08:00:00Z", last_message_preview: "spam",
+              unread: true, unread_count: 150,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderNaRota("/conversas");
+    await waitFor(() => screen.getByText("Poucas não lidas"));
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    // 150 > cap de 99 — mostra "99+", nunca o número exato (estouraria a linha da lista).
+    expect(screen.getByText("99+")).toBeInTheDocument();
+    expect(screen.queryByText("150")).not.toBeInTheDocument();
+
+    // Prévia da conversa não lida fica em negrito/escura; a já lida continua leve, como antes.
+    expect(screen.getByText("oi")).toHaveClass("font-semibold");
+    expect(screen.getByText("tudo certo")).not.toHaveClass("font-semibold");
+  });
+
   it("o separador de dia e o horário saem no fuso do TENANT, não no do navegador", async () => {
     // O fio agrupa por DIA (`dayKey`) e carimba cada bolha (`hhmm`), os dois no fuso do tenant.
     // O teste irmão abaixo mede as duas coisas com o tenant no MESMO fuso da máquina, e por isso
@@ -98,7 +140,7 @@ describe("ConversasPage", () => {
           data: [{
             chat_id: "c1", kind: "direct" as const, title: "Murilo Moreschi", phone: "5511977776666",
             client_id: "c1", last_message_at: "2026-07-19T23:30:00Z",
-            last_message_preview: "sempre na curva", unread: false,
+            last_message_preview: "sempre na curva", unread: false, unread_count: 0,
           }],
         });
       }
@@ -146,7 +188,7 @@ describe("ConversasPage", () => {
           data: [{
             chat_id: "c1", kind: "direct" as const, title: "Murilo Moreschi", phone: "5511977776666", client_id: "c1",
             last_message_at: "2026-07-20T17:19:00-03:00", last_message_preview: "Ok",
-            unread: false,
+            unread: false, unread_count: 0,
           }],
         });
       }
@@ -209,7 +251,7 @@ describe("ConversasPage", () => {
             chat_id: "g1", kind: "group" as const, title: "Automação Residencial",
             phone: null, client_id: null,
             last_message_at: "2026-07-20T11:05:00-03:00",
-            last_message_preview: "Gabriel B: alguém indica?", unread: true,
+            last_message_preview: "Gabriel B: alguém indica?", unread: true, unread_count: 1,
           }],
         });
       }
@@ -261,7 +303,7 @@ describe("ConversasPage", () => {
           data: [{
             chat_id: "c2", kind: "direct" as const, title: "Cliente Antigo", phone: "5511888888888", client_id: "c2",
             last_message_at: "2026-07-01T10:00:00Z", last_message_preview: "oi",
-            unread: false,
+            unread: false, unread_count: 0,
           }],
         });
       }
@@ -301,12 +343,12 @@ describe("ConversasPage", () => {
             {
               chat_id: "c1", kind: "direct" as const, title: "Cliente A", phone: "5511111111111", client_id: "c1",
               last_message_at: "2026-07-19T10:00:00Z", last_message_preview: "prévia A",
-              unread: false,
+              unread: false, unread_count: 0,
             },
             {
               chat_id: "c2", kind: "direct" as const, title: "Cliente B", phone: "5511222222222", client_id: "c2",
               last_message_at: "2026-07-19T11:00:00Z", last_message_preview: "prévia B",
-              unread: false,
+              unread: false, unread_count: 0,
             },
           ],
         });
@@ -361,13 +403,13 @@ describe("ConversasPage", () => {
 const CONVERSA_DIRETA = {
   chat_id: "c1", kind: "direct" as const, title: "Flavio Kato", phone: "5511999998888",
   client_id: "cli1", last_message_at: "2026-08-04T10:00:00Z",
-  last_message_preview: "Oi", unread: false,
+  last_message_preview: "Oi", unread: false, unread_count: 0,
 };
 
 const GRUPO = {
   chat_id: "g1", kind: "group" as const, title: "Turma 2026", phone: null,
   client_id: null, last_message_at: "2026-08-04T10:00:00Z",
-  last_message_preview: "Bom dia", unread: false,
+  last_message_preview: "Bom dia", unread: false, unread_count: 0,
 };
 
 const TIMELINE_DO_CRM = {
@@ -452,13 +494,13 @@ function mockarDuasConversas() {
             chat_id: "c1", kind: "direct" as const, title: "Doro Eventos",
             phone: "5511999999999", client_id: "cli-1",
             last_message_at: "2026-07-19T10:00:00Z",
-            last_message_preview: "Oi, quero o cardápio", unread: true,
+            last_message_preview: "Oi, quero o cardápio", unread: true, unread_count: 1,
           },
           {
             chat_id: "c2", kind: "direct" as const, title: "Murilo Moreschi",
             phone: "5511977776666", client_id: "cli-2",
             last_message_at: "2026-07-20T11:00:00Z",
-            last_message_preview: "Ok", unread: false,
+            last_message_preview: "Ok", unread: false, unread_count: 0,
           },
         ],
       });
@@ -595,7 +637,7 @@ describe("ConversasPage — carregando vs. vazia", () => {
       data: [{
         chat_id: "c1", kind: "direct" as const, title: "Ju", phone: "5511999998888",
         client_id: "cli-1", last_message_at: "2026-08-15T23:10:00Z",
-        last_message_preview: "Boa noite", unread: false,
+        last_message_preview: "Boa noite", unread: false, unread_count: 0,
       }],
     });
     // Resolveu e achou a conversa: o carregando neutro dá lugar ao fio de verdade.
@@ -665,7 +707,7 @@ describe("ConversasPage — lista de conversas fora de forma não derruba a tela
         client_id: "c1",
         last_message_at: "2026-07-19T10:00:00Z",
         last_message_preview: "Oi, quero o cardápio",
-        unread: false,
+        unread: false, unread_count: 0,
       },
     ]);
     renderNaRota("/conversas");
@@ -690,7 +732,7 @@ describe("ConversasPage — fio e templates fora de forma não derrubam a conver
           data: [{
             chat_id: "c1", kind: "direct" as const, title: "Doro Eventos", phone: "5511999999999",
             client_id: "c1", last_message_at: "2026-07-19T10:00:00Z",
-            last_message_preview: "Oi", unread: false,
+            last_message_preview: "Oi", unread: false, unread_count: 0,
           }],
         } as never);
       }

--- a/apps/web/src/features/conversas/ConversasPage.tsx
+++ b/apps/web/src/features/conversas/ConversasPage.tsx
@@ -43,6 +43,13 @@ function listStamp(iso: string | null, tz: string): string {
   return dayKey(iso, tz) === dayKey(new Date().toISOString(), tz) ? hhmm(iso, tz) : dayKey(iso, tz);
 }
 
+// Rótulo do badge de não lidas (estilo WhatsApp Web): número exato até 99, "99+" depois disso —
+// um contador de 3+ dígitos não cabe no badge sem esticar a linha da lista.
+const UNREAD_BADGE_CAP = 99;
+function unreadBadgeLabel(count: number): string {
+  return count > UNREAD_BADGE_CAP ? `${UNREAD_BADGE_CAP}+` : String(count);
+}
+
 export default function ConversasPage() {
   const fuso = useFuso();
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
@@ -141,10 +148,18 @@ export default function ConversasPage() {
                 </span>
                 <span className="flex shrink-0 items-center gap-1.5 text-[11px] text-neutral-400">
                   {listStamp(c.last_message_at, fuso)}
-                  {c.unread && <span className="h-2 w-2 rounded-full bg-primary-600" />}
+                  {c.unread_count > 0 && (
+                    <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-600 px-1 text-[10px] font-semibold text-white">
+                      {unreadBadgeLabel(c.unread_count)}
+                    </span>
+                  )}
                 </span>
               </div>
-              <p className="mt-0.5 truncate text-xs text-neutral-400">
+              <p
+                className={`mt-0.5 truncate text-xs ${
+                  c.unread_count > 0 ? "font-semibold text-neutral-700" : "text-neutral-400"
+                }`}
+              >
                 {c.last_message_preview}
               </p>
             </button>

--- a/apps/web/src/features/crm/BlocoDaConversa.test.tsx
+++ b/apps/web/src/features/crm/BlocoDaConversa.test.tsx
@@ -24,7 +24,7 @@ vi.mock("../../store/auth", () => ({ useFuso: () => fusoDoTenant }));
 const conversa = (chat_id: string, title: string) => ({
   chat_id, kind: "direct", title, phone: "5511999998888",
   client_id: "cli-1", last_message_at: "2026-08-15T23:10:00Z",
-  last_message_preview: "Boa noite", unread: false,
+  last_message_preview: "Boa noite", unread: false, unread_count: 0,
 });
 
 const mensagens = [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -875,6 +875,9 @@ export interface ConversationSummary {
   last_message_at: string | null;
   last_message_preview: string;
   unread: boolean;
+  /** Quantas mensagens `in` chegaram desde `last_read_at` — o número do badge estilo WhatsApp
+   * Web. Independente de `unread`, que é o booleano legado usado pelo ponto do Kanban. */
+  unread_count: number;
 }
 
 export interface TimelineEntry {


### PR DESCRIPTION
## Resumo

O único sinal de "não lida" na lista de Conversas era um pontinho de 8px do
lado do horário — fácil de não notar (feedback direto do usuário testando
a correção do #273).

- **Backend:** `list_conversations` agora calcula `unread_count` (nº de
  mensagens `in` desde `last_read_at`), reaproveitando o mesmo laço que já
  materializa as mensagens do tenant — sem query extra.
- **Frontend:** a lista mostra um badge verde com o número (cap em "99+"
  acima de 99) no lugar do pontinho, e a prévia da última mensagem fica em
  negrito quando há não lidas.
- O booleano `unread` existente **não muda** — ele alimenta o ponto do
  Kanban via `unread_client_ids` e tem teste de paridade entre os dois;
  `unread_count` é um campo novo e independente, sem risco pra esse
  contrato.

## Test plan
- [x] `pytest tests/test_whatsapp_inbox_nao_lidas.py tests/test_whatsapp_inbox_service.py` (novo teste cobre as 7 situações do cenário de não-lidas, incluindo os casos em que `unread_count` diverge de propósito do booleano `unread`)
- [x] `pytest` suíte completa do backend (2410 passed)
- [x] `ruff check .`
- [x] `vitest run` suíte completa do frontend (1225 passed), incluindo novo teste do badge + cap 99+ + negrito
- [x] `tsc --noEmit` e `eslint` no arquivo alterado