### PR TITLE
feat: documento, observações e anexo no próprio modal de lançamento

### DIFF
--- a/apps/api/app/modules/payables/models.py
+++ b/apps/api/app/modules/payables/models.py
@@ -97,6 +97,12 @@ class Payable(Base, TenantMixin, TimestampMixin):
     payment_code: Mapped[str] = mapped_column(Text, default="", nullable=False)
     # Anexo do boleto recebido (URL do PDF/imagem).
     attachment_url: Mapped[str] = mapped_column(String(1024), default="", nullable=False)
+    # Número/identificador do documento (nota fiscal, recibo...) — texto livre, sem validação de
+    # formato. Observações: nota livre do dono sobre a conta. Ambos aplicam-se a TODAS as
+    # ocorrências de uma recorrência (mesma disciplina de `description`/`supplier`), ao contrário
+    # de `payment_code`/`attachment_url`, que são por ocorrência.
+    documento: Mapped[str] = mapped_column(String(64), default="", nullable=False)
+    observacoes: Mapped[str] = mapped_column(Text, default="", nullable=False)
 
     agenda_event_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     external_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/apps/api/app/modules/payables/schemas.py
+++ b/apps/api/app/modules/payables/schemas.py
@@ -28,6 +28,8 @@ class PayableCreate(BaseModel):
     recurrence_count: int = Field(default=1, ge=1, le=60)  # quantas vezes repete
     payment_code: str = ""  # linha digitável do boleto OU Pix copia-e-cola
     attachment_url: str = Field(default="", max_length=1024)  # URL do boleto anexado
+    documento: str = Field(default="", max_length=64)  # nº do documento (nota fiscal, recibo...)
+    observacoes: str = ""  # nota livre do dono sobre a conta
 
     @field_validator("recurrence")
     @classmethod
@@ -55,6 +57,8 @@ class PayableUpdate(BaseModel):
     recurrence: str | None = None
     payment_code: str | None = None
     attachment_url: str | None = Field(default=None, max_length=1024)
+    documento: str | None = Field(default=None, max_length=64)
+    observacoes: str | None = None
 
     @field_validator("recurrence")
     @classmethod
@@ -145,6 +149,8 @@ class PayableOut(BaseModel):
     recurrence_group: str | None
     payment_code: str
     attachment_url: str
+    documento: str
+    observacoes: str
     # Story 8.12 AC12 — o vínculo com o razão bancário. `bank_account_id` é a decisão AUTORITATIVA
     # do usuário ("de qual conta saiu?"); `bank_transaction_id` é **cache de leitura** do movimento
     # gerado. Divergiram? Quem manda é o `origin_id` do movimento (`payables/models.py`).

--- a/apps/api/app/modules/payables/service.py
+++ b/apps/api/app/modules/payables/service.py
@@ -155,6 +155,8 @@ def payable_out(p: Payable, today: date) -> PayableOut:
         recurrence_group=p.recurrence_group,
         payment_code=p.payment_code,
         attachment_url=p.attachment_url,
+        documento=p.documento,
+        observacoes=p.observacoes,
         # Story 8.12 AC12 — o vínculo com o razão bancário fica VISÍVEL. Sem ele a UI da 8.13 não
         # tem como mostrar "saiu do Itaú PJ" nem como pré-selecionar a conta na correção.
         # ⚠️ Nenhuma superfície de `/admin/*` recebe estes campos (epic §2.1): não existe agregado
@@ -212,6 +214,10 @@ def build_payable(db: Session, *, tenant_id: str, actor: str, data: PayableCreat
             # boleto/anexo informados na criação só na 1ª ocorrência (as demais anexa-se depois)
             payment_code=data.payment_code if i == 0 else "",
             attachment_url=data.attachment_url if i == 0 else "",
+            # documento/observações descrevem a despesa em si (mesma disciplina de
+            # description/supplier acima): valem para TODAS as ocorrências, não só a primeira.
+            documento=data.documento,
+            observacoes=data.observacoes,
             status=STATUS_OPEN,
         )
         db.add(payable)
