### PR TITLE
feat(pagar): adiciona opção "Todos" ao filtro de status

### DIFF
--- a/apps/web/src/features/pagar/FiltrosDaLista.tsx
+++ b/apps/web/src/features/pagar/FiltrosDaLista.tsx
@@ -4,8 +4,13 @@ import type { CostCenter } from "../financeiro/costCenters";
 import type { ChartAccount } from "../financeiro/planoContas";
 import type { FiltroPagar } from "./filtros";
 
-/** Os recortes de status que a tela oferece. "Em aberto" são DOIS status, não um. */
+/**
+ * Os recortes de status que a tela oferece. "Em aberto" são DOIS status, não um; "Todos" é
+ * ZERO status — `paraQuery`/`paraUrl`/`ordem` (`filtros.ts`) já tratam `status: []` como "sem
+ * filtro", então este recorte não precisa de nenhum código novo fora desta lista.
+ */
 const RECORTES: { value: string; label: string; status: PayableStatus[] }[] = [
+  { value: "todos", label: "Todos", status: [] },
   { value: "abertas", label: "Em aberto", status: ["open", "scheduled"] },
   { value: "paid", label: "Pago", status: ["paid"] },
   { value: "scheduled", label: "Agendada", status: ["scheduled"] },
@@ -73,7 +78,10 @@ export default function FiltrosDaLista({
             const r = RECORTES.find((x) => x.value === e.target.value)!;
             // Histórico não tem por que herdar o horizonte de "o que eu devo": quem procura o que
             // já pagou quer olhar para trás, e um teto no fim do mês que vem não recorta nada ali.
-            const olhandoParaTras = r.status.every((s) => s === "paid" || s === "canceled");
+            // `r.status.length > 0` evita que "Todos" (status: []) caia aqui por vacuidade do
+            // `.every` — mesma guarda que `ordem()` usa em `filtros.ts`.
+            const olhandoParaTras =
+              r.status.length > 0 && r.status.every((s) => s === "paid" || s === "canceled");
             onChange({ ...valor, status: r.status, ate: olhandoParaTras ? null : valor.ate });
           }}
           className={`${campo} min-w-0 flex-1 sm:flex-none`}


### PR DESCRIPTION
## O que mudou

O seletor de **Status** da lista de Contas a Pagar ganha o recorte **"Todos"**, como primeira opção do dropdown.

Duas linhas de código em `apps/web/src/features/pagar/FiltrosDaLista.tsx`:

1. Nova entrada em `RECORTES`: `{ value: "todos", label: "Todos", status: [] }`.
2. Guarda no `.every()` que decide `olhandoParaTras`.

## Por quê

O dropdown só oferecia recortes que sempre escondem alguma coisa (Em aberto / Pago / Agendada / Cancelado). Não havia como ver a lista inteira de uma vez: quem queria conferir tudo tinha de trocar de recorte quatro vezes e somar de cabeça. Opção pedida pelo usuário.

## Por que não precisou de backend/API

A fiação de filtro em `filtros.ts` **já** trata `status: []` como "sem filtro", nos três lugares que importam:

- `paraQuery` — não emite o parâmetro `status` na chamada da API;
- `paraUrl` — não serializa o recorte na URL;
- `ordem` — já tem guarda de array vazio.

Ou seja, "Todos" é só mais uma entrada na lista de recortes da UI. Nenhuma rota, schema ou migration tocada.

## A aresta que precisou de guarda

`olhandoParaTras` decide se o recorte é "histórico" (e portanto não deve herdar o teto de data de "o que eu devo pagar"). Ele usa `.every()`, que sobre **array vazio é verdadeiro por vacuidade** — sem guarda, "Todos" seria tratado como recorte de passado e limparia o `valor.ate` do usuário.

Corrigido com `r.status.length > 0 &&`, exatamente a mesma guarda que `ordem()` já usa em `filtros.ts` para o mesmo motivo.

## Verificação

| Gate | Resultado |
|---|---|
| `pnpm --filter @e1p/web lint` (`--max-warnings 0`) | limpo |
| `pnpm --filter @e1p/web typecheck` (`tsc --noEmit`) | limpo |
| `vitest` — `PagarPage.test.tsx` + `filtros.test.ts` | **97/97** passando |

Suítes de backend (ruff/pytest) não foram rodadas localmente: nenhum arquivo Python foi tocado. O CI cobre o resto.
