### PR TITLE
feat: registra a self-chat da Vima em whatsapp_messages e loga a troca (reabertura do #283)

### DIFF
--- a/apps/api/app/modules/vima/whatsapp_conversa.py
+++ b/apps/api/app/modules/vima/whatsapp_conversa.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
+from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
@@ -38,6 +39,19 @@ _VISTAS: dict[str, float] = {}
 # mesma condição de roteamento e vira "pergunta nova": a Vima responde à própria resposta, que
 # ecoa de novo, indefinidamente (achado ao vivo em produção, 2026-08-31).
 _ULTIMAS_RESPOSTAS: dict[str, tuple[str, float]] = {}
+
+
+@dataclass(frozen=True)
+class Resultado:
+    """O que de fato foi perguntado e respondido — `whatsapp_inbox.service.ingest_webhook_payload`
+    usa isto pra gravar a troca em `whatsapp_messages` (a self-chat não passa pelo caminho normal
+    de gravação, ver comentário lá). `None` em vez deste tipo significa "nada de novo aconteceu":
+    reentrega do mesmo `wa_message_id`, eco da própria resposta da Vima, ou telefone sem usuário
+    correspondente — nenhum desses é uma pergunta de verdade, e gravar criaria ruído ou duplicata
+    na conversa."""
+
+    pergunta: str
+    resposta: str
 
 
 def _chave(tenant_id: str, phone: str) -> str:
@@ -103,10 +117,10 @@ def _usuario_do_telefone(db: Session, tenant_id: str, phone: str) -> User | None
 
 def responder(
     db: Session, *, tenant_id: str, phone: str, wa_message_id: str, texto: str, profile,
-) -> None:
+) -> Resultado | None:
     """O dono perguntou algo em TEXTO na self-chat — responde pelo MESMO canal. Ver `_responder`
     para o mecanismo compartilhado com `responder_audio`."""
