### PR TITLE
fix: restringe o gatilho da self-chat da Vima ao dono, não à equipe inteira

### DIFF
--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -275,6 +275,36 @@ def _e_telefone_da_equipe(db: Session, tenant_id: str, phone: str | None) -> boo
     return any(normalize_br(f) == chave for f in fones)
 
 
+def _e_o_dono(db: Session, tenant_id: str, phone: str | None) -> bool:
+    """O telefone é do DONO (`role == "owner"`) deste tenant — não de QUALQUER membro ativo da
+    equipe (isso é `_e_telefone_da_equipe`, que continua servindo pro propósito mais amplo: não
+    criar contato de CRM quando quem escreve é alguém do time).
+
+    Usado só para restringir o gatilho da self-chat da Vima (`vima/whatsapp_conversa.py`) à
+    self-chat DE VERDADE — o dono mandando mensagem pro PRÓPRIO número que ele mesmo conectou,
+    como a spec sempre descreveu (`docs/superpowers/specs/2026-08-28-vima-canal-whatsapp-
+    design.md`: "o dono manda mensagem pro próprio número conectado"). `_e_telefone_da_equipe`
+    bate com o telefone de QUALQUER usuário ativo do tenant, dono ou `sub_user` — e uma
+    conversa comum entre o dono e um `sub_user` cadastrado (ex.: para receber o briefing) batia
+    na MESMA condição, fazendo a Vima responder no lugar da pessoa (achado ao vivo em produção,
+    2026-08-31, tenant real: um `sub_user` sofreu exatamente isso).
+
+    Assume um único `owner` ativo por tenant (é o papel padrão do cadastro via `/register`,
+    nunca duplicado no fluxo normal de convite de `sub_user`) — não pagamos o custo de resolver
+    ambiguidade que a arquitetura de hoje não produz."""
+    chave = normalize_br(phone) if phone else None
+    if chave is None:
+        return False
+    fones = db.scalars(
+        select(User.phone)
+        .where(User.tenant_id == tenant_id)
+        .where(User.role == "owner")
+        .where(User.is_active.is_(True))
+        .where(User.phone.is_not(None))
+    ).all()
+    return any(normalize_br(f) == chave for f in fones)
+
+
 def _find_pending_echo(
     db: Session, *, chat_id: str, kind: str, text_body: str
 ) -> WhatsappMessage | None:
