### PR TITLE
fix: competência da conta a pagar segue o vencimento ao ser editada

### DIFF
--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -252,6 +252,7 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     """Edita a conta (dados + boleto/Pix). Mexer em valor/vencimento exige conta em aberto e
     sincroniza o evento da Agenda (move o vencimento, atualiza valor/título)."""
     p = get_payable(db, payable_id)
+    due_date_antigo = p.due_date
     core = (data.description, data.category, data.supplier, data.amount_cents,
             data.due_date, data.recurrence)
     if any(v is not None for v in core) and p.status != STATUS_OPEN:
@@ -303,6 +304,16 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
     if data.recurrence is not None:
         p.recurrence = data.recurrence
     if data.due_date is not None:
+        # Nenhuma tela oferece campo de competência: o único jeito de ela divergir do vencimento
+        # é o PATCH explícito tratado acima. Enquanto `competence_date` ainda vale o fallback da
+        # criação (== o vencimento ANTIGO), ela nunca foi reclassificada de propósito — editar o
+        # vencimento tem de levá-la junto, senão a DRE fica presa no mês do vencimento original
+        # enquanto Contas a Pagar já mostra a data nova (achado em produção, conta "Carlos
+        # PublIA": vencimento editado de 20/12 para 05/09, competência ficou órfã em 2026-12).
+        # Se `competence_date` já foi reclassificada (diverge do vencimento antigo), ela fica
+        # intocada — a mesma regra de `update_payment`/`apply_paid` para caixa × competência.
+        if data.competence_date is None and p.competence_date == due_date_antigo:
+            p.competence_date = data.due_date
         p.due_date = data.due_date
 
     # reverbera na Agenda (evento de vencimento vinculado)

--- a/apps/api/tests/test_payables.py
+++ b/apps/api/tests/test_payables.py
@@ -299,6 +299,39 @@ def test_reclassify_payable(client: TestClient, headers):
     assert out["chart_account_id"] == acc["id"]
 
 
+def test_edit_due_date_moves_unreclassified_competence(client: TestClient, headers):
+    """Achado em produção: conta criada com vencimento 2026-12-20 (competência default = mesma
+    data) tem o vencimento editado para 2026-09-05 sem nunca reclassificar a competência — ela
+    tem de seguir o vencimento novo, senão a DRE fica presa no mês antigo."""
+    b = client.post("/payables/bills", json=_bill(due_date="2026-12-20"), headers=headers).json()
+    assert b["competence_date"] == "2026-12-20"
+    resp = client.patch(
+        f"/payables/bills/{b['id']}", json={"due_date": "2026-09-05"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    out = resp.json()
+    assert out["due_date"] == "2026-09-05"
+    assert out["competence_date"] == "2026-09-05"
+
+
+def test_edit_due_date_keeps_explicitly_reclassified_competence(client: TestClient, headers):
+    """Competência reclassificada de propósito (diverge do vencimento) NÃO segue o vencimento numa
+    edição posterior — só o PATCH explícito de `competence_date` pode mudá-la (mesma regra de
+    caixa × competência de `update_payment`/`apply_paid`)."""
+    b = client.post(
+        "/payables/bills",
+        json=_bill(due_date="2026-12-20", competence_date="2026-11-30"),
+        headers=headers,
+    ).json()
+    resp = client.patch(
+        f"/payables/bills/{b['id']}", json={"due_date": "2026-09-05"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    out = resp.json()
+    assert out["due_date"] == "2026-09-05"
+    assert out["competence_date"] == "2026-11-30"
+
+
 def test_unset_payable_chart_account(client: TestClient, headers):
     """"" desvincula (→ sem categoria), mesmo padrão de contract_id/cost_center_id."""
     acc = client.post(


### PR DESCRIPTION
## O bug

Nenhuma tela do e1p expõe o campo `competence_date` de Contas a Pagar. Ele nasce sempre igual ao `due_date` no momento da criação e, na prática, só muda se alguém disparar um PATCH explícito de `competence_date`.

O problema: ao editar o vencimento de uma conta em aberto pela tela "Editar conta", o `update_payable` só atualizava `due_date` — nunca o `competence_date`. Como a DRE agrupa por competência, a conta ficava **presa no mês do vencimento ORIGINAL**, enquanto a tela de Contas a Pagar já exibia a data nova. Duas telas, duas verdades, sem nenhum jeito de o usuário perceber ou consertar pela interface.

## Achado ao vivo em produção

Conta **"Carlos PublIA - Repasse 28.000 ao total (7.000 em 20/08)"**: o vencimento foi editado de `2026-12-20` para `2026-09-05`, mas a conta continuava aparecendo na DRE de **dezembro** em vez de **setembro**.

## A correção

`update_payable` agora move o `competence_date` junto com o `due_date`, mas **somente quando a competência ainda vale o fallback automático da criação** — isto é, quando ela ainda é igual ao vencimento ANTIGO, sinal de que nunca foi reclassificada de propósito.

Se a competência já foi reclassificada explicitamente (via PATCH de `competence_date`), ela continua **intocada**. É a mesma regra de "caixa × competência não se invertem" que já governa `update_payment` e `apply_paid`.

## Testes

Dois testes novos em `apps/api/tests/test_payables.py`:

1. A competência **segue** o vencimento quando nunca foi reclassificada.
2. Uma competência **reclassificada explicitamente NÃO é sobrescrita** por uma edição de vencimento posterior.

A suíte completa (2250 testes) passou localmente.

## Nota sobre os dados

Os registros afetados **já foram corrigidos diretamente em produção**:

- a conta do Carlos (em aberto);
- 3 lançamentos já pagos com a mesma divergência: **CodeReview IOF**, **GPT/ChatGPT IOF** e **Pagamento Mafra**.

Portanto este PR é apenas a correção do código, para que a divergência não volte a acontecer.