-    _responder(
+    return _responder(
         db, tenant_id=tenant_id, phone=phone, wa_message_id=wa_message_id, texto=texto,
         profile=profile,
     )
@@ -115,7 +129,7 @@ def responder(
 def responder_audio(
     db: Session, *, tenant_id: str, phone: str, wa_message_id: str, audio_bytes: bytes,
     audio_mime_type: str, profile,
-) -> None:
+) -> Resultado | None:
     """O dono mandou uma NOTA DE VOZ na self-chat — transcreve (Groq) e segue o MESMO caminho de
     `responder`: a transcrição vira o `texto` que alimenta `pergunta.responder`, e a resposta
     final ECOA o que foi entendido (`🎤 "..."`), porque o dono nunca vê a transcrição em lugar
@@ -142,33 +156,34 @@ def responder_audio(
     acontece, não um risco novo.
     """
     if _ja_processada(wa_message_id):
-        return  # reentrega do webhook — já respondida (ou já falhou e já pedimos desculpa)
+        return None  # reentrega do webhook — já respondida (ou já falhou e já pedimos desculpa)
 
     user = _usuario_do_telefone(db, tenant_id, phone)
-    resultado = transcription.transcribe(
+    transcrito = transcription.transcribe(
         db, tenant_id=tenant_id, audio_bytes=audio_bytes, mime_type=audio_mime_type,
         user_id=user.id if user else None,
     )
-    if resultado is None:
+    if transcrito is None:
         _marcar_processada(wa_message_id)
-        whatsapp.send_text(
-            to=phone, text="Não consegui entender o áudio — tenta de novo em instantes.",
-            profile=profile,
-        )
-        return
+        desculpa = "Não consegui entender o áudio — tenta de novo em instantes."
+        whatsapp.send_text(to=phone, text=desculpa, profile=profile)
+        # `pergunta` fica com um rótulo, não a transcrição — não há transcrição nenhuma pra
+        # gravar (é justamente isso que falhou). Ainda assim vira uma linha na conversa: sem
+        # ela, a desculpa apareceria sozinha, sem contexto do que a originou.
+        return Resultado(pergunta="[áudio não reconhecido]", resposta=desculpa)
 
     db.commit()  # isola a cobrança da Groq (já ocorrida) de uma falha posterior em _responder
 
-    _responder(
-        db, tenant_id=tenant_id, phone=phone, wa_message_id=wa_message_id, texto=resultado.text,
-        profile=profile, eco=f'🎤 "{resultado.text}" — ',
+    return _responder(
+        db, tenant_id=tenant_id, phone=phone, wa_message_id=wa_message_id, texto=transcrito.text,
+        profile=profile, eco=f'🎤 "{transcrito.text}" — ',
     )
 
 
 def _responder(
     db: Session, *, tenant_id: str, phone: str, wa_message_id: str, texto: str, profile,
     eco: str = "",
-) -> None:
+) -> Resultado | None:
     """O mecanismo compartilhado por `responder` (texto) e `responder_audio` (voz, já
     transcrita): resolve o usuário, chama `pergunta.responder`, grava o turno no cache e manda a
     resposta pelo mesmo canal — com `eco` prefixado quando a pergunta veio de áudio.
@@ -181,14 +196,18 @@ def _responder(
     contrato), então essa tentativa é sempre segura.
     """
     if _ja_processada(wa_message_id):
-        return  # reentrega do webhook — já respondida
+        return None  # reentrega do webhook — já respondida
     _marcar_processada(wa_message_id)
 
     chave = _chave(tenant_id, phone)
     if _e_eco_da_propria_resposta(chave, texto):
         # O eco (ver `_ULTIMAS_RESPOSTAS`) da resposta que A PRÓPRIA VIMA acabou de mandar —
         # não é pergunta nova, e respondê-lo criaria um loop infinito de auto-resposta.
-        return
+        logger.info(
+            "[vima] eco da própria resposta ignorado: tenant=%s wa_message_id=%s",
+            tenant_id, wa_message_id,
+        )
+        return None
 
     user = _usuario_do_telefone(db, tenant_id, phone)
     if user is None:
@@ -196,23 +215,25 @@ def _responder(
         # (`_e_telefone_da_equipe`), mas não há garantia atômica entre a checagem e aqui —
         # melhor desistir em silêncio do que estourar.
         logger.warning("[vima] self-chat sem usuário correspondente: tenant=%s", tenant_id)
-        return
+        return None
 
     try:
-        resultado = pergunta_service.responder(
+        resposta = pergunta_service.responder(
             db, user=scheduler.como_ator(user), pergunta=texto, historico=_historico(chave),
         )
     except Exception:  # noqa: BLE001 — falha nunca fica muda (ver docstring)
         logger.exception("[vima] falha ao responder pergunta via WhatsApp self-chat")
         db.rollback()
-        whatsapp.send_text(
-            to=phone, text="Não consegui responder agora — tenta de novo em instantes.",
-            profile=profile,
-        )
-        return
+        desculpa = "Não consegui responder agora — tenta de novo em instantes."
+        whatsapp.send_text(to=phone, text=desculpa, profile=profile)
+        return Resultado(pergunta=texto, resposta=desculpa)
 
     _guardar_turno(chave, "usuario", texto)
-    _guardar_turno(chave, "vima", resultado.texto)
-    resposta_final = f"{eco}{resultado.texto}"
+    _guardar_turno(chave, "vima", resposta.texto)
+    resposta_final = f"{eco}{resposta.texto}"
     _marcar_resposta_enviada(chave, resposta_final)
     whatsapp.send_text(to=phone, text=resposta_final, profile=profile)
+    logger.info(
+        "[vima] self-chat respondida: tenant=%s wa_message_id=%s", tenant_id, wa_message_id,
+    )
+    return Resultado(pergunta=texto, resposta=resposta_final)

--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -379,16 +379,39 @@ def ingest_webhook_payload(
             )
             if e_self_chat:
                 if msg.kind == KIND_TEXT:
-                    vima_whatsapp.responder(
+                    resultado_vima = vima_whatsapp.responder(
                         db, tenant_id=tenant_id, phone=msg.from_phone,
                         wa_message_id=msg.wa_message_id, texto=msg.text_body, profile=profile,
                     )
                 else:
-                    vima_whatsapp.responder_audio(
+                    resultado_vima = vima_whatsapp.responder_audio(
                         db, tenant_id=tenant_id, phone=msg.from_phone,
                         wa_message_id=msg.wa_message_id, audio_bytes=msg.media_bytes or b"",
                         audio_mime_type=msg.media_mime_type or "", profile=profile,
                     )
+                # `None` = reentrega, eco da própria resposta, ou telefone sem usuário — nada
+                # de novo aconteceu, nada a gravar. Um `Resultado` é uma troca de verdade: sem
+                # gravá-la a self-chat inteira fica invisível pra tela de Conversas (achado ao
+                # investigar o loop de #280 — a conversa existia de verdade no WhatsApp do dono,
+                # mas não deixava NENHUM rastro no banco).
+                if resultado_vima is not None and msg.chat_jid:
+                    chat_vima = _get_or_create_chat(
+                        db, tenant_id=tenant_id, chat_jid=msg.chat_jid, kind=msg.chat_kind,
+                        client=None, profile=profile,
+                    )
+                    db.add(WhatsappMessage(
+                        tenant_id=tenant_id, client_id=None, direction=DIRECTION_OUT,
+                        kind=msg.kind, text_body=resultado_vima.pergunta,
+                        media_status=MEDIA_STATUS_NONE, wa_message_id=msg.wa_message_id,
+                        status="sent", chat_id=chat_vima.id,
+                        sender_phone=msg.sender_phone, sender_name=msg.sender_name,
+                    ))
+                    db.add(WhatsappMessage(
+                        tenant_id=tenant_id, client_id=None, direction=DIRECTION_OUT,
+                        kind=KIND_TEXT, text_body=resultado_vima.resposta,
+                        media_status=MEDIA_STATUS_NONE, wa_message_id=None, status="sent",
+                        chat_id=chat_vima.id,
+                    ))
                 db.commit()
                 continue
 

--- a/apps/api/tests/test_vima_whatsapp_conversa.py
+++ b/apps/api/tests/test_vima_whatsapp_conversa.py
@@ -166,6 +166,181 @@ def test_responder_guarda_o_turno_para_a_proxima_pergunta(db: Session, monkeypat
     ]
 
 
+def test_responder_devolve_pergunta_e_resposta_quando_respondeu(db: Session, monkeypatch):
+    """O retorno de `responder` é o que `whatsapp_inbox.service` usa pra decidir se grava a
+    troca em `whatsapp_messages` — precisa trazer o texto exato que foi perguntado e o texto
+    exato que foi mandado de volta pelo WhatsApp (ver `test_whatsapp_inbox_self_chat.py`)."""
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono14@example.com", name="Dono", password_hash="x",
+        phone="5511999990010",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="R$ 500,00", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990010", wa_message_id="wamid.devolve",
+        texto="quanto tenho a receber?", profile=None,
+    )
+
+    assert resultado == vc.Resultado(pergunta="quanto tenho a receber?", resposta="R$ 500,00")
+
+
+def test_responder_devolve_none_na_reentrega(db: Session, monkeypatch):
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono15@example.com", name="Dono", password_hash="x",
+        phone="5511999990011",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    primeiro = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990011", wa_message_id="wamid.reentrega",
+        texto="oi", profile=None,
+    )
+    segundo = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990011", wa_message_id="wamid.reentrega",
+        texto="oi", profile=None,
+    )
+
+    assert primeiro is not None
+    assert segundo is None  # reentrega do MESMO wa_message_id — nada novo a gravar
+
+
+def test_responder_devolve_none_no_eco_da_propria_resposta(db: Session, monkeypatch):
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono16@example.com", name="Dono", password_hash="x",
+        phone="5511999990012",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="Combinado!", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990012", wa_message_id="wamid.pergunta.eco",
+        texto="e essa semana?", profile=None,
+    )
+    eco = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990012", wa_message_id="wamid.eco.eco",
+        texto="Combinado!", profile=None,
+    )
+
+    assert eco is None  # não é pergunta nova — não pode virar uma segunda linha na conversa
+
+
+def test_responder_devolve_none_sem_usuario_correspondente(db: Session, monkeypatch):
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder", lambda *a, **kw: None,
+    )
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511900009998", wa_message_id="wamid.semuser2",
+        texto="oi", profile=None,
+    )
+    assert resultado is None
+
+
+def test_responder_devolve_pergunta_e_desculpa_quando_a_ia_falha(db: Session, monkeypatch):
+    """A desculpa TAMBÉM precisa ser gravável: é o que explica, na própria conversa do WhatsApp,
+    por que a Vima não respondeu de verdade — sem isso a falha fica visível só nos logs."""
+    user = User(
+        tenant_id=TENANT, email="dono17@example.com", name="Dono", password_hash="x",
+        phone="5511999990013",
+    )
+    db.add(user)
+    db.commit()
+
+    def _explode(db, *, user, pergunta, historico):
+        raise RuntimeError("Claude indisponível")
+
+    monkeypatch.setattr(vc.pergunta_service, "responder", _explode)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990013", wa_message_id="wamid.falha2",
+        texto="oi", profile=None,
+    )
+
+    assert resultado is not None
+    assert resultado.pergunta == "oi"
+    assert "não consegui" in resultado.resposta.lower()
+
+
+def test_responder_loga_info_quando_respondeu(db: Session, monkeypatch, caplog):
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono18@example.com", name="Dono", password_hash="x",
+        phone="5511999990014",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    with caplog.at_level("INFO", logger="e1p.vima"):
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990014", wa_message_id="wamid.log1",
+            texto="oi", profile=None,
+        )
+
+    assert any("wamid.log1" in r.message for r in caplog.records)
+
+
+def test_responder_loga_info_quando_ignora_eco(db: Session, monkeypatch, caplog):
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono19@example.com", name="Dono", password_hash="x",
+        phone="5511999990015",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="Combinado!", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990015", wa_message_id="wamid.log.pergunta",
+        texto="e essa semana?", profile=None,
+    )
+    with caplog.at_level("INFO", logger="e1p.vima"):
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990015", wa_message_id="wamid.log.eco",
+            texto="Combinado!", profile=None,
+        )
+
+    assert any("eco" in r.message.lower() for r in caplog.records)
+
+
 def test_responder_ignora_reentrega_do_mesmo_wa_message_id(db: Session, monkeypatch):
     from app.modules.vima.pergunta import Resposta
 
