### PR TITLE
feat: a Vima ganha a ferramenta consultar_clientes_atencao

### DIFF
--- a/apps/api/app/modules/vima/absences.py
+++ b/apps/api/app/modules/vima/absences.py
@@ -152,6 +152,25 @@ def coletar(
     )
 
 
+def clientes_em_atencao(
+    db: Session, *, hoje: date, agora: datetime, limiares: dict[str, int] | None = None,
+) -> list[Ausencia]:
+    """As três Ausências comerciais ligadas a um cliente, para a Vima responder sob demanda
+    (`consultar_clientes_atencao`) — contato sem resposta nossa, contato sumido, card parado.
+
+    Reusa as MESMAS regras de `coletar`, sem o filtro de "já dito" (`_calada`) e sem `pode_ver`:
+    quem perguntou agora quer o estado atual inteiro, não só a escalada desde o último briefing,
+    e a permissão já foi decidida antes de chegar aqui — pelo `Ferramenta.modulo="comercial"`
+    que filtra o que a Claude sequer vê (`vima/tools.py`).
+    """
+    lim = {**LIMIARES_PADRAO, **(limiares or {})}
+    return [
+        *_silencio_nosso(db, hoje, lim, agora),
+        *_contato_sumido(db, hoje, lim),
+        *_cards_parados(db, hoje, lim),
+    ]
+
+
 def _proximo_marco(anterior: int) -> int:
     """Em que intensidade esta ausência volta a ser notícia.
 

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -26,8 +26,9 @@ from app.modules.juridico import service as juridico_service
 from app.modules.marketing import service as marketing_service
 from app.modules.payables import service as payables_service
 from app.modules.receivables import service as receivables_service
-from app.modules.settings.service import tenant_timezone
+from app.modules.settings.service import hoje_do_tenant, tenant_timezone
 from app.modules.stock import service as stock_service
+from app.modules.vima import absences
 from app.modules.vima.permissions import pode_ver
 
 
@@ -191,6 +192,23 @@ def _consultar_item_estoque(db: Session, entrada: dict[str, Any]) -> dict[str, A
                 "baixo": i.quantity <= i.min_quantity,
             }
             for i in itens
+        ]
+    }
+
+
+def _consultar_clientes_atencao(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+    agora = datetime.now(UTC)
+    hoje = hoje_do_tenant(db, now=agora)
+    ausencias = absences.clientes_em_atencao(db, hoje=hoje, agora=agora)
+    return {
+        "clientes_em_atencao": [
+            {
+                "descricao": a.title,
+                "tipo": a.kind,
+                "dias": a.dias,
+                "cliente_id": a.client_id,
+            }
+            for a in ausencias
         ]
     }
 
@@ -416,6 +434,22 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_consultar_item_estoque,
+    ),
+    Ferramenta(
+        nome="consultar_clientes_atencao",
+        modulo="comercial",
+        definicao={
+            "name": "consultar_clientes_atencao",
+            "description": (
+                "Lista clientes que precisam de atenção agora: conversa de WhatsApp que "
+                "escreveu e ainda não foi respondida, contato que sumiu (sem falar há muitos "
+                "dias) ou negociação parada na mesma etapa do funil há tempo demais. Use para "
+                "perguntas como 'qual cliente precisa de atenção hoje?', 'estou deixando "
+                "alguém esperando?' ou 'algum contato sumiu?'."
+            ),
+            "input_schema": {"type": "object", "properties": {}},
+        },
+        executar=_consultar_clientes_atencao,
     ),
 ]
 

--- a/apps/api/tests/test_vima_absences.py
+++ b/apps/api/tests/test_vima_absences.py
@@ -15,7 +15,7 @@ from app.modules.crm.models import Client, PipelineStage
 from app.modules.payables.models import STATUS_OPEN, Payable
 from app.modules.receivables.models import STATUS_OPEN as CHARGE_OPEN
 from app.modules.receivables.models import Charge
-from app.modules.vima.absences import LIMIARES_PADRAO, coletar
+from app.modules.vima.absences import LIMIARES_PADRAO, clientes_em_atencao, coletar
 from app.modules.whatsapp_inbox.models import (
     CHAT_KIND_DIRECT,
     DIRECTION_IN,
@@ -460,4 +460,67 @@ def test_nenhum_limiar_novo_foi_introduzido():
     retroativa existe, então avisar depois do fechamento não perde nada.
     """
     assert "saldo_do_mes_dias" not in LIMIARES_PADRAO
