### PR TITLE
feat: Vima ganha ações de agenda — criar/cancelar/remarcar compromisso

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3023,6 +3023,49 @@ os dados reais de Financeiro, Agenda e CRM.
 - Hardening do anonimizador para nome próprio (NER) — dívida pré-existente que esta fatia
   ESTENDE o aceite de risco em vez de fechar.
 
+## Vima: ações de agenda (2026-09-01)
+
+> Spec: `docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md` ·
+> Plano: `docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md`
+
+Terceira fatia do caminho até o Jarbes, e a primeira em que a Vima ESCREVE. Fecha a dívida
+"Ações da Vima — hoje ela só LÊ" registrada nas duas fatias anteriores, e a Regra de Ouro nº 3
+(propagar `is_ai` nas escritas de agenda) — `agenda/service.py` já aceitava `by_ai` desde
+sempre, só nunca tinha sido chamado com `True`.
+
+- [x] **Três ferramentas novas em `vima/tools.py`** — `criar_compromisso`, `cancelar_compromisso`,
+  `remarcar_compromisso`, wrappers finos sobre `agenda_service.create_event/cancel_event/
+  reschedule_event`. Nenhuma regra de negócio nova: conflito de horário, espelho no Google, RLS
+  — tudo já existia no serviço.
+- [x] **Confirmação obrigatória por campo, não por mecanismo persistido.** Cada ferramenta de
+  escrita exige `confirmado: bool`; ausente/`false` devolve erro sem tocar o banco. O
+  prompt-sistema (`vima/pergunta.py`) instrui a Vima a resumir e pedir confirmação em texto
+  antes de chamar com `confirmado=true` — mesma disciplina (prompt + teste, não trava de
+  código) que já sustenta "a IA só narra, nunca origina número" no resto da Vima. Um token de
+  confirmação persistido entre chamadas HTTP foi considerado e rejeitado: contrariaria a
+  decisão já tomada de "sem persistência de conversa entre sessões".
+- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 11 ferramentas de leitura pré-existentes não
+  precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
+  (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
+  (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando
+  verde.
+- [x] **`consultar_agenda` passou a devolver `id`** — sem isso a Vima não tinha como referenciar
+  de volta um evento achado por consulta numa chamada de `cancelar_compromisso`/
+  `remarcar_compromisso`. Extraído `_evento_json`, compartilhado entre as quatro ferramentas de
+  agenda.
+- [x] **Erro de domínio chega com a mensagem real** — `tools.executar` ganhou um `except`
+  específico para `AgendaError`/`ValueError` antes do genérico, para a Vima saber narrar "evento
+  não encontrado" em vez de um "não consegui" apagado.
+- [x] **Prova de RLS** (`test_vima_tools_rls.py`) — dois tenants, `cancelar_compromisso` por id:
+  tenant B não alcança o evento de A, sob Postgres real.
+
+**Fora de escopo, declarado:**
+- Editar campos livres (título/local/descrição) via Vima — só criar, cancelar, remarcar.
+- Ferramentas de escrita para outros módulos (Financeiro, CRM, Jurídico, Marketing, Estoque).
+- Mecanismo de confirmação mais forte que prompt + campo obrigatório, caso o risco de
+  auto-confirmação (a Claude chamar a ferramenta de escrita na mesma rodada em que propôs, sem
+  o dono ver) se prove real em uso — hoje é decisão de custo/benefício, não lacuna desconhecida.
+
 ## Vima: canal WhatsApp (self-chat, Evolution) (2026-08-28)
 
 > Spec: `docs/superpowers/specs/2026-08-28-vima-canal-whatsapp-design.md` ·

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3023,49 +3023,6 @@ os dados reais de Financeiro, Agenda e CRM.
 - Hardening do anonimizador para nome próprio (NER) — dívida pré-existente que esta fatia
   ESTENDE o aceite de risco em vez de fechar.
 
-## Vima: ações de agenda (2026-09-01)
-
-> Spec: `docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md` ·
-> Plano: `docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md`
-
-Terceira fatia do caminho até o Jarbes, e a primeira em que a Vima ESCREVE. Fecha a dívida
-"Ações da Vima — hoje ela só LÊ" registrada nas duas fatias anteriores, e a Regra de Ouro nº 3
-(propagar `is_ai` nas escritas de agenda) — `agenda/service.py` já aceitava `by_ai` desde
-sempre, só nunca tinha sido chamado com `True`.
-
-- [x] **Três ferramentas novas em `vima/tools.py`** — `criar_compromisso`, `cancelar_compromisso`,
-  `remarcar_compromisso`, wrappers finos sobre `agenda_service.create_event/cancel_event/
-  reschedule_event`. Nenhuma regra de negócio nova: conflito de horário, espelho no Google, RLS
-  — tudo já existia no serviço.
-- [x] **Confirmação obrigatória por campo, não por mecanismo persistido.** Cada ferramenta de
-  escrita exige `confirmado: bool`; ausente/`false` devolve erro sem tocar o banco. O
-  prompt-sistema (`vima/pergunta.py`) instrui a Vima a resumir e pedir confirmação em texto
-  antes de chamar com `confirmado=true` — mesma disciplina (prompt + teste, não trava de
-  código) que já sustenta "a IA só narra, nunca origina número" no resto da Vima. Um token de
-  confirmação persistido entre chamadas HTTP foi considerado e rejeitado: contrariaria a
-  decisão já tomada de "sem persistência de conversa entre sessões".
-- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 11 ferramentas de leitura pré-existentes não
-  precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
-  (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
-  (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando
-  verde.
-- [x] **`consultar_agenda` passou a devolver `id`** — sem isso a Vima não tinha como referenciar
-  de volta um evento achado por consulta numa chamada de `cancelar_compromisso`/
-  `remarcar_compromisso`. Extraído `_evento_json`, compartilhado entre as quatro ferramentas de
-  agenda.
-- [x] **Erro de domínio chega com a mensagem real** — `tools.executar` ganhou um `except`
-  específico para `AgendaError`/`ValueError` antes do genérico, para a Vima saber narrar "evento
-  não encontrado" em vez de um "não consegui" apagado.
-- [x] **Prova de RLS** (`test_vima_tools_rls.py`) — dois tenants, `cancelar_compromisso` por id:
-  tenant B não alcança o evento de A, sob Postgres real.
-
-**Fora de escopo, declarado:**
-- Editar campos livres (título/local/descrição) via Vima — só criar, cancelar, remarcar.
-- Ferramentas de escrita para outros módulos (Financeiro, CRM, Jurídico, Marketing, Estoque).
-- Mecanismo de confirmação mais forte que prompt + campo obrigatório, caso o risco de
-  auto-confirmação (a Claude chamar a ferramenta de escrita na mesma rodada em que propôs, sem
-  o dono ver) se prove real em uso — hoje é decisão de custo/benefício, não lacuna desconhecida.
-
 ## Vima: canal WhatsApp (self-chat, Evolution) (2026-08-28)
 
 > Spec: `docs/superpowers/specs/2026-08-28-vima-canal-whatsapp-design.md` ·
@@ -3168,6 +3125,49 @@ ENTRADA: a resposta continua sempre em texto.
   falha na chamada e cai no caminho de erro já descrito.
 - Qualquer persistência de áudio ou transcrição além do cache curto de texto que
   `whatsapp_conversa.py` já mantinha para a fatia de texto.
+
+## Vima: ações de agenda (2026-09-01)
+
+> Spec: `docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md` ·
+> Plano: `docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md`
+
+Terceira fatia do caminho até o Jarbes, e a primeira em que a Vima ESCREVE. Fecha a dívida
+"Ações da Vima — hoje ela só LÊ" registrada nas duas fatias anteriores, e a Regra de Ouro nº 3
+(propagar `is_ai` nas escritas de agenda) — `agenda/service.py` já aceitava `by_ai` desde
+sempre, só nunca tinha sido chamado com `True`.
+
+- [x] **Três ferramentas novas em `vima/tools.py`** — `criar_compromisso`, `cancelar_compromisso`,
+  `remarcar_compromisso`, wrappers finos sobre `agenda_service.create_event/cancel_event/
+  reschedule_event`. Nenhuma regra de negócio nova: conflito de horário, espelho no Google, RLS
+  — tudo já existia no serviço.
+- [x] **Confirmação obrigatória por campo, não por mecanismo persistido.** Cada ferramenta de
+  escrita exige `confirmado: bool`; ausente/`false` devolve erro sem tocar o banco. O
+  prompt-sistema (`vima/pergunta.py`) instrui a Vima a resumir e pedir confirmação em texto
+  antes de chamar com `confirmado=true` — mesma disciplina (prompt + teste, não trava de
+  código) que já sustenta "a IA só narra, nunca origina número" no resto da Vima. Um token de
+  confirmação persistido entre chamadas HTTP foi considerado e rejeitado: contrariaria a
+  decisão já tomada de "sem persistência de conversa entre sessões".
+- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 11 ferramentas de leitura pré-existentes não
+  precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
+  (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
+  (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando
+  verde.
+- [x] **`consultar_agenda` passou a devolver `id`** — sem isso a Vima não tinha como referenciar
+  de volta um evento achado por consulta numa chamada de `cancelar_compromisso`/
+  `remarcar_compromisso`. Extraído `_evento_json`, compartilhado entre as quatro ferramentas de
+  agenda.
+- [x] **Erro de domínio chega com a mensagem real** — `tools.executar` ganhou um `except`
+  específico para `AgendaError`/`ValueError` antes do genérico, para a Vima saber narrar "evento
+  não encontrado" em vez de um "não consegui" apagado.
+- [x] **Prova de RLS** (`test_vima_tools_rls.py`) — dois tenants, `cancelar_compromisso` por id:
+  tenant B não alcança o evento de A, sob Postgres real.
+
+**Fora de escopo, declarado:**
+- Editar campos livres (título/local/descrição) via Vima — só criar, cancelar, remarcar.
+- Ferramentas de escrita para outros módulos (Financeiro, CRM, Jurídico, Marketing, Estoque).
+- Mecanismo de confirmação mais forte que prompt + campo obrigatório, caso o risco de
+  auto-confirmação (a Claude chamar a ferramenta de escrita na mesma rodada em que propôs, sem
+  o dono ver) se prove real em uso — hoje é decisão de custo/benefício, não lacuna desconhecida.
 
 ## Vima: o Registro de Fatos e o briefing (PRs #85 e #90, 2026-08-06/07)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3149,7 +3149,7 @@ sempre, só nunca tinha sido chamado com `True`.
   decisão já tomada de "sem persistência de conversa entre sessões".
 - [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 11 ferramentas de leitura pré-existentes não
   precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
-  (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
+  (carimbar a linha nova) e `actor` (auditoria). As 11 antigas ignoram o parâmetro
   (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando
   verde.
 - [x] **`consultar_agenda` passou a devolver `id`** — sem isso a Vima não tinha como referenciar

--- a/apps/api/app/modules/vima/pergunta.py
+++ b/apps/api/app/modules/vima/pergunta.py
@@ -57,7 +57,15 @@ def responder(db: Session, *, user: CurrentUser, pergunta: str, historico: list[
     seguro, mapa = anonymizer.mask(_com_historico(pergunta, historico))
 
     def _executar(nome: str, entrada: dict) -> str:
-        return tools.executar(db, user, nome, entrada)
+        # A entrada da ferramenta chega da Claude ainda MASCARADA (o texto que ela viu é
+        # `seguro`) — sem desmascarar aqui, um placeholder como `[FONE_1]` num título/local de
+        # `criar_compromisso` seria PERSISTIDO PERMANENTEMENTE em `agenda_events`, ao contrário
+        # da resposta final (que já é desmascarada abaixo). Mesmo `mapa` usado para a resposta.
+        entrada_real = {
+            k: anonymizer.unmask(v, mapa) if isinstance(v, str) else v
+            for k, v in entrada.items()
+        }
+        return tools.executar(db, user, nome, entrada_real)
 
     resultado = ai.complete_with_tools(
         db=db, tenant_id=user.tenant_id, task="vima.pergunta", system=_SYSTEM,

--- a/apps/api/app/modules/vima/pergunta.py
+++ b/apps/api/app/modules/vima/pergunta.py
@@ -24,7 +24,13 @@ _SYSTEM = (
     "Você é a Vima, a assistente do dono deste negócio dentro do e1p. Responda perguntas sobre "
     "o negócio SOMENTE com base no que as ferramentas devolverem — nunca invente um número, uma "
     "data ou um nome. Se não tiver uma ferramenta que responda a pergunta, diga isso claramente "
-    "em vez de adivinhar. Responda em português do Brasil, direto e sem rodeios."
+    "em vez de adivinhar. Responda em português do Brasil, direto e sem rodeios.\n\n"
+    "Antes de criar, cancelar ou remarcar um compromisso na agenda, resuma em texto o que você "
+    "entendeu (o quê, quando, com quem) e peça confirmação explícita do dono. SÓ chame "
+    "criar_compromisso, cancelar_compromisso ou remarcar_compromisso com confirmado=true depois "
+    "que o dono confirmar claramente numa mensagem seguinte — nunca no mesmo turno em que ele "
+    "pediu. Para cancelar ou remarcar, use consultar_agenda primeiro para achar o compromisso "
+    "certo; se houver mais de um compatível, pergunte qual antes de agir."
 )
 
 

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -41,15 +41,21 @@ from app.modules.vima import absences
 from app.modules.vima.permissions import pode_ver
 
 
-def _consultar_recebiveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_recebiveis(
+    db: Session, _user: CurrentUser, _entrada: dict[str, Any],
+) -> dict[str, Any]:
     return receivables_service.summary(db)
 
 
-def _consultar_pagaveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_pagaveis(
+    db: Session, _user: CurrentUser, _entrada: dict[str, Any],
+) -> dict[str, Any]:
     return payables_service.summary(db)
 
 
-def _consultar_projecao_caixa(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_projecao_caixa(
+    db: Session, _user: CurrentUser, _entrada: dict[str, Any],
+) -> dict[str, Any]:
     return asdict(projection_service.cash_projection(db))
 
 
@@ -65,14 +71,11 @@ def _evento_json(e: AgendaEvent) -> dict[str, Any]:
     """Serialização compartilhada entre `consultar_agenda` e as ferramentas de escrita — o `id`
     é o que permite à Claude referenciar de volta, numa chamada seguinte, um evento achado por
     consulta (`cancelar_compromisso`/`remarcar_compromisso` operam por `event_id`)."""
-    # SQLite devolve sem fuso; a comparação é sempre em UTC (mesma convenção de vima/service.py).
-    starts_at = e.starts_at if e.starts_at.tzinfo is not None else e.starts_at.replace(tzinfo=UTC)
-    ends_at = e.ends_at if e.ends_at.tzinfo is not None else e.ends_at.replace(tzinfo=UTC)
     return {
         "id": e.id,
         "titulo": e.title,
-        "inicio": starts_at.isoformat(),
-        "fim": ends_at.isoformat(),
+        "inicio": _aware(e.starts_at).isoformat(),
+        "fim": _aware(e.ends_at).isoformat(),
         "dia_inteiro": e.all_day,
         "status": e.status,
         "tipo": e.kind,
@@ -86,7 +89,9 @@ def _combinar_utc(dia: date, hora: time, tz_name: str) -> datetime:
     return datetime.combine(dia, hora, tzinfo=tenant_zone(tz_name)).astimezone(UTC)
 
 
-def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_agenda(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     tz = tenant_timezone(db)
     inicio = date.fromisoformat(entrada["data_inicio"])
     fim = date.fromisoformat(entrada.get("data_fim") or entrada["data_inicio"])
@@ -98,7 +103,9 @@ def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) 
     return {"eventos": [_evento_json(e) for e in eventos]}
 
 
-def _criar_compromisso(db: Session, user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _criar_compromisso(
+    db: Session, user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     tipo = entrada["tipo"]
     if tipo not in _TIPOS_CRIAVEIS_POR_CHAT:
         raise ValueError(f"tipo inválido para criar por chat: {tipo}")
@@ -142,11 +149,15 @@ def _criar_compromisso(db: Session, user: CurrentUser, entrada: dict[str, Any]) 
         "conflitos": [_evento_json(c) for c in conflitos],
     }
     if cliente_nao_encontrado:
-        resultado["aviso"] = f"cliente '{nome_cliente}' não encontrado no cadastro; criado sem vínculo"
+        resultado["aviso"] = (
+            f"cliente '{nome_cliente}' não encontrado no cadastro; criado sem vínculo"
+        )
     return resultado
 
 
-def _consultar_cliente(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_cliente(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     nome = entrada["nome"]
     clientes = crm_service.list_clients(db, search=nome, limit=5)
     resultado = []
@@ -172,7 +183,9 @@ def _aware(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
-def _consultar_clientes_recentes(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_clientes_recentes(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     limite = int(entrada.get("limite") or 5)
     clientes = crm_service.list_recent_clients(db, limit=200)
     dias = entrada.get("dias")
@@ -194,7 +207,9 @@ def _consultar_clientes_recentes(db: Session, _user: CurrentUser, entrada: dict[
     }
 
 
-def _consultar_documentos_juridicos(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_documentos_juridicos(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     client_id = None
     if entrada.get("cliente"):
         clientes = crm_service.list_clients(db, search=entrada["cliente"], limit=1)
@@ -221,7 +236,9 @@ def _consultar_documentos_juridicos(db: Session, _user: CurrentUser, entrada: di
     }
 
 
-def _consultar_campanhas_marketing(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_campanhas_marketing(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     campanhas = marketing_service.list_carousels(db)
     dias = entrada.get("dias")
     if dias:
@@ -240,7 +257,9 @@ def _consultar_campanhas_marketing(db: Session, _user: CurrentUser, entrada: dic
     }
 
 
-def _consultar_estoque_baixo(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_estoque_baixo(
+    db: Session, _user: CurrentUser, _entrada: dict[str, Any],
+) -> dict[str, Any]:
     itens = stock_service.low_stock(db)
     return {
         "itens": [
@@ -255,7 +274,9 @@ def _consultar_estoque_baixo(db: Session, _user: CurrentUser, _entrada: dict[str
     }
 
 
-def _consultar_item_estoque(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_item_estoque(
+    db: Session, _user: CurrentUser, entrada: dict[str, Any],
+) -> dict[str, Any]:
     nome = entrada["nome"].strip().lower()
     itens = [
         i for i in stock_service.list_items(db, only_active=True) if nome in i.name.lower()
@@ -274,7 +295,9 @@ def _consultar_item_estoque(db: Session, _user: CurrentUser, entrada: dict[str, 
     }
 
 
-def _consultar_clientes_atencao(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_clientes_atencao(
+    db: Session, _user: CurrentUser, _entrada: dict[str, Any],
+) -> dict[str, Any]:
     agora = datetime.now(UTC)
     hoje = hoje_do_tenant(db, now=agora)
     ausencias = absences.clientes_em_atencao(db, hoje=hoje, agora=agora)

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -11,14 +11,23 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.core.tenancy import CurrentUser
-from app.core.tz import day_window_utc
+from app.core.tz import day_window_utc, tenant_zone
 from app.modules.agenda import service as agenda_service
+from app.modules.agenda.models import (
+    KIND_ATENDIMENTO,
+    KIND_AUDIENCIA,
+    KIND_BLOQUEIO,
+    KIND_LEMBRETE,
+    KIND_REUNIAO,
+    AgendaEvent,
+)
+from app.modules.agenda.schemas import EventCreate
 from app.modules.crm import service as crm_service
 from app.modules.crm import timeline as crm_timeline
 from app.modules.financial_intelligence import projection as projection_service
@@ -44,6 +53,39 @@ def _consultar_projecao_caixa(db: Session, _user: CurrentUser, _entrada: dict[st
     return asdict(projection_service.cash_projection(db))
 
 
+# Tipos que fazem sentido nascer de uma conversa — exclui prazo/cobranca_*/google, derivados
+# de outro módulo ou de sync externo.
+_TIPOS_CRIAVEIS_POR_CHAT = {
+    KIND_ATENDIMENTO, KIND_REUNIAO, KIND_AUDIENCIA, KIND_BLOQUEIO, KIND_LEMBRETE,
+}
+_DURACAO_PADRAO = timedelta(hours=1)
+
+
+def _evento_json(e: AgendaEvent) -> dict[str, Any]:
+    """Serialização compartilhada entre `consultar_agenda` e as ferramentas de escrita — o `id`
+    é o que permite à Claude referenciar de volta, numa chamada seguinte, um evento achado por
+    consulta (`cancelar_compromisso`/`remarcar_compromisso` operam por `event_id`)."""
+    # SQLite devolve sem fuso; a comparação é sempre em UTC (mesma convenção de vima/service.py).
+    starts_at = e.starts_at if e.starts_at.tzinfo is not None else e.starts_at.replace(tzinfo=UTC)
+    ends_at = e.ends_at if e.ends_at.tzinfo is not None else e.ends_at.replace(tzinfo=UTC)
+    return {
+        "id": e.id,
+        "titulo": e.title,
+        "inicio": starts_at.isoformat(),
+        "fim": ends_at.isoformat(),
+        "dia_inteiro": e.all_day,
+        "status": e.status,
+        "tipo": e.kind,
+    }
+
+
+def _combinar_utc(dia: date, hora: time, tz_name: str) -> datetime:
+    """Combina uma data-calendário e uma hora de parede NO FUSO do tenant, convertidas para
+    UTC — mesma disciplina de `day_window_utc`, mas para um instante específico em vez da
+    meia-noite do dia."""
+    return datetime.combine(dia, hora, tzinfo=tenant_zone(tz_name)).astimezone(UTC)
+
+
 def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     tz = tenant_timezone(db)
     inicio = date.fromisoformat(entrada["data_inicio"])
@@ -53,19 +95,55 @@ def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) 
     eventos = agenda_service.list_events(
         db, start=janela_inicio, end=janela_fim, exclude_cancelled=True, limit=50,
     )
-    return {
-        "eventos": [
-            {
-                "titulo": e.title,
-                "inicio": e.starts_at.isoformat(),
-                "fim": e.ends_at.isoformat(),
-                "dia_inteiro": e.all_day,
-                "status": e.status,
-                "tipo": e.kind,
-            }
-            for e in eventos
-        ]
+    return {"eventos": [_evento_json(e) for e in eventos]}
+
+
+def _criar_compromisso(db: Session, user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+    tipo = entrada["tipo"]
+    if tipo not in _TIPOS_CRIAVEIS_POR_CHAT:
+        raise ValueError(f"tipo inválido para criar por chat: {tipo}")
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+
+    tz = tenant_timezone(db)
+    dia = date.fromisoformat(entrada["data"])
+    starts_at = _combinar_utc(dia, time.fromisoformat(entrada["hora_inicio"]), tz)
+    if entrada.get("hora_fim"):
+        ends_at = _combinar_utc(dia, time.fromisoformat(entrada["hora_fim"]), tz)
+    else:
+        ends_at = starts_at + _DURACAO_PADRAO
+    if ends_at <= starts_at:
+        raise ValueError("hora_fim deve ser depois de hora_inicio")
+
+    client_id = None
+    nome_cliente = entrada.get("cliente")
+    cliente_nao_encontrado = False
+    if nome_cliente:
+        clientes = crm_service.list_clients(db, search=nome_cliente, limit=1)
+        if clientes:
+            client_id = clientes[0].id
+        else:
+            cliente_nao_encontrado = True
+
+    evento, conflitos = agenda_service.create_event(
+        db, tenant_id=user.tenant_id, actor=user.user_id, by_ai=True,
+        data=EventCreate(
+            title=entrada["titulo"], kind=tipo, starts_at=starts_at, ends_at=ends_at,
+            location=entrada.get("local") or "", source="vima", client_id=client_id,
+        ),
+    )
+    resultado: dict[str, Any] = {
+        "compromisso": _evento_json(evento),
+        "conflitos": [_evento_json(c) for c in conflitos],
     }
+    if cliente_nao_encontrado:
+        resultado["aviso"] = f"cliente '{nome_cliente}' não encontrado no cadastro; criado sem vínculo"
+    return resultado
 
 
 def _consultar_cliente(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
@@ -295,6 +373,49 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_consultar_agenda,
+    ),
+    Ferramenta(
+        nome="criar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "criar_compromisso",
+            "description": (
+                "Cria um novo compromisso na agenda. SÓ chame com confirmado=true depois que o "
+                "dono confirmar explicitamente os detalhes numa mensagem anterior — antes "
+                "disso, resuma o que você entendeu e peça a confirmação em texto."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "titulo": {"type": "string", "description": "Título do compromisso."},
+                    "tipo": {
+                        "type": "string",
+                        "enum": ["atendimento", "reuniao", "audiencia", "bloqueio", "lembrete"],
+                        "description": "Tipo do compromisso.",
+                    },
+                    "data": {"type": "string", "description": "Data no formato AAAA-MM-DD."},
+                    "hora_inicio": {"type": "string", "description": "Hora de início, HH:MM."},
+                    "hora_fim": {
+                        "type": "string",
+                        "description": "Hora de término, HH:MM. Se omitida, dura 1h.",
+                    },
+                    "cliente": {
+                        "type": "string",
+                        "description": "Nome ou parte do nome do cliente, se houver um vinculado.",
+                    },
+                    "local": {"type": "string", "description": "Local do compromisso, se houver."},
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["titulo", "tipo", "data", "hora_inicio", "confirmado"],
+            },
+        },
+        executar=_criar_compromisso,
     ),
     Ferramenta(
         nome="consultar_cliente",

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -172,6 +172,40 @@ def _cancelar_compromisso(
     return {"compromisso": _evento_json(evento)}
 
 
+def _remarcar_compromisso(
+    db: Session, user: CurrentUser, entrada: dict[str, Any]
+) -> dict[str, Any]:
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+
+    evento_atual = agenda_service.get_event(db, entrada["event_id"])
+    duracao_original = evento_atual.ends_at - evento_atual.starts_at
+
+    tz = tenant_timezone(db)
+    dia = date.fromisoformat(entrada["nova_data"])
+    novo_inicio = _combinar_utc(dia, time.fromisoformat(entrada["nova_hora_inicio"]), tz)
+    if entrada.get("nova_hora_fim"):
+        novo_fim = _combinar_utc(dia, time.fromisoformat(entrada["nova_hora_fim"]), tz)
+    else:
+        novo_fim = novo_inicio + duracao_original
+    if novo_fim <= novo_inicio:
+        raise ValueError("nova_hora_fim deve ser depois de nova_hora_inicio")
+
+    evento, conflitos = agenda_service.reschedule_event(
+        db, event_id=entrada["event_id"], tenant_id=user.tenant_id, actor=user.user_id,
+        starts_at=novo_inicio, ends_at=novo_fim, by_ai=True,
+    )
+    return {
+        "compromisso": _evento_json(evento),
+        "conflitos": [_evento_json(c) for c in conflitos],
+    }
+
+
 def _consultar_cliente(
     db: Session, _user: CurrentUser, entrada: dict[str, Any],
 ) -> dict[str, Any]:
@@ -486,6 +520,47 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_cancelar_compromisso,
+    ),
+    Ferramenta(
+        nome="remarcar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "remarcar_compromisso",
+            "description": (
+                "Muda a data/hora de um compromisso existente. Use consultar_agenda primeiro "
+                "para achar o event_id certo. SÓ chame com confirmado=true depois que o dono "
+                "confirmar explicitamente o novo horário numa mensagem anterior."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "event_id": {
+                        "type": "string",
+                        "description": "Id do compromisso, obtido via consultar_agenda.",
+                    },
+                    "nova_data": {"type": "string", "description": "Nova data, AAAA-MM-DD."},
+                    "nova_hora_inicio": {
+                        "type": "string", "description": "Nova hora de início, HH:MM.",
+                    },
+                    "nova_hora_fim": {
+                        "type": "string",
+                        "description": (
+                            "Nova hora de término, HH:MM. Se omitida, preserva a duração "
+                            "original."
+                        ),
+                    },
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["event_id", "nova_data", "nova_hora_inicio", "confirmado"],
+            },
+        },
+        executar=_remarcar_compromisso,
     ),
     Ferramenta(
         nome="consultar_cliente",

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -65,6 +65,11 @@ _TIPOS_CRIAVEIS_POR_CHAT = {
     KIND_ATENDIMENTO, KIND_REUNIAO, KIND_AUDIENCIA, KIND_BLOQUEIO, KIND_LEMBRETE,
 }
 _DURACAO_PADRAO = timedelta(hours=1)
+# Mensagem idêntica nas três ferramentas de escrita — extraída para não triplicar o texto.
+_ERRO_CONFIRMACAO = (
+    "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+    "com confirmado=true"
+)
 
 
 def _evento_json(e: AgendaEvent) -> dict[str, Any]:
@@ -106,16 +111,16 @@ def _consultar_agenda(
 def _criar_compromisso(
     db: Session, user: CurrentUser, entrada: dict[str, Any],
 ) -> dict[str, Any]:
+    # Confirmação ANTES do tipo (mesma ordem de cancelar/remarcar): uma chamada não confirmada
+    # com tipo inválido deve pedir confirmação, não reprovar o tipo — nudge o modelo para o
+    # reparo certo (peça confirmação de novo) em vez de um erro que ele pode tentar "consertar"
+    # trocando o tipo por conta própria.
+    if not entrada.get("confirmado"):
+        return {"erro": _ERRO_CONFIRMACAO}
+
     tipo = entrada["tipo"]
     if tipo not in _TIPOS_CRIAVEIS_POR_CHAT:
         raise ValueError(f"tipo inválido para criar por chat: {tipo}")
-    if not entrada.get("confirmado"):
-        return {
-            "erro": (
-                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
-                "com confirmado=true"
-            )
-        }
 
     tz = tenant_timezone(db)
     dia = date.fromisoformat(entrada["data"])
@@ -159,12 +164,15 @@ def _cancelar_compromisso(
     db: Session, user: CurrentUser, entrada: dict[str, Any]
 ) -> dict[str, Any]:
     if not entrada.get("confirmado"):
-        return {
-            "erro": (
-                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
-                "com confirmado=true"
-            )
-        }
+        return {"erro": _ERRO_CONFIRMACAO}
+    # Mesma restrição de tipo de `criar_compromisso` (Regra de Ouro nº 3 / achado da revisão
+    # final): sem isto, `consultar_agenda` devolve eventos de QUALQUER tipo e a Vima podia
+    # cancelar um prazo jurídico ou uma cobrança por chat — pior que criar, já que cancelar é
+    # terminal (STATUS_CANCELLED não sai de TERMINAL_STATUSES). Busca o evento ANTES de cancelar
+    # para checar o tipo — uma query a mais, aceitável pela correção que ela compra.
+    evento = agenda_service.get_event(db, entrada["event_id"])
+    if evento.kind not in _TIPOS_CRIAVEIS_POR_CHAT:
+        raise ValueError(f"tipo não editável por chat: {evento.kind}")
     evento = agenda_service.cancel_event(
         db, event_id=entrada["event_id"], tenant_id=user.tenant_id, actor=user.user_id,
         by_ai=True,
@@ -176,14 +184,13 @@ def _remarcar_compromisso(
     db: Session, user: CurrentUser, entrada: dict[str, Any]
 ) -> dict[str, Any]:
     if not entrada.get("confirmado"):
-        return {
-            "erro": (
-                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
-                "com confirmado=true"
-            )
-        }
+        return {"erro": _ERRO_CONFIRMACAO}
 
     evento_atual = agenda_service.get_event(db, entrada["event_id"])
+    # Mesma restrição de tipo de `cancelar_compromisso`/`criar_compromisso` — reusa o evento já
+    # buscado para calcular `duracao_original`, sem query extra.
+    if evento_atual.kind not in _TIPOS_CRIAVEIS_POR_CHAT:
+        raise ValueError(f"tipo não editável por chat: {evento_atual.kind}")
     duracao_original = evento_atual.ends_at - evento_atual.starts_at
 
     tz = tenant_timezone(db)
@@ -471,7 +478,10 @@ FERRAMENTAS: list[Ferramenta] = [
                     "hora_inicio": {"type": "string", "description": "Hora de início, HH:MM."},
                     "hora_fim": {
                         "type": "string",
-                        "description": "Hora de término, HH:MM. Se omitida, dura 1h.",
+                        "description": (
+                            "Hora de término, HH:MM. Se omitida, dura 1h. (mesmo dia de data — "
+                            "não representa compromissos que atravessam a meia-noite)"
+                        ),
                     },
                     "cliente": {
                         "type": "string",
@@ -546,7 +556,8 @@ FERRAMENTAS: list[Ferramenta] = [
                         "type": "string",
                         "description": (
                             "Nova hora de término, HH:MM. Se omitida, preserva a duração "
-                            "original."
+                            "original. (mesmo dia de nova_data — não representa compromissos "
+                            "que atravessam a meia-noite)"
                         ),
                     },
                     "confirmado": {
@@ -744,7 +755,13 @@ def executar(db: Session, user: CurrentUser, nome: str, entrada: dict[str, Any])
     try:
         resultado = ferramenta.executar(db, user, entrada)
     except (agenda_service.AgendaError, ValueError) as exc:
+        # Defesa em profundidade: nenhum caminho hoje deixa a sessão suja neste ponto (todo
+        # `raise` acontece antes de qualquer mutação), mas a sessão sobrevive a até 6 turnos de
+        # tool-use (`ai.complete_with_tools`'s `max_tool_turns`) — um autoflush futuro não deve
+        # arriscar commitar estado parcial de uma escrita que falhou no meio.
+        db.rollback()
         return json.dumps({"erro": str(exc)})
     except Exception:  # noqa: BLE001 — tool_result sempre existe; a Claude decide o que dizer.
+        db.rollback()
         return json.dumps({"erro": "não foi possível consultar isso agora"})
     return json.dumps(resultado, default=str, ensure_ascii=False)

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -155,6 +155,23 @@ def _criar_compromisso(
     return resultado
 
 
+def _cancelar_compromisso(
+    db: Session, user: CurrentUser, entrada: dict[str, Any]
+) -> dict[str, Any]:
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+    evento = agenda_service.cancel_event(
+        db, event_id=entrada["event_id"], tenant_id=user.tenant_id, actor=user.user_id,
+        by_ai=True,
+    )
+    return {"compromisso": _evento_json(evento)}
+
+
 def _consultar_cliente(
     db: Session, _user: CurrentUser, entrada: dict[str, Any],
 ) -> dict[str, Any]:
@@ -439,6 +456,36 @@ FERRAMENTAS: list[Ferramenta] = [
             },
         },
         executar=_criar_compromisso,
+    ),
+    Ferramenta(
+        nome="cancelar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "cancelar_compromisso",
+            "description": (
+                "Cancela um compromisso existente. Use consultar_agenda primeiro para achar o "
+                "event_id certo. SÓ chame com confirmado=true depois que o dono confirmar "
+                "explicitamente qual compromisso cancelar numa mensagem anterior."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "event_id": {
+                        "type": "string",
+                        "description": "Id do compromisso, obtido via consultar_agenda.",
+                    },
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["event_id", "confirmado"],
+            },
+        },
+        executar=_cancelar_compromisso,
     ),
     Ferramenta(
         nome="consultar_cliente",

--- a/apps/api/app/modules/vima/tools.py
+++ b/apps/api/app/modules/vima/tools.py
@@ -32,19 +32,19 @@ from app.modules.vima import absences
 from app.modules.vima.permissions import pode_ver
 
 
-def _consultar_recebiveis(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_recebiveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
     return receivables_service.summary(db)
 
 
-def _consultar_pagaveis(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_pagaveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
     return payables_service.summary(db)
 
 
-def _consultar_projecao_caixa(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_projecao_caixa(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
     return asdict(projection_service.cash_projection(db))
 
 
-def _consultar_agenda(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     tz = tenant_timezone(db)
     inicio = date.fromisoformat(entrada["data_inicio"])
     fim = date.fromisoformat(entrada.get("data_fim") or entrada["data_inicio"])
@@ -68,7 +68,7 @@ def _consultar_agenda(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _consultar_cliente(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_cliente(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     nome = entrada["nome"]
     clientes = crm_service.list_clients(db, search=nome, limit=5)
     resultado = []
@@ -94,7 +94,7 @@ def _aware(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
-def _consultar_clientes_recentes(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_clientes_recentes(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     limite = int(entrada.get("limite") or 5)
     clientes = crm_service.list_recent_clients(db, limit=200)
     dias = entrada.get("dias")
@@ -116,7 +116,7 @@ def _consultar_clientes_recentes(db: Session, entrada: dict[str, Any]) -> dict[s
     }
 
 
-def _consultar_documentos_juridicos(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_documentos_juridicos(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     client_id = None
     if entrada.get("cliente"):
         clientes = crm_service.list_clients(db, search=entrada["cliente"], limit=1)
@@ -143,7 +143,7 @@ def _consultar_documentos_juridicos(db: Session, entrada: dict[str, Any]) -> dic
     }
 
 
-def _consultar_campanhas_marketing(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_campanhas_marketing(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     campanhas = marketing_service.list_carousels(db)
     dias = entrada.get("dias")
     if dias:
@@ -162,7 +162,7 @@ def _consultar_campanhas_marketing(db: Session, entrada: dict[str, Any]) -> dict
     }
 
 
-def _consultar_estoque_baixo(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_estoque_baixo(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
     itens = stock_service.low_stock(db)
     return {
         "itens": [
@@ -177,7 +177,7 @@ def _consultar_estoque_baixo(db: Session, _entrada: dict[str, Any]) -> dict[str,
     }
 
 
-def _consultar_item_estoque(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_item_estoque(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
     nome = entrada["nome"].strip().lower()
     itens = [
         i for i in stock_service.list_items(db, only_active=True) if nome in i.name.lower()
@@ -196,7 +196,7 @@ def _consultar_item_estoque(db: Session, entrada: dict[str, Any]) -> dict[str, A
     }
 
 
-def _consultar_clientes_atencao(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:
+def _consultar_clientes_atencao(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:
     agora = datetime.now(UTC)
     hoje = hoje_do_tenant(db, now=agora)
     ausencias = absences.clientes_em_atencao(db, hoje=hoje, agora=agora)
@@ -220,7 +220,9 @@ class Ferramenta:
     modulo: str
     # Schema no formato de tool-use da Anthropic (`name`/`description`/`input_schema`).
     definicao: dict[str, Any]
-    executar: Callable[[Session, dict[str, Any]], dict[str, Any]]
+    # `user` existe para as ferramentas de ESCRITA carimbarem tenant_id/actor — as de leitura
+    # ignoram (mesma convenção de parâmetro não usado do resto do arquivo: `_user`).
+    executar: Callable[[Session, CurrentUser, dict[str, Any]], dict[str, Any]]
 
 
 FERRAMENTAS: list[Ferramenta] = [
@@ -464,15 +466,19 @@ def executar(db: Session, user: CurrentUser, nome: str, entrada: dict[str, Any])
     """Executa uma ferramenta pelo nome, respeitando a MESMA lista que foi oferecida à Claude.
 
     Nunca deixa uma exceção subir crua: o loop de tool-use precisa de um `tool_result` sempre,
-    mesmo quando a consulta falha — a Claude é instruída (ver `vima/pergunta.py`) a dizer que
-    não conseguiu, nunca a inventar (Artigo IV, No Invention).
+    mesmo quando a consulta/escrita falha — a Claude é instruída (ver `vima/pergunta.py`) a
+    dizer que não conseguiu, nunca a inventar (Artigo IV, No Invention). Erro de domínio
+    (`AgendaError`) e de formato (`ValueError`) chegam com a mensagem REAL — a genérica é só
+    para o que não se sabe explicar.
     """
     disponiveis = {f.nome: f for f in ferramentas_disponiveis(user)}
     ferramenta = disponiveis.get(nome)
     if ferramenta is None:
         return json.dumps({"erro": "ferramenta indisponível para este usuário"})
     try:
-        resultado = ferramenta.executar(db, entrada)
+        resultado = ferramenta.executar(db, user, entrada)
+    except (agenda_service.AgendaError, ValueError) as exc:
+        return json.dumps({"erro": str(exc)})
     except Exception:  # noqa: BLE001 — tool_result sempre existe; a Claude decide o que dizer.
         return json.dumps({"erro": "não foi possível consultar isso agora"})
     return json.dumps(resultado, default=str, ensure_ascii=False)

--- a/apps/api/tests/test_vima_pergunta_service.py
+++ b/apps/api/tests/test_vima_pergunta_service.py
@@ -74,3 +74,11 @@ def test_historico_entra_no_texto_mandado_a_claude(db: Session, monkeypatch):
     assert "quanto tenho a receber?" in capturado["user_message"]
     assert "R$ 1.000,00" in capturado["user_message"]
     assert "e essa semana?" in capturado["user_message"]
+
+
+def test_system_prompt_exige_confirmacao_antes_de_escrever():
+    assert "confirmado=true" in pergunta._SYSTEM
+    assert "criar_compromisso" in pergunta._SYSTEM
+    assert "cancelar_compromisso" in pergunta._SYSTEM
+    assert "remarcar_compromisso" in pergunta._SYSTEM
+    assert "consultar_agenda" in pergunta._SYSTEM

--- a/apps/api/tests/test_vima_pergunta_service.py
+++ b/apps/api/tests/test_vima_pergunta_service.py
@@ -76,6 +76,36 @@ def test_historico_entra_no_texto_mandado_a_claude(db: Session, monkeypatch):
     assert "e essa semana?" in capturado["user_message"]
 
 
+def test_entrada_de_ferramenta_e_desmascarada_antes_de_executar(db: Session, monkeypatch):
+    # Achado #2 da revisão final: `_executar` mandava a entrada da ferramenta (o `tool_use.input`
+    # que a Claude devolve) direto para `tools.executar` SEM desmascarar — um placeholder como
+    # `[EMAIL_1]` num título/local de `criar_compromisso` seria persistido para sempre em
+    # `agenda_events`. Só o texto INICIAL ("busca o cliente joao@example.com") é mascarado, e o
+    # único padrão que bate ali é EMAIL, então o mapa terá exatamente {"[EMAIL_1]":
+    # "joao@example.com"} — usamos esse placeholder direto na "entrada de ferramenta" simulada,
+    # em vez de reconstruir o mapa à parte.
+    monkeypatch.setattr("app.config.settings.anthropic_api_key", "sk-fake")
+    capturado = {}
+
+    def _fake_tools_executar(_db, _user, _nome, entrada):
+        capturado["entrada"] = entrada
+        return "{}"
+
+    monkeypatch.setattr(pergunta.tools, "executar", _fake_tools_executar)
+
+    def _fake_loop(*, executar_ferramenta, **_kw):
+        executar_ferramenta("consultar_cliente", {"nome": "[EMAIL_1]"})
+        return type("R", (), {"text": "ok"})()
+
+    monkeypatch.setattr(pergunta.ai, "complete_with_tools", _fake_loop)
+
+    pergunta.responder(
+        db, user=_usuario(), pergunta="busca o cliente joao@example.com", historico=[]
+    )
+
+    assert capturado["entrada"]["nome"] == "joao@example.com"
+
+
 def test_system_prompt_exige_confirmacao_antes_de_escrever():
     assert "confirmado=true" in pergunta._SYSTEM
     assert "criar_compromisso" in pergunta._SYSTEM

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -34,14 +34,14 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_doze_ferramentas():
+def test_owner_ve_as_treze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente", "consultar_clientes_recentes",
-        "consultar_documentos_juridicos", "consultar_campanhas_marketing",
-        "consultar_estoque_baixo", "consultar_item_estoque", "consultar_clientes_atencao",
-        "criar_compromisso",
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso", "consultar_cliente",
+        "consultar_clientes_recentes", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "consultar_clientes_atencao",
     }
 
 
@@ -460,6 +460,66 @@ def test_criar_compromisso_cliente_nao_encontrado_avisa_mas_ainda_cria(db: Sessi
     ))
     assert resultado["compromisso"]["titulo"] == "Reunião"
     assert "não encontrado" in resultado["aviso"]
+
+
+# ── cancelar_compromisso ───────────────────────────────────────────────────────────────────
+
+
+def test_cancelar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, STATUS_SCHEDULED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.status == STATUS_SCHEDULED
+
+
+def test_cancelar_compromisso_confirmado_cancela(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert resultado["compromisso"]["status"] == "cancelled"
+
+
+def test_cancelar_compromisso_id_inexistente_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": "não-existe", "confirmado": True},
+    ))
+    assert "erro" in resultado
+
+
+def test_cancelar_compromisso_ja_cancelado_devolve_erro(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, STATUS_CANCELLED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO, status=STATUS_CANCELLED,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert "erro" in resultado
 
 
 # ── Falha nunca sobe crua ───────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -34,13 +34,14 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_onze_ferramentas():
+def test_owner_ve_as_doze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
         "consultar_agenda", "consultar_cliente", "consultar_clientes_recentes",
         "consultar_documentos_juridicos", "consultar_campanhas_marketing",
         "consultar_estoque_baixo", "consultar_item_estoque", "consultar_clientes_atencao",
+        "criar_compromisso",
     }
 
 
@@ -373,6 +374,92 @@ def test_consultar_clientes_atencao_sem_nada_pendente_devolve_lista_vazia(db: Se
         tools.executar(db, _usuario(), "consultar_clientes_atencao", {})
     )
     assert resultado["clientes_em_atencao"] == []
+
+
+# ── criar_compromisso ──────────────────────────────────────────────────────────────────────
+
+
+def test_criar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import AgendaEvent
+
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Falar com o Carlos", "tipo": "reuniao", "data": "2026-09-02",
+         "hora_inicio": "10:30"},
+    ))
+    assert "erro" in resultado
+    assert db.query(AgendaEvent).count() == 0
+
+
+def test_criar_compromisso_confirmado_cria_com_duracao_padrao_de_1h(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Falar com o Carlos", "tipo": "reuniao", "data": "2026-09-02",
+         "hora_inicio": "10:30", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Falar com o Carlos"
+    assert resultado["compromisso"]["inicio"] == "2026-09-02T13:30:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-02T14:30:00+00:00"
+    assert resultado["conflitos"] == []
+
+
+def test_criar_compromisso_respeita_hora_fim_explicita(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Audiência", "tipo": "audiencia", "data": "2026-09-02",
+         "hora_inicio": "09:00", "hora_fim": "11:00", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["inicio"] == "2026-09-02T12:00:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-02T14:00:00+00:00"
+
+
+def test_criar_compromisso_tipo_nao_criavel_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "X", "tipo": "prazo", "data": "2026-09-02", "hora_inicio": "10:00",
+         "confirmado": True},
+    ))
+    assert "erro" in resultado
+
+
+def test_criar_compromisso_devolve_conflito_sem_bloquear(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    db.add(AgendaEvent(
+        tenant_id=TENANT, title="Já marcado", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 13, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 14, 0, tzinfo=UTC),
+    ))
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Novo", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:30",
+         "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Novo"
+    assert len(resultado["conflitos"]) == 1
+    assert resultado["conflitos"][0]["titulo"] == "Já marcado"
+
+
+def test_criar_compromisso_vincula_cliente_encontrado_por_nome(db: Session):
+    db.add(Client(tenant_id=TENANT, name="Carlos Souza", phone="11999990000", source="manual"))
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Reunião", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:00",
+         "cliente": "Carlos", "confirmado": True},
+    ))
+    assert "aviso" not in resultado
+
+
+def test_criar_compromisso_cliente_nao_encontrado_avisa_mas_ainda_cria(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Reunião", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:00",
+         "cliente": "Ninguém", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Reunião"
+    assert "não encontrado" in resultado["aviso"]
 
 
 # ── Falha nunca sobe crua ───────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -34,14 +34,14 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
 
 
-def test_owner_ve_as_treze_ferramentas():
+def test_owner_ve_as_catorze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "criar_compromisso", "cancelar_compromisso", "consultar_cliente",
-        "consultar_clientes_recentes", "consultar_documentos_juridicos",
-        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
-        "consultar_clientes_atencao",
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso",
+        "remarcar_compromisso", "consultar_cliente", "consultar_clientes_recentes",
+        "consultar_documentos_juridicos", "consultar_campanhas_marketing",
+        "consultar_estoque_baixo", "consultar_item_estoque", "consultar_clientes_atencao",
     }
 
 
@@ -68,6 +68,13 @@ def test_sub_usuario_so_de_crm_ve_as_duas_ferramentas_de_cliente():
 def test_sub_usuario_so_de_comercial_so_ve_a_ferramenta_de_atencao():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["comercial"]))}
     assert nomes == {"consultar_clientes_atencao"}
+
+
+def test_sub_usuario_so_de_agenda_ve_a_leitura_e_as_tres_ferramentas_de_escrita():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["agenda"]))}
+    assert nomes == {
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso", "remarcar_compromisso",
+    }
 
 
 def test_toda_ferramenta_declara_um_input_schema_valido():
@@ -518,6 +525,100 @@ def test_cancelar_compromisso_ja_cancelado_devolve_erro(db: Session):
     db.commit()
     resultado = json.loads(tools.executar(
         db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert "erro" in resultado
+
+
+# ── remarcar_compromisso ───────────────────────────────────────────────────────────────────
+
+
+def test_remarcar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00"},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.starts_at == datetime(2026, 9, 2, 10, 0)
+
+
+def test_remarcar_compromisso_confirmado_preserva_duracao_original(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 30, tzinfo=UTC),  # 1h30 de duração
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert resultado["compromisso"]["inicio"] == "2026-09-03T18:00:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-03T19:30:00+00:00"
+
+
+def test_remarcar_compromisso_respeita_nova_hora_fim_explicita(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "nova_hora_fim": "16:00", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["fim"] == "2026-09-03T19:00:00+00:00"
+
+
+def test_remarcar_compromisso_devolve_conflito_sem_bloquear(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    alvo = AgendaEvent(
+        tenant_id=TENANT, title="Alvo", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    # nova_hora_inicio "15:00" é hora LOCAL (America/Sao_Paulo, UTC-3) → vira 18:00 UTC. O
+    # concorrente precisa sobrepor a JANELA CONVERTIDA, não o número "15:00" lido cru.
+    outro = AgendaEvent(
+        tenant_id=TENANT, title="Outro compromisso", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 3, 18, 30, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 3, 19, 30, tzinfo=UTC),
+    )
+    db.add_all([alvo, outro])
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": alvo.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert len(resultado["conflitos"]) == 1
+    assert resultado["conflitos"][0]["titulo"] == "Outro compromisso"
+
+
+def test_remarcar_compromisso_id_inexistente_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": "não-existe", "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
     ))
     assert "erro" in resultado
 

--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -4,8 +4,10 @@ contrato "nunca deixa exceção subir crua" (o loop de tool-use precisa de um to
 import json
 from datetime import UTC, date, datetime, timedelta
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.audit import AuditEntry
 from app.core.tenancy import CurrentUser
 from app.modules.crm.models import Client, PipelineStage
 from app.modules.juridico.models import LegalDocument
@@ -29,6 +31,18 @@ def _usuario(role: str = "owner", modulos: list[str] | None = None) -> CurrentUs
         user_id="u1", tenant_id=TENANT, role=role,
         allowed_modules=modulos or [], is_platform_admin=False,
     )
+
+
+def _latest_audit_is_ai(db: Session, action: str) -> bool:
+    # Réplica exata do helper de `test_agenda.py::_latest_audit_is_ai` — mesma query, mesmo
+    # contrato, para não inventar um segundo jeito de checar o mesmo rastro.
+    entry = db.scalars(
+        select(AuditEntry)
+        .where(AuditEntry.action == action)
+        .order_by(AuditEntry.created_at.desc())
+    ).first()
+    assert entry is not None, f"nenhum AuditEntry para {action}"
+    return entry.is_ai
 
 
 # ── Catálogo e permissão ────────────────────────────────────────────────────────────────────
@@ -399,6 +413,8 @@ def test_criar_compromisso_sem_confirmado_nao_escreve(db: Session):
 
 
 def test_criar_compromisso_confirmado_cria_com_duracao_padrao_de_1h(db: Session):
+    from app.modules.agenda.models import AgendaEvent
+
     resultado = json.loads(tools.executar(
         db, _usuario(), "criar_compromisso",
         {"titulo": "Falar com o Carlos", "tipo": "reuniao", "data": "2026-09-02",
@@ -408,6 +424,11 @@ def test_criar_compromisso_confirmado_cria_com_duracao_padrao_de_1h(db: Session)
     assert resultado["compromisso"]["inicio"] == "2026-09-02T13:30:00+00:00"
     assert resultado["compromisso"]["fim"] == "2026-09-02T14:30:00+00:00"
     assert resultado["conflitos"] == []
+    # Regra de Ouro nº 3: escrita originada pela Vima carimba is_ai/created_by_ai — o propósito
+    # inteiro desta fatia (achado #1 da revisão final: zero teste cobria isto antes).
+    assert _latest_audit_is_ai(db, "agenda.event.create") is True
+    evento = db.get(AgendaEvent, resultado["compromisso"]["id"])
+    assert evento.created_by_ai is True
 
 
 def test_criar_compromisso_respeita_hora_fim_explicita(db: Session):
@@ -426,7 +447,10 @@ def test_criar_compromisso_tipo_nao_criavel_devolve_erro(db: Session):
         {"titulo": "X", "tipo": "prazo", "data": "2026-09-02", "hora_inicio": "10:00",
          "confirmado": True},
     ))
-    assert "erro" in resultado
+    # Prova que a mensagem REAL (ValueError específico, não o "não foi possível" genérico) chega
+    # até quem chamou — achado #8 da revisão final: até aqui, só "erro" in resultado era checado,
+    # o que continuaria passando mesmo se o `except (AgendaError, ValueError)` fosse apagado.
+    assert "tipo inválido para criar por chat" in resultado["erro"]
 
 
 def test_criar_compromisso_devolve_conflito_sem_bloquear(db: Session):
@@ -504,13 +528,15 @@ def test_cancelar_compromisso_confirmado_cancela(db: Session):
         db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
     ))
     assert resultado["compromisso"]["status"] == "cancelled"
+    assert _latest_audit_is_ai(db, "agenda.event.cancel") is True
 
 
 def test_cancelar_compromisso_id_inexistente_devolve_erro(db: Session):
     resultado = json.loads(tools.executar(
         db, _usuario(), "cancelar_compromisso", {"event_id": "não-existe", "confirmado": True},
     ))
-    assert "erro" in resultado
+    # Mensagem REAL do AgendaError (`get_event`), não o genérico — mesmo achado #8.
+    assert "não encontrado" in resultado["erro"]
 
 
 def test_cancelar_compromisso_ja_cancelado_devolve_erro(db: Session):
@@ -527,6 +553,28 @@ def test_cancelar_compromisso_ja_cancelado_devolve_erro(db: Session):
         db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
     ))
     assert "erro" in resultado
+
+
+def test_cancelar_compromisso_tipo_nao_editavel_devolve_erro(db: Session):
+    # Achado #3 da revisão final: `cancelar_compromisso`/`remarcar_compromisso` recebem um
+    # `event_id` livre de `consultar_agenda`, que devolve eventos de QUALQUER tipo — sem esta
+    # checagem, a Vima podia cancelar um prazo jurídico ou uma cobrança por chat. Mesma lista
+    # `_TIPOS_CRIAVEIS_POR_CHAT` de `criar_compromisso`.
+    from app.modules.agenda.models import KIND_PRAZO, STATUS_SCHEDULED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Prazo processual", kind=KIND_PRAZO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.status == STATUS_SCHEDULED
 
 
 # ── remarcar_compromisso ───────────────────────────────────────────────────────────────────
@@ -568,6 +616,7 @@ def test_remarcar_compromisso_confirmado_preserva_duracao_original(db: Session):
     ))
     assert resultado["compromisso"]["inicio"] == "2026-09-03T18:00:00+00:00"
     assert resultado["compromisso"]["fim"] == "2026-09-03T19:30:00+00:00"
+    assert _latest_audit_is_ai(db, "agenda.event.reschedule") is True
 
 
 def test_remarcar_compromisso_respeita_nova_hora_fim_explicita(db: Session):
@@ -620,7 +669,55 @@ def test_remarcar_compromisso_id_inexistente_devolve_erro(db: Session):
         {"event_id": "não-existe", "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
          "confirmado": True},
     ))
+    # Mesma checagem de conteúdo do achado #8.
+    assert "não encontrado" in resultado["erro"]
+
+
+def test_remarcar_compromisso_tipo_nao_editavel_devolve_erro(db: Session):
+    # Mesma checagem de tipo do achado #3, agora para remarcar — usa cobranca_receber para
+    # variar em relação ao prazo já coberto em cancelar_compromisso.
+    from app.modules.agenda.models import KIND_COBRANCA_RECEBER, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Cobrança", kind=KIND_COBRANCA_RECEBER,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
     assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.starts_at == datetime(2026, 9, 2, 10, 0)
+    assert evento.ends_at == datetime(2026, 9, 2, 11, 0)
+
+
+def test_remarcar_compromisso_evento_terminal_devolve_erro(db: Session):
+    # Achado #7 da revisão final: `cancelar_compromisso` tem
+    # `test_cancelar_compromisso_ja_cancelado_devolve_erro`; `remarcar_compromisso` não tinha
+    # equivalente — `reschedule_event` também rejeita TERMINAL_STATUSES (cancelado ou feito).
+    from app.modules.agenda.models import KIND_REUNIAO, STATUS_CANCELLED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO, status=STATUS_CANCELLED,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.starts_at == datetime(2026, 9, 2, 10, 0)
+    assert evento.ends_at == datetime(2026, 9, 2, 11, 0)
 
 
 # ── Falha nunca sobe crua ───────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_vima_tools_rls.py
+++ b/apps/api/tests/test_vima_tools_rls.py
@@ -134,3 +134,61 @@ def test_consultar_cliente_isola_por_tenant() -> None:
         # vazia dos dois lados escondendo uma RLS aberta demais.
         assert resultado_a["clientes"][0]["nome"] == "Maria Fernandes"
         assert resultado_b["clientes"][0]["nome"] == "Maria Fernandes"
+
+
+def _criar_evento(app_url: str, *, tenant_id: str, titulo: str) -> str:
+    from datetime import UTC, datetime
+
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    with _tenant_session(app_url, tenant_id) as session:
+        evento = AgendaEvent(
+            tenant_id=tenant_id, title=titulo, kind=KIND_REUNIAO,
+            starts_at=datetime(2026, 9, 10, 14, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 9, 10, 15, 0, tzinfo=UTC),
+        )
+        session.add(evento)
+        session.commit()
+        return evento.id
+
+
+def _cancelar_compromisso(app_url: str, *, tenant_id: str, event_id: str) -> dict:
+    import json
+
+    from app.core.tenancy import CurrentUser
+    from app.modules.vima import tools
+
+    usuario = CurrentUser(user_id="u1", tenant_id=tenant_id, role="owner", allowed_modules=[])
+    with _tenant_session(app_url, tenant_id) as session:
+        resultado = tools.executar(
+            session, usuario, "cancelar_compromisso",
+            {"event_id": event_id, "confirmado": True},
+        )
+        return json.loads(resultado)
+
+
+def test_cancelar_compromisso_nao_alcanca_evento_de_outro_tenant() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine", username=_ROOT_USER, password=_ROOT_PASS, dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+        evento_id = _criar_evento(app_url, tenant_id=tenant_a, titulo="Reunião do tenant A")
+
+        # Tenant B tenta cancelar o evento de A pelo MESMO id — se a RLS falhar, ele consegue.
+        resultado_b = _cancelar_compromisso(app_url, tenant_id=tenant_b, event_id=evento_id)
+        assert "erro" in resultado_b, "RLS falhou: tenant B conseguiu alcançar o evento de A"
+
+        # Controle positivo: o próprio dono (tenant A) cancela sem problema — não é RLS fechada
+        # demais escondendo os dois lados.
+        resultado_a = _cancelar_compromisso(app_url, tenant_id=tenant_a, event_id=evento_id)
+        assert resultado_a["compromisso"]["status"] == "cancelled"

--- a/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
+++ b/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
@@ -47,7 +47,7 @@ Nenhum arquivo novo, nenhuma migration — tudo reaproveita `agenda/service.py`,
 - Consumes: `agenda_service.create_event(db, *, tenant_id, actor, by_ai, data: EventCreate) -> tuple[AgendaEvent, list[AgendaEvent]]`; `agenda_service.AgendaError`; `EventCreate` (`app.modules.agenda.schemas`); `crm_service.list_clients(db, search, limit) -> list[Client]`; `tenant_zone(tz_name) -> ZoneInfo` (`app.core.tz`, já existe, ainda não importado em `tools.py`); `tenant_timezone(db) -> str` (já importado).
 - Produces: `_evento_json(e: AgendaEvent) -> dict[str, Any]` — serialização compartilhada, usada por `_consultar_agenda` e pelas 3 ferramentas de escrita (Tasks 2/3 dependem dela). `Ferramenta.executar` passa a ser `Callable[[Session, CurrentUser, dict[str, Any]], dict[str, Any]]` — Tasks 2/3 seguem essa assinatura.
 
-Hoje `Ferramenta.executar` só recebe `(db, entrada)` porque as 9 ferramentas de leitura não precisam de identidade — a sessão já vem RLS-escopada. Escrever exige `tenant_id` (para carimbar a linha nova) e `actor` (para o rastro de auditoria), então esta task alarga a assinatura para TODAS as ferramentas — as de leitura passam a receber `user` e ignorá-lo (mesma convenção de parâmetro não usado que o arquivo já tem: `_entrada` quando o dado não é lido).
+Hoje `Ferramenta.executar` só recebe `(db, entrada)` porque as 11 ferramentas de leitura pré-existentes não precisam de identidade — a sessão já vem RLS-escopada. Escrever exige `tenant_id` (para carimbar a linha nova) e `actor` (para o rastro de auditoria), então esta task alarga a assinatura para TODAS as ferramentas — as de leitura passam a receber `user` e ignorá-lo (mesma convenção de parâmetro não usado que o arquivo já tem: `_entrada` quando o dado não é lido).
 
 - [ ] **Step 1: Rodar a suíte atual para ter uma baseline verde**
 
@@ -618,31 +618,37 @@ E na lista `FERRAMENTAS`, logo depois da entrada de `criar_compromisso`:
 
 - [ ] **Step 4: Atualizar a contagem do catálogo**
 
-`FERRAMENTAS` agora tem 11 entradas — o teste de contagem da Task 1 (`test_owner_ve_as_dez_ferramentas`) quebraria sem este ajuste. Troque:
+**Correção de planejamento (achada na revisão da Task 1):** o codebase real, na hora em que a Task 1 rodou, já tinha 11 ferramentas de leitura, não 9 — `consultar_clientes_recentes` (`modulo="crm"`) e `consultar_clientes_atencao` (`modulo="comercial"`) já existiam e não estavam no brief original. A Task 1 já foi corrigida para refletir isso (catálogo fechou em 12 = 11 + `criar_compromisso`, teste renomeado para `test_owner_ve_as_doze_ferramentas`). Esta task soma mais uma: 13.
+
+`FERRAMENTAS` agora tem 13 entradas — o teste de contagem que a Task 1 deixou (`test_owner_ve_as_doze_ferramentas`) quebraria sem este ajuste. Troque:
 
 ```python
-def test_owner_ve_as_dez_ferramentas():
+def test_owner_ve_as_doze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_agenda", "criar_compromisso", "consultar_cliente",
+        "consultar_clientes_recentes", "consultar_documentos_juridicos",
         "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
-        "criar_compromisso",
+        "consultar_clientes_atencao",
     }
 ```
 
 por:
 
 ```python
-def test_owner_ve_as_onze_ferramentas():
+def test_owner_ve_as_treze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso", "consultar_cliente",
+        "consultar_clientes_recentes", "consultar_documentos_juridicos",
         "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
-        "criar_compromisso", "cancelar_compromisso",
+        "consultar_clientes_atencao",
     }
 ```
+
+(Antes de escrever este teste, confirme o nome exato do teste deixado pela Task 1 e a lista completa de nomes em `apps/api/app/modules/vima/tools.py` — `grep -n 'nome="' apps/api/app/modules/vima/tools.py` — porque o codebase pode ter mudado mais desde que este plano foi escrito. Use o que está no arquivo, não a lista acima, se divergirem.)
 
 - [ ] **Step 5: Rodar os testes e confirmar verde**
 
@@ -856,16 +862,19 @@ E na lista `FERRAMENTAS`, logo depois da entrada de `cancelar_compromisso`:
 
 - [ ] **Step 4: Atualizar a contagem do catálogo e adicionar o teste de permissão por módulo `agenda`**
 
-Troque (de novo) `test_owner_ve_as_onze_ferramentas` por:
+**Correção de planejamento (a mesma da Task 2):** o catálogo real tem 2 ferramentas de leitura a mais do que este plano previu (`consultar_clientes_recentes`, `consultar_clientes_atencao` — ver a nota na Task 2). Confirme o nome do teste e a lista completa que a Task 2 deixou (`grep -n 'nome="' apps/api/app/modules/vima/tools.py` e o nome da última função `test_owner_ve_as_*` em `test_vima_tools.py`) antes de trocar — use o que está no arquivo se divergir do que está aqui.
+
+Troque (de novo) `test_owner_ve_as_treze_ferramentas` por:
 
 ```python
-def test_owner_ve_as_doze_ferramentas():
+def test_owner_ve_as_catorze_ferramentas():
     nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
     assert nomes == {
         "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
-        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
-        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
-        "criar_compromisso", "cancelar_compromisso", "remarcar_compromisso",
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso",
+        "remarcar_compromisso", "consultar_cliente", "consultar_clientes_recentes",
+        "consultar_documentos_juridicos", "consultar_campanhas_marketing",
+        "consultar_estoque_baixo", "consultar_item_estoque", "consultar_clientes_atencao",
     }
 ```
 
@@ -882,7 +891,7 @@ def test_sub_usuario_so_de_agenda_ve_a_leitura_e_as_tres_ferramentas_de_escrita(
 - [ ] **Step 5: Rodar a suíte inteira do arquivo e confirmar verde**
 
 Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -v`
-Expected: PASS em todos — catálogo com 12 ferramentas, 17 testes novos desde o início do plano.
+Expected: PASS em todos — catálogo com 14 ferramentas (11 pré-existentes + as 3 novas desta fatia), 17 testes novos desde o início do plano.
 
 - [ ] **Step 6: Rodar a suíte completa da API para checar que nada mais quebrou**
 
@@ -1093,7 +1102,7 @@ sempre, só nunca tinha sido chamado com `True`.
   código) que já sustenta "a IA só narra, nunca origina número" no resto da Vima. Um token de
   confirmação persistido entre chamadas HTTP foi considerado e rejeitado: contrariaria a
   decisão já tomada de "sem persistência de conversa entre sessões".
-- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 9 ferramentas de leitura não
+- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 11 ferramentas de leitura pré-existentes não
   precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
   (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
   (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando

--- a/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
+++ b/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
@@ -1,0 +1,1125 @@
+# Vima: ações de agenda — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar à Vima três ferramentas de escrita — `criar_compromisso`, `cancelar_compromisso`, `remarcar_compromisso` — no mesmo loop de tool-use que hoje só lê, fechando a dívida "Ações da Vima" do CLAUDE.md e a Regra de Ouro nº 3 (propagar `is_ai` nas escritas de agenda).
+
+**Architecture:** Três wrappers finos em `vima/tools.py` sobre `agenda_service.create_event/cancel_event/reschedule_event`, que já aceitam `by_ai`. Nenhuma regra de negócio nova (conflito, RLS, espelho no Google já existem no serviço). Confirmação obrigatória via campo `confirmado: bool` + disciplina de prompt em `vima/pergunta.py`. Mesmo gate de permissão das ferramentas de leitura (`pode_ver(user, "agenda")`).
+
+**Tech Stack:** Python 3.13, FastAPI, SQLAlchemy, pytest (SQLite em memória para unitário, Postgres real via testcontainers para RLS).
+
+**Spec:** `docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md`
+
+## Global Constraints
+
+- Escrita só ocorre com `confirmado=true` explícito no payload da ferramenta — ausente ou `false` devolve `{"erro": "..."}` sem tocar o banco (spec, "Confirmação").
+- Toda chamada de escrita passa `by_ai=True` e `actor=user.user_id` para os serviços de agenda (Regra de Ouro nº 3 do CLAUDE.md).
+- Nenhuma query filtra tenant manualmente — a sessão já vem RLS-escopada (Regra de Ouro nº 1); só o `tenant_id` explícito é passado ao CRIAR uma linha nova, exatamente como `agenda_service.create_event` já exige.
+- `criar_compromisso` só aceita `tipo` em `{atendimento, reuniao, audiencia, bloqueio, lembrete}` — os demais `ALL_KINDS` (`prazo`, `cobranca_receber`, `cobranca_pagar`, `google`) são derivados de outro módulo, nunca criados por chat.
+- Duração padrão de 1h quando a hora de término é omitida, em `criar_compromisso` e `remarcar_compromisso`.
+- Gate de visibilidade das 3 ferramentas novas é `pode_ver(user, "agenda")` — mesmo critério das ferramentas de leitura, nenhuma dimensão de permissão nova.
+- Erros de domínio (`AgendaError`) e de formato (`ValueError`) chegam ao `tool_result` com a mensagem real, não a genérica — a Claude precisa saber SE foi "evento não encontrado" vs. "não consegui de jeito nenhum" para narrar direito (Artigo IV, No Invention: nunca dizer que deu certo quando não deu).
+
+---
+
+## File Structure
+
+| Arquivo | Papel |
+|---|---|
+| `apps/api/app/modules/vima/tools.py` | Modificado: 3 ferramentas novas + `_evento_json` compartilhado + `Ferramenta.executar` ganha `user: CurrentUser` |
+| `apps/api/tests/test_vima_tools.py` | Modificado: testes das 3 ferramentas novas + contagem do catálogo |
+| `apps/api/app/modules/vima/pergunta.py` | Modificado: `_SYSTEM` ganha a disciplina de confirmação |
+| `apps/api/tests/test_vima_pergunta_service.py` | Modificado: teste do novo trecho do prompt |
+| `apps/api/tests/test_vima_tools_rls.py` | Modificado: prova de RLS cross-tenant para `cancelar_compromisso` |
+| `CLAUDE.md` | Modificado: nova seção `## Vima: ações de agenda` |
+
+Nenhum arquivo novo, nenhuma migration — tudo reaproveita `agenda/service.py`, `agenda/schemas.py` e `agenda/models.py` como já existem.
+
+---
+
+### Task 1: `criar_compromisso` (+ widen `Ferramenta.executar` para receber `user`)
+
+**Files:**
+- Modify: `apps/api/app/modules/vima/tools.py`
+- Test: `apps/api/tests/test_vima_tools.py`
+
+**Interfaces:**
+- Consumes: `agenda_service.create_event(db, *, tenant_id, actor, by_ai, data: EventCreate) -> tuple[AgendaEvent, list[AgendaEvent]]`; `agenda_service.AgendaError`; `EventCreate` (`app.modules.agenda.schemas`); `crm_service.list_clients(db, search, limit) -> list[Client]`; `tenant_zone(tz_name) -> ZoneInfo` (`app.core.tz`, já existe, ainda não importado em `tools.py`); `tenant_timezone(db) -> str` (já importado).
+- Produces: `_evento_json(e: AgendaEvent) -> dict[str, Any]` — serialização compartilhada, usada por `_consultar_agenda` e pelas 3 ferramentas de escrita (Tasks 2/3 dependem dela). `Ferramenta.executar` passa a ser `Callable[[Session, CurrentUser, dict[str, Any]], dict[str, Any]]` — Tasks 2/3 seguem essa assinatura.
+
+Hoje `Ferramenta.executar` só recebe `(db, entrada)` porque as 9 ferramentas de leitura não precisam de identidade — a sessão já vem RLS-escopada. Escrever exige `tenant_id` (para carimbar a linha nova) e `actor` (para o rastro de auditoria), então esta task alarga a assinatura para TODAS as ferramentas — as de leitura passam a receber `user` e ignorá-lo (mesma convenção de parâmetro não usado que o arquivo já tem: `_entrada` quando o dado não é lido).
+
+- [ ] **Step 1: Rodar a suíte atual para ter uma baseline verde**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py tests/test_vima_pergunta_service.py -v`
+Expected: todos os testes existentes passam.
+
+- [ ] **Step 2: Alargar a assinatura de `Ferramenta.executar` e o dispatch em `executar()`**
+
+Em `apps/api/app/modules/vima/tools.py`, troque:
+
+```python
+@dataclass
+class Ferramenta:
+    nome: str
+    # Nome de módulo em `User.allowed_modules` — decide se a Claude VÊ esta ferramenta.
+    modulo: str
+    # Schema no formato de tool-use da Anthropic (`name`/`description`/`input_schema`).
+    definicao: dict[str, Any]
+    executar: Callable[[Session, dict[str, Any]], dict[str, Any]]
+```
+
+por:
+
+```python
+@dataclass
+class Ferramenta:
+    nome: str
+    # Nome de módulo em `User.allowed_modules` — decide se a Claude VÊ esta ferramenta.
+    modulo: str
+    # Schema no formato de tool-use da Anthropic (`name`/`description`/`input_schema`).
+    definicao: dict[str, Any]
+    # `user` existe para as ferramentas de ESCRITA carimbarem tenant_id/actor — as de leitura
+    # ignoram (mesma convenção de parâmetro não usado do resto do arquivo: `_user`).
+    executar: Callable[[Session, CurrentUser, dict[str, Any]], dict[str, Any]]
+```
+
+E troque o corpo de `executar()`:
+
+```python
+def executar(db: Session, user: CurrentUser, nome: str, entrada: dict[str, Any]) -> str:
+    """Executa uma ferramenta pelo nome, respeitando a MESMA lista que foi oferecida à Claude.
+
+    Nunca deixa uma exceção subir crua: o loop de tool-use precisa de um `tool_result` sempre,
+    mesmo quando a consulta falha — a Claude é instruída (ver `vima/pergunta.py`) a dizer que
+    não conseguiu, nunca a inventar (Artigo IV, No Invention).
+    """
+    disponiveis = {f.nome: f for f in ferramentas_disponiveis(user)}
+    ferramenta = disponiveis.get(nome)
+    if ferramenta is None:
+        return json.dumps({"erro": "ferramenta indisponível para este usuário"})
+    try:
+        resultado = ferramenta.executar(db, entrada)
+    except Exception:  # noqa: BLE001 — tool_result sempre existe; a Claude decide o que dizer.
+        return json.dumps({"erro": "não foi possível consultar isso agora"})
+    return json.dumps(resultado, default=str, ensure_ascii=False)
+```
+
+por:
+
+```python
+def executar(db: Session, user: CurrentUser, nome: str, entrada: dict[str, Any]) -> str:
+    """Executa uma ferramenta pelo nome, respeitando a MESMA lista que foi oferecida à Claude.
+
+    Nunca deixa uma exceção subir crua: o loop de tool-use precisa de um `tool_result` sempre,
+    mesmo quando a consulta/escrita falha — a Claude é instruída (ver `vima/pergunta.py`) a
+    dizer que não conseguiu, nunca a inventar (Artigo IV, No Invention). Erro de domínio
+    (`AgendaError`) e de formato (`ValueError`) chegam com a mensagem REAL — a genérica é só
+    para o que não se sabe explicar.
+    """
+    disponiveis = {f.nome: f for f in ferramentas_disponiveis(user)}
+    ferramenta = disponiveis.get(nome)
+    if ferramenta is None:
+        return json.dumps({"erro": "ferramenta indisponível para este usuário"})
+    try:
+        resultado = ferramenta.executar(db, user, entrada)
+    except (agenda_service.AgendaError, ValueError) as exc:
+        return json.dumps({"erro": str(exc)})
+    except Exception:  # noqa: BLE001 — tool_result sempre existe; a Claude decide o que dizer.
+        return json.dumps({"erro": "não foi possível consultar isso agora"})
+    return json.dumps(resultado, default=str, ensure_ascii=False)
+```
+
+Agora ajuste a assinatura das 9 funções de leitura (uma troca de linha cada, corpo inalterado):
+
+| Função | Linha atual | Linha nova |
+|---|---|---|
+| `_consultar_recebiveis` | `def _consultar_recebiveis(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_recebiveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_pagaveis` | `def _consultar_pagaveis(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_pagaveis(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_projecao_caixa` | `def _consultar_projecao_caixa(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_projecao_caixa(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_agenda` | `def _consultar_agenda(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_agenda(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_cliente` | `def _consultar_cliente(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_cliente(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_documentos_juridicos` | `def _consultar_documentos_juridicos(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_documentos_juridicos(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_campanhas_marketing` | `def _consultar_campanhas_marketing(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_campanhas_marketing(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_estoque_baixo` | `def _consultar_estoque_baixo(db: Session, _entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_estoque_baixo(db: Session, _user: CurrentUser, _entrada: dict[str, Any]) -> dict[str, Any]:` |
+| `_consultar_item_estoque` | `def _consultar_item_estoque(db: Session, entrada: dict[str, Any]) -> dict[str, Any]:` | `def _consultar_item_estoque(db: Session, _user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:` |
+
+Nenhuma outra linha dessas 9 funções muda.
+
+- [ ] **Step 3: Rodar a suíte de novo — deve continuar 100% verde (refactor não muda comportamento)**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -v`
+Expected: mesmos testes de antes, todos PASS. Se algum quebrar, a assinatura foi trocada errado — pare e corrija antes de seguir.
+
+- [ ] **Step 4: Commit do refactor isolado**
+
+```bash
+git add apps/api/app/modules/vima/tools.py
+git commit -m "refactor(vima): Ferramenta.executar ganha CurrentUser, sem mudar comportamento"
+```
+
+- [ ] **Step 5: Escrever os testes (falhando) de `criar_compromisso`**
+
+Adicione em `apps/api/tests/test_vima_tools.py`, numa seção nova `# ── criar_compromisso ──` (após a seção de `consultar_agenda`):
+
+```python
+def test_criar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import AgendaEvent
+
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Falar com o Carlos", "tipo": "reuniao", "data": "2026-09-02",
+         "hora_inicio": "10:30"},
+    ))
+    assert "erro" in resultado
+    assert db.query(AgendaEvent).count() == 0
+
+
+def test_criar_compromisso_confirmado_cria_com_duracao_padrao_de_1h(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Falar com o Carlos", "tipo": "reuniao", "data": "2026-09-02",
+         "hora_inicio": "10:30", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Falar com o Carlos"
+    assert resultado["compromisso"]["inicio"] == "2026-09-02T13:30:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-02T14:30:00+00:00"
+    assert resultado["conflitos"] == []
+
+
+def test_criar_compromisso_respeita_hora_fim_explicita(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Audiência", "tipo": "audiencia", "data": "2026-09-02",
+         "hora_inicio": "09:00", "hora_fim": "11:00", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["inicio"] == "2026-09-02T12:00:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-02T14:00:00+00:00"
+
+
+def test_criar_compromisso_tipo_nao_criavel_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "X", "tipo": "prazo", "data": "2026-09-02", "hora_inicio": "10:00",
+         "confirmado": True},
+    ))
+    assert "erro" in resultado
+
+
+def test_criar_compromisso_devolve_conflito_sem_bloquear(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    db.add(AgendaEvent(
+        tenant_id=TENANT, title="Já marcado", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 13, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 14, 0, tzinfo=UTC),
+    ))
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Novo", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:30",
+         "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Novo"
+    assert len(resultado["conflitos"]) == 1
+    assert resultado["conflitos"][0]["titulo"] == "Já marcado"
+
+
+def test_criar_compromisso_vincula_cliente_encontrado_por_nome(db: Session):
+    db.add(Client(tenant_id=TENANT, name="Carlos Souza", phone="11999990000", source="manual"))
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Reunião", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:00",
+         "cliente": "Carlos", "confirmado": True},
+    ))
+    assert "aviso" not in resultado
+
+
+def test_criar_compromisso_cliente_nao_encontrado_avisa_mas_ainda_cria(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "criar_compromisso",
+        {"titulo": "Reunião", "tipo": "reuniao", "data": "2026-09-02", "hora_inicio": "10:00",
+         "cliente": "Ninguém", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["titulo"] == "Reunião"
+    assert "não encontrado" in resultado["aviso"]
+```
+
+- [ ] **Step 6: Rodar os testes novos e confirmar que falham por `ImportError`/`KeyError` de ferramenta inexistente**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -k criar_compromisso -v`
+Expected: FAIL — `criar_compromisso` ainda não está em `FERRAMENTAS`.
+
+- [ ] **Step 7: Implementar `_evento_json`, o refactor de `_consultar_agenda` para usá-lo, e `_criar_compromisso`**
+
+No topo de `apps/api/app/modules/vima/tools.py`, ajuste os imports:
+
+```python
+from datetime import UTC, date, datetime, timedelta
+```
+vira
+```python
+from datetime import UTC, date, datetime, time, timedelta
+```
+
+```python
+from app.core.tz import day_window_utc
+```
+vira
+```python
+from app.core.tz import day_window_utc, tenant_zone
+```
+
+Adicione, junto aos outros imports de módulo:
+
+```python
+from app.modules.agenda.models import (
+    KIND_ATENDIMENTO,
+    KIND_AUDIENCIA,
+    KIND_BLOQUEIO,
+    KIND_LEMBRETE,
+    KIND_REUNIAO,
+    AgendaEvent,
+)
+from app.modules.agenda.schemas import EventCreate
+```
+
+Adicione, logo antes de `def _consultar_agenda(...)`:
+
+```python
+# Tipos que fazem sentido nascer de uma conversa — exclui prazo/cobranca_*/google, derivados
+# de outro módulo ou de sync externo.
+_TIPOS_CRIAVEIS_POR_CHAT = {
+    KIND_ATENDIMENTO, KIND_REUNIAO, KIND_AUDIENCIA, KIND_BLOQUEIO, KIND_LEMBRETE,
+}
+_DURACAO_PADRAO = timedelta(hours=1)
+
+
+def _evento_json(e: AgendaEvent) -> dict[str, Any]:
+    """Serialização compartilhada entre `consultar_agenda` e as ferramentas de escrita — o `id`
+    é o que permite à Claude referenciar de volta, numa chamada seguinte, um evento achado por
+    consulta (`cancelar_compromisso`/`remarcar_compromisso` operam por `event_id`)."""
+    return {
+        "id": e.id,
+        "titulo": e.title,
+        "inicio": e.starts_at.isoformat(),
+        "fim": e.ends_at.isoformat(),
+        "dia_inteiro": e.all_day,
+        "status": e.status,
+        "tipo": e.kind,
+    }
+
+
+def _combinar_utc(dia: date, hora: time, tz_name: str) -> datetime:
+    """Combina uma data-calendário e uma hora de parede NO FUSO do tenant, convertidas para
+    UTC — mesma disciplina de `day_window_utc`, mas para um instante específico em vez da
+    meia-noite do dia."""
+    return datetime.combine(dia, hora, tzinfo=tenant_zone(tz_name)).astimezone(UTC)
+```
+
+Troque o corpo de `_consultar_agenda` (o `return` no final) de:
+
+```python
+    return {
+        "eventos": [
+            {
+                "titulo": e.title,
+                "inicio": e.starts_at.isoformat(),
+                "fim": e.ends_at.isoformat(),
+                "dia_inteiro": e.all_day,
+                "status": e.status,
+                "tipo": e.kind,
+            }
+            for e in eventos
+        ]
+    }
+```
+
+por:
+
+```python
+    return {"eventos": [_evento_json(e) for e in eventos]}
+```
+
+Adicione, depois de `_consultar_agenda` (antes de `_consultar_cliente`):
+
+```python
+def _criar_compromisso(db: Session, user: CurrentUser, entrada: dict[str, Any]) -> dict[str, Any]:
+    tipo = entrada["tipo"]
+    if tipo not in _TIPOS_CRIAVEIS_POR_CHAT:
+        raise ValueError(f"tipo inválido para criar por chat: {tipo}")
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+
+    tz = tenant_timezone(db)
+    dia = date.fromisoformat(entrada["data"])
+    starts_at = _combinar_utc(dia, time.fromisoformat(entrada["hora_inicio"]), tz)
+    if entrada.get("hora_fim"):
+        ends_at = _combinar_utc(dia, time.fromisoformat(entrada["hora_fim"]), tz)
+    else:
+        ends_at = starts_at + _DURACAO_PADRAO
+    if ends_at <= starts_at:
+        raise ValueError("hora_fim deve ser depois de hora_inicio")
+
+    client_id = None
+    nome_cliente = entrada.get("cliente")
+    cliente_nao_encontrado = False
+    if nome_cliente:
+        clientes = crm_service.list_clients(db, search=nome_cliente, limit=1)
+        if clientes:
+            client_id = clientes[0].id
+        else:
+            cliente_nao_encontrado = True
+
+    evento, conflitos = agenda_service.create_event(
+        db, tenant_id=user.tenant_id, actor=user.user_id, by_ai=True,
+        data=EventCreate(
+            title=entrada["titulo"], kind=tipo, starts_at=starts_at, ends_at=ends_at,
+            location=entrada.get("local") or "", source="vima", client_id=client_id,
+        ),
+    )
+    resultado: dict[str, Any] = {
+        "compromisso": _evento_json(evento),
+        "conflitos": [_evento_json(c) for c in conflitos],
+    }
+    if cliente_nao_encontrado:
+        resultado["aviso"] = f"cliente '{nome_cliente}' não encontrado no cadastro; criado sem vínculo"
+    return resultado
+```
+
+Por fim, adicione a `Ferramenta` na lista `FERRAMENTAS`, logo depois da entrada de `consultar_agenda`:
+
+```python
+    Ferramenta(
+        nome="criar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "criar_compromisso",
+            "description": (
+                "Cria um novo compromisso na agenda. SÓ chame com confirmado=true depois que o "
+                "dono confirmar explicitamente os detalhes numa mensagem anterior — antes "
+                "disso, resuma o que você entendeu e peça a confirmação em texto."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "titulo": {"type": "string", "description": "Título do compromisso."},
+                    "tipo": {
+                        "type": "string",
+                        "enum": ["atendimento", "reuniao", "audiencia", "bloqueio", "lembrete"],
+                        "description": "Tipo do compromisso.",
+                    },
+                    "data": {"type": "string", "description": "Data no formato AAAA-MM-DD."},
+                    "hora_inicio": {"type": "string", "description": "Hora de início, HH:MM."},
+                    "hora_fim": {
+                        "type": "string",
+                        "description": "Hora de término, HH:MM. Se omitida, dura 1h.",
+                    },
+                    "cliente": {
+                        "type": "string",
+                        "description": "Nome ou parte do nome do cliente, se houver um vinculado.",
+                    },
+                    "local": {"type": "string", "description": "Local do compromisso, se houver."},
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["titulo", "tipo", "data", "hora_inicio", "confirmado"],
+            },
+        },
+        executar=_criar_compromisso,
+    ),
+```
+
+- [ ] **Step 8: Atualizar o teste de contagem do catálogo**
+
+Em `test_vima_tools.py`, troque:
+
+```python
+def test_owner_ve_as_nove_ferramentas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
+    assert nomes == {
+        "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+    }
+```
+
+por:
+
+```python
+def test_owner_ve_as_dez_ferramentas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
+    assert nomes == {
+        "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "criar_compromisso",
+    }
+```
+
+- [ ] **Step 9: Rodar a suíte inteira do arquivo e confirmar verde**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -v`
+Expected: PASS em todos, incluindo os 7 testes novos de `criar_compromisso`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/app/modules/vima/tools.py apps/api/tests/test_vima_tools.py
+git commit -m "feat(vima): criar_compromisso — primeira ferramenta de escrita da Vima"
+```
+
+---
+
+### Task 2: `cancelar_compromisso`
+
+**Files:**
+- Modify: `apps/api/app/modules/vima/tools.py`
+- Test: `apps/api/tests/test_vima_tools.py`
+
+**Interfaces:**
+- Consumes: `agenda_service.cancel_event(db, *, event_id, tenant_id, actor, by_ai=False) -> AgendaEvent`; `agenda_service.get_event` (indireto, via `cancel_event`); `_evento_json` (Task 1).
+- Produces: nada consumido por tasks seguintes além do padrão já estabelecido.
+
+- [ ] **Step 1: Escrever os testes (falhando)**
+
+Adicione em `test_vima_tools.py`, numa seção nova `# ── cancelar_compromisso ──`:
+
+```python
+def test_cancelar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, STATUS_SCHEDULED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.status == STATUS_SCHEDULED
+
+
+def test_cancelar_compromisso_confirmado_cancela(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert resultado["compromisso"]["status"] == "cancelled"
+
+
+def test_cancelar_compromisso_id_inexistente_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": "não-existe", "confirmado": True},
+    ))
+    assert "erro" in resultado
+
+
+def test_cancelar_compromisso_ja_cancelado_devolve_erro(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, STATUS_CANCELLED, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO, status=STATUS_CANCELLED,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "cancelar_compromisso", {"event_id": evento.id, "confirmado": True},
+    ))
+    assert "erro" in resultado
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -k cancelar_compromisso -v`
+Expected: FAIL — ferramenta ainda não existe.
+
+- [ ] **Step 3: Implementar `_cancelar_compromisso` e registrar em `FERRAMENTAS`**
+
+Em `apps/api/app/modules/vima/tools.py`, adicione depois de `_criar_compromisso`:
+
+```python
+def _cancelar_compromisso(
+    db: Session, user: CurrentUser, entrada: dict[str, Any]
+) -> dict[str, Any]:
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+    evento = agenda_service.cancel_event(
+        db, event_id=entrada["event_id"], tenant_id=user.tenant_id, actor=user.user_id,
+        by_ai=True,
+    )
+    return {"compromisso": _evento_json(evento)}
+```
+
+E na lista `FERRAMENTAS`, logo depois da entrada de `criar_compromisso`:
+
+```python
+    Ferramenta(
+        nome="cancelar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "cancelar_compromisso",
+            "description": (
+                "Cancela um compromisso existente. Use consultar_agenda primeiro para achar o "
+                "event_id certo. SÓ chame com confirmado=true depois que o dono confirmar "
+                "explicitamente qual compromisso cancelar numa mensagem anterior."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "event_id": {
+                        "type": "string",
+                        "description": "Id do compromisso, obtido via consultar_agenda.",
+                    },
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["event_id", "confirmado"],
+            },
+        },
+        executar=_cancelar_compromisso,
+    ),
+```
+
+- [ ] **Step 4: Atualizar a contagem do catálogo**
+
+`FERRAMENTAS` agora tem 11 entradas — o teste de contagem da Task 1 (`test_owner_ve_as_dez_ferramentas`) quebraria sem este ajuste. Troque:
+
+```python
+def test_owner_ve_as_dez_ferramentas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
+    assert nomes == {
+        "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "criar_compromisso",
+    }
+```
+
+por:
+
+```python
+def test_owner_ve_as_onze_ferramentas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
+    assert nomes == {
+        "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "criar_compromisso", "cancelar_compromisso",
+    }
+```
+
+- [ ] **Step 5: Rodar os testes e confirmar verde**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -v`
+Expected: PASS em todos.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/app/modules/vima/tools.py apps/api/tests/test_vima_tools.py
+git commit -m "feat(vima): cancelar_compromisso"
+```
+
+---
+
+### Task 3: `remarcar_compromisso` (+ testes de permissão por módulo)
+
+**Files:**
+- Modify: `apps/api/app/modules/vima/tools.py`
+- Test: `apps/api/tests/test_vima_tools.py`
+
+**Interfaces:**
+- Consumes: `agenda_service.get_event(db, event_id) -> AgendaEvent`; `agenda_service.reschedule_event(db, *, event_id, tenant_id, actor, starts_at, ends_at, by_ai=False) -> tuple[AgendaEvent, list[AgendaEvent]]`; `_evento_json`, `_combinar_utc` (Task 1).
+- Produces: catálogo final de 12 ferramentas — Task 5 (RLS) e Task 6 (docs) assumem esse estado final.
+
+- [ ] **Step 1: Escrever os testes (falhando)**
+
+Adicione em `test_vima_tools.py`, numa seção nova `# ── remarcar_compromisso ──`:
+
+```python
+def test_remarcar_compromisso_sem_confirmado_nao_escreve(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00"},
+    ))
+    assert "erro" in resultado
+    db.refresh(evento)
+    assert evento.starts_at == datetime(2026, 9, 2, 10, 0, tzinfo=UTC)
+
+
+def test_remarcar_compromisso_confirmado_preserva_duracao_original(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 30, tzinfo=UTC),  # 1h30 de duração
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert resultado["compromisso"]["inicio"] == "2026-09-03T18:00:00+00:00"
+    assert resultado["compromisso"]["fim"] == "2026-09-03T19:30:00+00:00"
+
+
+def test_remarcar_compromisso_respeita_nova_hora_fim_explicita(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    evento = AgendaEvent(
+        tenant_id=TENANT, title="Reunião", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    db.add(evento)
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": evento.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "nova_hora_fim": "16:00", "confirmado": True},
+    ))
+    assert resultado["compromisso"]["fim"] == "2026-09-03T19:00:00+00:00"
+
+
+def test_remarcar_compromisso_devolve_conflito_sem_bloquear(db: Session):
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    alvo = AgendaEvent(
+        tenant_id=TENANT, title="Alvo", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 2, 10, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 2, 11, 0, tzinfo=UTC),
+    )
+    # nova_hora_inicio "15:00" é hora LOCAL (America/Sao_Paulo, UTC-3) → vira 18:00 UTC. O
+    # concorrente precisa sobrepor a JANELA CONVERTIDA, não o número "15:00" lido cru.
+    outro = AgendaEvent(
+        tenant_id=TENANT, title="Outro compromisso", kind=KIND_REUNIAO,
+        starts_at=datetime(2026, 9, 3, 18, 30, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 3, 19, 30, tzinfo=UTC),
+    )
+    db.add_all([alvo, outro])
+    db.commit()
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": alvo.id, "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert len(resultado["conflitos"]) == 1
+    assert resultado["conflitos"][0]["titulo"] == "Outro compromisso"
+
+
+def test_remarcar_compromisso_id_inexistente_devolve_erro(db: Session):
+    resultado = json.loads(tools.executar(
+        db, _usuario(), "remarcar_compromisso",
+        {"event_id": "não-existe", "nova_data": "2026-09-03", "nova_hora_inicio": "15:00",
+         "confirmado": True},
+    ))
+    assert "erro" in resultado
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -k remarcar_compromisso -v`
+Expected: FAIL — ferramenta ainda não existe.
+
+- [ ] **Step 3: Implementar `_remarcar_compromisso` e registrar em `FERRAMENTAS`**
+
+Adicione depois de `_cancelar_compromisso`:
+
+```python
+def _remarcar_compromisso(
+    db: Session, user: CurrentUser, entrada: dict[str, Any]
+) -> dict[str, Any]:
+    if not entrada.get("confirmado"):
+        return {
+            "erro": (
+                "peça a confirmação explícita do dono antes de chamar esta ferramenta de novo "
+                "com confirmado=true"
+            )
+        }
+
+    evento_atual = agenda_service.get_event(db, entrada["event_id"])
+    duracao_original = evento_atual.ends_at - evento_atual.starts_at
+
+    tz = tenant_timezone(db)
+    dia = date.fromisoformat(entrada["nova_data"])
+    novo_inicio = _combinar_utc(dia, time.fromisoformat(entrada["nova_hora_inicio"]), tz)
+    if entrada.get("nova_hora_fim"):
+        novo_fim = _combinar_utc(dia, time.fromisoformat(entrada["nova_hora_fim"]), tz)
+    else:
+        novo_fim = novo_inicio + duracao_original
+    if novo_fim <= novo_inicio:
+        raise ValueError("nova_hora_fim deve ser depois de nova_hora_inicio")
+
+    evento, conflitos = agenda_service.reschedule_event(
+        db, event_id=entrada["event_id"], tenant_id=user.tenant_id, actor=user.user_id,
+        starts_at=novo_inicio, ends_at=novo_fim, by_ai=True,
+    )
+    return {
+        "compromisso": _evento_json(evento),
+        "conflitos": [_evento_json(c) for c in conflitos],
+    }
+```
+
+E na lista `FERRAMENTAS`, logo depois da entrada de `cancelar_compromisso`:
+
+```python
+    Ferramenta(
+        nome="remarcar_compromisso",
+        modulo="agenda",
+        definicao={
+            "name": "remarcar_compromisso",
+            "description": (
+                "Muda a data/hora de um compromisso existente. Use consultar_agenda primeiro "
+                "para achar o event_id certo. SÓ chame com confirmado=true depois que o dono "
+                "confirmar explicitamente o novo horário numa mensagem anterior."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "event_id": {
+                        "type": "string",
+                        "description": "Id do compromisso, obtido via consultar_agenda.",
+                    },
+                    "nova_data": {"type": "string", "description": "Nova data, AAAA-MM-DD."},
+                    "nova_hora_inicio": {
+                        "type": "string", "description": "Nova hora de início, HH:MM.",
+                    },
+                    "nova_hora_fim": {
+                        "type": "string",
+                        "description": (
+                            "Nova hora de término, HH:MM. Se omitida, preserva a duração "
+                            "original."
+                        ),
+                    },
+                    "confirmado": {
+                        "type": "boolean",
+                        "description": (
+                            "true SOMENTE depois que o dono confirmou explicitamente numa "
+                            "mensagem anterior."
+                        ),
+                    },
+                },
+                "required": ["event_id", "nova_data", "nova_hora_inicio", "confirmado"],
+            },
+        },
+        executar=_remarcar_compromisso,
+    ),
+```
+
+- [ ] **Step 4: Atualizar a contagem do catálogo e adicionar o teste de permissão por módulo `agenda`**
+
+Troque (de novo) `test_owner_ve_as_onze_ferramentas` por:
+
+```python
+def test_owner_ve_as_doze_ferramentas():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("owner"))}
+    assert nomes == {
+        "consultar_recebiveis", "consultar_pagaveis", "consultar_projecao_caixa",
+        "consultar_agenda", "consultar_cliente", "consultar_documentos_juridicos",
+        "consultar_campanhas_marketing", "consultar_estoque_baixo", "consultar_item_estoque",
+        "criar_compromisso", "cancelar_compromisso", "remarcar_compromisso",
+    }
+```
+
+E adicione, na seção "Catálogo e permissão":
+
+```python
+def test_sub_usuario_so_de_agenda_ve_a_leitura_e_as_tres_ferramentas_de_escrita():
+    nomes = {f.nome for f in tools.ferramentas_disponiveis(_usuario("sub_user", ["agenda"]))}
+    assert nomes == {
+        "consultar_agenda", "criar_compromisso", "cancelar_compromisso", "remarcar_compromisso",
+    }
+```
+
+- [ ] **Step 5: Rodar a suíte inteira do arquivo e confirmar verde**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools.py -v`
+Expected: PASS em todos — catálogo com 12 ferramentas, 17 testes novos desde o início do plano.
+
+- [ ] **Step 6: Rodar a suíte completa da API para checar que nada mais quebrou**
+
+Run: `cd apps/api && python -m pytest -q`
+Expected: `... passed` (suíte SQLite; `rls_e2e` fica de fora, é a Task 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/app/modules/vima/tools.py apps/api/tests/test_vima_tools.py
+git commit -m "feat(vima): remarcar_compromisso — fecha o trio de escrita da agenda"
+```
+
+---
+
+### Task 4: Disciplina de confirmação no prompt-sistema
+
+**Files:**
+- Modify: `apps/api/app/modules/vima/pergunta.py`
+- Test: `apps/api/tests/test_vima_pergunta_service.py`
+
+**Interfaces:**
+- Consumes: nada novo — só o texto de `_SYSTEM` já existente.
+- Produces: nada consumido por outras tasks.
+
+- [ ] **Step 1: Escrever o teste (falhando)**
+
+Adicione em `test_vima_pergunta_service.py`:
+
+```python
+def test_system_prompt_exige_confirmacao_antes_de_escrever():
+    assert "confirmado=true" in pergunta._SYSTEM
+    assert "criar_compromisso" in pergunta._SYSTEM
+    assert "cancelar_compromisso" in pergunta._SYSTEM
+    assert "remarcar_compromisso" in pergunta._SYSTEM
+    assert "consultar_agenda" in pergunta._SYSTEM
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_pergunta_service.py -k system_prompt -v`
+Expected: FAIL — `_SYSTEM` ainda não menciona nenhuma das ferramentas de escrita.
+
+- [ ] **Step 3: Estender `_SYSTEM`**
+
+Em `apps/api/app/modules/vima/pergunta.py`, troque:
+
+```python
+_SYSTEM = (
+    "Você é a Vima, a assistente do dono deste negócio dentro do e1p. Responda perguntas sobre "
+    "o negócio SOMENTE com base no que as ferramentas devolverem — nunca invente um número, uma "
+    "data ou um nome. Se não tiver uma ferramenta que responda a pergunta, diga isso claramente "
+    "em vez de adivinhar. Responda em português do Brasil, direto e sem rodeios."
+)
+```
+
+por:
+
+```python
+_SYSTEM = (
+    "Você é a Vima, a assistente do dono deste negócio dentro do e1p. Responda perguntas sobre "
+    "o negócio SOMENTE com base no que as ferramentas devolverem — nunca invente um número, uma "
+    "data ou um nome. Se não tiver uma ferramenta que responda a pergunta, diga isso claramente "
+    "em vez de adivinhar. Responda em português do Brasil, direto e sem rodeios.\n\n"
+    "Antes de criar, cancelar ou remarcar um compromisso na agenda, resuma em texto o que você "
+    "entendeu (o quê, quando, com quem) e peça confirmação explícita do dono. SÓ chame "
+    "criar_compromisso, cancelar_compromisso ou remarcar_compromisso com confirmado=true depois "
+    "que o dono confirmar claramente numa mensagem seguinte — nunca no mesmo turno em que ele "
+    "pediu. Para cancelar ou remarcar, use consultar_agenda primeiro para achar o compromisso "
+    "certo; se houver mais de um compatível, pergunte qual antes de agir."
+)
+```
+
+- [ ] **Step 4: Rodar os testes e confirmar verde**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_pergunta_service.py -v`
+Expected: PASS em todos.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/modules/vima/pergunta.py apps/api/tests/test_vima_pergunta_service.py
+git commit -m "feat(vima): prompt-sistema exige confirmação explícita antes de escrever"
+```
+
+---
+
+### Task 5: Prova de RLS cross-tenant para `cancelar_compromisso`
+
+**Files:**
+- Modify: `apps/api/tests/test_vima_tools_rls.py`
+
+**Interfaces:**
+- Consumes: `tools.executar` (já com a assinatura da Task 1), `_tenant_session`/`_bootstrap_rls_role`/`_run_migrations_as_app` (já existentes no arquivo).
+- Produces: nada consumido por outras tasks — é o fim da cadeia de testes.
+
+Mesmo raciocínio do `consultar_cliente` já provado neste arquivo: `cancelar_compromisso` recebe um `event_id` livre — é a ferramenta de escrita mais direta em "alcançar a linha de outro tenant pelo id", então é a prova representativa (mesmo padrão do arquivo: uma ferramenta por família, não as três).
+
+- [ ] **Step 1: Adicionar os helpers e o teste**
+
+Em `apps/api/tests/test_vima_tools_rls.py`, adicione depois de `_consultar_cliente`:
+
+```python
+def _criar_evento(app_url: str, *, tenant_id: str, titulo: str) -> str:
+    from datetime import UTC, datetime
+
+    from app.modules.agenda.models import KIND_REUNIAO, AgendaEvent
+
+    with _tenant_session(app_url, tenant_id) as session:
+        evento = AgendaEvent(
+            tenant_id=tenant_id, title=titulo, kind=KIND_REUNIAO,
+            starts_at=datetime(2026, 9, 10, 14, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 9, 10, 15, 0, tzinfo=UTC),
+        )
+        session.add(evento)
+        session.commit()
+        return evento.id
+
+
+def _cancelar_compromisso(app_url: str, *, tenant_id: str, event_id: str) -> dict:
+    import json
+
+    from app.core.tenancy import CurrentUser
+    from app.modules.vima import tools
+
+    usuario = CurrentUser(user_id="u1", tenant_id=tenant_id, role="owner", allowed_modules=[])
+    with _tenant_session(app_url, tenant_id) as session:
+        resultado = tools.executar(
+            session, usuario, "cancelar_compromisso",
+            {"event_id": event_id, "confirmado": True},
+        )
+        return json.loads(resultado)
+
+
+def test_cancelar_compromisso_nao_alcanca_evento_de_outro_tenant() -> None:
+    with PostgresContainer(
+        "postgres:16-alpine", username=_ROOT_USER, password=_ROOT_PASS, dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+        evento_id = _criar_evento(app_url, tenant_id=tenant_a, titulo="Reunião do tenant A")
+
+        # Tenant B tenta cancelar o evento de A pelo MESMO id — se a RLS falhar, ele consegue.
+        resultado_b = _cancelar_compromisso(app_url, tenant_id=tenant_b, event_id=evento_id)
+        assert "erro" in resultado_b, "RLS falhou: tenant B conseguiu alcançar o evento de A"
+
+        # Controle positivo: o próprio dono (tenant A) cancela sem problema — não é RLS fechada
+        # demais escondendo os dois lados.
+        resultado_a = _cancelar_compromisso(app_url, tenant_id=tenant_a, event_id=evento_id)
+        assert resultado_a["compromisso"]["status"] == "cancelled"
+```
+
+- [ ] **Step 2: Rodar (precisa de Docker rodando — testcontainers sobe um Postgres real)**
+
+Run: `cd apps/api && python -m pytest tests/test_vima_tools_rls.py -m rls_e2e -v`
+Expected: PASS nos dois testes do arquivo (`test_consultar_cliente_isola_por_tenant` + o novo).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/test_vima_tools_rls.py
+git commit -m "test(vima): prova de RLS cross-tenant para cancelar_compromisso"
+```
+
+---
+
+### Task 6: Documentar a fatia no CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: nada — só resume o que as Tasks 1-5 já fizeram.
+- Produces: nada.
+
+Mesmo padrão das duas seções anteriores da Vima (`## Vima: pergunte e receba resposta`, `## Vima: canal WhatsApp`) — procure por `## Vima: canal WhatsApp (self-chat, Evolution) (2026-08-28)` no `CLAUDE.md` e adicione a nova seção IMEDIATAMENTE ANTES dela (mantém a ordem cronológica das seções da Vima).
+
+- [ ] **Step 1: Adicionar a seção**
+
+```markdown
+## Vima: ações de agenda (2026-09-01)
+
+> Spec: `docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md` ·
+> Plano: `docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md`
+
+Terceira fatia do caminho até o Jarbes, e a primeira em que a Vima ESCREVE. Fecha a dívida
+"Ações da Vima — hoje ela só LÊ" registrada nas duas fatias anteriores, e a Regra de Ouro nº 3
+(propagar `is_ai` nas escritas de agenda) — `agenda/service.py` já aceitava `by_ai` desde
+sempre, só nunca tinha sido chamado com `True`.
+
+- [x] **Três ferramentas novas em `vima/tools.py`** — `criar_compromisso`, `cancelar_compromisso`,
+  `remarcar_compromisso`, wrappers finos sobre `agenda_service.create_event/cancel_event/
+  reschedule_event`. Nenhuma regra de negócio nova: conflito de horário, espelho no Google, RLS
+  — tudo já existia no serviço.
+- [x] **Confirmação obrigatória por campo, não por mecanismo persistido.** Cada ferramenta de
+  escrita exige `confirmado: bool`; ausente/`false` devolve erro sem tocar o banco. O
+  prompt-sistema (`vima/pergunta.py`) instrui a Vima a resumir e pedir confirmação em texto
+  antes de chamar com `confirmado=true` — mesma disciplina (prompt + teste, não trava de
+  código) que já sustenta "a IA só narra, nunca origina número" no resto da Vima. Um token de
+  confirmação persistido entre chamadas HTTP foi considerado e rejeitado: contrariaria a
+  decisão já tomada de "sem persistência de conversa entre sessões".
+- [x] **`Ferramenta.executar` ganhou `CurrentUser`** — as 9 ferramentas de leitura não
+  precisavam de identidade (a sessão já vem RLS-escopada); escrever precisa de `tenant_id`
+  (carimbar a linha nova) e `actor` (auditoria). As 9 antigas ignoram o parâmetro
+  (`_user`), refactor sem mudança de comportamento, provado pela suíte existente continuando
+  verde.
+- [x] **`consultar_agenda` passou a devolver `id`** — sem isso a Vima não tinha como referenciar
+  de volta um evento achado por consulta numa chamada de `cancelar_compromisso`/
+  `remarcar_compromisso`. Extraído `_evento_json`, compartilhado entre as quatro ferramentas de
+  agenda.
+- [x] **Erro de domínio chega com a mensagem real** — `tools.executar` ganhou um `except`
+  específico para `AgendaError`/`ValueError` antes do genérico, para a Vima saber narrar "evento
+  não encontrado" em vez de um "não consegui" apagado.
+- [x] **Prova de RLS** (`test_vima_tools_rls.py`) — dois tenants, `cancelar_compromisso` por id:
+  tenant B não alcança o evento de A, sob Postgres real.
+
+**Fora de escopo, declarado:**
+- Editar campos livres (título/local/descrição) via Vima — só criar, cancelar, remarcar.
+- Ferramentas de escrita para outros módulos (Financeiro, CRM, Jurídico, Marketing, Estoque).
+- Mecanismo de confirmação mais forte que prompt + campo obrigatório, caso o risco de
+  auto-confirmação (a Claude chamar a ferramenta de escrita na mesma rodada em que propôs, sem
+  o dono ver) se prove real em uso — hoje é decisão de custo/benefício, não lacuna desconhecida.
+
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md registra a fatia de ações de agenda da Vima"
+```

--- a/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
+++ b/docs/superpowers/plans/2026-09-01-vima-acoes-de-agenda.md
@@ -16,7 +16,7 @@
 - Toda chamada de escrita passa `by_ai=True` e `actor=user.user_id` para os serviços de agenda (Regra de Ouro nº 3 do CLAUDE.md).
 - Nenhuma query filtra tenant manualmente — a sessão já vem RLS-escopada (Regra de Ouro nº 1); só o `tenant_id` explícito é passado ao CRIAR uma linha nova, exatamente como `agenda_service.create_event` já exige.
 - `criar_compromisso` só aceita `tipo` em `{atendimento, reuniao, audiencia, bloqueio, lembrete}` — os demais `ALL_KINDS` (`prazo`, `cobranca_receber`, `cobranca_pagar`, `google`) são derivados de outro módulo, nunca criados por chat.
-- Duração padrão de 1h quando a hora de término é omitida, em `criar_compromisso` e `remarcar_compromisso`.
+- Duração padrão de 1h quando a hora de término é omitida em `criar_compromisso`. Em `remarcar_compromisso`, a hora de término omitida preserva a DURAÇÃO ORIGINAL do evento (não reinicia para 1h) — decisão de produto: mover um compromisso não deveria mudar seu tamanho. Ver Task 3.
 - Gate de visibilidade das 3 ferramentas novas é `pode_ver(user, "agenda")` — mesmo critério das ferramentas de leitura, nenhuma dimensão de permissão nova.
 - Erros de domínio (`AgendaError`) e de formato (`ValueError`) chegam ao `tool_result` com a mensagem real, não a genérica — a Claude precisa saber SE foi "evento não encontrado" vs. "não consegui de jeito nenhum" para narrar direito (Artigo IV, No Invention: nunca dizer que deu certo quando não deu).
 

--- a/docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md
+++ b/docs/superpowers/specs/2026-09-01-vima-acoes-de-agenda-design.md
@@ -1,0 +1,211 @@
+# Vima: ações de agenda (terceira fatia do caminho até o Jarbes)
+
+## Por que existe
+
+As duas fatias anteriores (`docs/superpowers/specs/2026-08-28-vima-pergunte-design.md` e
+`2026-08-28-vima-canal-whatsapp-design.md`) deram à Vima um loop de tool-use e um canal de
+WhatsApp, mas ela só **LÊ** — a spec do Pergunte declarou explicitamente fora de escopo: "Ações
+(a Vima só LÊ nesta fatia — nenhuma ferramenta escreve nada)", e o CLAUDE.md do projeto carrega
+essa dívida nomeada desde então:
+
+> "Ações da Vima — hoje ela só LÊ; quando existir escrita, precisa do rastro 'Ação executada pela
+> IA' que uma ferramenta de leitura não precisa."
+
+A infraestrutura para isso já foi deixada pronta em `agenda/service.py`: `create_event`,
+`cancel_event` e `reschedule_event` já aceitam `by_ai: bool` e já gravam auditoria com
+`is_ai=by_ai` — só nunca foram chamadas com `True` porque não existe ainda um ator de IA no loop
+de tool-use. Isso também fecha a **Regra de Ouro nº 3** do projeto ("propagar `is_ai` em
+create/update/cancel/reschedule"), hoje congelada porque `CurrentUser.is_ai` nunca vale `True`
+nesse caminho.
+
+Esta fatia dá à Vima a primeira capacidade de **escrever**: criar, cancelar e remarcar
+compromissos da Agenda, a partir de uma conversa em texto ou WhatsApp — pedido original: "quero
+agendar um compromisso... falar com o Carlos às 10:30, amanhã".
+
+## Escopo desta fatia
+
+- **Domínio:** só Agenda. Nenhuma ferramenta de escrita para Financeiro/CRM/Jurídico/Marketing/
+  Estoque nesta fatia.
+- **Ações:** criar, cancelar, remarcar. As três reaproveitam os serviços determinísticos que já
+  existem — nenhuma regra de negócio nova (conflito de horário, espelho no Google, RLS).
+- **Confirmação obrigatória antes de escrever:** decisão do fundador. A Vima resume o que
+  entendeu em texto puro e só executa a ferramenta depois que o dono confirmar explicitamente
+  numa mensagem seguinte. Ver seção "Confirmação" abaixo — é disciplina de prompt + um campo
+  obrigatório na ferramenta, não um mecanismo à prova de bala (mesma categoria de garantia que já
+  rege "a IA só narra, nunca origina número").
+- **Canais:** texto (`/vima/perguntas`) e WhatsApp self-chat, os dois de graça — ambos já passam
+  por `vima/pergunta.responder`, ponto único de entrada que esta fatia estende.
+- **Permissão:** mesma regra das ferramentas de leitura — `pode_ver(user, "agenda")` decide se a
+  Vima sequer mostra as ferramentas de escrita à Claude. Simétrico ao que já vale na REST API
+  hoje (`require_module("agenda")`, sem restrição adicional a `owner`): quem já pode criar/
+  cancelar/remarcar pela tela, pode pela Vima.
+- **Tipos de evento criáveis por chat:** `atendimento`, `reuniao`, `audiencia`, `bloqueio`,
+  `lembrete`. Exclui `prazo`, `cobranca_receber`, `cobranca_pagar` e `google` — esses nascem
+  derivados de outro módulo ou de uma sincronização externa, não faz sentido a Vima os criar do
+  zero.
+
+## Fora de escopo (declarado, não esquecido)
+
+- Ferramentas de escrita para qualquer módulo além de Agenda.
+- Editar campos livres do evento (título, local, descrição) depois de criado — só remarcar
+  (data/hora) e cancelar. Renomear/editar continua exclusivo da tela manual.
+- Um mecanismo de confirmação mais forte que "o prompt manda pedir e o campo obrigatório
+  bloqueia se ausente" — por exemplo, um token de confirmação persistido entre chamadas HTTP.
+  Contrariaria a decisão já tomada de "sem persistência de conversa entre sessões" da fatia
+  anterior; ver "Alternativas consideradas".
+- Vínculo automático a um evento do Google Calendar pré-existente fora do e1p (a Vima só cria/
+  altera o que já é gerenciado pelo `agenda_events`; o espelho no Google continua sendo
+  consequência, via `google_calendar/service.py`, exatamente como já é para a tela manual).
+
+## Arquitetura
+
+Mesmo loop de tool-use das fatias anteriores — três ferramentas novas na mesma lista que a
+Claude já recebe, filtradas pelo mesmo `pode_ver`. Nenhum endpoint novo: `POST /vima/pergunta`
+continua sendo a única porta de entrada, para os dois canais.
+
+```
+dono: "agendar às 10:30 com o Carlos, amanhã"
+        │
+        ▼
+POST /vima/pergunta {pergunta, historico[]}
+        │
+        ▼
+Claude decide: falta confirmação → responde em texto puro
+        │        ("Confirma: reunião com o Carlos, amanhã 10:30-11:30?")
+        ▼
+front exibe; dono digita "sim, confirma"
+        │
+        ▼
+POST /vima/pergunta {pergunta: "sim, confirma", historico: [...]}
+        │
+        ▼
+Claude chama criar_compromisso(confirmado=true, ...)
+        │
+        ▼
+tools.executar → agenda_service.create_event(by_ai=True) ──► audit.record(is_ai=True)
+        │
+        ▼
+Claude narra o resultado ("Criado. Sem conflito." / "Criado, mas você já tem X nesse horário.")
+```
+
+Cancelar/remarcar seguem o mesmo desenho, com um passo a mais ANTES da confirmação: quando o
+pedido não traz um `event_id` explícito (nunca traz — o dono fala em linguagem natural), a Vima
+usa a ferramenta de leitura `consultar_agenda`, já existente, para achar o(s) candidato(s). Se
+achar um só, resume e pede confirmação; se achar mais de um, pergunta qual antes de prosseguir;
+se não achar nenhum, diz isso e não inventa um `event_id`.
+
+## Backend
+
+### Ferramentas novas (`vima/tools.py`)
+
+| Ferramenta | Módulo (gate) | Wrapper de | Retorna |
+|---|---|---|---|
+| `criar_compromisso` | `agenda` | `agenda_service.create_event(by_ai=True)` | evento criado + lista de conflitos |
+| `cancelar_compromisso` | `agenda` | `agenda_service.cancel_event(by_ai=True)` | evento cancelado |
+| `remarcar_compromisso` | `agenda` | `agenda_service.reschedule_event(by_ai=True)` | evento remarcado + lista de conflitos |
+
+Cada uma é um wrapper fino, no mesmo espírito das oito ferramentas de leitura: monta o
+`EventCreate`/argumentos do serviço a partir da `entrada` (dict vindo da chamada de ferramenta da
+Claude), resolve fuso do tenant com `tenant_timezone` + `day_window_utc` (mesmo padrão de
+`_consultar_agenda`), chama o serviço síncrono existente, devolve um dict serializável.
+
+**`criar_compromisso`** — schema de entrada:
+
+```json
+{
+  "titulo": "string, obrigatório",
+  "tipo": "atendimento | reuniao | audiencia | bloqueio | lembrete, obrigatório",
+  "data": "AAAA-MM-DD, obrigatório",
+  "hora_inicio": "HH:MM, obrigatório",
+  "hora_fim": "HH:MM, opcional — omitido usa 1h de duração padrão",
+  "cliente": "nome ou parte do nome, opcional — resolvido via crm_service.list_clients, mesmo caminho de consultar_cliente",
+  "local": "string, opcional",
+  "confirmado": "boolean, obrigatório"
+}
+```
+
+Se `confirmado` não for `true`, a ferramenta NÃO chama `create_event` — devolve
+`{"erro": "peça a confirmação do dono antes de chamar esta ferramenta de novo com confirmado=true"}`.
+Isso vale para as três ferramentas de escrita, mesma mecânica.
+
+**`cancelar_compromisso`** / **`remarcar_compromisso`** — recebem `event_id` (a Claude só tem
+esse valor depois de ter chamado `consultar_agenda`) + `confirmado`; remarcar recebe também
+`nova_data`/`nova_hora_inicio`/`nova_hora_fim`. Erros de domínio já existentes (`AgendaError` —
+evento não encontrado, já finalizado/cancelado) viram `{"erro": "..."}` no `tool_result`, mesmo
+tratamento que `tools.executar` já dá a qualquer exceção hoje.
+
+### `by_ai` e auditoria
+
+As três chamadas passam `by_ai=True` e `actor=user.user_id` (a identidade de quem PERGUNTOU,
+não um ator sintético de IA — `CurrentUser.is_ai` continua sendo sobre o chamador da API, uma
+dimensão diferente). Isso é literalmente o que falta hoje: `agenda/router.py` só chama esses
+serviços com `by_ai=user.is_ai`, que é sempre `False` no caminho humano. Fecha a Regra de Ouro
+nº 3 sem tocar em `agenda/service.py` — o parâmetro já existe, só nunca foi exercitado com
+`True`.
+
+### Prompt-sistema (`vima/pergunta.py`)
+
+Estende o `_SYSTEM` atual com a disciplina de confirmação:
+
+> Antes de criar, cancelar ou remarcar um compromisso, resuma o que você entendeu (o quê, quando,
+> com quem) em uma mensagem de texto e peça confirmação explícita. Só chame a ferramenta de
+> escrita com `confirmado=true` depois que o dono confirmar claramente numa mensagem seguinte —
+> nunca no mesmo turno em que ele pediu. Para cancelar ou remarcar, primeiro use
+> `consultar_agenda` para achar o compromisso certo; se houver mais de um compatível, pergunte
+> qual antes de agir.
+
+Nenhuma mudança em `ai.complete_with_tools` (o loop genérico) nem em `tools.executar` além de
+registrar as três ferramentas novas na lista `FERRAMENTAS`.
+
+## Confirmação: por que prompt + campo obrigatório, e não um mecanismo mais forte
+
+Considerada e rejeitada: um tool de duas fases (`propor_compromisso` devolve um token de
+confirmação; um segundo tool só aceita esse token). Reduziria — não eliminaria — o risco de a
+Claude confirmar consigo mesma no mesmo turno (o loop de tool-use já roda várias rodadas dentro
+de UMA chamada HTTP; nada estrutural impede a Claude de chamar as duas ferramentas em sequência,
+sem o dono ver a proposta, a menos que o token dependesse de algo persistido ENTRE requisições
+HTTP). Isso exigiria guardar estado de "proposta pendente" em algum lugar (tabela nova ou cache),
+contrariando a decisão já tomada nas duas fatias anteriores — "sem persistência de conversa entre
+sessões" — pelo ganho de segurança que a prática já aceita hoje como suficiente: a mesma
+disciplina de prompt que sustenta "a IA só narra, nunca origina número" em todo o resto da Vima.
+O campo `confirmado` obrigatório é o meio-termo: não impede a Claude de "se auto-confirmar", mas
+IMPEDE a ferramenta de escrever quando ele está ausente — cobre o caso de a Claude chamar a
+ferramenta cedo demais por engano, e deixa rastro auditável (`confirmado` aparece no payload da
+chamada, visível em log).
+
+## Tratamento de erro e degradação
+
+- Sem `ANTHROPIC_API_KEY`: mesma resposta de hoje ("A Vima está sem acesso à IA agora...") — a
+  Vima nunca tenta escrever sem o loop de IA rodando.
+- `AgendaError` (evento não encontrado, já finalizado, kind inválido) vira `{"erro": "..."}` no
+  `tool_result` — a Claude é instruída (mesma regra do `_SYSTEM` já existente) a dizer que não
+  conseguiu, nunca a inventar que deu certo.
+- Conflito de horário NÃO bloqueia a criação/remarcação — mesmo comportamento do endpoint REST
+  hoje: cria/remarca e devolve a lista de conflitos, a Claude narra ("criei, mas você já tem X
+  nesse horário").
+
+## Testes
+
+Mesmo padrão de `test_vima_tools.py` (unitário, uma ferramenta por vez, banco SQLite de teste) e
+`test_vima_tools_rls.py` (RLS cross-tenant sob Postgres real):
+
+- Cada ferramenta: caminho feliz (`confirmado=true` → evento criado/cancelado/remarcado,
+  `by_ai=True` no registro de auditoria).
+- Caminho `confirmado` ausente/`false` → erro, nenhuma escrita no banco.
+- `criar_compromisso` com `hora_fim` omitido → duração de 1h.
+- `criar_compromisso`/`remarcar_compromisso` com conflito → evento criado/remarcado mesmo assim,
+  lista de conflitos não vazia no retorno.
+- `cancelar_compromisso`/`remarcar_compromisso` com `event_id` de evento já cancelado/finalizado
+  → erro, sem mudança de estado.
+- RLS: dois tenants, cada um só consegue cancelar/remarcar o PRÓPRIO evento por id (evento do
+  outro tenant não é encontrado, sob Postgres real — mesmo bootstrap de
+  `test_vima_tools_rls.py`).
+- `ferramentas_disponiveis`: usuário sem módulo `agenda` não vê as três ferramentas novas.
+
+## Dívida (declarada, não desta fatia)
+
+- Editar campos livres (título/local/descrição) via Vima.
+- Ferramentas de escrita para outros módulos (Financeiro, CRM, Jurídico, Marketing, Estoque).
+- Mecanismo de confirmação mais forte que prompt + campo obrigatório, caso o risco de
+  auto-confirmação se prove real em uso (hoje é uma decisão de custo/benefício, não uma lacuna
+  desconhecida).


### PR DESCRIPTION
## Summary

Terceira fatia do caminho até o Jarbes, e a primeira em que a Vima **escreve**. Dá à Vima três ferramentas de escrita no mesmo loop de tool-use que hoje só lê — `criar_compromisso`, `cancelar_compromisso`, `remarcar_compromisso` — fechando a dívida "Ações da Vima" registrada no CLAUDE.md e a Regra de Ouro nº 3 (propagar `is_ai` nas escritas de agenda).

- Wrappers finos sobre `agenda_service.create_event/cancel_event/reschedule_event`, que já aceitavam `by_ai` — nenhuma regra de negócio nova (conflito de horário, RLS, espelho no Google já existiam).
- Confirmação obrigatória: cada ferramenta exige `confirmado: bool`; o prompt-sistema instrui a Vima a resumir e pedir confirmação em texto antes de chamar com `confirmado=true`.
- `criar_compromisso`/`cancelar_compromisso`/`remarcar_compromisso` só operam sobre os 5 tipos "seguros" (atendimento/reuniao/audiencia/bloqueio/lembrete) — nunca sobre prazo/cobrança/sync do Google, mesmo para cancelar/remarcar (achado na revisão final: o gate original só cobria criação).
- Entradas de ferramenta são desmascaradas antes de chegar ao banco (achado na revisão final: um placeholder do anonimizador podia ser persistido permanentemente no título de um evento).
- Auditoria (`is_ai=True`) agora coberta por teste em cada caminho feliz (achado na revisão final: a alegação central da fatia não tinha nenhum teste provando isso).
- Prova de RLS cross-tenant para `cancelar_compromisso` sob Postgres real.

Construído com brainstorming → spec → plano → subagent-driven-development (6 tasks, cada uma com implementador + revisor independentes) → revisão final de todo o branch → uma rodada de correção.

## Test plan

- [x] `pytest tests/test_vima_tools.py tests/test_vima_pergunta_service.py -v` — verde
- [x] `pytest tests/test_vima_tools_rls.py -m rls_e2e -v` (Postgres real via testcontainers) — verde, prova RLS cross-tenant
- [x] `ruff check .` — limpo
- [x] Suíte completa da API (`pytest -q`): 2471 passed, 1 skipped, 0 failed
- [x] Revisão final de todo o branch (opus) + 1 rodada de correção + re-revisão — limpa

🤖 Gerado com [Claude Code](https://claude.com/claude-code)