@@ -532,6 +707,57 @@ def test_responder_audio_falha_apos_transcricao_preserva_ledger_da_groq_e_manda_
     assert linha.user_id == user.id
     assert linha.audio_seconds == 2.5
     assert linha.tenant_id == TENANT
+
+
+def test_responder_audio_devolve_pergunta_transcrita_e_resposta_com_eco(
+    db: Session, monkeypatch,
+):
+    from app.core.transcription import TranscriptionResult
+    from app.modules.vima.pergunta import Resposta
+
+    user = User(
+        tenant_id=TENANT, email="dono20@example.com", name="Dono", password_hash="x",
+        phone="5511999990016",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc.transcription, "transcribe",
+        lambda db, *, tenant_id, audio_bytes, mime_type, user_id=None: TranscriptionResult(
+            text="quanto tenho a receber?", audio_seconds=2.1,
+        ),
+    )
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="R$ 500,00", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    resultado = vc.responder_audio(
+        db, tenant_id=TENANT, phone="5511999990016", wa_message_id="wamid.audiodevolve",
+        audio_bytes=b"audio-bytes", audio_mime_type="audio/ogg", profile=None,
+    )
+
+    assert resultado == vc.Resultado(
+        pergunta="quanto tenho a receber?",
+        resposta='🎤 "quanto tenho a receber?" — R$ 500,00',
+    )
+
+
+def test_responder_audio_devolve_resultado_quando_nao_entende_o_audio(
+    db: Session, monkeypatch,
+):
+    monkeypatch.setattr(vc.transcription, "transcribe", lambda *a, **kw: None)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    resultado = vc.responder_audio(
+        db, tenant_id=TENANT, phone="5511999990017", wa_message_id="wamid.audiosemtexto",
+        audio_bytes=b"ruido", audio_mime_type="audio/ogg", profile=None,
+    )
+
+    assert resultado is not None
+    assert "não consegui" in resultado.resposta.lower()
 
 
 def test_responder_audio_ignora_reentrega_do_mesmo_wa_message_id(db: Session, monkeypatch):

