### PR TITLE
feat: a Vima ganha a ferramenta consultar_clientes_recentes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2976,6 +2976,21 @@ os dados reais de Financeiro, Agenda e CRM.
   datetime sem fuso, então a comparação sempre normaliza para UTC antes (helper `_aware()` em
   `tools.py`) — comparar naive com aware estoura `TypeError`, que o `try/except` de `executar()`
   engoliria como `{"erro": ...}` em vez de filtrar corretamente.
+- [x] **`vima/tools.py` — `consultar_clientes_recentes` (2026-08-30)** — a Vima não sabia
+  responder "qual foi o último contato que entrou no CRM?" nem "quem entrou ontem?": a única
+  ferramenta de CRM era `consultar_cliente`, que exige um NOME e não tem como listar por ordem
+  de entrada. Nova ferramenta, mesmo formato de wrapper fino: `crm.list_recent_clients`
+  (`created_at` desc, `limit` interno de 200) + filtro de `dias` em PYTHON — mesma decisão de
+  `consultar_documentos_juridicos`/`consultar_campanhas_marketing` acima, pela mesma razão
+  (SQLite sob teste não tem fuso nativo; comparar a coluna em SQL ali é terreno instável).
+  `limite` (padrão 5) corta a lista DEPOIS do filtro de dias, nunca antes — senão "quem entrou
+  esta semana" perderia gente se a semana tivesse mais de 5 entradas. `entrou_em` é o
+  `created_at` em ISO, sem reaproveitar `ultima_interacao` (que é sobre INTERAÇÃO, não entrada).
+  - ⚠️ **O teste de ordenação fixa `created_at` explícito, não confia no relógio real.** O
+    SQLite dos testes unitários tem `func.now()` com resolução de SEGUNDO — dois `Client`
+    criados no mesmo teste podem empatar e o desempate (`Client.id.desc()`, um uuid) embaralha a
+    ordem esperada. Mesma classe já registrada para `AuditEntry`/histórico de saques neste
+    arquivo; a correção é a mesma: datar os fixtures à mão.
 - [x] **`vima/pergunta.py`** — mascara a pergunta + histórico reenviado pelo front via
   `core/anonymizer` antes de mandar (Regra de Ouro nº 2), roda o loop, desmascara a resposta
   final, grava `vima.pergunta.respondida` no audit quando a IA de fato respondeu. Sem

