### PR TITLE
fix: guarda a Vima contra loop de auto-eco na self-chat do WhatsApp

### DIFF
--- a/apps/api/app/modules/vima/whatsapp_conversa.py
+++ b/apps/api/app/modules/vima/whatsapp_conversa.py
@@ -30,6 +30,15 @@ TTL_DEDUP_SEGUNDOS = 5 * 60
 _HISTORICO: dict[str, list[tuple[float, pergunta_service.Turno]]] = {}
 _VISTAS: dict[str, float] = {}
 
+# Última resposta que A PRÓPRIA VIMA mandou para cada telefone, por (texto, expira). A Evolution
+# está inscrita em MESSAGES_UPSERT e ecoa de volta toda mensagem que o produto manda (mesmo
+# mecanismo do eco em `whatsapp_inbox.service.ingest_webhook_payload`) — numa self-chat, esse eco
+# tem `from_me=True` igual a uma pergunta real do dono, e chega com um `wa_message_id` NOVO
+# (`_VISTAS` não pega, pois não é reentrega do MESMO evento). Sem esta guarda, o eco bate na
+# mesma condição de roteamento e vira "pergunta nova": a Vima responde à própria resposta, que
+# ecoa de novo, indefinidamente (achado ao vivo em produção, 2026-08-31).
+_ULTIMAS_RESPOSTAS: dict[str, tuple[str, float]] = {}
+
 
 def _chave(tenant_id: str, phone: str) -> str:
     return f"{tenant_id}:{normalize_br(phone) or phone}"
@@ -60,6 +69,18 @@ def _guardar_turno(chave: str, papel: str, texto: str) -> None:
     _HISTORICO.setdefault(chave, []).append(
         (expira, pergunta_service.Turno(papel=papel, texto=texto))
     )
+
+
+def _e_eco_da_propria_resposta(chave: str, texto: str) -> bool:
+    registrada = _ULTIMAS_RESPOSTAS.get(chave)
+    if registrada is None:
+        return False
+    texto_anterior, expira = registrada
+    return expira > time.monotonic() and texto_anterior == texto
+
+
+def _marcar_resposta_enviada(chave: str, texto: str) -> None:
+    _ULTIMAS_RESPOSTAS[chave] = (texto, time.monotonic() + TTL_DEDUP_SEGUNDOS)
 
 
 def _usuario_do_telefone(db: Session, tenant_id: str, phone: str) -> User | None:
@@ -163,6 +184,12 @@ def _responder(
         return  # reentrega do webhook — já respondida
     _marcar_processada(wa_message_id)
 
+    chave = _chave(tenant_id, phone)
+    if _e_eco_da_propria_resposta(chave, texto):
+        # O eco (ver `_ULTIMAS_RESPOSTAS`) da resposta que A PRÓPRIA VIMA acabou de mandar —
+        # não é pergunta nova, e respondê-lo criaria um loop infinito de auto-resposta.
+        return
+
     user = _usuario_do_telefone(db, tenant_id, phone)
     if user is None:
         # Defensivo: o chamador já confirmou que o telefone é de um usuário ativo
@@ -170,8 +197,6 @@ def _responder(
         # melhor desistir em silêncio do que estourar.
         logger.warning("[vima] self-chat sem usuário correspondente: tenant=%s", tenant_id)
         return
-
-    chave = _chave(tenant_id, phone)
 
     try:
         resultado = pergunta_service.responder(
@@ -188,4 +213,6 @@ def _responder(
 
     _guardar_turno(chave, "usuario", texto)
     _guardar_turno(chave, "vima", resultado.texto)
-    whatsapp.send_text(to=phone, text=f"{eco}{resultado.texto}", profile=profile)
+    resposta_final = f"{eco}{resultado.texto}"
+    _marcar_resposta_enviada(chave, resposta_final)
+    whatsapp.send_text(to=phone, text=resposta_final, profile=profile)

--- a/apps/api/tests/test_vima_whatsapp_conversa.py
+++ b/apps/api/tests/test_vima_whatsapp_conversa.py
@@ -13,6 +13,7 @@ def setup_function():
     # teste vazaria pro próximo e a ordem de execução passaria a importar.
     vc._VISTAS.clear()
     vc._HISTORICO.clear()
+    vc._ULTIMAS_RESPOSTAS.clear()
 
 
 # ── Dedup de reentrega ──────────────────────────────────────────────────────────────────────
@@ -205,6 +206,82 @@ def test_responder_sem_usuario_correspondente_nao_estoura(db: Session, monkeypat
         texto="oi", profile=None,
     )
     assert chamado["n"] == 0  # nunca chegou a chamar pergunta.responder
+
+
+def test_responder_ignora_eco_da_propria_resposta(db: Session, monkeypatch):
+    """A Evolution ecoa de volta, via MESSAGES_UPSERT, toda mensagem que o próprio produto manda
+    pro self-chat — inclusive a resposta que a Vima acabou de enviar (mesmo mecanismo do eco de
+    `whatsapp_inbox.service`, ver comentário em `ingest_webhook_payload`). Esse eco chega com um
+    `wa_message_id` NOVO e genuíno (não é reentrega do mesmo evento, então `_ja_processada` não
+    pega) e bate na MESMA condição de roteamento que uma pergunta real (`from_me` + `da_equipe` +
+    texto) — sem uma guarda, a Vima responde à própria resposta, que ecoa nova, para sempre."""
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono12@example.com", name="Dono", password_hash="x",
+        phone="5511999990001",
+    )
+    db.add(user)
+    db.commit()
+
+    chamadas = {"n": 0}
+
+    def _fake_pergunta_responder(db, *, user, pergunta, historico):
+        chamadas["n"] += 1
+        return Resposta(texto="Combinado! Fico por aqui.", por_ia=True)
+
+    monkeypatch.setattr(vc.pergunta_service, "responder", _fake_pergunta_responder)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990001", wa_message_id="wamid.pergunta",
+        texto="e essa semana, quanto tenho a pagar?", profile=None,
+    )
+    assert chamadas["n"] == 1
+
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990001", wa_message_id="wamid.eco",
+        texto="Combinado! Fico por aqui.", profile=None,
+    )
+    assert chamadas["n"] == 1  # o eco da própria resposta não vira pergunta nova
+
+
+def test_responder_nao_ignora_pergunta_igual_ao_eco_depois_do_ttl(db: Session, monkeypatch):
+    """A guarda do eco é por TEMPO curto (mesmo TTL do dedup), não para sempre — se o dono
+    realmente perguntar de novo o mesmo texto que a Vima respondeu, depois do TTL isso volta a
+    ser uma pergunta válida."""
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono13@example.com", name="Dono", password_hash="x",
+        phone="5511999990002",
+    )
+    db.add(user)
+    db.commit()
+
+    agora = [3000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+
+    chamadas = {"n": 0}
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: chamadas.update(n=chamadas["n"] + 1)
+        or Resposta(texto="oi", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990002", wa_message_id="wamid.p1",
+        texto="pergunta original", profile=None,
+    )
+    assert chamadas["n"] == 1
+
+    agora[0] += vc.TTL_DEDUP_SEGUNDOS + 1
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990002", wa_message_id="wamid.p2",
+        texto="oi", profile=None,
+    )
+    assert chamadas["n"] == 2  # TTL expirado — texto igual à resposta antiga é pergunta válida
 
 
 def test_responder_falha_no_meio_manda_desculpa_em_vez_de_estourar(db: Session, monkeypatch):


### PR DESCRIPTION
## Resumo

Em 31/08/2026 a Vima (self-chat WhatsApp, #268/#271) entrou em loop de auto-resposta em produção: respondeu à própria resposta indefinidamente ("Combinado! 👋 ..." repetido, depois só emoji de aceno) até o dono precisar desconectar a conta pelo celular.

**Causa raiz:** a Evolution está inscrita em `MESSAGES_UPSERT` e ecoa de volta toda mensagem que o próprio produto manda (mesmo mecanismo do eco já documentado em `whatsapp_inbox/service.py::ingest_webhook_payload`). Numa self-chat, esse eco chega com `from_me=True` idêntico a uma pergunta real do dono, batendo na mesma condição de roteamento que despacha para `vima/whatsapp_conversa.py`. O dedup por `wa_message_id` não pega porque o eco chega com um ID genuinamente novo (não é reentrega do mesmo evento webhook).

**Fix:** `whatsapp_conversa.py` passa a guardar a última resposta que a própria Vima mandou para cada telefone (texto + TTL de 5min, mesma janela do dedup existente) e ignora qualquer mensagem recebida que bata com ela — cobre tanto o caminho de texto quanto o de áudio transcrito, já que os dois passam por `_responder`.

## Test plan

- [x] `test_responder_ignora_eco_da_propria_resposta` — reproduz o loop (RED: 2 chamadas à IA) e prova o fix (GREEN: 1 chamada)
- [x] `test_responder_nao_ignora_pergunta_igual_ao_eco_depois_do_ttl` — a guarda expira; pergunta real repetida depois do TTL volta a ser respondida
- [x] `pytest tests/ -k "vima or whatsapp"` — 493 passed
- [x] `ruff check` nos arquivos alterados — limpo