--- a/apps/api/tests/test_whatsapp_inbox_self_chat.py
+++ b/apps/api/tests/test_whatsapp_inbox_self_chat.py
@@ -62,6 +62,115 @@ def test_self_chat_roteia_para_vima_sem_gravar_no_crm(db, monkeypatch):
     assert db.scalar(select(Client)) is None
 
 
+def test_self_chat_grava_pergunta_e_resposta_quando_a_vima_respondeu(db, monkeypatch):
+    """`responder` devolveu um `Resultado` (perguntou e respondeu de verdade, não foi eco nem
+    reentrega) — a troca precisa aparecer na tela de Conversas, senão o dono não tem como saber
+    o que a Vima andou dizendo pelo self-chat (achado ao investigar o loop de #280: a self-chat
+    inteira era invisível pro banco)."""
+    user = User(
+        tenant_id=TENANT_ID, email="dono4@example.com", name="Dono", password_hash="x",
+        phone="5511988889001",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc, "responder",
+        lambda *a, **kw: vc.Resultado(
+            pergunta="quanto tenho a receber?", resposta="Você tem R$ 500,00 a receber.",
+        ),
+    )
+
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID,
+        messages=[_self_chat_msg(
+            wa_message_id="self.grava", from_phone="5511988889001",
+            text_body="quanto tenho a receber?", chat_jid="5511988889001@s.whatsapp.net",
+        )],
+    )
+
+    chat = db.scalar(
+        select(WhatsappChat).where(WhatsappChat.chat_jid == "5511988889001@s.whatsapp.net")
+    )
+    assert chat is not None
+    assert chat.client_id is None  # self-chat continua sem virar contato do CRM
+
+    mensagens = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.chat_id == chat.id)
+        .order_by(WhatsappMessage.created_at)
+    ).all()
+    assert [(m.direction, m.text_body) for m in mensagens] == [
+        ("out", "quanto tenho a receber?"),
+        ("out", "Você tem R$ 500,00 a receber."),
+    ]
+    assert mensagens[0].wa_message_id == "self.grava"
+    assert mensagens[0].client_id is None
+    assert mensagens[1].client_id is None
+    assert db.scalar(select(Client)) is None  # ainda não vira lead
+
+
+def test_self_chat_nao_grava_nada_quando_responder_devolve_none(db, monkeypatch):
+    # Eco da própria resposta, reentrega, ou telefone sem usuário — `responder` devolve `None` e
+    # não há nada de novo a gravar (regressão: não pode duplicar nem criar ruído na conversa).
+    user = User(
+        tenant_id=TENANT_ID, email="dono5@example.com", name="Dono", password_hash="x",
+        phone="5511988889002",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(vc, "responder", lambda *a, **kw: None)
+
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID,
+        messages=[_self_chat_msg(
+            wa_message_id="self.nada", from_phone="5511988889002",
+            chat_jid="5511988889002@s.whatsapp.net",
+        )],
+    )
+
+    assert db.scalar(select(WhatsappMessage)) is None
+    assert db.scalar(select(WhatsappChat)) is None
+
+
+def test_audio_na_self_chat_grava_pergunta_com_kind_audio(db, monkeypatch):
+    user = User(
+        tenant_id=TENANT_ID, email="dono6@example.com", name="Dono", password_hash="x",
+        phone="5511988889003",
+    )
+    db.add(user)
+    db.commit()
+
+    monkeypatch.setattr(
+        vc, "responder_audio",
+        lambda *a, **kw: vc.Resultado(
+            pergunta="quanto tenho a receber?",
+            resposta='🎤 "quanto tenho a receber?" — R$ 500,00',
+        ),
+    )
+
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID,
+        messages=[_self_chat_msg(
+            wa_message_id="self.audio.grava", kind="audio", text_body="",
+            from_phone="5511988889003", chat_jid="5511988889003@s.whatsapp.net",
+            media_bytes=b"\x00\x01audio-bytes", media_mime_type="audio/ogg",
+        )],
+    )
+
+    chat = db.scalar(
+        select(WhatsappChat).where(WhatsappChat.chat_jid == "5511988889003@s.whatsapp.net")
+    )
+    assert chat is not None
+    mensagens = db.scalars(
+        select(WhatsappMessage).where(WhatsappMessage.chat_id == chat.id)
+        .order_by(WhatsappMessage.created_at)
+    ).all()
+    assert [m.kind for m in mensagens] == ["audio", "text"]
+    assert mensagens[0].text_body == "quanto tenho a receber?"
+    assert mensagens[1].text_body == '🎤 "quanto tenho a receber?" — R$ 500,00'
+
+
 def test_audio_na_self_chat_roteia_para_responder_audio(db, monkeypatch):
     user = User(
         tenant_id=TENANT_ID, email="dono2@example.com", name="Dono", password_hash="x",

--- a/apps/api/tests/test_whatsapp_inbox_self_chat.py
+++ b/apps/api/tests/test_whatsapp_inbox_self_chat.py
@@ -73,6 +73,7 @@ def test_self_chat_grava_pergunta_e_resposta_quando_a_vima_respondeu(db, monkeyp
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988889001")
 
     monkeypatch.setattr(
         vc, "responder",
@@ -118,6 +119,7 @@ def test_self_chat_nao_grava_nada_quando_responder_devolve_none(db, monkeypatch)
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988889002")
 
     monkeypatch.setattr(vc, "responder", lambda *a, **kw: None)
 
@@ -140,6 +142,7 @@ def test_audio_na_self_chat_grava_pergunta_com_kind_audio(db, monkeypatch):
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988889003")
 
     monkeypatch.setattr(
         vc, "responder_audio",


### PR DESCRIPTION
## Resumo

O #283 mergeou, mas para a base errada: eu tinha aberto contra `fix/vima-selfchat-so-o-dono` (dependia do #282), e essa branch nunca foi mergeada em `main` — só o #282 foi (squash direto). O commit do #283 ficou órfão, fora de `main`.

Este PR é o MESMO commit (`d855169`), cherry-picked em cima do `main` atual (que já tem o #282). Sem conflito — o conteúdo do #282 é idêntico nas duas branches, só o hash do commit mudou pelo squash.

## O que traz (conteúdo do #283)

Investigando o loop de #280, a self-chat inteira (pergunta do dono + resposta da Vima) se mostrou invisível para o banco: `ingest_webhook_payload` chama `vima_whatsapp.responder`/`responder_audio` e faz `continue` antes do bloco que grava mensagens, e a resposta sai por `whatsapp.send_text` sem nenhum insert.

- `whatsapp_conversa.responder`/`responder_audio` devolvem `Resultado(pergunta, resposta)` quando responderam de verdade (`None` em reentrega, eco da própria resposta, ou telefone sem usuário).
- `ingest_webhook_payload` grava pergunta+resposta em `whatsapp_messages` quando recebe um `Resultado` — aparece na tela de Conversas, sem virar lead do CRM.
- `logger.info` quando a Vima responde e quando o guard de eco (#280) ignora uma mensagem.

## Test plan

- [x] `pytest tests/test_vima_whatsapp_conversa.py tests/test_whatsapp_inbox_self_chat.py` — 42 passed (idêntico ao #283, mesmo commit)
- [x] `ruff check` nos arquivos alterados — limpo