--- a/apps/api/app/modules/crm/service.py
+++ b/apps/api/app/modules/crm/service.py
@@ -409,6 +409,20 @@ def list_clients(
     return list(db.scalars(stmt).all())
 
 
+def list_recent_clients(db: Session, *, limit: int = 20) -> list[Client]:
+    """Clientes mais recentemente adicionados ao CRM, do mais novo para o mais antigo.
+
+    Irmã de `list_clients` (que ordena por nome e serve o board), não uma variação dela: aqui
+    quem importa é QUANDO o cliente entrou, não a lista alfabética. Usada pela Vima para
+    responder "qual foi o último contato que entrou" — filtro por janela de dias fica a cargo
+    do chamador (mesmo motivo de `vima/tools._consultar_documentos_juridicos`: comparar
+    `created_at` direto no SQLite dos testes, sem fuso nativo, é terreno instável).
+    """
+    limit = max(1, min(limit, 100))
+    stmt = select(Client).order_by(Client.created_at.desc(), Client.id.desc()).limit(limit)
+    return list(db.scalars(stmt).all())
+
+
 def get_client(db: Session, client_id: str) -> Client:
     client = db.get(Client, client_id)
     if client is None:

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -93,6 +93,28 @@ def _aware(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
+def _consultar_clientes_recentes(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+    limite = int(entrada.get("limite") or 5)
+    clientes = crm_service.list_recent_clients(db, limit=200)
+    dias = entrada.get("dias")
+    if dias:
+        corte = datetime.now(UTC) - timedelta(days=int(dias))
+        clientes = [c for c in clientes if _aware(c.created_at) >= corte]
+    return {
+        "clientes": [
+            {
+                "id": c.id,
+                "nome": c.name,
+                "telefone": c.phone,
+                "tags": c.tags,
+                "origem": c.source,
+                "entrou_em": c.created_at.isoformat(),
+            }
+            for c in clientes[:limite]
+        ]
+    }
+
+
 def _consultar_documentos_juridicos(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
     client_id = None
     if entrada.get("cliente"):
@@ -272,6 +294,40 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_consultar_cliente,
+    ),
+    Ferramenta(
+        nome="consultar_clientes_recentes",
+        modulo="crm",
+        definicao={
+            "name": "consultar_clientes_recentes",
+            "description": (
+                "Lista os clientes mais recentemente adicionados ao CRM, do mais novo para o "
+                "mais antigo, com nome, telefone, tags, origem e quando entraram. Use para "
+                "perguntas como 'qual foi o último contato/cliente que entrou no CRM' (omita "
+                "'dias' e olhe o primeiro da lista) ou 'quem entrou ontem/essa semana' "
+                "(use 'dias': 1 para ontem, 7 para essa semana)."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "dias": {
+                        "type": "integer",
+                        "description": (
+                            "Só considera clientes entrados nos últimos N dias. Omita para não "
+                            "filtrar por data."
+                        ),
+                    },
+                    "limite": {
+                        "type": "integer",
+                        "description": (
+                            "Quantos clientes retornar, do mais novo para o mais antigo. "
+                            "Padrão 5."
+                        ),
+                    },
+                },
+            },
+        },
+        executar=_consultar_clientes_recentes,
     ),
     Ferramenta(
         nome="consultar_documentos_juridicos",

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -2,7 +2,7 @@
 contrato "nunca deixa exceção subir crua" (o loop de tool-use precisa de um tool_result sempre).
 """
 import json
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
@@ -28,12 +28,13 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_nove_ferramentas():
+def test_owner_ve_as_dez_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
-        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "consultar_agenda", "consultar_cliente", "consultar_clientes_recentes",
+        "consultar_documentos_juridicos", "consultar_campanhas_marketing",
+        "consultar_estoque_baixo", "consultar_item_estoque",
     }
 
 
@@ -52,9 +53,9 @@ def test_sub_usuario_so_de_stock_ve_as_duas_ferramentas_de_estoque():
     assert nomes == {"consultar_estoque_baixo", "consultar_item_estoque"}
 
 
-def test_sub_usuario_so_de_crm_so_ve_a_ferramenta_de_cliente():
+def test_sub_usuario_so_de_crm_ve_as_duas_ferramentas_de_cliente():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["crm"]))}
-    assert nomes == {"consultar_cliente"}
+    assert nomes == {"consultar_cliente", "consultar_clientes_recentes"}
 
 
 def test_toda_ferramenta_declara_um_input_schema_valido():
@@ -141,6 +142,66 @@ def test_consultar_cliente_encontra_por_nome_parcial(db: Session):
 
 def test_consultar_cliente_sem_match_devolve_lista_vazia(db: Session):
     resultado = json.loads(tools.executar(db, _usuario(), "consultar_cliente", {"nome": "Ninguém"}))
+    assert resultado["clientes"] == []
+
+
+# ── consultar_clientes_recentes ─────────────────────────────────────────────────────────────
+
+
+def test_consultar_clientes_recentes_ordena_do_mais_novo_pro_mais_antigo(db: Session):
+    # created_at explícito: o SQLite tem resolução de SEGUNDO em func.now(), e dois commits no
+    # mesmo segundo empatariam — a mesma classe registrada no CLAUDE.md para AuditEntry/saques.
+    agora = datetime.now(UTC)
+    mais_antigo = Client(
+        tenant_id=TENANT, name="Ana", phone="11900000001", source="manual",
+        created_at=agora - timedelta(hours=1),
+    )
+    db.add(mais_antigo)
+    mais_novo = Client(
+        tenant_id=TENANT, name="Beto", phone="11900000002", source="whatsapp", created_at=agora,
+    )
+    db.add(mais_novo)
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_recentes", {})
+    )
+    nomes = [c["nome"] for c in resultado["clientes"]]
+    assert nomes == ["Beto", "Ana"]
+    assert resultado["clientes"][0]["origem"] == "whatsapp"
+    assert "entrou_em" in resultado["clientes"][0]
+
+
+def test_consultar_clientes_recentes_respeita_o_limite(db: Session):
+    for i in range(3):
+        db.add(Client(
+            tenant_id=TENANT, name=f"Cliente {i}", phone=f"1190000000{i}", source="manual",
+        ))
+        db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_recentes", {"limite": 2})
+    )
+    assert len(resultado["clientes"]) == 2
+
+
+def test_consultar_clientes_recentes_filtra_por_dias(db: Session):
+    antigo = Client(
+        tenant_id=TENANT, name="Antigo", phone="11900000009", source="manual",
+        created_at=datetime.now(UTC) - timedelta(days=10),
+    )
+    db.add(antigo)
+    db.add(Client(tenant_id=TENANT, name="Recente", phone="11900000008", source="manual"))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_recentes", {"dias": 1})
+    )
+    nomes = [c["nome"] for c in resultado["clientes"]]
+    assert nomes == ["Recente"]
+
+
+def test_consultar_clientes_recentes_sem_clientes_devolve_lista_vazia(db: Session):
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_recentes", {})
+    )
     assert resultado["clientes"] == []
 
 


### PR DESCRIPTION
## Resumo
- A Vima (`/vima/perguntas`) só tinha `consultar_cliente` (busca por nome) — perguntas como "qual foi o último contato que entrou no CRM" ou "quem entrou ontem" sempre caíam em "não tenho ferramenta pra isso", mesmo sendo perguntas legítimas do dono do negócio.
- Nova ferramenta `consultar_clientes_recentes`: lista os clientes mais recentes do CRM (`created_at` desc), com filtro opcional de `dias` (mesmo padrão de `consultar_documentos_juridicos`/`consultar_campanhas_marketing` — filtro em Python, não SQL, pelo mesmo motivo já documentado de SQLite sem fuso nativo) e `limite` (padrão 5).
- Nova `crm.service.list_recent_clients` — irmã de `list_clients` (que ordena por nome), sem mexer no comportamento existente.

## Test plan
- [x] `pytest tests/test_vima_tools.py -q` — 28 testes, incluindo 4 novos cobrindo ordenação, limite, filtro de dias e lista vazia
- [x] `ruff check` limpo
- [x] Suite completa do backend: `2414 passed, 1 skipped` (0 falhas)
- [x] Entrada correspondente no `CLAUDE.md` (§5, passo 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)