@@ -263,6 +269,10 @@ def update_payable(db: Session, *, payable_id: str, tenant_id: str, actor: str, 
         p.payment_code = data.payment_code
     if data.attachment_url is not None:
         p.attachment_url = data.attachment_url
+    if data.documento is not None:
+        p.documento = data.documento
+    if data.observacoes is not None:
+        p.observacoes = data.observacoes
     # Story 5.2: reclassificação (competência/conta do plano de contas) — metadado contábil, não
     # toca no caminho de dinheiro; ajustável a qualquer momento.
     if data.competence_date is not None:

--- a/apps/api/app/modules/receivables/models.py
+++ b/apps/api/app/modules/receivables/models.py
@@ -74,6 +74,11 @@ class Charge(Base, TenantMixin, TimestampMixin):
     cost_center_id: Mapped[str | None] = mapped_column(String(36), index=True, nullable=True)
     # Stub do gateway: Pix copia-e-cola / linha do boleto / link de pagamento.
     payment_code: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    # Número/identificador do documento (nota fiscal, recibo...) — texto livre. Observações: nota
+    # livre do dono sobre a cobrança. Mesma disciplina de description: valem para TODAS as
+    # ocorrências de uma recorrência.
+    documento: Mapped[str] = mapped_column(String(64), default="", nullable=False)
+    observacoes: Mapped[str] = mapped_column(Text, default="", nullable=False)
     transaction_id: Mapped[str | None] = mapped_column(String(36), nullable=True)  # tx da carteira
     # evento de vencimento na agenda
     agenda_event_id: Mapped[str | None] = mapped_column(String(36), nullable=True)

--- a/apps/api/app/modules/receivables/router.py
+++ b/apps/api/app/modules/receivables/router.py
@@ -55,6 +55,8 @@ def _out(charge: Charge, db: Session, hoje: date_type) -> ChargeOut:
         recurrence=charge.recurrence,
         recurrence_group=charge.recurrence_group,
         payment_code=charge.payment_code,
+        documento=charge.documento,
+        observacoes=charge.observacoes,
         transaction_id=charge.transaction_id,
         created_at=charge.created_at,
         gateway_provider=charge.gateway_provider,

--- a/apps/api/app/modules/receivables/schemas.py
+++ b/apps/api/app/modules/receivables/schemas.py
@@ -29,6 +29,8 @@ class ChargeCreate(BaseModel):
     cost_center_id: str | None = None
     recurrence: str = "none"  # none/weekly/monthly/yearly
     recurrence_count: int = Field(default=1, ge=1, le=60)
+    documento: str = Field(default="", max_length=64)  # nº do documento (nota fiscal, recibo...)
+    observacoes: str = ""  # nota livre do dono sobre a cobrança
 
     @field_validator("recurrence")
     @classmethod
@@ -76,6 +78,8 @@ class ChargeOut(BaseModel):
     recurrence: str
     recurrence_group: str | None
     payment_code: str
+    documento: str
+    observacoes: str
     transaction_id: str | None
     created_at: datetime
     # Gateway real (Asaas) — somente-leitura; None quando a cobrança foi gerada pelo stub.
@@ -143,6 +147,8 @@ class ChargeUpdate(BaseModel):
     # Story 5.5: (re)vincular a um centro de custo. None = "não altera"; "" desvincula ("Não
     # atribuído"). Mesmo padrão de contract_id.
     cost_center_id: str | None = None
+    documento: str | None = Field(default=None, max_length=64)
+    observacoes: str | None = None
 
 
 class WebhookPayment(BaseModel):

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -240,6 +240,8 @@ def build_charge(db: Session, *, tenant_id: str, actor: str, data: ChargeCreate)
         chart_account_id=data.chart_account_id,
         contract_id=data.contract_id,
         cost_center_id=data.cost_center_id,
+        documento=data.documento,
+        observacoes=data.observacoes,
         status=STATUS_OPEN,
     )
     db.add(charge)