@@ -357,14 +387,21 @@ def ingest_webhook_payload(
 
             da_equipe = _e_telefone_da_equipe(db, tenant_id, msg.from_phone)
 
-            # Self-chat: o dono perguntando à Vima pelo próprio número conectado. Só existe no
-            # Evolution — `from_me` é exclusivo daquele transporte (a Meta nunca entrega mensagem
-            # própria no webhook, ver `core/whatsapp/inbound.py`) —, então não há guarda extra de
-            # "é Evolution?" aqui: a condição já é estruturalmente inalcançável na Meta. TEXTO e
-            # ÁUDIO (transcrito antes de responder, ver `vima/whatsapp_conversa
-            # .responder_audio`) viram pergunta; outra mídia (imagem/documento/vídeo) cai no
+            # Self-chat: o dono perguntando à Vima pelo próprio número conectado — checado por
+            # `_e_o_dono` (só o `owner`), NÃO por `da_equipe` (qualquer usuário ativo, incluindo
+            # `sub_user`): uma conversa comum com um colega de equipe cadastrado não pode virar
+            # self-chat só porque o telefone dele também está em `users` (ver docstring de
+            # `_e_o_dono`). Só existe no Evolution — `from_me` é exclusivo daquele transporte (a
+            # Meta nunca entrega mensagem própria no webhook, ver `core/whatsapp/inbound.py`) —,
+            # então não há guarda extra de "é Evolution?" aqui: a condição já é estruturalmente
+            # inalcançável na Meta. TEXTO e ÁUDIO (transcrito antes de responder, ver
+            # `vima/whatsapp_conversa.responder_audio`) viram pergunta; outra mídia
+            # (imagem/documento/vídeo) cai no
             # comportamento normal abaixo.
-            if msg.from_me and da_equipe and msg.kind in (KIND_TEXT, KIND_AUDIO):
+            if (
+                msg.from_me and msg.kind in (KIND_TEXT, KIND_AUDIO)
+                and _e_o_dono(db, tenant_id, msg.from_phone)
+            ):
                 if msg.kind == KIND_TEXT:
                     vima_whatsapp.responder(
                         db, tenant_id=tenant_id, phone=msg.from_phone,

--- a/apps/api/tests/test_whatsapp_inbox_self_chat.py
+++ b/apps/api/tests/test_whatsapp_inbox_self_chat.py
@@ -145,6 +145,41 @@ def test_dono_respondendo_cliente_pelo_proprio_celular_nao_e_self_chat(db, monke
     assert row.direction == "out"  # comportamento pré-existente, inalterado
 
 
+def test_conversa_com_sub_user_cadastrado_nao_e_self_chat(db, monkeypatch):
+    """`from_me=True` e a contraparte é telefone de um usuário ATIVO do tenant — mas um
+    `sub_user` (ex.: funcionário cadastrado pra receber o briefing), não o `owner`. Isso não é
+    self-chat de verdade (o dono conversando consigo mesmo): é o dono conversando NORMALMENTE
+    com um colega de equipe pelo mesmo WhatsApp. Achado ao vivo em produção 2026-08-31: bater
+    com QUALQUER telefone de equipe (não só o do próprio dono) fazia a Vima sequestrar essa
+    conversa e responder no lugar da pessoa."""
+    User_owner = User(
+        tenant_id=TENANT_ID, email="dono3@example.com", name="Dono", password_hash="x",
+        phone="5511988880099", role="owner",
+    )
+    sub_user = User(
+        tenant_id=TENANT_ID, email="colega@example.com", name="Colega", password_hash="x",
+        phone="5511977778888", role="sub_user",
+    )
+    db.add_all([User_owner, sub_user])
+    db.commit()
+
+    chamado = {"n": 0}
+    monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
+
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID,
+        messages=[_self_chat_msg(
+            wa_message_id="colega.1", from_phone="5511977778888",
+            text_body="te mandei o link do produto", chat_jid="5511977778888@s.whatsapp.net",
+        )],
+    )
+
+    assert chamado["n"] == 0  # não roteou para a Vima
+    row = db.scalar(select(WhatsappMessage).where(WhatsappMessage.wa_message_id == "colega.1"))
+    assert row is not None  # grava normalmente, como qualquer conversa com a equipe
+    assert row.direction == "out"
+
+
 def test_cliente_comum_nao_aciona_a_vima(db, monkeypatch):
     chamado = {"n": 0}
     monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))


### PR DESCRIPTION
## Resumo

Investigando o loop de auto-eco corrigido em #280, veio à tona uma segunda falha de design no mesmo mecanismo: o gatilho da self-chat da Vima (`from_me and da_equipe`) usa `_e_telefone_da_equipe`, que bate com o telefone de **qualquer** usuário ativo do tenant — `owner` ou `sub_user`.

Isso faz uma conversa comum entre o dono e um `sub_user` cadastrado (ex.: alguém que recebe o briefing por WhatsApp, logo tem telefone em `users.phone`) também bater na condição de self-chat — e a Vima passa a responder no lugar da pessoa, em vez da conversa seguir normal.

**Confirmado em produção:** a conversa onde o loop de #280 apareceu era entre o dono e um `sub_user` real de um tenant (`role='sub_user'`, verificado direto no banco), não uma self-chat de verdade.

## Fix

Introduz `_e_o_dono`, que filtra por `role == 'owner'` (papel padrão do cadastro via `/register`, nunca duplicado no fluxo de convite de `sub_user`), e troca o gatilho de self-chat pra usar essa checagem em vez de `_e_telefone_da_equipe` — que continua existindo e servindo pro propósito original (não criar contato de CRM quando quem escreve é alguém do time, dono ou `sub_user`).

## Test plan

- [x] `test_conversa_com_sub_user_cadastrado_nao_e_self_chat` — reproduz o problema (RED) e prova o fix (GREEN)
- [x] `pytest tests/test_whatsapp_inbox_self_chat.py` — 6 passed (inclui as regressões já existentes: cliente comum, dono respondendo cliente, imagem na self-chat)
- [x] `pytest tests/ -k "vima or whatsapp or crm or inbox"` — 568 passed
- [x] `ruff check` nos arquivos alterados — limpo