### PR TITLE
feat(admin): editar permissões de um funcionário já cadastrado

### DIFF
--- a/apps/web/src/features/admin/PlatformUsers.test.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { navSections } from "../../app/navigation";
 import { api } from "../../lib/api";
 import { PageActionsProvider, usePageActions } from "../../store/pageActions";
 import { assentar } from "../../test/assentar";
-import PlatformUsers from "./PlatformUsers";
+import PlatformUsers, { MODULES } from "./PlatformUsers";
 
 // Story 7.18 — Task 4. Rede sempre mockada (IV2): nenhum teste bate em /admin real.
 vi.mock("../../lib/api", () => ({
@@ -207,6 +208,80 @@ describe("PlatformUsers/OfficeCard — suspender/excluir usuário: tratamento de
   });
 });
 
+// ── Editar permissões de um funcionário já cadastrado ─────────────────────────────────────────
+//
+// Até aqui `allowed_modules` só era definido na criação (`AddStaffModal`) — não havia nenhum jeito
+// de VER ou AJUSTAR depois pela UI. O Master tinha de inspecionar a resposta de `GET /admin/users`
+// no DevTools para descobrir por que um item da sidebar sumiu para um funcionário.
+describe("PlatformUsers/OfficeCard — editar permissões de um funcionário (EditPermissionsModal)", () => {
+  async function openCard(user: ReturnType<typeof userEvent.setup>) {
+    renderPage();
+    await user.click(await screen.findByText("Escritório Alpha Ltda"));
+    expect(await screen.findByText("Funcionário Alpha")).toBeInTheDocument();
+  }
+
+  it("só o funcionário (staff) recebe o botão de editar — o dono sempre vê tudo, editar não teria efeito", async () => {
+    const user = userEvent.setup({ delay: null });
+    await openCard(user);
+
+    expect(screen.getAllByTitle("Editar permissões")).toHaveLength(1);
+  });
+
+  it("abre pré-preenchido com os módulos ATUAIS do usuário, e salvar envia só o que está marcado", async () => {
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
+    vi.mocked(api.patch).mockResolvedValue({ data: {} } as never);
+    await openCard(user);
+
+    await user.click(screen.getByTitle("Editar permissões"));
+    expect(await screen.findByRole("heading", { name: "Permissões de Funcionário Alpha" })).toBeInTheDocument();
+
+    // staffUser.allowed_modules = ["crm"]: o pill de CRM já nasce marcado (fundo roxo).
+    expect(screen.getByRole("button", { name: "CRM" })).toHaveClass("bg-primary-500");
+    expect(screen.getByRole("button", { name: "Configurações" })).not.toHaveClass("bg-primary-500");
+
+    // Marca Configurações (o módulo que faltava para o Leonardo) e desmarca CRM.
+    await user.click(screen.getByRole("button", { name: "Configurações" }));
+    await user.click(screen.getByRole("button", { name: "CRM" }));
+    await user.click(screen.getByRole("button", { name: "Salvar permissões" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(api.patch)).toHaveBeenCalledWith("/admin/users/user-staff", {
+        allowed_modules: ["settings"],
+      }),
+    );
+  });
+
+  it("desmarcar tudo salva lista VAZIA — é o valor que `hasModule` lê como acesso total, não ausência de mudança", async () => {
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
+    vi.mocked(api.patch).mockResolvedValue({ data: {} } as never);
+    await openCard(user);
+
+    await user.click(screen.getByTitle("Editar permissões"));
+    await screen.findByRole("heading", { name: "Permissões de Funcionário Alpha" });
+    await user.click(screen.getByRole("button", { name: "CRM" })); // único módulo marcado (fixture)
+    await user.click(screen.getByRole("button", { name: "Salvar permissões" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(api.patch)).toHaveBeenCalledWith("/admin/users/user-staff", { allowed_modules: [] }),
+    );
+  });
+
+  it("caminho infeliz: api.patch rejeita → erro no modal, e o modal NÃO fecha sozinho", async () => {
+    const user = userEvent.setup({ delay: null }); // ver nota de perf no 1o teste deste arquivo
+    vi.mocked(api.patch).mockRejectedValueOnce({
+      response: { data: { detail: "Falha ao salvar as permissões." } },
+    });
+    await openCard(user);
+
+    await user.click(screen.getByTitle("Editar permissões"));
+    await screen.findByRole("heading", { name: "Permissões de Funcionário Alpha" });
+    await user.click(screen.getByRole("button", { name: "Salvar permissões" }));
+
+    expect(await screen.findByText("Falha ao salvar as permissões.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Permissões de Funcionário Alpha" })).toBeInTheDocument();
+  });
+});
+
 // ── A tela de confirmação não pode mentir sobre o envio (fix de 2026-08-05) ──────────────────
 //
 // Bug real de produção: o Master cadastrou um funcionário por WhatsApp e a tela disse
@@ -322,5 +397,43 @@ describe("PlatformUsers — lista de contas fora de forma não derruba a aba (#2
 
     expect(screen.getByText("Escritório Alpha Ltda")).toBeInTheDocument();
     expect(screen.queryByText("Nenhuma conta ainda.")).not.toBeInTheDocument();
+  });
+});
+
+// ── Gate: todo módulo de negócio da sidebar precisa poder ser CONCEDIDO pelo admin ────────────
+//
+// `MODULES` (o seletor de `AddStaffModal`/`EditPermissionsModal`) é uma cópia manual do conjunto
+// de `item.module` de `app/navigation.ts` — foi divergirem que deixou o Master sem como conceder
+// `settings` a um funcionário (o item já existia na sidebar desde a RBAC de 2026-08-25; a caixa
+// para marcá-lo nunca existiu neste seletor). Sem um gate mecânico, a próxima rota nova com
+// `module` ganha o mesmo destino: aparece na sidebar de quem tem o módulo, e não há como o Master
+// concedê-la a mais ninguém — o defeito é silencioso, porque a tela de admin continua "funcionando".
+describe("PlatformUsers — o seletor de módulos do admin cobre toda a sidebar (issue Leonardo/settings)", () => {
+  it("todo `module` usado em algum item de navigation.ts está no seletor de permissões", () => {
+    const modulosDaSidebar = new Set(
+      navSections
+        .flatMap((secao) => secao.items)
+        .map((item) => item.module)
+        .filter((m): m is string => Boolean(m)),
+    );
+    const modulosDoSeletor = new Set(MODULES.map((m) => m.key));
+
+    const faltando = [...modulosDaSidebar].filter((m) => !modulosDoSeletor.has(m));
+
+    expect(faltando).toEqual([]);
+  });
+
+  it("contra-teste: o gate REALMENTE falha quando um módulo da sidebar não está no seletor", () => {
+    const modulosDaSidebar = new Set(
+      navSections
+        .flatMap((secao) => secao.items)
+        .map((item) => item.module)
+        .filter((m): m is string => Boolean(m)),
+    );
+    const seletorSemSettings = new Set(MODULES.filter((m) => m.key !== "settings").map((m) => m.key));
+
+    const faltando = [...modulosDaSidebar].filter((m) => !seletorSemSettings.has(m));
+
+    expect(faltando).toEqual(["settings"]);
   });
 });