@@ -435,6 +437,10 @@ def update_charge(db: Session, *, charge_id: str, tenant_id: str, actor: str, da
             raise ReceivableError("Centro de custo não encontrado", 404)
         else:
             charge.cost_center_id = data.cost_center_id
+    if data.documento is not None:
+        charge.documento = data.documento
+    if data.observacoes is not None:
+        charge.observacoes = data.observacoes
 
     ev = db.get(AgendaEvent, charge.agenda_event_id) if charge.agenda_event_id else None
     if ev is not None:

--- a/apps/api/app/modules/wallet/models.py
+++ b/apps/api/app/modules/wallet/models.py
@@ -65,6 +65,11 @@ class Transaction(Base, TenantMixin, TimestampMixin):
     chart_account_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     cost_center_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
+    # Número/identificador do documento (nota fiscal, recibo...) — texto livre. Observações: nota
+    # livre do dono sobre a venda.
+    documento: Mapped[str] = mapped_column(String(64), default="", nullable=False)
+    observacoes: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
     # Onda 3 — a qual saque esta venda pertence. NULL = ainda não sacada, **ou** sacada antes da
     # migration 0077 (não há backfill, e não pode haver: aqueles saques nunca foram registrados,
     # então não existe linha a que pertencer — a mesma manobra da 2b-ii).

--- a/apps/api/app/modules/wallet/schemas.py
+++ b/apps/api/app/modules/wallet/schemas.py
@@ -22,6 +22,8 @@ class TransactionCreate(BaseModel):
     competence_date: date | None = None
     chart_account_id: str | None = None
     cost_center_id: str | None = None
+    documento: str = Field(default="", max_length=64)  # nº do documento (nota fiscal, recibo...)
+    observacoes: str = ""  # nota livre do dono sobre a venda
 
     @field_validator("kind")
     @classmethod
@@ -53,6 +55,8 @@ class TransactionOut(BaseModel):
     competence_date: date | None
     chart_account_id: str | None
     cost_center_id: str | None
+    documento: str
+    observacoes: str
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/apps/api/app/modules/wallet/service.py
+++ b/apps/api/app/modules/wallet/service.py
@@ -114,6 +114,8 @@ def build_transaction(
     competence_date: date | None = None,
     chart_account_id: str | None = None,
     cost_center_id: str | None = None,
+    documento: str = "",
+    observacoes: str = "",
 ) -> Transaction:
     """Cria a transação + ganho da plataforma na sessão SEM commitar.
 
@@ -147,6 +149,8 @@ def build_transaction(
         competence_date=competence_date or hoje_do_tenant(db),
         chart_account_id=chart_account_id,
         cost_center_id=cost_center_id,
+        documento=documento,
+        observacoes=observacoes,
     )
     db.add(tx)
     # Registro GLOBAL do ganho da plataforma (sem RLS) — alimenta o painel do Master.
@@ -167,6 +171,7 @@ def create_transaction(
         gross_cents=data.gross_cents, description=data.description, client_id=data.client_id,
         external_ref=data.external_ref, competence_date=data.competence_date,
         chart_account_id=data.chart_account_id, cost_center_id=data.cost_center_id,
+        documento=data.documento, observacoes=data.observacoes,
     )
     db.commit()
     db.refresh(tx)

--- a/apps/api/migrations/versions/0085_documento_observacoes_lancamentos.py
+++ b/apps/api/migrations/versions/0085_documento_observacoes_lancamentos.py
@@ -1,0 +1,43 @@
+"""payables/charges/transactions ganham documento e observacoes
+
+Revision ID: 0085
+Revises: 0084
+Create Date: 2026-09-01
+
+Por quê: as telas de lançamento (Registrar venda, Nova cobrança, Nova conta a pagar) não tinham
+onde guardar o número do documento (nota fiscal, recibo...) nem uma observação livre — só existia
+`description`, que funciona como título curto da linha, não como anotação.
+
+`server_default=''` PERMANENTE (mesma disciplina da migration 0084): DDL puro, sem backfill sob
+FORCE RLS. Os três `*Create` (`PayableCreate`/`ChargeCreate`/`TransactionCreate`) já default para
+"" quando omitidos, então o server_default só cobre a criação da coluna em cima de linhas
+existentes — nenhum caminho de escrita depende dele depois disso.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0085"
+down_revision: str | None = "0084"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES = ("payables", "charges", "transactions")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(
+            table, sa.Column("documento", sa.String(64), nullable=False, server_default="")
+        )
+        op.add_column(
+            table, sa.Column("observacoes", sa.Text(), nullable=False, server_default="")
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.drop_column(table, "observacoes")
+        op.drop_column(table, "documento")

--- a/apps/api/tests/test_payables.py
+++ b/apps/api/tests/test_payables.py
@@ -95,6 +95,35 @@ def test_create_bill_with_payment_code(client: TestClient, headers):
     assert b["attachment_url"] == "https://x.com/boleto.pdf"
 
 
+def test_create_bill_with_documento_e_observacoes(client: TestClient, headers):
+    b = client.post(
+        "/payables/bills",
+        json=_bill(documento="NF-4471", observacoes="Combinado com o síndico"),
+        headers=headers,
+    ).json()
+    assert b["documento"] == "NF-4471"
+    assert b["observacoes"] == "Combinado com o síndico"
+
+
+def test_create_bill_sem_documento_e_observacoes_usa_vazio(client: TestClient, headers):
+    b = client.post("/payables/bills", json=_bill(), headers=headers).json()
+    assert b["documento"] == ""
+    assert b["observacoes"] == ""
+
+
+def test_edit_bill_documento_e_observacoes(client: TestClient, headers):
+    b = client.post("/payables/bills", json=_bill(), headers=headers).json()
+    resp = client.patch(
+        f"/payables/bills/{b['id']}",
+        json={"documento": "NF-9002", "observacoes": "Reajuste anual"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    out = resp.json()
+    assert out["documento"] == "NF-9002"
+    assert out["observacoes"] == "Reajuste anual"
+
+
 def test_recurring_generates_occurrences(client: TestClient, headers):
     client.post(
         "/payables/bills",

--- a/apps/api/tests/test_receivables.py
+++ b/apps/api/tests/test_receivables.py
@@ -48,6 +48,35 @@ def _charge(**over):
     return {**base, **over}
 
 
+def test_create_charge_with_documento_e_observacoes(client: TestClient, headers):
+    c = client.post(
+        "/receivables/charges",
+        json=_charge(documento="NF-118", observacoes="Cliente pediu nota até dia 5"),
+        headers=headers,
+    ).json()
+    assert c["documento"] == "NF-118"
+    assert c["observacoes"] == "Cliente pediu nota até dia 5"
+
+
+def test_create_charge_sem_documento_e_observacoes_usa_vazio(client: TestClient, headers):
+    c = client.post("/receivables/charges", json=_charge(), headers=headers).json()
+    assert c["documento"] == ""
+    assert c["observacoes"] == ""
+
+
+def test_edit_charge_documento_e_observacoes(client: TestClient, headers):
+    c = client.post("/receivables/charges", json=_charge(), headers=headers).json()
+    resp = client.patch(
+        f"/receivables/charges/{c['id']}",
+        json={"documento": "NF-220", "observacoes": "Segunda via"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    out = resp.json()
+    assert out["documento"] == "NF-220"
+    assert out["observacoes"] == "Segunda via"
+
+
 def test_boleto_charge_generates_pdf_attachment(client: TestClient, headers):
     c = client.post("/receivables/charges", json=_charge(method="boleto"), headers=headers).json()
     atts = client.get(

--- a/apps/api/tests/test_wallet.py
+++ b/apps/api/tests/test_wallet.py
@@ -55,6 +55,31 @@ def test_create_pix_is_available(client: TestClient, headers):
     assert tx["status"] == "available"
 
 
+def test_create_transaction_with_documento_e_observacoes(client: TestClient, headers):
+    resp = client.post(
+        "/wallet/transactions",
+        json={
+            "kind": "service", "method": "pix", "gross_cents": 10000, "description": "Consulta",
+            "documento": "NF-77", "observacoes": "Pago via pix na hora",
+        },
+        headers=headers,
+    )
+    tx = resp.json()
+    assert tx["documento"] == "NF-77"
+    assert tx["observacoes"] == "Pago via pix na hora"
+
+
+def test_create_transaction_sem_documento_e_observacoes_usa_vazio(client: TestClient, headers):
+    resp = client.post(
+        "/wallet/transactions",
+        json={"kind": "service", "method": "pix", "gross_cents": 10000, "description": "Consulta"},
+        headers=headers,
+    )
+    tx = resp.json()
+    assert tx["documento"] == ""
+    assert tx["observacoes"] == ""
+
+
 def test_create_card_is_pending(client: TestClient, headers):
     tx = client.post(
         "/wallet/transactions",

--- a/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.test.tsx
@@ -114,6 +114,45 @@ describe("CobrancasPage — Nova cobrança (Story 7.5, Task 2)", () => {
     expect(screen.getByRole("heading", { name: "Nova cobrança" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Gerar cobrança" })).toBeEnabled();
   });
+
+  it("envia documento e observações no POST", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "c-novo" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova cobrança" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "150,00");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-09-10" } });
+    await user.type(screen.getByLabelText("Documento (opcional)"), "NF-118");
+    await user.type(screen.getByLabelText("Observações (opcional)"), "Cliente pediu nota");
+    await user.click(screen.getByRole("button", { name: "Gerar cobrança" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/receivables/charges",
+      expect.objectContaining({ documento: "NF-118", observacoes: "Cliente pediu nota" }),
+    );
+  });
+
+  // A cobrança precisa de um `id` real ANTES de aceitar anexo (Attachments.tsx exige owner_id
+  // existente) — por isso o modal não fecha ao salvar: ele troca para a fase de anexo.
+  it("depois de criar, o modal troca para a fase de anexo (sem fechar) e 'Concluir' fecha", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "c-novo", description: "Mensalidade" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova cobrança" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "150,00");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-09-10" } });
+    await user.click(screen.getByRole("button", { name: "Gerar cobrança" }));
+
+    expect(await screen.findByText(/Cobrança criada: Mensalidade/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Contrato" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Boleto" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Concluir" }));
+    expect(screen.queryByRole("heading", { name: "Nova cobrança" })).not.toBeInTheDocument();
+  });
 });
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════

--- a/apps/web/src/features/cobrancas/CobrancasPage.tsx
+++ b/apps/web/src/features/cobrancas/CobrancasPage.tsx
@@ -453,8 +453,13 @@ function NewChargeModal({
   const [clients, setClients] = useState<Client[]>([]);
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [contractId, setContractId] = useState("");
+  const [documento, setDocumento] = useState("");
+  const [observacoes, setObservacoes] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Fase 2: a cobrança já foi criada (tem `id` real) e o modal continua aberto só para o anexo,
+  // que precisa de um dono que já existe (ver Attachments.tsx). `null` = ainda na fase 1.
+  const [criada, setCriada] = useState<Charge | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -471,7 +476,7 @@ function NewChargeModal({
     setSaving(true);
     try {
       const amount_cents = parseCentsBRL(value);
-      await api.post("/receivables/charges", {
+      const { data } = await api.post<Charge>("/receivables/charges", {
         kind,
         method,
         amount_cents,
@@ -483,15 +488,12 @@ function NewChargeModal({
         contract_id: contractId || null,
         recurrence,
         recurrence_count: recurrence === "none" ? 1 : Math.max(1, Math.min(60, parseInt(recurrenceCount, 10) || 1)),
+        documento,
+        observacoes,
       });
+      // A lista já reflete a cobrança criada; o modal continua aberto na fase 2 (anexo opcional).
       onCreated();
-      setValue("");
-      setDueDate("");
-      setDescription("");
-      setChartAccountId("");
-      setCostCenterId("");
-      setContractId("");
-      onClose();
+      setCriada(data);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {
@@ -499,8 +501,47 @@ function NewChargeModal({
     }
   }
 
+  function fechar() {
+    setValue("");
+    setDueDate("");
+    setDescription("");
+    setChartAccountId("");
+    setCostCenterId("");
+    setContractId("");
+    setDocumento("");
+    setObservacoes("");
+    setCriada(null);
+    onClose();
+  }
+
+  if (criada) {
+    return (
+      <Modal title="Nova cobrança" open={open} onClose={fechar}>
+        <div className="space-y-4">
+          <p className="text-sm text-neutral-500">
+            Cobrança criada: {criada.client_name || criada.description || "Cobrança"}.
+          </p>
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-600">Anexar arquivos (PDF, JPEG ou PNG)</p>
+            <Attachments
+              ownerType="charge"
+              ownerId={criada.id}
+              slots={[{ key: "contrato", label: "Contrato" }, { key: "boleto", label: "Boleto" }]}
+            />
+          </div>
+          <button
+            onClick={fechar}
+            className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500"
+          >
+            Concluir
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
   return (
-    <Modal title="Nova cobrança" open={open} onClose={onClose}>
+    <Modal title="Nova cobrança" open={open} onClose={fechar}>
       <div className="space-y-3">
         <label className="block">
           <span className="mb-1 block text-xs font-medium text-neutral-600">Cliente</span>
@@ -540,6 +581,7 @@ function NewChargeModal({
           <Field label="Vencimento" type="date" value={dueDate} onChange={setDueDate} />
         </div>
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Mensalidade" />
+        <Field label="Documento (opcional)" value={documento} onChange={setDocumento} placeholder="NF 1234" />
         <div className="flex gap-2">
           <div className="flex-1">
             <ChartAccountSelect
@@ -590,6 +632,10 @@ function NewChargeModal({
             Gera uma cobrança por período, cada uma com seu vencimento e boleto.
           </p>
         )}
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Observações (opcional)</span>
+          <textarea value={observacoes} onChange={(e) => setObservacoes(e.target.value)} rows={2} placeholder="Anotações sobre esta cobrança" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+        </label>
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}

--- a/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.test.tsx
@@ -81,6 +81,45 @@ describe("FinanceiroPage — separador de milhar (#224)", () => {
   });
 });
 
+describe("FinanceiroPage — Registrar venda: documento/observações e anexo", () => {
+  it("envia documento e observações no POST", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "tx-novo" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Registrar venda" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "150,00");
+    await user.type(screen.getByLabelText("Documento (opcional)"), "NF-77");
+    await user.type(screen.getByLabelText("Observações (opcional)"), "Pago na hora");
+    await user.click(screen.getByRole("button", { name: "Registrar" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/wallet/transactions",
+      expect.objectContaining({ documento: "NF-77", observacoes: "Pago na hora" }),
+    );
+  });
+
+  // A venda precisa de um `id` real ANTES de aceitar anexo (Attachments.tsx exige owner_id
+  // existente) — por isso o modal não fecha ao salvar: ele troca para a fase de anexo.
+  it("depois de registrar, o modal troca para a fase de anexo (sem fechar) e 'Concluir' fecha", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "tx-novo", description: "Consulta" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Registrar venda" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "150,00");
+    await user.click(screen.getByRole("button", { name: "Registrar" }));
+
+    expect(await screen.findByText(/Venda registrada: Consulta/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Contrato" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Comprovante" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Concluir" }));
+    expect(screen.queryByRole("heading", { name: "Registrar venda" })).not.toBeInTheDocument();
+  });
+});
+
 // ── `GET /wallet/summary` fora de forma (issue #247) ────────────────────────────────────
 //
 // `setSummary(s.data)` recebia o payload CRU. `summary.available_cents`/etc. são lidos direto nos

--- a/apps/web/src/features/financeiro/FinanceiroPage.tsx
+++ b/apps/web/src/features/financeiro/FinanceiroPage.tsx
@@ -1,5 +1,6 @@
 import type { Transaction, WalletSummary } from "@e1p/shared-types";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Attachments from "../../components/Attachments";
 import Modal, { Field } from "../../components/Modal";
 import { api, apiErrorMessage } from "../../lib/api";
 import { usePrimaryAction } from "../../store/pageActions";
@@ -277,28 +278,32 @@ function NewSaleModal({
   const [description, setDescription] = useState("");
   const [chartAccountId, setChartAccountId] = useState("");
   const [costCenterId, setCostCenterId] = useState("");
+  const [documento, setDocumento] = useState("");
+  const [observacoes, setObservacoes] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Fase 2: a venda já foi registrada (tem `id` real) e o modal continua aberto só para o anexo,
+  // que precisa de um dono que já existe (ver Attachments.tsx). `null` = ainda na fase 1.
+  const [criada, setCriada] = useState<Transaction | null>(null);
 
   async function save() {
     setError(null);
     setSaving(true);
     try {
       const gross_cents = parseCentsBRL(value);
-      await api.post("/wallet/transactions", {
+      const { data } = await api.post<Transaction>("/wallet/transactions", {
         kind,
         method,
         gross_cents,
         description,
         chart_account_id: chartAccountId || null,
         cost_center_id: costCenterId || null,
+        documento,
+        observacoes,
       });
+      // A lista já reflete a venda registrada; o modal continua aberto na fase 2 (anexo opcional).
       onCreated();
-      setValue("");
-      setDescription("");
-      setChartAccountId("");
-      setCostCenterId("");
-      onClose();
+      setCriada(data);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {
@@ -306,8 +311,46 @@ function NewSaleModal({
     }
   }
 
+  function fechar() {
+    setValue("");
+    setDescription("");
+    setChartAccountId("");
+    setCostCenterId("");
+    setDocumento("");
+    setObservacoes("");
+    setCriada(null);
+    onClose();
+  }
+
+  if (criada) {
+    return (
+      <Modal title="Registrar venda" open={open} onClose={fechar}>
+        <div className="space-y-4">
+          <p className="text-sm text-neutral-500">Venda registrada: {criada.description || "Venda"}.</p>
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-600">Anexar arquivos (PDF, JPEG ou PNG)</p>
+            <Attachments
+              ownerType="transaction"
+              ownerId={criada.id}
+              slots={[
+                { key: "contrato", label: "Contrato" },
+                { key: "comprovante", label: "Comprovante" },
+              ]}
+            />
+          </div>
+          <button
+            onClick={fechar}
+            className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500"
+          >
+            Concluir
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
   return (
-    <Modal title="Registrar venda" open={open} onClose={onClose}>
+    <Modal title="Registrar venda" open={open} onClose={fechar}>
       <div className="space-y-3">
         <label className="block">
           <span className="mb-1 block text-xs font-medium text-neutral-600">Tipo (define o split)</span>
@@ -339,6 +382,7 @@ function NewSaleModal({
         </label>
         <Field label="Valor (R$)" value={value} onChange={setValue} placeholder="150,00" />
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Consulta" />
+        <Field label="Documento (opcional)" value={documento} onChange={setDocumento} placeholder="NF 1234" />
         <div className="flex gap-2">
           <div className="flex-1">
             <ChartAccountSelect
@@ -352,6 +396,10 @@ function NewSaleModal({
             <CostCenterSelect value={costCenterId} onChange={setCostCenterId} />
           </div>
         </div>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Observações (opcional)</span>
+          <textarea value={observacoes} onChange={(e) => setObservacoes(e.target.value)} rows={2} placeholder="Anotações sobre esta venda" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+        </label>
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}

--- a/apps/web/src/features/pagar/PagarPage.test.tsx
+++ b/apps/web/src/features/pagar/PagarPage.test.tsx
@@ -155,6 +155,47 @@ describe("PagarPage — Nova conta a pagar (Story 7.5, Task 1)", () => {
     expect(screen.getByText("Nova conta a pagar")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Adicionar conta" })).toBeEnabled();
   });
+
+  it("envia documento e observações no POST", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "b-novo" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova conta" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "250,00");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-08-01" } });
+    await user.type(screen.getByLabelText("Documento (opcional)"), "NF-4471");
+    await user.type(screen.getByLabelText("Observações (opcional)"), "Combinado com o síndico");
+    await user.click(screen.getByRole("button", { name: "Adicionar conta" }));
+
+    await waitFor(() => expect(vi.mocked(api.post)).toHaveBeenCalled());
+    expect(vi.mocked(api.post)).toHaveBeenCalledWith(
+      "/payables/bills",
+      expect.objectContaining({ documento: "NF-4471", observacoes: "Combinado com o síndico" }),
+    );
+  });
+
+  // A conta a pagar precisa de um `id` real ANTES de aceitar anexo (Attachments.tsx exige
+  // owner_id existente) — por isso o modal não fecha ao salvar: ele troca para a fase de anexo.
+  it("depois de criar, o modal troca para a fase de anexo (sem fechar) e 'Concluir' fecha", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({ data: { id: "b-novo", description: "Aluguel" } } as never);
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Nova conta" }));
+    await user.type(screen.getByLabelText("Valor (R$)"), "250,00");
+    fireEvent.change(screen.getByLabelText("Vencimento"), { target: { value: "2026-08-01" } });
+    await user.click(screen.getByRole("button", { name: "Adicionar conta" }));
+
+    // O título do modal continua o mesmo; o CONTEÚDO virou a fase de anexo.
+    expect(await screen.findByText(/Conta criada: Aluguel/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Boleto" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Contrato" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Comprovante" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Concluir" }));
+    expect(screen.queryByText("Nova conta a pagar")).not.toBeInTheDocument();
+  });
 });
 
 // Task 11 — a correção do problema original: sem slot próprio, o comprovante era arquivado em

--- a/apps/web/src/features/pagar/PagarPage.tsx
+++ b/apps/web/src/features/pagar/PagarPage.tsx
@@ -686,15 +686,20 @@ function NewBillModal({
   const [recurrenceCount, setRecurrenceCount] = useState(inicial?.recurrenceCount ?? "12");
   const [paymentCode, setPaymentCode] = useState(inicial?.paymentCode ?? "");
   const [contractId, setContractId] = useState(inicial?.contractId ?? "");
+  const [documento, setDocumento] = useState("");
+  const [observacoes, setObservacoes] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Fase 2: a conta já foi criada (tem `id` real) e o modal continua aberto só para o anexo, que
+  // precisa de um dono que já existe (ver Attachments.tsx). `null` = ainda na fase 1 (formulário).
+  const [criada, setCriada] = useState<Payable | null>(null);
 
   async function save() {
     setError(null);
     setSaving(true);
     try {
       const amount_cents = parseCentsBRL(value);
-      await api.post("/payables/bills", {
+      const { data } = await api.post<Payable>("/payables/bills", {
         description,
         chart_account_id: chartAccountId || null,
         cost_center_id: costCenterId || null,
@@ -705,17 +710,12 @@ function NewBillModal({
         recurrence_count: recurrence === "none" ? 1 : Math.max(1, Math.min(60, parseInt(recurrenceCount, 10) || 1)),
         payment_code: paymentCode,
         contract_id: contractId || null,
+        documento,
+        observacoes,
       });
+      // A lista já reflete a conta criada; o modal continua aberto na fase 2 (anexo opcional).
       onCreated();
-      setDescription("");
-      setChartAccountId("");
-      setCostCenterId("");
-      setSupplier("");
-      setValue("");
-      setDueDate("");
-      setPaymentCode("");
-      setContractId("");
-      onClose();
+      setCriada(data);
     } catch (err) {
       setError(apiErrorMessage(err));
     } finally {
@@ -723,8 +723,53 @@ function NewBillModal({
     }
   }
 
+  function fechar() {
+    setDescription("");
+    setChartAccountId("");
+    setCostCenterId("");
+    setSupplier("");
+    setValue("");
+    setDueDate("");
+    setPaymentCode("");
+    setContractId("");
+    setDocumento("");
+    setObservacoes("");
+    setCriada(null);
+    onClose();
+  }
+
+  if (criada) {
+    return (
+      <Modal title="Nova conta a pagar" open={open} onClose={fechar}>
+        <div className="space-y-4">
+          <p className="text-sm text-neutral-500">
+            Conta criada: {criada.description || criada.supplier || "Conta"}.
+          </p>
+          <div>
+            <p className="mb-2 text-xs font-medium text-neutral-600">Anexar arquivos (PDF, JPEG ou PNG)</p>
+            <Attachments
+              ownerType="payable"
+              ownerId={criada.id}
+              slots={[
+                { key: "boleto", label: "Boleto" },
+                { key: "contrato", label: "Contrato" },
+                { key: "comprovante", label: "Comprovante" },
+              ]}
+            />
+          </div>
+          <button
+            onClick={fechar}
+            className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500"
+          >
+            Concluir
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
   return (
-    <Modal title="Nova conta a pagar" open={open} onClose={onClose}>
+    <Modal title="Nova conta a pagar" open={open} onClose={fechar}>
       <div className="space-y-3">
         <Field label="Descrição" value={description} onChange={setDescription} placeholder="Aluguel" />
         <Field label="Fornecedor" value={supplier} onChange={setSupplier} placeholder="Imobiliária" />
@@ -745,6 +790,7 @@ function NewBillModal({
           <Field label="Valor (R$)" value={value} onChange={setValue} placeholder="2500,00" />
           <Field label="Vencimento" type="date" value={dueDate} onChange={setDueDate} />
         </div>
+        <Field label="Documento (opcional)" value={documento} onChange={setDocumento} placeholder="NF 1234" />
         <div className="flex gap-2">
           <label className="flex-1">
             <span className="mb-1 block text-xs font-medium text-neutral-600">Recorrência</span>
@@ -764,9 +810,13 @@ function NewBillModal({
           </p>
         )}
         <ContractSelect value={contractId} onChange={setContractId} />
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-neutral-600">Observações (opcional)</span>
+          <textarea value={observacoes} onChange={(e) => setObservacoes(e.target.value)} rows={2} placeholder="Anotações sobre esta conta" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+        </label>
         <div className="rounded-lg bg-neutral-50 p-3">
           <p className="mb-2 text-xs font-medium text-neutral-600">Pix copia-e-cola / linha do boleto (opcional)</p>
-          <textarea value={paymentCode} onChange={(e) => setPaymentCode(e.target.value)} rows={2} placeholder="Cole o código aqui (os arquivos do boleto/contrato você anexa depois, em Boleto/Pix)" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
+          <textarea value={paymentCode} onChange={(e) => setPaymentCode(e.target.value)} rows={2} placeholder="Cole o código aqui (os arquivos do boleto/contrato você anexa depois de salvar)" className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-primary-400" />
         </div>
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -370,6 +370,8 @@ export interface Transaction {
   chart_account_id: UUID | null;
   // Story 5.10: vínculo opcional ao centro de custo (2ª dimensão); null = "Não atribuído".
   cost_center_id: UUID | null;
+  documento: string;
+  observacoes: string;
   created_at: string;
 }
 
@@ -436,6 +438,8 @@ export interface Charge {
   // Regime de CAIXA (`paid_at`) × regime de COMPETÊNCIA (`competence_date`) — nunca se invertem.
   competence_date: string | null;
   paid_at: string | null;
+  documento: string;
+  observacoes: string;
   created_at: string;
 }
 
@@ -480,6 +484,8 @@ export interface Payable {
   recurrence_group: string | null;
   payment_code: string;
   attachment_url: string;
+  documento: string;
+  observacoes: string;
   created_at: string;
 }
 


### PR DESCRIPTION
## Por quê

As três telas de lançamento — **Registrar venda** (Carteira), **Nova cobrança** (Contas a Receber) e **Nova conta a pagar** (Contas a Pagar) — tinham dois furos que obrigavam o dono a voltar depois na linha já criada para terminar o que começou.

## O que muda

### 1. Campos `documento` e `observacoes` nas três telas

Não havia onde guardar o número do documento (nota fiscal, recibo) nem uma anotação livre: só existia `description`, que funciona como título curto da linha, não como anotação. Entram dois campos opcionais:

- **Documento** — texto curto, número da nota/documento.
- **Observações** — nota livre.

Backend: migration `0085_documento_observacoes_lancamentos.py` adiciona as colunas em `payables`, `charges` e `transactions`, com `server_default=''` **permanente** — DDL puro, sem backfill sob FORCE RLS, mesma disciplina da 0084. Os três `*Create` já default para `""` quando o campo é omitido, então o `server_default` só cobre a criação da coluna sobre linhas existentes. Models, schemas e services dos três módulos acompanham.

`packages/shared-types` ganha `documento`/`observacoes` em `Payable`, `Charge` e `Transaction`, para as três telas lerem a mesma forma que a API grava.

### 2. Anexo (Boleto/Contrato/Comprovante) no próprio modal de criação

Antes, anexar só era possível numa **tela separada, depois** de a conta/cobrança/venda já existir — `Attachments.tsx` exige um `owner_id` real, e no formulário de criação esse id ainda não existe.

Agora, ao salvar o formulário: o registro é criado normalmente (a lista já atualiza) e o **mesmo modal**, em vez de fechar, troca de conteúdo e mostra os botões de anexo **já habilitados com o id real**. O botão de ação vira **"Concluir"**, que apenas fecha o modal — cada arquivo sobe sozinho ao ser escolhido, não há um segundo "salvar" para o anexo.

## Plano de teste

- [x] Backend: `pytest -q -m "not rls_e2e"` → **2386 passed, 1 skipped, 0 failed**
- [x] Backend: `ruff check .` em `apps/api` → **limpo**
- [x] Frontend: `npx vitest run` em `apps/web` → **95 arquivos, 1231 testes, 0 falhas**
- [x] Frontend: `npx tsc --noEmit` → **limpo**
- [x] Frontend: `npx eslint` nos arquivos tocados → **limpo**
- [x] Backend implementado com **TDD** — teste vermelho antes de cada implementação, verde depois
- [x] Cadeia de migration conferida: `0085` → `down_revision 0084`, sem colisão de revision

## Notas para o review

- A migration é aditiva e idempotente por natureza (três `add_column` com default), sem backfill — não toca linha existente.
- Nenhuma mudança de fluxo nas telas de anexo já existentes; o caminho antigo (anexar depois, pela tela do registro) continua funcionando.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