+
+
+# ── clientes_em_atencao (Vima: consultar_clientes_atencao) ─────────────────────────────────
+
+AGORA = datetime(2026, 8, 6, 23, 59, 59, tzinfo=UTC)
+
+
+@pytest.fixture()
+def conversa_sumida(db: Session) -> WhatsappChat:
+    """Última mensagem é posterior ao corte de autoria e, na data de referência do teste que a
+    usa (10/09), já passou o limiar padrão de 30 dias sem falar."""
+    chat = _chat(db, jid="5511955554444@s.whatsapp.net", titulo="Renata")
+    db.add(
+        WhatsappMessage(
+            tenant_id=TENANT, chat_id=chat.id, direction=DIRECTION_IN,
+            text_body="Oi, tudo bem?",
+            created_at=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+        )
+    )
+    db.commit()
+    return chat
+
+
+def test_clientes_em_atencao_junta_as_tres_familias_comerciais(
+    db, conversa_esperando_resposta, conversa_sumida, card_parado_ha_12_dias,
+):
+    # Data de referência própria: "sumido" só cruza o limiar de 30 dias bem depois do corte de
+    # autoria (05/08) — HOJE/AGORA do módulo (06/08) não deixam essa janela existir.
+    hoje = date(2026, 9, 10)
+    agora = datetime(2026, 9, 10, 23, 59, 59, tzinfo=UTC)
+    kinds = {a.kind for a in clientes_em_atencao(db, hoje=hoje, agora=agora)}
+    assert kinds == {
+        "comercial.contato.esperando_resposta",
+        "comercial.contato.sumido",
+        "comercial.card.parado",
+    }
+
+
+def test_clientes_em_atencao_nao_traz_familias_de_fora_do_comercial(
+    db, conta_vencendo_amanha,
+):
+    """Financeiro e Agenda não são "atenção ao cliente" — ficam de fora por escopo, não por
+    permissão (esta função não recebe `user`; quem gateia é o `Ferramenta.modulo` da Vima)."""
+    kinds = {a.kind for a in clientes_em_atencao(db, hoje=HOJE, agora=AGORA)}
+    assert not any(k.startswith("financeiro.") or k.startswith("agenda.") for k in kinds)
+
+
+def test_clientes_em_atencao_nao_aplica_o_silencio_do_briefing(db, card_parado_ha_12_dias):
+    """Diferente de `coletar`, não existe `ja_reportadas` aqui: quem pergunta agora quer o
+    estado inteiro, não só a escalada desde o último briefing."""
+    ausencias = clientes_em_atencao(db, hoje=HOJE, agora=AGORA)
+    assert any(a.kind == "comercial.card.parado" for a in ausencias)
+
+
+def test_clientes_em_atencao_respeita_limiares_injetados(db, card_parado_ha_12_dias):
+    ausencias = clientes_em_atencao(
+        db, hoje=HOJE, agora=AGORA, limiares={**LIMIARES_PADRAO, "card_parado_dias": 30},
+    )
+    assert not any(a.kind == "comercial.card.parado" for a in ausencias)
+
+
+def test_clientes_em_atencao_sem_nada_pendente_devolve_lista_vazia(db):
+    assert clientes_em_atencao(db, hoje=HOJE, agora=AGORA) == []
     assert not [k for k in LIMIARES_PADRAO if "conferencia" in k or "saldo" in k]

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -1,4 +1,4 @@
-"""As nove ferramentas de leitura que a Vima oferece à Claude — permissão, delegação e o
+"""As onze ferramentas de leitura que a Vima oferece à Claude — permissão, delegação e o
 contrato "nunca deixa exceção subir crua" (o loop de tool-use precisa de um tool_result sempre).
 """
 import json
@@ -7,13 +7,19 @@ from datetime import UTC, date, datetime, timedelta
 from sqlalchemy.orm import Session
 
 from app.core.tenancy import CurrentUser
-from app.modules.crm.models import Client
+from app.modules.crm.models import Client, PipelineStage
 from app.modules.juridico.models import LegalDocument
 from app.modules.marketing.models import Carousel
 from app.modules.receivables.models import METHOD_PIX, STATUS_OPEN, Charge
 from app.modules.stock.models import StockItem
 from app.modules.vima import tools
 from app.modules.wallet.models import KIND_SERVICE
+from app.modules.whatsapp_inbox.models import (
+    CHAT_KIND_DIRECT,
+    DIRECTION_IN,
+    WhatsappChat,
+    WhatsappMessage,
+)
 
 TENANT = "t1"
 
@@ -28,13 +34,13 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_dez_ferramentas():
+def test_owner_ve_as_onze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
         "consultar_agenda", "consultar_cliente", "consultar_clientes_recentes",
         "consultar_documentos_juridicos", "consultar_campanhas_marketing",
-        "consultar_estoque_baixo", "consultar_item_estoque",
+        "consultar_estoque_baixo", "consultar_item_estoque", "consultar_clientes_atencao",
     }
 
 
@@ -56,6 +62,11 @@ def test_sub_usuario_so_de_stock_ve_as_duas_ferramentas_de_estoque():
 def test_sub_usuario_so_de_crm_ve_as_duas_ferramentas_de_cliente():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["crm"]))}
     assert nomes == {"consultar_cliente", "consultar_clientes_recentes"}
+
+
+def test_sub_usuario_so_de_comercial_so_ve_a_ferramenta_de_atencao():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["comercial"]))}
+    assert nomes == {"consultar_clientes_atencao"}
 
 
 def test_toda_ferramenta_declara_um_input_schema_valido():
@@ -313,6 +324,55 @@ def test_consultar_item_estoque_sem_match_devolve_lista_vazia(db: Session):
         tools.executar(db, _usuario(), "consultar_item_estoque", {"nome": "Ninguém"})
     )
     assert resultado["itens"] == []
+
+
+# ── consultar_clientes_atencao ──────────────────────────────────────────────────────────────
+
+
+def test_consultar_clientes_atencao_traz_contato_sem_resposta_nossa(db: Session):
+    chat = WhatsappChat(
+        tenant_id=TENANT, chat_jid="5511999998888@s.whatsapp.net",
+        kind=CHAT_KIND_DIRECT, title="Carlos",
+    )
+    db.add(chat)
+    db.flush()
+    db.add(WhatsappMessage(
+        tenant_id=TENANT, chat_id=chat.id, direction=DIRECTION_IN,
+        text_body="Bom dia, conseguiu ver aquilo?",
+        created_at=datetime.now(UTC) - timedelta(hours=48),
+    ))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_atencao", {})
+    )
+    motivos = {c["tipo"] for c in resultado["clientes_em_atencao"]}
+    assert "comercial.contato.esperando_resposta" in motivos
+
+
+def test_consultar_clientes_atencao_traz_card_parado(db: Session):
+    etapa = PipelineStage(tenant_id=TENANT, name="Em contato", position=1)
+    db.add(etapa)
+    db.flush()
+    db.add(Client(
+        tenant_id=TENANT, name="Carlos", stage_id=etapa.id,
+        stage_entered_at=datetime.now(UTC) - timedelta(days=15),
+    ))
+    db.commit()
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_atencao", {})
+    )
+    parado = next(
+        c for c in resultado["clientes_em_atencao"] if c["tipo"] == "comercial.card.parado"
+    )
+    assert "Carlos" in parado["descricao"]
+    assert parado["dias"] >= 15
+
+
+def test_consultar_clientes_atencao_sem_nada_pendente_devolve_lista_vazia(db: Session):
+    resultado = json.loads(
+        tools.executar(db, _usuario(), "consultar_clientes_atencao", {})
+    )
+    assert resultado["clientes_em_atencao"] == []
 
 
 # ── Falha nunca sobe crua ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumo

- Perguntas como "qual cliente precisa de atenção hoje?" ou "estou deixando alguém esperando?" caíam em "não tenho ferramenta pra isso" — mesmo a resposta já estando calculada em outro lugar do produto.
- Nova função `absences.clientes_em_atencao()` compõe as **3 regras comerciais já existentes** do briefing diário (contato sem resposta nossa, contato sumido, card parado), sem duplicar cálculo e sem o filtro de "já dito" (`_calada`) — quem pergunta agora quer o estado atual inteiro.
- Nova ferramenta `consultar_clientes_atencao` em `vima/tools.py`, gateada por `modulo="comercial"` — mesmo escopo de permissão que já protege essas 3 regras no briefing.

## Test plan

- [x] `pytest tests/test_vima_absences.py tests/test_vima_tools.py` — 61 passed (8 novos, 2 atualizados)
- [x] Suíte completa do backend: 2423 passed, 1 skipped
- [x] `ruff check` limpo nos arquivos alterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)