### PR TITLE
fix: fecha dois buracos no eco da self-chat da Vima e adiciona circuit breaker

### DIFF
--- a/apps/api/app/modules/notifications/service.py
+++ b/apps/api/app/modules/notifications/service.py
@@ -287,6 +287,21 @@ def process_pending(db: Session, *, tenant_id: str, limit: int = 50) -> int:
                     text=notification.message,
                     profile=profile,
                 )
+                if status == "sent":
+                    # Import tardio (não no topo do módulo): `vima.whatsapp_conversa` importa
+                    # `vima.scheduler`, que por sua vez importa ESTE módulo — import circular se
+                    # feito no nível do módulo. Este texto foi mandado pro `recipient`, que pode
+                    # ser o MESMO número que a self-chat da Vima escuta (ex.: aviso de card
+                    # movido pro dono, `on_client_moved`) — sem registrar aqui, o eco dessa
+                    # notificação bate na condição de roteamento de self-chat e vira "pergunta
+                    # nova" pra Vima (achado ao vivo em produção, tenant Dóro Eventos,
+                    # 2026-09-01; ver `vima/whatsapp_conversa.py::registrar_envio_externo`).
+                    from app.modules.vima.whatsapp_conversa import registrar_envio_externo
+
+                    registrar_envio_externo(
+                        tenant_id=notification.tenant_id, phone=notification.recipient,
+                        texto=notification.message,
+                    )
             notification.status = status
         except Exception as exc:  # noqa: BLE001 — isola a falha de UMA notificação (IV2)
             logger.exception(

--- a/apps/api/app/modules/vima/whatsapp_conversa.py
+++ b/apps/api/app/modules/vima/whatsapp_conversa.py
@@ -11,9 +11,10 @@ import logging
 import time
 from dataclasses import dataclass
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core import transcription, whatsapp
+from app.core import email, transcription, whatsapp
 from app.core.phone import normalize_br
 from app.modules.auth.models import User
 from app.modules.vima import pergunta as pergunta_service
@@ -38,7 +39,28 @@ _VISTAS: dict[str, float] = {}
 # (`_VISTAS` não pega, pois não é reentrega do MESMO evento). Sem esta guarda, o eco bate na
 # mesma condição de roteamento e vira "pergunta nova": a Vima responde à própria resposta, que
 # ecoa de novo, indefinidamente (achado ao vivo em produção, 2026-08-31).
+#
+# NÃO é escrita só pelas respostas de sucesso (`_marcar_resposta_enviada`, dentro de
+# `_enviar_e_registrar`) — `registrar_envio_externo` deixa QUALQUER outro módulo que mande
+# mensagem pro mesmo número (hoje: `notifications.service.process_pending`, que despacha
+# `on_client_moved` e outros avisos de CRM pro telefone do dono) avisar esta guarda também. Sem
+# isso, o eco de uma notificação normal bate na mesma condição de roteamento de self-chat e vira
+# "pergunta nova" (achado ao vivo em produção, tenant Dóro Eventos, 2026-09-01 — ver também o
+# circuit breaker abaixo, a barreira de última linha para quando um mecanismo de eco NOVO e ainda
+# não mapeado aparecer).
 _ULTIMAS_RESPOSTAS: dict[str, tuple[str, float]] = {}
+
+# Circuit breaker: barreira dura e AGNÓSTICA a mecanismo — cobre qualquer loop de auto-resposta,
+# não só o eco de texto idêntico que `_ULTIMAS_RESPOSTAS` reconhece. Se a Vima mandar
+# `LIMITE_BREAKER` respostas ou mais pro MESMO telefone em menos de `TTL_BREAKER_JANELA_SEGUNDOS`,
+# para de mandar por `TTL_BREAKER_COOLDOWN_SEGUNDOS` e avisa o dono por e-mail (nunca por
+# WhatsApp — é justamente o canal sob suspeita de loop). Ver `_bloqueado_pelo_breaker`.
+TTL_BREAKER_JANELA_SEGUNDOS = 2 * 60
+LIMITE_BREAKER = 3
+TTL_BREAKER_COOLDOWN_SEGUNDOS = 30 * 60
+
+_ENVIOS_RECENTES: dict[str, list[float]] = {}
+_BREAKER_ACIONADO: dict[str, float] = {}
 
 
 @dataclass(frozen=True)
@@ -95,6 +117,85 @@ def _e_eco_da_propria_resposta(chave: str, texto: str) -> bool:
 
 def _marcar_resposta_enviada(chave: str, texto: str) -> None:
     _ULTIMAS_RESPOSTAS[chave] = (texto, time.monotonic() + TTL_DEDUP_SEGUNDOS)
+
+
+def registrar_envio_externo(*, tenant_id: str, phone: str, texto: str) -> None:
+    """Pra código FORA deste módulo que manda uma mensagem pro mesmo número que a self-chat
+    escuta — hoje, `notifications.service.process_pending` logo após um `whatsapp.send_text` bem
+    sucedido. Sem isso, o eco dessa mensagem bate na condição de roteamento de self-chat e vira
+    "pergunta nova" pra Vima (ver docstring de `_ULTIMAS_RESPOSTAS`)."""
+    _marcar_resposta_enviada(_chave(tenant_id, phone), texto)
+
+
+def _janela_de_envios(chave: str) -> list[float]:
+    agora = time.monotonic()
+    vivos = [t for t in _ENVIOS_RECENTES.get(chave, []) if t > agora - TTL_BREAKER_JANELA_SEGUNDOS]
+    _ENVIOS_RECENTES[chave] = vivos
+    return vivos
+
+
+def _breaker_em_cooldown(chave: str) -> bool:
+    expira = _BREAKER_ACIONADO.get(chave)
+    return expira is not None and expira > time.monotonic()
+
+
+def _contar_envio_para_breaker(chave: str) -> None:
+    _janela_de_envios(chave).append(time.monotonic())
+
+
+def _bloqueado_pelo_breaker(db: Session, chave: str, *, tenant_id: str, phone: str) -> bool:
+    """True quando NADA deve ser mandado agora: já em cooldown, ou esta seria a mensagem que
+    estoura `LIMITE_BREAKER` na janela — nesse caso o breaker é acionado NESTA chamada, ANTES de
+    mandar (não depois): a tentativa que estouraria o limite nunca chega a sair."""
+    if _breaker_em_cooldown(chave):
+        return True
+    if len(_janela_de_envios(chave)) >= LIMITE_BREAKER:
+        _acionar_breaker(db, chave, tenant_id=tenant_id, phone=phone)
+        return True
+    return False
+
+
+def _acionar_breaker(db: Session, chave: str, *, tenant_id: str, phone: str) -> None:
+    _BREAKER_ACIONADO[chave] = time.monotonic() + TTL_BREAKER_COOLDOWN_SEGUNDOS
+    logger.critical(
+        "[vima] CIRCUIT BREAKER acionado na self-chat — %d+ respostas em %ds pro mesmo número; "
+        "bloqueada por %dmin. tenant=%s phone=%s",
+        LIMITE_BREAKER, TTL_BREAKER_JANELA_SEGUNDOS, TTL_BREAKER_COOLDOWN_SEGUNDOS // 60,
+        tenant_id, phone,
+    )
+    _alertar_por_email(db, tenant_id=tenant_id, phone=phone)
+
+
+def _alertar_por_email(db: Session, *, tenant_id: str, phone: str) -> None:
+    """SEMPRE por e-mail, NUNCA por WhatsApp — é justamente o canal sob suspeita de loop; e-mail
+    é estruturalmente incapaz de realimentar esse mecanismo."""
+    owner = db.scalar(select(User).where(User.tenant_id == tenant_id, User.role == "owner"))
+    if owner is None or not owner.email:
+        logger.error(
+            "[vima] circuit breaker acionado mas sem e-mail de owner pra avisar: tenant=%s",
+            tenant_id,
+        )
+        return
+    email.send_email(
+        to=owner.email,
+        subject="[e1p] Vima bloqueada — possível loop de auto-resposta no WhatsApp",
+        body=(
+            f"A Vima tentou mandar {LIMITE_BREAKER} respostas seguidas ou mais pro número "
+            f"{phone} em menos de {TTL_BREAKER_JANELA_SEGUNDOS // 60} minutos e foi bloqueada "
+            f"automaticamente por {TTL_BREAKER_COOLDOWN_SEGUNDOS // 60} minutos, como proteção "
+            "contra loop de auto-resposta (eco do WhatsApp). Isso pode indicar um bug — vale "
+            "checar os logs do período (\"CIRCUIT BREAKER\", logger e1p.vima)."
+        ),
+    )
+
+
+def _enviar_e_registrar(*, chave: str, phone: str, texto: str, profile) -> None:
+    """Ponto único por onde toda resposta da Vima na self-chat sai de verdade — registra pra
+    guarda de eco e pro circuit breaker ANTES de mandar, nunca depois: um envio que falhasse
+    silenciosamente em registrar não contaria pro limite, e a barreira dependeria de sorte."""
+    _marcar_resposta_enviada(chave, texto)
+    _contar_envio_para_breaker(chave)
+    whatsapp.send_text(to=phone, text=texto, profile=profile)
 
 
 def _usuario_do_telefone(db: Session, tenant_id: str, phone: str) -> User | None:
@@ -165,8 +266,14 @@ def responder_audio(
     )
     if transcrito is None:
         _marcar_processada(wa_message_id)
+        chave = _chave(tenant_id, phone)
+        if _bloqueado_pelo_breaker(db, chave, tenant_id=tenant_id, phone=phone):
+            logger.warning(
+                "[vima] self-chat (áudio) bloqueada pelo circuit breaker: tenant=%s", tenant_id,
+            )
+            return None
         desculpa = "Não consegui entender o áudio — tenta de novo em instantes."
-        whatsapp.send_text(to=phone, text=desculpa, profile=profile)
+        _enviar_e_registrar(chave=chave, phone=phone, texto=desculpa, profile=profile)
         # `pergunta` fica com um rótulo, não a transcrição — não há transcrição nenhuma pra
         # gravar (é justamente isso que falhou). Ainda assim vira uma linha na conversa: sem
         # ela, a desculpa apareceria sozinha, sem contexto do que a originou.
@@ -209,6 +316,16 @@ def _responder(
         )
         return None
 
+    if _bloqueado_pelo_breaker(db, chave, tenant_id=tenant_id, phone=phone):
+        # Barreira de última linha (ver `_ULTIMAS_RESPOSTAS` e o bloco do circuit breaker no
+        # topo do módulo): independente de reconhecer eco ou não, a Vima já mandou respostas
+        # demais pro mesmo número em pouco tempo — para de mandar.
+        logger.warning(
+            "[vima] self-chat bloqueada pelo circuit breaker: tenant=%s wa_message_id=%s",
+            tenant_id, wa_message_id,
+        )
+        return None
+
     user = _usuario_do_telefone(db, tenant_id, phone)
     if user is None:
         # Defensivo: o chamador já confirmou que o telefone é de um usuário ativo
@@ -225,14 +342,13 @@ def _responder(
         logger.exception("[vima] falha ao responder pergunta via WhatsApp self-chat")
         db.rollback()
         desculpa = "Não consegui responder agora — tenta de novo em instantes."
-        whatsapp.send_text(to=phone, text=desculpa, profile=profile)
+        _enviar_e_registrar(chave=chave, phone=phone, texto=desculpa, profile=profile)
         return Resultado(pergunta=texto, resposta=desculpa)
 
     _guardar_turno(chave, "usuario", texto)
     _guardar_turno(chave, "vima", resposta.texto)
     resposta_final = f"{eco}{resposta.texto}"
-    _marcar_resposta_enviada(chave, resposta_final)
-    whatsapp.send_text(to=phone, text=resposta_final, profile=profile)
+    _enviar_e_registrar(chave=chave, phone=phone, texto=resposta_final, profile=profile)
     logger.info(
         "[vima] self-chat respondida: tenant=%s wa_message_id=%s", tenant_id, wa_message_id,
     )

--- a/apps/api/tests/test_notifications_queue.py
+++ b/apps/api/tests/test_notifications_queue.py
@@ -250,6 +250,46 @@ def test_process_pending_skips_notification_before_next_attempt_at(db, monkeypat
     assert n.status == "pending"
 
 
+def test_process_pending_registra_envio_de_texto_contra_eco_da_self_chat(db, monkeypatch):
+    """Achado ao vivo (tenant Dóro Eventos, 2026-09-01): `on_client_moved` manda pro MESMO
+    número que a self-chat da Vima escuta. Sem isso, o eco da notificação vira "pergunta nova"
+    pra Vima e pode entrar em loop — ver `vima/whatsapp_conversa.py::registrar_envio_externo`."""
+    from app.modules.vima import whatsapp_conversa as vc
+
+    texto = '📌 O cliente Fulano foi movido para a etapa "Contrato Fechado".'
+    _pending(db, recipient="5511999990099", message=texto)
+    monkeypatch.setattr(
+        whatsapp, "send_text",
+        lambda *, to, text, profile=None, token=None, phone_id=None: "sent",
+    )
+    service.process_pending(db, tenant_id=TENANT)
+
+    chave = vc._chave(TENANT, "5511999990099")
+    assert vc._e_eco_da_propria_resposta(chave, texto) is True
+
+
+def test_process_pending_nao_registra_envio_de_template_contra_eco(db, monkeypatch):
+    """Só `send_text` (texto livre) é comparável literalmente contra o que a self-chat recebe de
+    volta — um template não tem o texto final disponível aqui da mesma forma, e a self-chat
+    nunca manda template nenhum, então não há eco desse tipo pra prevenir."""
+    from app.modules.vima import whatsapp_conversa as vc
+
+    service.enqueue(
+        db, tenant_id=TENANT, channel="whatsapp", recipient="5511999990098",
+        message="preview", whatsapp_template_name="tmpl_x", whatsapp_template_language="pt_BR",
+        whatsapp_template_variables=[],
+    )
+    db.commit()
+    monkeypatch.setattr(
+        whatsapp, "send_template",
+        lambda **_kw: "sent",
+    )
+    service.process_pending(db, tenant_id=TENANT)
+
+    chave = vc._chave(TENANT, "5511999990098")
+    assert vc._e_eco_da_propria_resposta(chave, "preview") is False
+
+
 def test_backoff_never_schedules_past_expiry(db, monkeypatch):
     n = _pending(db, message="boom")
     n.expires_at = datetime.now(UTC) + timedelta(minutes=5)  # validade curta

--- a/apps/api/tests/test_vima_whatsapp_conversa.py
+++ b/apps/api/tests/test_vima_whatsapp_conversa.py
@@ -14,6 +14,8 @@ def setup_function():
     vc._VISTAS.clear()
     vc._HISTORICO.clear()
     vc._ULTIMAS_RESPOSTAS.clear()
+    vc._ENVIOS_RECENTES.clear()
+    vc._BREAKER_ACIONADO.clear()
 
 
 # ── Dedup de reentrega ──────────────────────────────────────────────────────────────────────
@@ -791,3 +793,288 @@ def test_responder_audio_ignora_reentrega_do_mesmo_wa_message_id(db: Session, mo
         )
 
     assert chamadas["n"] == 1  # não paga a Groq de novo numa reentrega
+
+
+# ── Achado ao vivo, tenant Dóro Eventos, 2026-09-01 ─────────────────────────────────────────
+#
+# Card movido → notificação de CRM mandada pro MESMO número da self-chat (fora deste módulo,
+# `notifications/service.py`) → nunca registrada aqui → o eco dela virou "pergunta nova" →
+# `pergunta.responder` explodiu nesse texto → a DESCULPA também nunca foi registrada → o eco DA
+# DESCULPA virou "pergunta nova" de novo → mesma exceção → mesma desculpa → loop sem fim (6+
+# repetições no WhatsApp do dono, até ele desconectar a conta pelo celular).
+
+
+def test_responder_registra_a_desculpa_contra_o_proprio_eco(db: Session, monkeypatch):
+    """A desculpa mandada quando `pergunta.responder` falha precisa entrar na MESMA guarda de
+    eco que a resposta de sucesso — senão, se ela mesma ecoar, vira "pergunta nova", gera a
+    MESMA exceção, gera a MESMA desculpa, e o loop nunca para."""
+    user = User(
+        tenant_id=TENANT, email="dono21@example.com", name="Dono", password_hash="x",
+        phone="5511999990018",
+    )
+    db.add(user)
+    db.commit()
+
+    chamadas = {"n": 0}
+
+    def _explode(db, *, user, pergunta, historico):
+        chamadas["n"] += 1
+        raise RuntimeError("Claude indisponível")
+
+    monkeypatch.setattr(vc.pergunta_service, "responder", _explode)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990018", wa_message_id="wamid.falhaeco1",
+        texto="oi", profile=None,
+    )
+    assert chamadas["n"] == 1
+
+    eco_da_desculpa = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990018", wa_message_id="wamid.falhaeco2",
+        texto=resultado.resposta, profile=None,
+    )
+
+    assert eco_da_desculpa is None  # o eco da PRÓPRIA desculpa não pode virar pergunta nova
+    assert chamadas["n"] == 1  # e portanto não chama pergunta.responder de novo
+
+
+def test_registrar_envio_externo_evita_que_uma_notificacao_vire_pergunta(
+    db: Session, monkeypatch,
+):
+    """`notifications/service.py::process_pending` manda notificações de CRM (ex.: aviso de card
+    movido) pro MESMO número que a self-chat escuta — sem registrar esse envio aqui, o eco dessa
+    notificação bate na condição de roteamento de self-chat e vira "pergunta nova" pra Vima."""
+    chamadas = {"n": 0}
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda *a, **kw: chamadas.update(n=chamadas["n"] + 1),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    texto_notificacao = (
+        '📌 O cliente Aldemiro Cassetulla Jr foi movido para a etapa "Contrato Fechado".'
+    )
+    vc.registrar_envio_externo(
+        tenant_id=TENANT, phone="5511999990019", texto=texto_notificacao,
+    )
+
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990019", wa_message_id="wamid.notif.eco",
+        texto=texto_notificacao, profile=None,
+    )
+
+    assert resultado is None
+    assert chamadas["n"] == 0  # nunca virou pergunta pra Vima
+
+
+# ── Circuit breaker: barreira dura contra QUALQUER loop, conhecido ou não ──────────────────
+#
+# A guarda de eco acima cobre o mecanismo específico já mapeado (texto idêntico ecoado). O
+# circuit breaker é a barreira de ÚLTIMA linha, indiferente ao MOTIVO: se a Vima mandar mais que
+# `LIMITE_BREAKER` respostas pro mesmo número em menos de `TTL_BREAKER_JANELA_SEGUNDOS`, para de
+# mandar — mesmo que um bug futuro faça o eco chegar com texto levemente diferente a cada vez, ou
+# gere uma pergunta "nova" de verdade a cada rodada.
+
+
+def _usuario_breaker(db: Session, phone: str, sufixo: str) -> User:
+    user = User(
+        tenant_id=TENANT, email=f"breaker{sufixo}@example.com", name="Dono", password_hash="x",
+        phone=phone, role="owner",
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def test_circuit_breaker_bloqueia_apos_o_limite_de_respostas_na_janela(
+    db: Session, monkeypatch,
+):
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990020", "1")
+
+    agora = [4000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+
+    chamadas = {"n": 0}
+
+    def _fake_pergunta_responder(db, *, user, pergunta, historico):
+        chamadas["n"] += 1
+        return Resposta(texto=f"resposta {chamadas['n']}", por_ia=True)
+
+    monkeypatch.setattr(vc.pergunta_service, "responder", _fake_pergunta_responder)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    for i in range(vc.LIMITE_BREAKER + 2):
+        agora[0] += 1  # todas dentro da janela de vc.TTL_BREAKER_JANELA_SEGUNDOS
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990020", wa_message_id=f"wamid.breaker.{i}",
+            texto=f"pergunta distinta {i}", profile=None,
+        )
+
+    assert chamadas["n"] == vc.LIMITE_BREAKER  # bloqueou a partir do limite — nunca passou dele
+
+
+def test_circuit_breaker_loga_critical_quando_aciona(db: Session, monkeypatch, caplog):
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990022", "2")
+
+    agora = [5000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    for i in range(vc.LIMITE_BREAKER):
+        agora[0] += 1
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990022", wa_message_id=f"wamid.critlog.{i}",
+            texto=f"pergunta {i}", profile=None,
+        )
+
+    with caplog.at_level("CRITICAL", logger="e1p.vima"):
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990022", wa_message_id="wamid.critlog.extra",
+            texto="pergunta extra", profile=None,
+        )
+
+    assert any("circuit breaker" in r.message.lower() for r in caplog.records)
+
+
+def test_circuit_breaker_alerta_o_owner_por_email_quando_aciona(db: Session, monkeypatch):
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990023", "3")
+
+    agora = [6000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    capturado = {}
+    monkeypatch.setattr(
+        vc.email, "send_email",
+        lambda *, to, subject, body: capturado.update(to=to, subject=subject, body=body)
+        or "sent",
+    )
+
+    for i in range(vc.LIMITE_BREAKER):
+        agora[0] += 1
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990023", wa_message_id=f"wamid.mail.{i}",
+            texto=f"pergunta {i}", profile=None,
+        )
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990023", wa_message_id="wamid.mail.extra",
+        texto="pergunta extra", profile=None,
+    )
+
+    # NUNCA por WhatsApp (é o canal sob suspeita) — o alerta sai por e-mail, canal
+    # estruturalmente separado do que pode estar em loop.
+    assert capturado["to"] == "breaker3@example.com"
+    assert "5511999990023" in capturado["body"]
+
+
+def test_circuit_breaker_nao_manda_mais_nada_uma_vez_acionado(db: Session, monkeypatch):
+    """Depois de acionar, nem a PRÓPRIA tentativa que estourou o limite manda mensagem — o
+    breaker decide ANTES de chamar `pergunta.responder`, não depois."""
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990024", "4")
+
+    agora = [7000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+
+    enviados = {"n": 0}
+    monkeypatch.setattr(
+        vc.whatsapp, "send_text", lambda **_kw: enviados.update(n=enviados["n"] + 1) or "sent",
+    )
+
+    for i in range(vc.LIMITE_BREAKER):
+        agora[0] += 1
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990024", wa_message_id=f"wamid.semenvio.{i}",
+            texto=f"pergunta {i}", profile=None,
+        )
+    assert enviados["n"] == vc.LIMITE_BREAKER
+
+    resultado = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990024", wa_message_id="wamid.semenvio.extra",
+        texto="pergunta extra", profile=None,
+    )
+
+    assert resultado is None
+    assert enviados["n"] == vc.LIMITE_BREAKER  # a tentativa que estourou não manda nada
+
+
+def test_circuit_breaker_libera_depois_do_cooldown(db: Session, monkeypatch):
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990025", "5")
+
+    agora = [8000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+
+    chamadas = {"n": 0}
+
+    def _fake_pergunta_responder(db, *, user, pergunta, historico):
+        chamadas["n"] += 1
+        return Resposta(texto=f"resposta {chamadas['n']}", por_ia=True)
+
+    monkeypatch.setattr(vc.pergunta_service, "responder", _fake_pergunta_responder)
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    for i in range(vc.LIMITE_BREAKER + 1):
+        agora[0] += 1
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990025", wa_message_id=f"wamid.cooldown.{i}",
+            texto=f"pergunta {i}", profile=None,
+        )
+    assert chamadas["n"] == vc.LIMITE_BREAKER  # bloqueado
+
+    agora[0] += vc.TTL_BREAKER_COOLDOWN_SEGUNDOS + 1
+    vc.responder(
+        db, tenant_id=TENANT, phone="5511999990025", wa_message_id="wamid.cooldown.depois",
+        texto="pergunta depois do cooldown", profile=None,
+    )
+    assert chamadas["n"] == vc.LIMITE_BREAKER + 1  # cooldown passou — volta a responder
+
+
+def test_circuit_breaker_e_por_numero_nao_bloqueia_outro_telefone(db: Session, monkeypatch):
+    from app.modules.vima.pergunta import Resposta
+
+    _usuario_breaker(db, "5511999990026", "6a")
+    _usuario_breaker(db, "5511999990027", "6b")
+
+    agora = [9000.0]
+    monkeypatch.setattr(vc.time, "monotonic", lambda: agora[0])
+    monkeypatch.setattr(
+        vc.pergunta_service, "responder",
+        lambda db, *, user, pergunta, historico: Resposta(texto="ok", por_ia=True),
+    )
+    monkeypatch.setattr(vc.whatsapp, "send_text", lambda **_kw: "sent")
+
+    for i in range(vc.LIMITE_BREAKER + 1):
+        agora[0] += 1
+        vc.responder(
+            db, tenant_id=TENANT, phone="5511999990026", wa_message_id=f"wamid.tel1.{i}",
+            texto=f"pergunta {i}", profile=None,
+        )
+
+    resultado_outro_telefone = vc.responder(
+        db, tenant_id=TENANT, phone="5511999990027", wa_message_id="wamid.tel2.1",
+        texto="pergunta em outro número", profile=None,
+    )
+
+    assert resultado_outro_telefone is not None  # o breaker do telefone 1 não afeta o telefone 2


