### PR TITLE
fix: gatilho da self-chat da Vima usa o número REALMENTE conectado

### DIFF
--- a/apps/api/app/modules/whatsapp_inbox/service.py
+++ b/apps/api/app/modules/whatsapp_inbox/service.py
@@ -44,6 +44,7 @@ from app.modules.whatsapp_inbox.models import (
     WhatsappChat,
     WhatsappMessage,
 )
+from app.modules.whatsapp_session import service as whatsapp_session_service
 from app.modules.whatsapp_templates.models import (
     PAYLOAD_BOTAO_BRIEFING,
     STATUS_APPROVED,
@@ -275,36 +276,6 @@ def _e_telefone_da_equipe(db: Session, tenant_id: str, phone: str | None) -> boo
     return any(normalize_br(f) == chave for f in fones)
 
 
-def _e_o_dono(db: Session, tenant_id: str, phone: str | None) -> bool:
-    """O telefone é do DONO (`role == "owner"`) deste tenant — não de QUALQUER membro ativo da
-    equipe (isso é `_e_telefone_da_equipe`, que continua servindo pro propósito mais amplo: não
-    criar contato de CRM quando quem escreve é alguém do time).
-
-    Usado só para restringir o gatilho da self-chat da Vima (`vima/whatsapp_conversa.py`) à
-    self-chat DE VERDADE — o dono mandando mensagem pro PRÓPRIO número que ele mesmo conectou,
-    como a spec sempre descreveu (`docs/superpowers/specs/2026-08-28-vima-canal-whatsapp-
-    design.md`: "o dono manda mensagem pro próprio número conectado"). `_e_telefone_da_equipe`
-    bate com o telefone de QUALQUER usuário ativo do tenant, dono ou `sub_user` — e uma
-    conversa comum entre o dono e um `sub_user` cadastrado (ex.: para receber o briefing) batia
-    na MESMA condição, fazendo a Vima responder no lugar da pessoa (achado ao vivo em produção,
-    2026-08-31, tenant real: um `sub_user` sofreu exatamente isso).
-
-    Assume um único `owner` ativo por tenant (é o papel padrão do cadastro via `/register`,
-    nunca duplicado no fluxo normal de convite de `sub_user`) — não pagamos o custo de resolver
-    ambiguidade que a arquitetura de hoje não produz."""
-    chave = normalize_br(phone) if phone else None
-    if chave is None:
-        return False
-    fones = db.scalars(
-        select(User.phone)
-        .where(User.tenant_id == tenant_id)
-        .where(User.role == "owner")
-        .where(User.is_active.is_(True))
-        .where(User.phone.is_not(None))
-    ).all()
-    return any(normalize_br(f) == chave for f in fones)
-
-
 def _find_pending_echo(
     db: Session, *, chat_id: str, kind: str, text_body: str
 ) -> WhatsappMessage | None:
@@ -387,21 +358,26 @@ def ingest_webhook_payload(
 
             da_equipe = _e_telefone_da_equipe(db, tenant_id, msg.from_phone)
 
-            # Self-chat: o dono perguntando à Vima pelo próprio número conectado — checado por
-            # `_e_o_dono` (só o `owner`), NÃO por `da_equipe` (qualquer usuário ativo, incluindo
-            # `sub_user`): uma conversa comum com um colega de equipe cadastrado não pode virar
-            # self-chat só porque o telefone dele também está em `users` (ver docstring de
-            # `_e_o_dono`). Só existe no Evolution — `from_me` é exclusivo daquele transporte (a
+            # Self-chat: o dono perguntando à Vima pelo PRÓPRIO número conectado — checado
+            # contra `whatsapp_session.connected_phone` (o `ownerJid` que a própria Evolution
+            # devolve), NÃO contra `da_equipe` (qualquer usuário ativo do tenant, dono ou
+            # `sub_user`). As duas coisas costumam coincidir, mas não são a mesma informação:
+            # achado ao vivo em produção (2026-08-31) — um tenant real tinha o WhatsApp
+            # conectado no celular de um `sub_user`, não do `owner` cadastrado, e uma conversa
+            # comum entre os dois batia na condição antiga, fazendo a Vima responder no lugar
+            # da pessoa. Só existe no Evolution — `from_me` é exclusivo daquele transporte (a
             # Meta nunca entrega mensagem própria no webhook, ver `core/whatsapp/inbound.py`) —,
             # então não há guarda extra de "é Evolution?" aqui: a condição já é estruturalmente
             # inalcançável na Meta. TEXTO e ÁUDIO (transcrito antes de responder, ver
             # `vima/whatsapp_conversa.responder_audio`) viram pergunta; outra mídia
-            # (imagem/documento/vídeo) cai no
-            # comportamento normal abaixo.
-            if (
+            # (imagem/documento/vídeo) cai no comportamento normal abaixo.
+            e_self_chat = (
                 msg.from_me and msg.kind in (KIND_TEXT, KIND_AUDIO)
-                and _e_o_dono(db, tenant_id, msg.from_phone)
-            ):
+                and normalize_br(msg.from_phone) is not None
+                and normalize_br(msg.from_phone)
+                == normalize_br(whatsapp_session_service.connected_phone(tenant_id))
+            )
+            if e_self_chat:
                 if msg.kind == KIND_TEXT:
                     vima_whatsapp.responder(
                         db, tenant_id=tenant_id, phone=msg.from_phone,

--- a/apps/api/app/modules/whatsapp_session/service.py
+++ b/apps/api/app/modules/whatsapp_session/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import secrets
+import time
 
 import httpx
 from sqlalchemy import select
@@ -24,6 +25,15 @@ from app.modules.whatsapp_session.models import (
 )
 
 logger = logging.getLogger("e1p.whatsapp")
+
+# `connected_phone()` roda no caminho do webhook (por MENSAGEM, ver
+# `whatsapp_inbox/service.py::ingest_webhook_payload`) — cachear evita uma chamada de rede à
+# Evolution por mensagem recebida. O número conectado raramente muda, então 1h é folgado sem
+# custar caro: no pior caso, alguém reconecta com um número novo e a self-chat da Vima fica até
+# 1h reconhecendo o número antigo — bem melhor que pagar rede a cada mensagem. Mesmo espírito do
+# `_TITLE_RETRY` de `whatsapp_inbox/service.py::_resolve_group_title`.
+_CONNECTED_PHONE_CACHE: dict[str, tuple[str | None, float]] = {}
+_CONNECTED_PHONE_TTL_SECONDS = 60 * 60
 
 
 class WhatsappSessionError(Exception):
@@ -180,6 +190,59 @@ def _fetch_evolution_status(instance: str) -> str | None:
         if item.get("name") == instance:
             return item.get("connectionStatus")
     return None
+
+
+def _fetch_owner_phone(instance: str) -> str | None:
+    """O telefone (só dígitos) da conta WhatsApp que está REALMENTE conectada nesta instância —
+    lido do `ownerJid` que a própria Evolution devolve, não de nenhum campo do nosso banco (não
+    existe nenhum: `PublicWhatsappInstance` guarda só o segredo do webhook e o status).
+
+    Confirmado ao vivo contra a Evolution v2.3.7 em produção (2026-08-31): o campo sobrevive à
+    desconexão (`connectionStatus: "close"` ainda traz o `ownerJid` de quem conectou por
+    último) — então não checamos status aqui, só extraímos o telefone se ele vier."""
+    try:
+        resp = httpx.get(
+            f"{settings.evolution_api_url}/instance/fetchInstances",
+            headers=_headers(), params={"instanceName": instance}, timeout=10,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        return None
+    data = resp.json()
+    items = data if isinstance(data, list) else []
+    for item in items:
+        if item.get("name") != instance:
+            continue
+        owner_jid = item.get("ownerJid")
+        if not isinstance(owner_jid, str) or not owner_jid.endswith("@s.whatsapp.net"):
+            return None
+        phone = owner_jid.split("@", 1)[0].split(":", 1)[0]  # `:device` em JID multi-dispositivo
+        return phone or None
+    return None
+
+
+def connected_phone(tenant_id: str) -> str | None:
+    """O telefone DE VERDADE conectado via Evolution para este tenant — não confundir com
+    `User.role == "owner"` no e1p, que é só o nível de permissão dentro do SaaS.
+
+    As duas coisas costumam ser a mesma pessoa, mas não são a mesma informação: achado ao vivo
+    em produção em 2026-08-31, um tenant real tinha o WhatsApp conectado no celular de um
+    `sub_user` (funcionário), não do `owner` cadastrado. Quem consegue mandar "mensagem para
+    você mesmo" de verdade é sempre quem segurou o celular durante o QR code — e isso só a
+    própria Evolution sabe dizer (via `ownerJid`), nunca a tabela `users`.
+
+    Cacheado (ver `_CONNECTED_PHONE_TTL_SECONDS`) porque é chamado por MENSAGEM recebida, no
+    caminho do webhook (`whatsapp_inbox/service.py::ingest_webhook_payload`, na checagem de
+    self-chat da Vima) — sem cache, cada mensagem pagaria uma chamada de rede à Evolution."""
+    instance = _instance_name(tenant_id)
+    cached = _CONNECTED_PHONE_CACHE.get(instance)
+    if cached is not None:
+        phone, expira = cached
+        if expira > time.monotonic():
+            return phone
+    phone = _fetch_owner_phone(instance)
+    _CONNECTED_PHONE_CACHE[instance] = (phone, time.monotonic() + _CONNECTED_PHONE_TTL_SECONDS)
+    return phone
 
 
 def get_status(db: Session, *, tenant_id: str) -> str:

--- a/apps/api/tests/test_whatsapp_inbox_self_chat.py
+++ b/apps/api/tests/test_whatsapp_inbox_self_chat.py
@@ -1,5 +1,10 @@
 """A self-chat da Vima roteia para `vima/whatsapp_conversa`, não para o inbox normal — e as
-outras três formas de `from_me`/`da_equipe` continuam se comportando como antes (regressão)."""
+outras três formas de `from_me`/`da_equipe` continuam se comportando como antes (regressão).
+
+O gatilho de self-chat compara `from_phone` contra `whatsapp_session.connected_phone` — o
+telefone REALMENTE conectado via Evolution (lido do `ownerJid`), não contra `User.role` nem
+contra "qualquer usuário ativo do tenant". `_conectado` abaixo simula essa resposta sem bater
+na rede de verdade; cada teste escolhe qual telefone está "conectado" para o cenário dele."""
 from sqlalchemy import select
 
 from app.core.whatsapp.inbound import InboundMessage
@@ -22,6 +27,12 @@ def _self_chat_msg(**over) -> InboundMessage:
     return InboundMessage(**base)
 
 
+def _conectado(monkeypatch, phone: str | None) -> None:
+    monkeypatch.setattr(
+        inbox_service.whatsapp_session_service, "connected_phone", lambda tenant_id: phone,
+    )
+
+
 def test_self_chat_roteia_para_vima_sem_gravar_no_crm(db, monkeypatch):
     user = User(
         tenant_id=TENANT_ID, email="dono@example.com", name="Dono", password_hash="x",
@@ -29,6 +40,7 @@ def test_self_chat_roteia_para_vima_sem_gravar_no_crm(db, monkeypatch):
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988889999")
 
     chamada = {}
 
@@ -57,6 +69,7 @@ def test_audio_na_self_chat_roteia_para_responder_audio(db, monkeypatch):
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988880001")
 
     chamada = {}
 
@@ -97,6 +110,7 @@ def test_imagem_na_self_chat_continua_no_caminho_normal_sem_erro(db, monkeypatch
     )
     db.add(user)
     db.commit()
+    _conectado(monkeypatch, "5511988880009")
 
     chamado = {"n": 0}
     monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
@@ -119,7 +133,8 @@ def test_imagem_na_self_chat_continua_no_caminho_normal_sem_erro(db, monkeypatch
 
 
 def test_dono_respondendo_cliente_pelo_proprio_celular_nao_e_self_chat(db, monkeypatch):
-    # from_me=True, mas a CONTRAPARTE é um cliente, não um usuário do tenant — não é self-chat.
+    # from_me=True, mas a CONTRAPARTE é um cliente, não o número conectado — não é self-chat.
+    _conectado(monkeypatch, "5511988889999")
     chamado = {"n": 0}
     monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
 
@@ -145,14 +160,32 @@ def test_dono_respondendo_cliente_pelo_proprio_celular_nao_e_self_chat(db, monke
     assert row.direction == "out"  # comportamento pré-existente, inalterado
 
 
-def test_conversa_com_sub_user_cadastrado_nao_e_self_chat(db, monkeypatch):
-    """`from_me=True` e a contraparte é telefone de um usuário ATIVO do tenant — mas um
-    `sub_user` (ex.: funcionário cadastrado pra receber o briefing), não o `owner`. Isso não é
-    self-chat de verdade (o dono conversando consigo mesmo): é o dono conversando NORMALMENTE
-    com um colega de equipe pelo mesmo WhatsApp. Achado ao vivo em produção 2026-08-31: bater
-    com QUALQUER telefone de equipe (não só o do próprio dono) fazia a Vima sequestrar essa
+def test_cliente_comum_nao_aciona_a_vima(db, monkeypatch):
+    _conectado(monkeypatch, "5511988889999")
+    chamado = {"n": 0}
+    monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
+
+    inbox_service.ingest_webhook_payload(
+        db, tenant_id=TENANT_ID,
+        messages=[_self_chat_msg(
+            wa_message_id="cliente.1", from_phone="5511966665555", from_me=False,
+            text_body="oi, quero saber do produto", chat_jid="5511966665555@s.whatsapp.net",
+        )],
+    )
+
+    assert chamado["n"] == 0
+    client = db.scalar(select(Client).where(Client.phone == "5511966665555"))
+    assert client is not None  # vira lead normalmente, como sempre
+
+
+def test_conversa_com_sub_user_cadastrado_mas_nao_conectado_nao_e_self_chat(db, monkeypatch):
+    """`from_me=True` e a contraparte é telefone de um `sub_user` ATIVO do tenant — mas o
+    número REALMENTE conectado via Evolution (`connected_phone`) é outro (o do `owner`, neste
+    cenário). Isso não é self-chat: é o dono conversando NORMALMENTE com um colega de equipe
+    pelo mesmo WhatsApp. Achado ao vivo em produção 2026-08-31: bater com QUALQUER telefone de
+    equipe cadastrado (em vez do telefone REALMENTE conectado) fazia a Vima sequestrar essa
     conversa e responder no lugar da pessoa."""
-    User_owner = User(
+    owner = User(
         tenant_id=TENANT_ID, email="dono3@example.com", name="Dono", password_hash="x",
         phone="5511988880099", role="owner",
     )
@@ -160,8 +193,9 @@ def test_conversa_com_sub_user_cadastrado_nao_e_self_chat(db, monkeypatch):
         tenant_id=TENANT_ID, email="colega@example.com", name="Colega", password_hash="x",
         phone="5511977778888", role="sub_user",
     )
-    db.add_all([User_owner, sub_user])
+    db.add_all([owner, sub_user])
     db.commit()
+    _conectado(monkeypatch, "5511988880099")  # o número conectado é o do OWNER, não o do colega
 
     chamado = {"n": 0}
     monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
@@ -180,18 +214,33 @@ def test_conversa_com_sub_user_cadastrado_nao_e_self_chat(db, monkeypatch):
     assert row.direction == "out"
 
 
-def test_cliente_comum_nao_aciona_a_vima(db, monkeypatch):
-    chamado = {"n": 0}
-    monkeypatch.setattr(vc, "responder", lambda *a, **kw: chamado.update(n=chamado["n"] + 1))
+def test_self_chat_funciona_para_sub_user_cujo_telefone_e_o_conectado(db, monkeypatch):
+    """O espelho do teste acima: quando o número REALMENTE conectado é o de um `sub_user`
+    (cenário real de produção: o WhatsApp do tenant está no celular de um funcionário, não do
+    `owner` cadastrado), a self-chat DELE funciona normalmente — `role` não entra na decisão,
+    só o telefone conectado."""
+    sub_user = User(
+        tenant_id=TENANT_ID, email="funcionario@example.com", name="Funcionário",
+        password_hash="x", phone="5511977778888", role="sub_user",
+    )
+    db.add(sub_user)
+    db.commit()
+    _conectado(monkeypatch, "5511977778888")  # o WhatsApp conectado é o do sub_user
+
+    chamada = {}
+    monkeypatch.setattr(
+        vc, "responder",
+        lambda db, *, tenant_id, phone, wa_message_id, texto, profile: chamada.update(
+            phone=phone, texto=texto,
+        ),
+    )
 
     inbox_service.ingest_webhook_payload(
         db, tenant_id=TENANT_ID,
         messages=[_self_chat_msg(
-            wa_message_id="cliente.1", from_phone="5511966665555", from_me=False,
-            text_body="oi, quero saber do produto", chat_jid="5511966665555@s.whatsapp.net",
+            wa_message_id="funcionario.1", from_phone="5511977778888",
+            text_body="quanto tenho a receber?", chat_jid="5511977778888@s.whatsapp.net",
         )],
     )
 
-    assert chamado["n"] == 0
-    client = db.scalar(select(Client).where(Client.phone == "5511966665555"))
-    assert client is not None  # vira lead normalmente, como sempre
+    assert chamada == {"phone": "5511977778888", "texto": "quanto tenho a receber?"}

--- a/apps/api/tests/test_whatsapp_session_service.py
+++ b/apps/api/tests/test_whatsapp_session_service.py
@@ -15,6 +15,10 @@ TENANT_ID = "22222222-2222-2222-2222-222222222222"
 
 @pytest.fixture(autouse=True)
 def _evolution_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `_CONNECTED_PHONE_CACHE` é module-level (dict global) — sem limpar, o cache de um teste
+    # vazaria pro próximo e a ordem de execução passaria a importar (mesmo motivo de `setup_
+    # function` limpar `_VISTAS`/`_HISTORICO` em `test_vima_whatsapp_conversa.py`).
+    session_service._CONNECTED_PHONE_CACHE.clear()
     monkeypatch.setattr(settings, "evolution_api_key", "global-key")
     monkeypatch.setattr(settings, "evolution_api_url", "http://evolution:8080")
     monkeypatch.setattr(settings, "internal_api_base_url", "http://api:8000")
@@ -424,3 +428,124 @@ def test_nao_ressuscita_sessao_que_o_dono_desconectou(
 
 def test_nao_promove_tenant_sem_instancia(db) -> None:
     assert session_service.promote_pending_connections(db, tenant_id=TENANT_ID) == 0
+
+
+# ── connected_phone() — o telefone REALMENTE conectado, não o `owner` cadastrado no e1p ─────
+#
+# Achado ao vivo em produção (2026-08-31): `User.role == "owner"` (quem administra o SaaS) e
+# "quem escaneou o QR code e é dono do WhatsApp conectado" são frequentemente PESSOAS
+# DIFERENTES — um tenant real tinha o WhatsApp conectado no celular de um `sub_user`
+# (funcionário), não do `owner`. `ownerJid`, que a própria Evolution devolve em
+# `/instance/fetchInstances`, é o único jeito confiável de saber quem é.
+
+
+def test_connected_phone_le_o_ownerJid_da_evolution(db, monkeypatch: pytest.MonkeyPatch) -> None:
+    db.add(PublicWhatsappInstance(
+        instance_name="e1p-" + TENANT_ID, tenant_id=TENANT_ID, webhook_secret="s",
+        last_status=session_service.STATUS_CONNECTED,
+    ))
+    db.commit()
+
+    def _fake_get(url: str, **kwargs: object) -> object:
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> list:
+                return [{
+                    "name": "e1p-" + TENANT_ID, "connectionStatus": "open",
+                    "ownerJid": "554399212788@s.whatsapp.net",
+                }]
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    assert session_service.connected_phone(TENANT_ID) == "554399212788"
+
+
+def test_connected_phone_sobrevive_a_desconexao(db, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Confirmado ao vivo: a Evolution mantém o `ownerJid` no fetchInstances mesmo com
+    # connectionStatus "close" (ex.: logo após o dono desconectar pelo celular) — o mapeamento
+    # "quem é o dono desta instância" não devia depender de estar conectado neste instante.
+    def _fake_get(url: str, **kwargs: object) -> object:
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> list:
+                return [{
+                    "name": "e1p-" + TENANT_ID, "connectionStatus": "close",
+                    "ownerJid": "554399212788@s.whatsapp.net",
+                }]
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    assert session_service.connected_phone(TENANT_ID) == "554399212788"
+
+
+def test_connected_phone_none_quando_instancia_nao_aparece(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fake_get(url: str, **kwargs: object) -> object:
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> list:
+                return []
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    assert session_service.connected_phone(TENANT_ID) is None
+
+
+def test_connected_phone_none_quando_evolution_falha(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fake_get(url: str, **kwargs: object) -> object:
+        raise httpx.ConnectError("sem rede")
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+    assert session_service.connected_phone(TENANT_ID) is None
+
+
+def test_connected_phone_cacheia_entre_chamadas(db, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_service._CONNECTED_PHONE_CACHE.clear()
+    agora = [5000.0]
+    monkeypatch.setattr(session_service.time, "monotonic", lambda: agora[0])
+    chamadas = {"n": 0}
+
+    def _fake_get(url: str, **kwargs: object) -> object:
+        chamadas["n"] += 1
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> list:
+                return [{
+                    "name": "e1p-" + TENANT_ID, "connectionStatus": "open",
+                    "ownerJid": "554399212788@s.whatsapp.net",
+                }]
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+    assert session_service.connected_phone(TENANT_ID) == "554399212788"
+    assert session_service.connected_phone(TENANT_ID) == "554399212788"
+    assert chamadas["n"] == 1  # a segunda chamada veio do cache
+
+    agora[0] += session_service._CONNECTED_PHONE_TTL_SECONDS + 1
+    assert session_service.connected_phone(TENANT_ID) == "554399212788"
+    assert chamadas["n"] == 2  # TTL expirou — refez a chamada


### PR DESCRIPTION
## Resumo

Substitui #282 (mergeado). Aquele PR restringia o gatilho da self-chat da Vima a `User.role == 'owner'`, mas confirmei ao vivo contra a Evolution API de um tenant real que **o número conectado via QR code é frequentemente de um `sub_user`, não do `owner` cadastrado no e1p**. `role` é o nível de permissão dentro do SaaS; "quem segurou o celular durante o QR code" é outra informação inteiramente — a única fonte confiável é a própria Evolution.

Confirmado ao vivo (`/instance/fetchInstances` de um tenant real):
```json
{"ownerJid": "554399212788@s.whatsapp.net", "profileName": "Carlos Hackmann", "connectionStatus": "close", ...}
```
`Carlos Hackmann` é `sub_user` nesse tenant — com o fix de #282, a self-chat pararia de funcionar de vez pra ele (nenhum usuário bateria com `role == 'owner'` no telefone conectado).

## Fix

Introduz `whatsapp_session.connected_phone(tenant_id)`: lê o campo `ownerJid` que a própria Evolution devolve, cacheado por 1h (roda no caminho do webhook, por mensagem — sem cache seria uma chamada de rede por mensagem recebida). Confirmado que o campo sobrevive à desconexão (`connectionStatus: "close"` ainda traz o `ownerJid` de quem conectou por último).

O gatilho de self-chat em `whatsapp_inbox/service.py` passa a comparar `from_phone` contra esse número — não contra `User.role`, não contra `_e_telefone_da_equipe` (que continua existindo, servindo pro propósito original: não criar contato de CRM quando quem escreve é alguém do time, dono ou `sub_user`). Remove `_e_o_dono` (de #282), agora sem uso.

## Test plan

- [x] `test_connected_phone_*` (5 testes novos em `test_whatsapp_session_service.py`) — lê `ownerJid`, sobrevive à desconexão, cacheia por TTL, `None` em falha de rede/instância ausente
- [x] `test_conversa_com_sub_user_cadastrado_mas_nao_conectado_nao_e_self_chat` — o cenário real do incidente: `sub_user` cadastrado, mas o número conectado é outro → não é self-chat
- [x] `test_self_chat_funciona_para_sub_user_cujo_telefone_e_o_conectado` — o espelho: quando o número conectado É o de um `sub_user`, a self-chat dele funciona normalmente
- [x] `pytest tests/test_whatsapp_inbox_self_chat.py tests/test_whatsapp_session_service.py tests/test_whatsapp_inbox_service.py` — 74 passed
- [x] `pytest tests/ -k "vima or whatsapp or crm or inbox"` — 573 passed, 1 falha pré-existente e não relacionada (`test_vima_tools.py`, off-by-one de dias, não toca nenhum arquivo deste PR)
- [x] `ruff check` nos arquivos alterados — limpo