--- a/apps/web/src/features/admin/PlatformUsers.tsx
+++ b/apps/web/src/features/admin/PlatformUsers.tsx
@@ -1,6 +1,6 @@
 import type { AccountInvite, StaffInvite, TenantUsers, User } from "@e1p/shared-types";
 import {
-  Building2, ChevronDown, GraduationCap, Power, Search, Trash2, UserPlus, Users,
+  Building2, ChevronDown, GraduationCap, Pencil, Power, Search, Trash2, UserPlus, Users,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Modal, { Field } from "../../components/Modal";
@@ -97,21 +97,59 @@ function InviteResult({
 }
 
 // Módulos que um funcionário pode receber (vazio = acesso a tudo).
-const MODULES: { key: string; label: string }[] = [
-  { key: "crm", label: "CRM" },
+//
+// ⚠️ Precisa espelhar o conjunto de `module` usado em `app/navigation.ts` — é o mesmo nome que
+// `require_module` usa no backend. Faltava aqui `cockpit`, `bank`, `financial_intelligence`,
+// `investments`, `cost_centers`, `pages` e `settings`: o Master nunca teve como CONCEDER esses
+// módulos a um funcionário, porque a lista que alimenta este seletor nunca os teve. Foi assim
+// que um funcionário cadastrado com módulos restritos ficou sem acesso a Configurações — não dava
+// para marcar essa caixa, porque a caixa não existia.
+export const MODULES: { key: string; label: string }[] = [
+  { key: "cockpit", label: "Dashboard" },
   { key: "agenda", label: "Agenda" },
+  { key: "crm", label: "CRM" },
+  { key: "wallet", label: "Financeiro" },
+  { key: "bank", label: "Contas & Saldos" },
   { key: "receivables", label: "Cobranças" },
   { key: "payables", label: "Contas a Pagar" },
+  { key: "financial_intelligence", label: "DRE, Lucratividade & Projeção" },
+  { key: "investments", label: "Investimentos" },
   { key: "chart_of_accounts", label: "Plano de contas" },
-  { key: "wallet", label: "Financeiro" },
+  { key: "cost_centers", label: "Centros de custo" },
   { key: "quotes", label: "Orçamentos" },
   { key: "contracts", label: "Contratos" },
   { key: "products", label: "Produtos" },
   { key: "stock", label: "Estoque" },
   { key: "marketing", label: "Marketing" },
-  { key: "funnels", label: "Funis" },
+  { key: "funnels", label: "Funil de Vendas" },
+  { key: "pages", label: "Sites" },
   { key: "juridico", label: "Jurídico" },
+  { key: "settings", label: "Configurações" },
 ];
+
+/** Grade de módulos reutilizada pelo cadastro e pela edição — a mesma lista, o mesmo toggle. */
+function ModulePicker({ selected, onToggle }: { selected: string[]; onToggle: (key: string) => void }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-sm font-medium text-neutral-600">Acesso a módulos</p>
+      <p className="mb-2 text-xs text-neutral-400">Nenhum marcado = acesso a tudo.</p>
+      <div className="flex flex-wrap gap-1.5">
+        {MODULES.map((m) => (
+          <button
+            key={m.key}
+            type="button"
+            onClick={() => onToggle(m.key)}
+            className={`rounded-pill px-2.5 py-1 text-xs font-medium ${
+              selected.includes(m.key) ? "bg-primary-500 text-white" : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200"
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function PlatformUsers() {
   const [nodes, setNodes] = useState<TenantUsers[]>([]);
@@ -213,6 +251,7 @@ function OfficeCard({
   onChanged: () => void;
 }) {
   const [addStaff, setAddStaff] = useState(false);
+  const [editUser, setEditUser] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
   const active = node.admin?.is_active ?? true;
 
@@ -281,7 +320,9 @@ function OfficeCard({
             {node.staff.length === 0 ? (
               <Empty text="Nenhum funcionário." />
             ) : (
-              node.staff.map((u) => <UserRow key={u.id} user={u} onToggle={toggleUser} onDelete={removeUser} />)
+              node.staff.map((u) => (
+                <UserRow key={u.id} user={u} onToggle={toggleUser} onEdit={setEditUser} onDelete={removeUser} />
+              ))
             )}
           </Group>
 
@@ -308,6 +349,14 @@ function OfficeCard({
           tenantId={node.tenant.id}
           onClose={() => setAddStaff(false)}
           onCreated={() => { setAddStaff(false); onChanged(); }}
+        />
+      )}
+
+      {editUser && (
+        <EditPermissionsModal
+          user={editUser}
+          onClose={() => setEditUser(null)}
+          onSaved={() => { setEditUser(null); onChanged(); }}
         />
       )}
     </div>
@@ -337,7 +386,14 @@ function Group({ title, action, children }: { title: string; action?: React.Reac
   );
 }
 
-function UserRow({ user, onToggle, onDelete }: { user: User; onToggle: (u: User) => void; onDelete?: (u: User) => void }) {
+function UserRow({
+  user, onToggle, onEdit, onDelete,
+}: {
+  user: User;
+  onToggle: (u: User) => void;
+  onEdit?: (u: User) => void;
+  onDelete?: (u: User) => void;
+}) {
   return (
     <div className="flex items-center justify-between py-2">
       <div className="min-w-0">
@@ -348,6 +404,15 @@ function UserRow({ user, onToggle, onDelete }: { user: User; onToggle: (u: User)
         <p className="truncate text-xs text-neutral-400">{user.email}</p>
       </div>
       <div className="flex shrink-0 gap-1">
+        {onEdit && (
+          <button
+            onClick={() => onEdit(user)}
+            title="Editar permissões"
+            className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100"
+          >
+            <Pencil size={15} />
+          </button>
+        )}
         <button
           onClick={() => onToggle(user)}
           title={user.is_active ? "Suspender" : "Reativar"}
@@ -447,24 +512,7 @@ function AddStaffModal({ tenantId, onClose, onCreated }: { tenantId: string; onC
           </div>
         </div>
 
-        <div>
-          <p className="mb-1.5 text-sm font-medium text-neutral-600">Acesso a módulos</p>
-          <p className="mb-2 text-xs text-neutral-400">Nenhum marcado = acesso a tudo (você ajusta depois).</p>
-          <div className="flex flex-wrap gap-1.5">
-            {MODULES.map((m) => (
-              <button
-                key={m.key}
-                type="button"
-                onClick={() => toggle(m.key)}
-                className={`rounded-pill px-2.5 py-1 text-xs font-medium ${
-                  modules.includes(m.key) ? "bg-primary-500 text-white" : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200"
-                }`}
-              >
-                {m.label}
-              </button>
-            ))}
-          </div>
-        </div>
+        <ModulePicker selected={modules} onToggle={toggle} />
         {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
         <button
           onClick={save}
@@ -472,6 +520,60 @@ function AddStaffModal({ tenantId, onClose, onCreated }: { tenantId: string; onC
           className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
         >
           {saving ? "Cadastrando..." : "Cadastrar e enviar senha"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+/**
+ * Edita `allowed_modules` de um funcionário JÁ cadastrado. `AddStaffModal` só marca o acesso na
+ * criação; até aqui não havia nenhum jeito de VER ou AJUSTAR depois — o Master tinha de consultar
+ * a rede do navegador para descobrir por que um item da sidebar sumiu para alguém.
+ *
+ * Só faz sentido para `role === "sub_user"`: o dono (`owner`) sempre vê tudo, independente de
+ * `allowed_modules` (`lib/access.ts::hasModule`), então editar a lista dele não teria efeito
+ * nenhum — `OfficeCard` não oferece este modal para a linha do admin.
+ */
+function EditPermissionsModal({
+  user, onClose, onSaved,
+}: {
+  user: User;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [modules, setModules] = useState<string[]>(user.allowed_modules);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  function toggle(key: string) {
+    setModules((m) => (m.includes(key) ? m.filter((k) => k !== key) : [...m, key]));
+  }
+
+  async function save() {
+    setError(null);
+    setSaving(true);
+    try {
+      await api.patch(`/admin/users/${user.id}`, { allowed_modules: modules });
+      onSaved();
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title={`Permissões de ${user.name}`} open onClose={onClose}>
+      <div className="space-y-3">
+        <ModulePicker selected={modules} onToggle={toggle} />
+        {error && <p className="rounded-lg bg-red-50 p-2 text-sm text-danger">{error}</p>}
+        <button
+          onClick={save}
+          disabled={saving}
+          className="w-full rounded-pill bg-accent-400 py-2.5 font-semibold text-white transition hover:bg-accent-500 disabled:opacity-60"
+        >
+          {saving ? "Salvando..." : "Salvar permissões"}
         </button>
       </div>
     </Modal>


### PR DESCRIPTION
## Problema

A tela `/admin` (Super Admin / Master) tinha dois buracos de UX que se somavam em um bug real:

1. **O seletor de módulos estava incompleto.** A lista `MODULES` em `PlatformUsers.tsx` cobria apenas 13 dos 20 módulos de negócio do app. Faltavam `cockpit`, `bank`, `financial_intelligence`, `investments`, `cost_centers`, `pages` e `settings`. Na prática, o Master **nunca teve como conceder "Configurações"** (nem os outros seis) a um funcionário pela interface.
2. **Não havia como editar permissões depois do cadastro.** `allowed_modules` só era definido no momento da criação do usuário. Depois disso, a UI não mostrava nem permitia ajustar nada.

O efeito combinado apareceu em produção: o funcionário Leonardo (tenant Doro Eventos) ficou sem o item "Configurações" na sidebar e **não existia caminho pela UI para corrigir** — só inspecionando/alterando a API na mão.

## Solução

1. **Completa a lista `MODULES`** para cobrir todo módulo usado em `app/navigation.ts`.
2. **Botão de editar (ícone lápis) em cada linha de funcionário.** Abre um `EditPermissionsModal` novo, pré-preenchido com os módulos atuais do usuário, e salva via `PATCH /admin/users/{id}`. O botão **não** aparece para o dono/owner, que sempre tem acesso total independente de `allowed_modules`.
3. **Extrai o componente `ModulePicker`**, compartilhado entre o modal de criação e o de edição, para não duplicar a grade de toggles.
4. **Teste-gate contra a regressão de origem.** `PlatformUsers.test.tsx` compara dinamicamente o conjunto de `MODULES` contra todo `item.module` declarado em `app/navigation.ts` e falha se algum módulo da sidebar ficar de fora do seletor de permissões. Assim, quando uma rota/módulo novo for adicionado no futuro, o teste acusa antes de virar um "Leonardo sem Configurações". Inclui um contra-teste que prova que o gate realmente falha quando um módulo está faltando.

## Arquivos

- `apps/web/src/features/admin/PlatformUsers.tsx`
- `apps/web/src/features/admin/PlatformUsers.test.tsx`

## Plano de teste

Já rodado nesta branch:

- [x] `vitest` — 18/18 testes verdes (inclui o gate `MODULES` × `navigation.ts` e o contra-teste)
- [x] `eslint` — limpo
- [x] `pnpm typecheck` — sem erros

Falta:

- [ ] Validação manual em `/admin`: abrir o lápis de um funcionário, conferir que os módulos vêm pré-marcados corretamente, conceder "Configurações", salvar e verificar que o item aparece na sidebar do funcionário
- [ ] Confirmar que o botão de editar não aparece na linha do dono/owner
- [ ] Job `frontend` do CI verde neste PR

## Notas

- Mudança restrita ao frontend do admin — nenhuma migration, nenhum endpoint novo (usa o `PATCH /admin/users/{id}` já existente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
