### PR TITLE
fix(busca): impede o Chrome de autofillar e-mail no campo de busca global

### DIFF
--- a/apps/web/src/features/busca/BuscaGlobal.tsx
+++ b/apps/web/src/features/busca/BuscaGlobal.tsx
@@ -83,6 +83,12 @@ export default function BuscaGlobal() {
         aria-controls="busca-resultados"
         aria-autocomplete="list"
         placeholder="Buscar cliente, contrato ou documento"
+        // Sem isto o Chrome preenche este campo com o e-mail salvo do autofill de
+        // contato — o mesmo endereço treinado pelo `type="email"` da tela de login,
+        // no mesmo domínio. O preenchimento silencioso dispara `onChange` e abre o
+        // dropdown de "nada encontrado" sozinho, sem o usuário ter digitado nada.
+        autoComplete="off"
+        name="busca-global"
         value={termo}
         onChange={(e) => {
           setTermo(e.target.value);


### PR DESCRIPTION
## O que acontecia

Em produção (`e1p.criativaeduca.com.br`), o campo de busca da barra de cima abria sozinho o
dropdown **"Nada encontrado para «e-mail-do-usuário»"** — sem ninguém ter digitado nada. Bastava
focar o campo ou navegar entre telas. Reportado com print pelo dono, na `/config`.

## Causa raiz

O `<input>` de `BuscaGlobal.tsx` não declarava **`type`, `name` nem `autoComplete`**.

A tela de login do **mesmo domínio** tem um campo `type="email"`, e é isso que treina o autofill de
contato do Chrome. Diante de um campo de texto genérico e anônimo, o navegador o considera
candidato a receber esse endereço e o preenche por conta própria.

O preenchimento não é inerte: ele **dispara o `onChange` do React**, que roda a busca com o e-mail
como termo e abre o dropdown de "nada encontrado". Do ponto de vista do dono, a tela age sozinha.

## A correção

Duas linhas no input, com o comentário do porquê ao lado (o próximo leitor precisa saber que
`autoComplete="off"` aqui é regra e não estilo — removê-lo devolve o defeito em silêncio):

- **`autoComplete="off"`** — diz ao navegador para não oferecer autofill neste campo;
- **`name="busca-global"`** — dá identidade ao campo. Campo anônimo é justamente o que o Chrome
  casa com qualquer heurística de contato.

Nenhum outro comportamento muda: `value`/`onChange`, a navegação por teclado e os atributos ARIA
(`aria-controls`, `aria-autocomplete`) seguem intactos.

## Alcance

**Um arquivo, 6 linhas adicionadas, nenhuma removida** — `apps/web/src/features/busca/BuscaGlobal.tsx`.
Sem backend, sem migration, sem mudança de contrato.

## Verificação

- `vitest src/features/busca/BuscaGlobal.test.tsx` — **6 de 6 verdes** (a navegação por seta entre
  grupos, o Enter com e sem item focado);
- `eslint` no arquivo — limpo.

O aceite final é manual e só o navegador de verdade dá: abrir a `/config` no Chrome logado, focar a
busca e confirmar que o dropdown **não** abre sozinho. Nenhum teste de jsdom consegue afirmar isso —
o autofill é comportamento do navegador, não do DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
