### PR TITLE
fix(pagar): filtro "Todos" ordena decrescente, nao crescente

### DIFF
--- a/apps/web/src/features/pagar/FiltrosDaLista.tsx
+++ b/apps/web/src/features/pagar/FiltrosDaLista.tsx
@@ -78,8 +78,10 @@ export default function FiltrosDaLista({
             const r = RECORTES.find((x) => x.value === e.target.value)!;
             // Histórico não tem por que herdar o horizonte de "o que eu devo": quem procura o que
             // já pagou quer olhar para trás, e um teto no fim do mês que vem não recorta nada ali.
-            // `r.status.length > 0` evita que "Todos" (status: []) caia aqui por vacuidade do
-            // `.every` — mesma guarda que `ordem()` usa em `filtros.ts`.
+            // "Todos" fica de fora: mistura contas ainda abertas, então o teto continua valendo
+            // para elas — diferente de `ordem()` (`filtros.ts`), que trata "Todos" como histórico
+            // só para efeito de ordenação. `r.status.length > 0` evita que "Todos" (status: [])
+            // caia aqui por vacuidade do `.every`.
             const olhandoParaTras =
               r.status.length > 0 && r.status.every((s) => s === "paid" || s === "canceled");
             onChange({ ...valor, status: r.status, ate: olhandoParaTras ? null : valor.ate });

--- a/apps/web/src/features/pagar/filtros.test.ts
+++ b/apps/web/src/features/pagar/filtros.test.ts
@@ -120,9 +120,9 @@ describe("paraQuery", () => {
 
 describe("paraQuery — a ORDEM da lista (olhar para tras x olhar para a frente)", () => {
   // Provado por mutacao (issue #191): o unico caso de ordenacao que existia era `status: ["paid"]`
-  // ⇒ `desc`. Isso deixava metade do predicado solto — o `.every` podia virar `.some`, o
-  // `"canceled"` podia virar `""` e o `status.length > 0` podia virar `>= 0`, tudo verde. Os tres
-  // casos abaixo sao os que separam esses programas, e cada um e uma tela que o dono abre.
+  // ⇒ `desc`. Isso deixava metade do predicado solto — o `.every` podia virar `.some` e o
+  // `"canceled"` podia virar `""`, tudo verde. Os tres casos abaixo sao os que separam esses
+  // programas, e cada um e uma tela que o dono abre.
   const base = filtroPadrao("2026-08-18");
 
   it("historico cancelado tambem e olhar para tras", () => {
@@ -140,11 +140,11 @@ describe("paraQuery — a ORDEM da lista (olhar para tras x olhar para a frente)
     expect(paraQuery({ ...base, status: ["paid", "open"], ate: null }, 50, 0).order).toBe("asc");
   });
 
-  it("sem nenhum status marcado ('todos') a ordem e crescente, nao decrescente", () => {
-    // Pegadinha real do `every`: `[].every(...)` e `true` por vacuidade, entao o `status.length > 0`
-    // e a UNICA coisa segurando o caso "todos" no lado certo. Trocado por `>= 0`, a visao "todos"
-    // abriria pelo mais antigo — a lista que ninguem quer ver primeiro.
-    expect(paraQuery({ ...base, status: [], ate: null }, 50, 0).order).toBe("asc");
+  it("sem nenhum status marcado ('todos') a ordem e decrescente, como historico", () => {
+    // "Todos" carrega anos de contas pagas por baixo das abertas; abrir pelo vencimento mais
+    // antigo enterraria o que e recente. Por isso o caso vazio e tratado ANTES do `.every` —
+    // `[].every(...)` e `true` por vacuidade e cairia no ramo errado se dependesse dele.
+    expect(paraQuery({ ...base, status: [], ate: null }, 50, 0).order).toBe("desc");
   });
 });
 

--- a/apps/web/src/features/pagar/filtros.ts
+++ b/apps/web/src/features/pagar/filtros.ts
@@ -50,10 +50,15 @@ export function filtroPadrao(hojeYmd: string): FiltroPagar {
   };
 }
 
-/** Histórico se lê do mais recente para o mais antigo; o que se deve, do mais próximo em diante. */
+/**
+ * Histórico se lê do mais recente para o mais antigo; o que se deve, do mais próximo em diante.
+ * "Todos" (status: []) entra no balde de histórico: sem recorte, a lista tem anos de contas pagas
+ * por baixo, e abrir pelo vencimento mais antigo enterraria tudo que é recente.
+ */
 function ordem(status: PayableStatus[]): "asc" | "desc" {
+  if (status.length === 0) return "desc";
   const olhandoParaTras = status.every((s) => s === "paid" || s === "canceled");
-  return status.length > 0 && olhandoParaTras ? "desc" : "asc";
+  return olhandoParaTras ? "desc" : "asc";
 }
 
 /** Serializa para os `params` do axios. Chave vazia é OMITIDA, nunca mandada como null. */


### PR DESCRIPTION
## Resumo
- O filtro "Todos" (status: []) em Contas a Pagar caia no ramo `asc` de `ordem()` (`filtros.ts`) por causa do guarda `status.length > 0` — `[].every(...)` e `true` por vacuidade, entao sem esse guarda o caso vazio ficava indefinido, e com ele caia no lado errado (asc em vez de desc).
- Sem recorte de status a lista mistura anos de contas pagas com as abertas; ordenar do vencimento mais antigo para o mais novo enterrava o que e recente — reportado ao vivo em `/pagar?status=&ate=`.
- Corrigido tratando `status.length === 0` como historico (`desc`) antes de cair no `.every`.
- Atualizado o teste que antes fixava o comportamento antigo (`filtros.test.ts`) e o comentario em `FiltrosDaLista.tsx` que citava a guarda antiga de `ordem()`.

## Test plan
- [x] `pnpm --filter @e1p/web vitest run src/features/pagar/` — 168 testes, todos verdes
- [x] `pnpm --filter @e1p/web lint`
- [x] `pnpm --filter @e1p/web typecheck`