### PR TITLE
fix: Ausências da Vima comparam data local do tenant, não data UTC crua

### DIFF
--- a/apps/api/app/modules/vima/absences.py
+++ b/apps/api/app/modules/vima/absences.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from app.core.facts import COM_FORMULARIO_RECEBIDO, Fact
 from app.core.tenancy import CurrentUser
+from app.core.tz import local_date
 from app.modules.agenda.models import (
     KIND_PRAZO,
     STATUS_CANCELLED,
@@ -40,6 +41,7 @@ from app.modules.payables.models import STATUS_OPEN as PAYABLE_ABERTA
 from app.modules.payables.models import Payable
 from app.modules.receivables.models import STATUS_OPEN as COBRANCA_ABERTA
 from app.modules.receivables.models import Charge
+from app.modules.settings.service import tenant_timezone
 from app.modules.vima.permissions import pode_ver
 from app.modules.whatsapp_inbox.models import (
     DIRECTION_IN,
@@ -122,6 +124,7 @@ def coletar(
     """
     lim: dict[str, int | None] = {**LIMIARES_PADRAO, **(limiares or {})}
     instante = agora or datetime.combine(hoje, time.max, tzinfo=UTC)
+    tz_name = tenant_timezone(db)
     fora: list[Ausencia] = []
 
     if pode_ver(user, "agenda"):
@@ -131,9 +134,9 @@ def coletar(
         # Não recebe `lim`: esta regra é **sem limiar**, de propósito — ver a docstring dela.
         fora.extend(_saldo_do_mes_nao_declarado(db, hoje))
     if pode_ver(user, "comercial"):
-        fora.extend(_silencio_nosso(db, hoje, lim, instante))
-        fora.extend(_contato_sumido(db, hoje, lim))
-        fora.extend(_cards_parados(db, hoje, lim))
+        fora.extend(_silencio_nosso(db, hoje, lim, instante, tz_name))
+        fora.extend(_contato_sumido(db, hoje, lim, tz_name))
+        fora.extend(_cards_parados(db, hoje, lim, tz_name))
         # `None` significa REGRA NÃO EXECUTADA, não "limiar infinito" — mesma forma do filtro
         # de permissão, que não roda a regra em vez de calcular e esconder. Só topo seco pode
         # ser desligado, porque é a única que dispara sobre o VAZIO: sem cards não há card
@@ -164,10 +167,11 @@ def clientes_em_atencao(
     que filtra o que a Claude sequer vê (`vima/tools.py`).
     """
     lim = {**LIMIARES_PADRAO, **(limiares or {})}
+    tz_name = tenant_timezone(db)
     return [
-        *_silencio_nosso(db, hoje, lim, agora),
-        *_contato_sumido(db, hoje, lim),
-        *_cards_parados(db, hoje, lim),
+        *_silencio_nosso(db, hoje, lim, agora, tz_name),
+        *_contato_sumido(db, hoje, lim, tz_name),
+        *_cards_parados(db, hoje, lim, tz_name),
     ]
 
 
@@ -417,9 +421,14 @@ def _nome_da_conversa(chat: WhatsappChat) -> str:
 
 
 def _silencio_nosso(
-    db: Session, hoje: date, lim: dict[str, int], agora: datetime
+    db: Session, hoje: date, lim: dict[str, int], agora: datetime, tz_name: str | None
 ) -> list[Ausencia]:
-    """A última palavra foi do contato, e faz tempo. É a ausência de uma resposta NOSSA."""
+    """A última palavra foi do contato, e faz tempo. É a ausência de uma resposta NOSSA.
+
+    `local_date` (não `.date()` cru) converte `created_at` pro fuso do tenant antes de comparar
+    com `hoje` — que já é local (`hoje_do_tenant`). Sem isso, entre meia-noite UTC e meia-noite
+    local (3h de janela, todo dia, `America/Sao_Paulo`) a conta de dias sai errada por 1: achado
+    ao vivo no CI, madrugada de 2026-09-01."""
     corte = agora - timedelta(hours=lim["sem_resposta_nossa_horas"])
     fora: list[Ausencia] = []
     for chat, msg in _ultimas_mensagens(db):
@@ -427,7 +436,7 @@ def _silencio_nosso(
             continue
         if _naive(msg.created_at) >= _naive(corte):
             continue
-        dias = (hoje - msg.created_at.date()).days
+        dias = (hoje - local_date(msg.created_at, tz_name)).days
         fora.append(
             Ausencia(
                 module="comercial", kind="comercial.contato.esperando_resposta",
@@ -439,11 +448,14 @@ def _silencio_nosso(
     return fora
 
 
-def _contato_sumido(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausencia]:
-    """Conversa que simplesmente parou — de qualquer lado."""
+def _contato_sumido(
+    db: Session, hoje: date, lim: dict[str, int], tz_name: str | None
+) -> list[Ausencia]:
+    """Conversa que simplesmente parou — de qualquer lado. `local_date` pelo mesmo motivo de
+    `_silencio_nosso`, acima."""
     fora: list[Ausencia] = []
     for chat, msg in _ultimas_mensagens(db):
-        dias = (hoje - msg.created_at.date()).days
+        dias = (hoje - local_date(msg.created_at, tz_name)).days
         if dias < lim["contato_sumido_dias"]:
             continue
         fora.append(
@@ -457,8 +469,11 @@ def _contato_sumido(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausenc
     return fora
 
 
-def _cards_parados(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausencia]:
-    """Card parado na mesma etapa. Etapa terminal (ganho/perdido) não conta: acabou."""
+def _cards_parados(
+    db: Session, hoje: date, lim: dict[str, int], tz_name: str | None
+) -> list[Ausencia]:
+    """Card parado na mesma etapa. Etapa terminal (ganho/perdido) não conta: acabou. `local_date`
+    pelo mesmo motivo de `_silencio_nosso`, acima."""
     limite = hoje - timedelta(days=lim["card_parado_dias"])
     cards = db.execute(
         select(Client, PipelineStage)
@@ -473,7 +488,7 @@ def _cards_parados(db: Session, hoje: date, lim: dict[str, int]) -> list[Ausenci
 
     fora: list[Ausencia] = []
     for card, etapa in cards:
-        entrou = card.stage_entered_at.date()
+        entrou = local_date(card.stage_entered_at, tz_name)
         if entrou > limite:
             continue
         dias = (hoje - entrou).days

--- a/apps/api/tests/test_vima_absences.py
+++ b/apps/api/tests/test_vima_absences.py
@@ -134,6 +134,36 @@ def test_contato_sem_resposta_nossa_aparece(db, usuario_owner, conversa_esperand
     assert any(a.kind == "comercial.contato.esperando_resposta" for a in ausencias)
 
 
+def test_silencio_e_sumido_contam_certo_perto_da_meia_noite_utc(db, usuario_owner):
+    """Mesmo achado de `test_card_parado_conta_certo_perto_da_meia_noite_utc`, agora para as
+    duas regras que leem `WhatsappMessage.created_at` — 01h UTC de 06/08 é 22h de 05/08 em São
+    Paulo (UTC-3): dia de calendário DIFERENTE do de `.date()` cru sobre o instante UTC.
+
+    Precisa vir DEPOIS de `CORTE_AUTORIA` (05/08/2026, ver `_ultimas_mensagens`) para não ser
+    filtrada por um motivo alheio a este teste — por isso `hoje`/`agora` ficam bem à frente
+    (15/09), com folga sobre os dois limiares padrão (30 dias de `contato_sumido_dias`, 24h de
+    `sem_resposta_nossa_horas`)."""
+    chat = _chat(db, jid="5511955554444@s.whatsapp.net", titulo="Roberto")
+    db.add(
+        WhatsappMessage(
+            tenant_id=TENANT, chat_id=chat.id, direction=DIRECTION_IN,
+            text_body="oi, tudo bem?", created_at=datetime(2026, 8, 6, 1, 0, tzinfo=UTC),
+        )
+    )
+    db.commit()
+
+    ausencias = coletar(
+        db, user=usuario_owner, hoje=date(2026, 9, 15),
+        agora=datetime(2026, 9, 15, 2, 0, tzinfo=UTC),
+    ).ditas
+
+    # 15/09 - 05/08 (local) = 41, não 40 (15/09 - 06/08 UTC)
+    silencio = next(a for a in ausencias if a.kind == "comercial.contato.esperando_resposta")
+    assert silencio.dias == 41
+    sumido = next(a for a in ausencias if a.kind == "comercial.contato.sumido")
+    assert sumido.dias == 41
+
+
 def test_ignora_mensagens_anteriores_a_correcao_de_autoria(
     db, usuario_owner, conversa_antiga_toda_in
 ):
@@ -149,6 +179,24 @@ def test_card_parado_usa_stage_entered_at(db, usuario_owner, card_parado_ha_12_d
     ausencias = coletar(db, user=usuario_owner, hoje=HOJE).ditas
     parado = next(a for a in ausencias if a.kind == "comercial.card.parado")
     assert parado.dias == 12
+
+
+def test_card_parado_conta_certo_perto_da_meia_noite_utc(db, usuario_owner):
+    """01h UTC de 25/07 é 22h de 24/07 em São Paulo (UTC-3, o fuso padrão) — dia de calendário
+    DIFERENTE do de `stage_entered_at.date()` cru. Achado ao vivo no CI (madrugada de
+    2026-09-01): comparar por essa data crua em vez de convertê-la pro fuso do tenant fazia a
+    conta sair 1 dia curta (mesma janela de 3h se repete toda madrugada, `America/Sao_Paulo`)."""
+    etapa = PipelineStage(tenant_id=TENANT, name="Em contato", position=1)
+    db.add(etapa)
+    db.flush()
+    db.add(Client(
+        id="c-madrugada", tenant_id=TENANT, name="Carlos", stage_id=etapa.id,
+        stage_entered_at=datetime(2026, 7, 25, 1, 0, tzinfo=UTC),
+    ))
+    db.commit()
+    ausencias = coletar(db, user=usuario_owner, hoje=HOJE).ditas
+    parado = next(a for a in ausencias if a.kind == "comercial.card.parado")
+    assert parado.dias == 13  # 06/08 - 24/07 (local) = 13, não 12 (06/08 - 25/07 UTC)
 
 
 def test_topo_seco_quando_nao_ha_formulario_na_janela(db, usuario_owner):


### PR DESCRIPTION
## Resumo

Causa raiz do CI quebrado no #285 (`test_vima_tools.py::test_consultar_clientes_atencao_traz_card_parado`, `14 >= 15` falhando). Não é flake aleatória — é sistemática: acontece toda madrugada, numa janela de ~3h entre meia-noite UTC e meia-noite em `America/Sao_Paulo` (o fuso padrão do tenant).

`_silencio_nosso`, `_contato_sumido` e `_cards_parados` (`vima/absences.py`) comparam `hoje` (já convertido pro fuso do tenant via `hoje_do_tenant`) contra `.date()` **cru** de um datetime UTC (`created_at`/`stage_entered_at`). Nessa janela de 3h, a data-calendário UTC e a data-calendário local divergem, e a conta de dias sai 1 a menos.

Mesma classe de bug já registrada no projeto para a Agenda (CLAUDE.md §6.0/§6.1) — só que ainda não tinha sido corrigida neste módulo.

## Fix

Troca `.date()` cru por `local_date()` (já existe em `core/tz.py`, feito exatamente para isto) nas três funções — `tz_name` vem de `tenant_timezone(db)`, computado uma vez em `coletar()`/`clientes_em_atencao()` e passado adiante.

**`_prazos_estourados` NÃO muda** — evento de dia inteiro é gravado à meia-noite UTC da data de vencimento por design (já documentado no comentário da própria função: "compara-se por DATA DE CALENDÁRIO, nunca por horário local"). Convertê-lo pro fuso local introduziria um bug novo, não corrigiria um existente.

## Test plan

- [x] 2 testes novos em `test_vima_absences.py`, reproduzindo a janela de 3h com datas fixas (não dependem do relógio real) — RED confirmado revertendo o fix (`git stash`) antes de reaplicá-lo: `12 == 13` e `40 == 41` falhando, exatamente o padrão do bug
- [x] `pytest tests/test_vima_absences.py tests/test_vima_tools.py` — 63 passed (inclui o teste que quebrou o CI do #285)
- [x] `pytest tests/ -k "vima or absences"` — 181 passed
- [x] `ruff check` nos arquivos alterados — limpo