### PR DESCRIPTION
## Resumo

Fecha #290 — o loop de auto-resposta da self-chat da Vima voltou (tenant Dóro Eventos, 2026-09-01) mesmo com #280/#282/#285 já em main, por um caminho diferente que aqueles PRs não cobriam.

**Causa raiz (dois buracos na guarda de eco `_ULTIMAS_RESPOSTAS`):**
1. `notifications/service.py::on_client_moved` (via `process_pending`) manda notificações de CRM pro MESMO número que a self-chat escuta, mas nunca registrava esse envio na guarda — o eco da notificação virava "pergunta nova" pra Vima.
2. A mensagem de desculpa mandada no `except` de `_responder` também nunca era registrada — se ela mesma ecoasse, virava "pergunta nova" de novo, gerando a MESMA exceção e a MESMA desculpa, em loop.

Sequência real do incidente: card movido → notificação ecoa (buraco 1) → vira pergunta → `pergunta.responder` lança exceção nesse texto → desculpa mandada, não registrada (buraco 2) → desculpa ecoa → vira pergunta → mesma exceção → mesma desculpa → repete (6+ vezes, até o dono desconectar a conta pelo celular).

## O que mudou

- `vima/whatsapp_conversa.py::registrar_envio_externo()` — chamado por `notifications/service.py::process_pending` logo após um `send_text` bem-sucedido, fecha o buraco 1.
- A desculpa do `except` passa a sair por `_enviar_e_registrar()`, que registra na guarda de eco ANTES de mandar, fecha o buraco 2.
- **Circuit breaker novo**, agnóstico ao mecanismo específico de eco: se a self-chat mandar 3+ respostas pro mesmo número em menos de 2 minutos, bloqueia por 30min e avisa o dono por **e-mail** (nunca por WhatsApp — é justamente o canal sob suspeita) + loga `CRITICAL`. É a barreira de última linha: cobre qualquer causa futura de loop, mapeada ou não, sem depender de reconhecer o texto exato.

## Test plan

- [x] TDD: testes escritos antes da implementação, RED confirmado, depois GREEN.
- [x] `pytest tests/test_vima_whatsapp_conversa.py tests/test_notifications_queue.py tests/test_notifications.py -q` — 64 passed.
- [x] `pytest -q` (suíte completa da API) — 2466 passed, 1 skipped, 0 failures.
- [x] `ruff check` nos arquivos alterados — limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)