### PR TITLE
feat(legal): Política de Privacidade e Termos de Serviço como páginas públicas

### DIFF
--- a/apps/api/tests/test_vima_tools.py
+++ b/apps/api/tests/test_vima_tools.py
@@ -2,7 +2,7 @@
 contrato "nunca deixa exceção subir crua" (o loop de tool-use precisa de um tool_result sempre).
 """
 import json
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -13,6 +13,7 @@ from app.modules.crm.models import Client, PipelineStage
 from app.modules.juridico.models import LegalDocument
 from app.modules.marketing.models import Carousel
 from app.modules.receivables.models import METHOD_PIX, STATUS_OPEN, Charge
+from app.modules.settings.service import hoje_do_tenant
 from app.modules.stock.models import StockItem
 from app.modules.vima import tools
 from app.modules.wallet.models import KIND_SERVICE
@@ -110,9 +111,18 @@ def test_executar_recusa_ferramenta_fora_da_lista_permitida(db: Session):
 
 
 def test_consultar_recebiveis_delega_para_o_resumo_real(db: Session):
+    """O vencimento é RELATIVO a hoje de propósito, e uma data fixa aqui é bug.
+
+    `summary` separa `open_cents` de `overdue_cents` comparando `due_date` com
+    `hoje_do_tenant(db)`. A versão anterior deste teste fixava `date(2026, 9, 1)` — que era
+    futuro quando foi escrito e virou passado em 2026-09-02, jogando os 50 mil centavos em
+    `overdue_cents` e derrubando o CI de TODOS os PRs do dia, sem nenhum diff culpado.
+    Mesma classe de bomba-relógio do #84/#101: ancore em `hoje_do_tenant`, nunca no calendário.
+    """
     db.add(Charge(
         tenant_id=TENANT, description="Consultoria", kind=KIND_SERVICE, method=METHOD_PIX,
-        amount_cents=50_000, due_date=date(2026, 9, 1), status=STATUS_OPEN,
+        amount_cents=50_000, due_date=hoje_do_tenant(db) + timedelta(days=30),
+        status=STATUS_OPEN,
     ))
     db.commit()
     resultado = json.loads(tools.executar(db, _usuario(), "consultar_recebiveis", {}))

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -32,6 +32,8 @@ import FunnelBuilderPage from "../features/funis/FunnelBuilderPage";
 import JuridicoDocumentPage from "../features/juridico/JuridicoDocumentPage";
 import JuridicoPage from "../features/juridico/JuridicoPage";
 import JuridicoWizardPage from "../features/juridico/JuridicoWizardPage";
+import PrivacidadePage from "../features/legal/PrivacidadePage";
+import TermosPage from "../features/legal/TermosPage";
 import CarrosselBuilderPage from "../features/marketing/CarrosselBuilderPage";
 import MarketingPage from "../features/marketing/MarketingPage";
 import CompartilharPage from "../features/pagar/CompartilharPage";
@@ -63,6 +65,11 @@ export default function App() {
         <Route path="/orcamento/:slug" element={<PublicProposalPage />} />
         <Route path="/contrato/:slug" element={<PublicContractPage />} />
         <Route path="/p/:slug" element={<PublicPage />} />
+        {/* Documentos legais: PÚBLICOS de propósito. A tela de consentimento OAuth do Google
+            exige que o link da Política de Privacidade abra sem login, e uma pessoa que ainda
+            não é assinante precisa poder ler os Termos antes de virar uma. */}
+        <Route path="/privacidade" element={<PrivacidadePage />} />
+        <Route path="/termos" element={<TermosPage />} />
         <Route element={<ProtectedLayout />}>
           {/*
             A raiz autenticada não é mais o Cockpit direto: `EntradaDoDia` decide a porta do dia

--- a/apps/web/src/features/auth/LoginPage.test.tsx
+++ b/apps/web/src/features/auth/LoginPage.test.tsx
@@ -2,6 +2,7 @@ import type { AuthToken, Tenant, User } from "@e1p/shared-types";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AxiosError } from "axios";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Testes de componente da UI de `auth` — LoginPage/LoginForm (Story 7.4, AC1/AC3).
@@ -28,6 +29,19 @@ vi.mock("../../lib/api", async (importActual) => {
 });
 
 import LoginPage from "./LoginPage";
+
+/**
+ * A tela passou a exibir, fora do cartão, os links para `/privacidade` e `/termos` — e `<Link>`
+ * exige contexto de rota. Envolver aqui mantém os testes exercitando o COMPONENTE REAL, em vez
+ * de trocar os links por `<a>` só para não precisar de um Router no teste.
+ */
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
 
 const tenant: Tenant = {
   id: "t-1",
@@ -66,7 +80,7 @@ describe("LoginPage / LoginForm (Story 7.4 — portão de entrada)", () => {
   it("caminho feliz: login válido chama POST /auth/login e propaga token/usuário/tenant", async () => {
     postMock.mockResolvedValueOnce({ data: authToken });
 
-    render(<LoginPage />);
+    renderLoginPage();
 
     await userEvent.type(screen.getByLabelText("E-mail"), "joao@e1p.com");
     await userEvent.type(screen.getByLabelText("Senha"), "senha-super-secreta");
@@ -91,7 +105,7 @@ describe("LoginPage / LoginForm (Story 7.4 — portão de entrada)", () => {
     };
     postMock.mockRejectedValueOnce(err);
 
-    render(<LoginPage />);
+    renderLoginPage();
 
     await userEvent.type(screen.getByLabelText("E-mail"), "joao@e1p.com");
     await userEvent.type(screen.getByLabelText("Senha"), "senha-errada");
@@ -106,7 +120,7 @@ describe("LoginPage / LoginForm (Story 7.4 — portão de entrada)", () => {
   });
 
   it("caminho infeliz: campos vazios não chamam a API (validação nativa de `required`)", async () => {
-    render(<LoginPage />);
+    renderLoginPage();
 
     // Submete sem preencher nada — os inputs são `required`, então o jsdom bloqueia o submit.
     await userEvent.click(screen.getByRole("button", { name: /^entrar$/i }));
@@ -128,7 +142,7 @@ describe("ForgotForm — dev_reset_token só é exibido se tiver FORMA de token"
   });
 
   async function pedirRedefinicao() {
-    render(<LoginPage />);
+    renderLoginPage();
     await userEvent.click(screen.getByRole("button", { name: /esqueci minha senha/i }));
     await userEvent.type(screen.getByLabelText(/e-mail/i), "joao@e1p.com");
     await userEvent.click(screen.getByRole("button", { name: /enviar/i }));

--- a/apps/web/src/features/auth/LoginPage.tsx
+++ b/apps/web/src/features/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import type { AuthToken } from "@e1p/shared-types";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { api, apiErrorMessage } from "../../lib/api";
 import { useAuth } from "../../store/auth";
 
@@ -10,7 +11,7 @@ export default function LoginPage() {
   const [mode, setMode] = useState<Mode>("login");
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-primary-500 p-4">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-primary-500 p-4">
       {/* `campos-tocaveis`: esta tela tem CÓPIA PRÓPRIA do `Field` (abaixo, l. ~203) e não passa
           pelo `components/Modal.tsx` — o conserto de lá não chega até aqui. Medido: e-mail e senha
           a 38px na PRIMEIRA tela do produto. Ver `styles/index.css`. */}
@@ -28,6 +29,18 @@ export default function LoginPage() {
         )}
         {mode === "reset" && <ResetForm onDone={() => setMode("login")} />}
       </div>
+      {/* Fora do cartão, e não dentro do `LoginForm`: os documentos legais precisam estar
+          alcançáveis nos três modos da tela (entrar, recuperar, redefinir) e por quem ainda não
+          é assinante. E o link que a tela de consentimento OAuth do Google exige que exista. */}
+      <nav className="text-center text-xs text-white/80">
+        <Link to="/privacidade" className="hover:underline">
+          Política de Privacidade
+        </Link>
+        <span aria-hidden="true"> · </span>
+        <Link to="/termos" className="hover:underline">
+          Termos de Serviço
+        </Link>
+      </nav>
     </div>
   );
 }

--- a/apps/web/src/features/legal/LegalLayout.tsx
+++ b/apps/web/src/features/legal/LegalLayout.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { CONTROLADOR, VIGENCIA } from "./controlador";
+
+/**
+ * Moldura das duas páginas legais (`/privacidade` e `/termos`).
+ *
+ * São PÚBLICAS por obrigação, não por conveniência: o Google exige que o link da Política de
+ * Privacidade abra sem login para publicar o app OAuth (ver `docs/GO-LIVE-CHECKLIST.md` §5).
+ * Por isso ficam fora do `ProtectedLayout` e não tocam em `useAuth` — uma pessoa que nunca
+ * teve conta precisa conseguir ler.
+ */
+export default function LegalLayout({
+  titulo,
+  subtitulo,
+  outroDocumento,
+  children,
+}: {
+  titulo: string;
+  subtitulo: string;
+  /** Link cruzado para o documento irmão: quem lê um quase sempre quer o outro. */
+  outroDocumento: { to: string; label: string };
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-b border-neutral-200 bg-white">
+        <div className="mx-auto flex max-w-3xl items-center justify-between gap-3 px-4 py-4">
+          <Link to="/login" className="flex items-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-500 font-bold text-white">
+              e1
+            </div>
+            <span className="text-xl font-bold text-neutral-800">e1p</span>
+          </Link>
+          <Link to={outroDocumento.to} className="text-sm text-primary-600 hover:underline">
+            {outroDocumento.label}
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-2xl font-bold text-neutral-800 sm:text-3xl">{titulo}</h1>
+        <p className="mt-2 text-sm text-neutral-500">{subtitulo}</p>
+        <p className="mt-1 text-sm text-neutral-500">Última atualização: {VIGENCIA}.</p>
+
+        <article className="mt-8 space-y-8">{children}</article>
+
+        <footer className="mt-12 border-t border-neutral-200 pt-6 text-xs text-neutral-500">
+          <p>
+            {CONTROLADOR.razaoSocial} — CNPJ {CONTROLADOR.cnpj}. Contato:{" "}
+            <a className="text-primary-600 hover:underline" href={`mailto:${CONTROLADOR.email}`}>
+              {CONTROLADOR.email}
+            </a>
+            .
+          </p>
+          <p className="mt-2">
+            <Link to={outroDocumento.to} className="text-primary-600 hover:underline">
+              {outroDocumento.label}
+            </Link>
+            {" · "}
+            <Link to="/login" className="text-primary-600 hover:underline">
+              Entrar no e1p
+            </Link>
+          </p>
+        </footer>
+      </main>
+    </div>
+  );
+}
+
+/** Seção numerada. O `id` permite citar um trecho específico por link (`/termos#responsabilidades`). */
+export function Secao({ id, titulo, children }: { id: string; titulo: string; children: ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-4">
+      <h2 className="text-lg font-bold text-neutral-800">{titulo}</h2>
+      <div className="mt-3 space-y-3 text-sm leading-relaxed text-neutral-700">{children}</div>
+    </section>
+  );
+}
+
+/** Lista de itens do corpo de uma seção. */
+export function Lista({ children }: { children: ReactNode }) {
+  return <ul className="list-disc space-y-2 pl-5">{children}</ul>;
+}
+
+/**
+ * Tabela de um documento legal. `overflow-x-auto` porque a tela mais estreita suportada é 360px
+ * e uma tabela de 3 colunas não cabe nela — rolar a tabela é melhor que rolar a página inteira.
+ */
+export function Tabela({ cabecalho, linhas }: { cabecalho: string[]; linhas: string[][] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[32rem] border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-neutral-300">
+            {cabecalho.map((c) => (
+              <th key={c} className="py-2 pr-4 font-semibold text-neutral-800">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {linhas.map((linha) => (
+            <tr key={linha.join("|")} className="border-b border-neutral-200 align-top">
+              {linha.map((celula, i) => (
+                <td key={i} className="py-2 pr-4 text-neutral-700">
+                  {celula}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/features/legal/PaginasLegais.test.tsx
+++ b/apps/web/src/features/legal/PaginasLegais.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+// `useAuth` mockado como DESLOGADO de propósito (mesmo padrão de `App.test.tsx`): o que estes
+// testes provam é justamente que os dois documentos legais abrem SEM sessão. Se um dia alguém
+// mover essas rotas para dentro do `ProtectedLayout`, o redirecionamento para `/login` quebra
+// esta suíte — que é o alarme que queremos, porque publicar o app OAuth do Google depende de a
+// Política de Privacidade abrir para quem não tem conta nenhuma.
+vi.mock("../../store/auth", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => ({ isAuthenticated: false, user: null }),
+}));
+vi.mock("../../store/useIdleTimeout", () => ({
+  useIdleTimeout: () => ({ showWarning: false, stayConnected: vi.fn() }),
+}));
+
+import App from "../../app/App";
+
+/** Texto da página com espaços normalizados — o JSX quebra frases em várias linhas. */
+function textoDaPagina() {
+  return (document.body.textContent ?? "").replace(/\s+/g, " ");
+}
+
+function abrir(rota: string) {
+  return render(
+    <MemoryRouter initialEntries={[rota]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+describe("Páginas legais são públicas", () => {
+  it.each([
+    ["/privacidade", "Política de Privacidade"],
+    ["/termos", "Termos de Serviço"],
+  ])("%s abre sem sessão", (rota, titulo) => {
+    abrir(rota);
+    expect(screen.getByRole("heading", { level: 1, name: titulo })).toBeTruthy();
+  });
+
+  it.each(["/privacidade", "/termos"])(
+    "%s identifica o responsável com razão social, CNPJ e contato",
+    (rota) => {
+      abrir(rota);
+      const texto = textoDaPagina();
+      expect(texto).toContain("FLAVIO KATO LTDA");
+      expect(texto).toContain("65.623.582/0001-08");
+      expect(texto).toContain("flaviokato76@gmail.com");
+    },
+  );
+
+  it("cada documento leva ao outro", () => {
+    abrir("/privacidade");
+    expect(
+      screen.getAllByRole("link", { name: "Termos de Serviço" }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("a tela de login leva aos dois documentos", () => {
+    abrir("/login");
+    expect(screen.getByRole("link", { name: "Política de Privacidade" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Termos de Serviço" })).toBeTruthy();
+  });
+});
+
+// ── Cláusula de Uso Limitado do Google ────────────────────────────────────────────────────
+//
+// Não é texto de enfeite: a Google API Services User Data Policy exige que um app que usa
+// escopos de usuário (aqui, `calendar.events` + `userinfo.email`) declare o compromisso de Uso
+// Limitado na política de privacidade, e a revisão do Google procura essa frase. Apagá-la ao
+// "melhorar a redação" reprovaria a publicação sem quebrar nada visível — por isso a asserção é
+// pelo texto LITERAL, e não por um `toContain("Uso Limitado")` que passaria com a frase mutilada.
+describe("Política de Privacidade — cláusula de Uso Limitado do Google", () => {
+  it("declara o compromisso na íntegra", () => {
+    abrir("/privacidade");
+    expect(textoDaPagina()).toContain(
+      "O uso e a transferência, pelo e1p, de informações recebidas das APIs do Google " +
+        "obedecerão à Política de Dados do Usuário dos Serviços de API do Google, incluindo " +
+        "os requisitos de Uso Limitado.",
+    );
+  });
+
+  it("aponta para a política do Google", () => {
+    abrir("/privacidade");
+    const link = screen.getByRole("link", {
+      name: "Política de Dados do Usuário dos Serviços de API do Google",
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://developers.google.com/terms/api-services-user-data-policy",
+    );
+  });
+
+  it("lista os escopos que o app realmente pede, e só eles", () => {
+    abrir("/privacidade");
+    const texto = textoDaPagina();
+    expect(texto).toContain("calendar.events");
+    expect(texto).toContain("userinfo.email");
+    // O compromisso de escopo mínimo, que é o que o revisor do Google confere contra a tela de
+    // consentimento. Some junto com a frase se alguém generalizar o texto.
+    expect(texto).toContain(
+      "Não lemos seus e-mails, arquivos, contatos ou qualquer outro dado da sua conta Google.",
+    );
+  });
+});

--- a/apps/web/src/features/legal/PrivacidadePage.tsx
+++ b/apps/web/src/features/legal/PrivacidadePage.tsx
@@ -1,0 +1,348 @@
+import LegalLayout, { Lista, Secao, Tabela } from "./LegalLayout";
+import { CONTROLADOR } from "./controlador";
+
+/**
+ * Política de Privacidade — página PÚBLICA em `/privacidade`.
+ *
+ * Existe por três exigências concretas, não por formalidade:
+ *  1. LGPD (Lei 13.709/2018) art. 9º — informação clara sobre o tratamento.
+ *  2. Google OAuth — a aba Branding da tela de consentimento exige a URL desta página para
+ *     publicar o app; sem publicar, o refresh token morre a cada 7 dias.
+ *  3. Google API Services User Data Policy — a seção "Uso Limitado" abaixo é literal e
+ *     obrigatória para qualquer app que leia escopos de usuário do Google.
+ *
+ * O conteúdo descreve o que o sistema REALMENTE faz. Ao mudar coleta, integração ou retenção
+ * no produto, este texto muda junto — descrever a mais é tão errado quanto omitir.
+ */
+export default function PrivacidadePage() {
+  return (
+    <LegalLayout
+      titulo="Política de Privacidade"
+      subtitulo={`Como o ${CONTROLADOR.produto} trata dados pessoais.`}
+      outroDocumento={{ to: "/termos", label: "Termos de Serviço" }}
+    >
+      <Secao id="quem-somos" titulo="1. Quem trata seus dados">
+        <p>
+          O {CONTROLADOR.produto} é operado por <strong>{CONTROLADOR.razaoSocial}</strong>, inscrita
+          no CNPJ sob o nº {CONTROLADOR.cnpj} ("nós"). Para qualquer assunto relativo a dados
+          pessoais, incluindo o exercício dos seus direitos, o canal é{" "}
+          <a className="text-primary-600 hover:underline" href={`mailto:${CONTROLADOR.email}`}>
+            {CONTROLADOR.email}
+          </a>
+          , que também responde pelo encarregado de dados (DPO) previsto no art. 41 da LGPD.
+        </p>
+        <p>
+          Esta política se aplica ao aplicativo web do {CONTROLADOR.produto} e a todas as suas
+          integrações. Ao criar uma conta ou usar o sistema, você declara ter lido este documento.
+        </p>
+      </Secao>
+
+      <Secao id="dois-papeis" titulo="2. Dois papéis diferentes, e isso importa">
+        <p>
+          O {CONTROLADOR.produto} é um sistema de gestão: você o usa para administrar o seu próprio
+          negócio. Isso cria duas relações distintas, com responsabilidades distintas:
+        </p>
+        <Lista>
+          <li>
+            <strong>Sobre os seus dados de conta</strong> (o cadastro da sua empresa, o seu usuário,
+            a cobrança da assinatura, os registros de acesso) somos <strong>controladores</strong>:
+            decidimos por que e como tratá-los, nos termos desta política.
+          </li>
+          <li>
+            <strong>Sobre os dados que você insere no sistema</strong> — seus clientes, seus
+            contratos, suas conversas, seus lançamentos financeiros — somos{" "}
+            <strong>operadores</strong>. Quem decide o que coletar, por quê e por quanto tempo é
+            você, que é o controlador desses dados. Nós apenas os tratamos conforme as suas
+            instruções, expressas pelo uso do sistema, e conforme os Termos de Serviço.
+          </li>
+        </Lista>
+        <p>
+          Na prática: se um cliente seu pedir a exclusão dos dados dele, o pedido é seu para
+          atender, e o {CONTROLADOR.produto} lhe dá as ferramentas para isso. Se você pedir a
+          exclusão da sua conta, o pedido é nosso para atender.
+        </p>
+      </Secao>
+
+      <Secao id="dados-coletados" titulo="3. Que dados são tratados">
+        <Tabela
+          cabecalho={["Categoria", "Dados", "Origem"]}
+          linhas={[
+            [
+              "Conta e empresa",
+              "Razão social, CPF/CNPJ, fuso horário, nome, e-mail, senha (armazenada apenas como hash), telefone, endereço, perfil de acesso e módulos liberados.",
+              "Você, ao contratar e ao cadastrar usuários.",
+            ],
+            [
+              "Clientes e leads",
+              "Nome, e-mail, telefone, CPF, data de nascimento, gênero, etiquetas, anotações e o histórico de interações que você registra.",
+              "Você, ou formulários e páginas públicas que você mesmo publica.",
+            ],
+            [
+              "Conversas de WhatsApp",
+              "Mensagens enviadas e recebidas, número do contato, nome de exibição e anexos, quando você conecta um número ao sistema.",
+              "A integração de WhatsApp que você ativar.",
+            ],
+            [
+              "Agenda",
+              "Compromissos, participantes, horários e links de reunião; o e-mail da conta Google conectada.",
+              "Você e, se conectada, a sua conta Google.",
+            ],
+            [
+              "Financeiro e documentos",
+              "Contas a pagar e a receber, lançamentos, saldos, contratos, propostas, peças jurídicas e arquivos anexados.",
+              "Você.",
+            ],
+            [
+              "Registros técnicos",
+              "Data e hora de acesso, ações relevantes em trilha de auditoria e registros de erro do servidor.",
+              "Gerados automaticamente pelo uso.",
+            ],
+          ]}
+        />
+        <p>
+          Não coletamos dados seus em sites de terceiros, não compramos listas e não fazemos
+          rastreamento publicitário. O {CONTROLADOR.produto} não tem cookies de terceiros nem pixels
+          de rede de anúncios.
+        </p>
+      </Secao>
+
+      <Secao id="finalidades" titulo="4. Para que os dados são usados">
+        <Lista>
+          <li>
+            <strong>Prestar o serviço</strong> — executar as funções que você aciona: cadastrar
+            clientes, emitir cobranças, agendar compromissos, gerar documentos, trocar mensagens.
+            Base legal: execução de contrato (art. 7º, V, da LGPD).
+          </li>
+          <li>
+            <strong>Autenticar e proteger</strong> — verificar quem entra, encerrar sessões ociosas,
+            manter trilha de auditoria e investigar uso indevido. Base legal: legítimo interesse e
+            cumprimento de obrigação legal.
+          </li>
+          <li>
+            <strong>Comunicar</strong> — avisos operacionais sobre a sua conta, o briefing diário
+            que você habilitar e respostas de suporte. Base legal: execução de contrato.
+          </li>
+          <li>
+            <strong>Cobrar a assinatura</strong> e cumprir obrigações fiscais e contábeis. Base
+            legal: cumprimento de obrigação legal.
+          </li>
+        </Lista>
+        <p>
+          Não vendemos dados pessoais, não os cedemos para publicidade de terceiros e não os usamos
+          para treinar modelos de inteligência artificial.
+        </p>
+      </Secao>
+
+      <Secao id="ia" titulo="5. Inteligência artificial e anonimização">
+        <p>
+          Algumas funções do {CONTROLADOR.produto} usam modelos de IA da Anthropic (Claude) para
+          redigir textos, resumir informações e responder perguntas sobre o seu negócio.
+        </p>
+        <p>
+          Antes de qualquer texto sair do sistema em direção à IA, ele passa por um anonimizador que
+          substitui CPF, CNPJ, e-mails, telefones e números de cartão por marcadores genéricos. A
+          resposta volta com esses marcadores e os valores reais são reinseridos localmente, já
+          dentro da nossa infraestrutura. O provedor de IA, portanto, não recebe esses
+          identificadores.
+        </p>
+        <p>
+          O conteúdo enviado à Anthropic não é usado para treinar os modelos dela. As respostas de
+          IA são geradas automaticamente e podem conter erros: elas não substituem orientação
+          jurídica, contábil ou financeira profissional. Ver a cláusula correspondente nos Termos de
+          Serviço.
+        </p>
+      </Secao>
+
+      <Secao id="google" titulo="6. Dados recebidos das APIs do Google">
+        <p>
+          Se você conectar a sua conta Google, o {CONTROLADOR.produto} solicita dois escopos, e
+          apenas eles:
+        </p>
+        <Lista>
+          <li>
+            <code className="rounded bg-neutral-100 px-1">calendar.events</code> — para criar,
+            alterar e cancelar no seu Google Agenda os compromissos que você marca no sistema,
+            incluindo a geração do link do Google Meet, e para manter os dois lados sincronizados.
+          </li>
+          <li>
+            <code className="rounded bg-neutral-100 px-1">userinfo.email</code> — apenas para exibir
+            qual conta Google está conectada, de modo que você saiba onde os eventos estão sendo
+            criados.
+          </li>
+        </Lista>
+        <p>
+          Não lemos seus e-mails, arquivos, contatos ou qualquer outro dado da sua conta Google.
+          Você pode revogar o acesso a qualquer momento, dentro do {CONTROLADOR.produto} ou em{" "}
+          <a
+            className="text-primary-600 hover:underline"
+            href="https://myaccount.google.com/permissions"
+            target="_blank"
+            rel="noreferrer"
+          >
+            myaccount.google.com/permissions
+          </a>
+          . Ao revogar, apagamos as credenciais armazenadas e a sincronização para de funcionar; os
+          eventos já criados permanecem onde estão.
+        </p>
+        <p className="rounded-lg bg-neutral-100 p-3">
+          <strong>Uso Limitado.</strong> O uso e a transferência, pelo {CONTROLADOR.produto}, de
+          informações recebidas das APIs do Google obedecerão à{" "}
+          <a
+            className="text-primary-600 hover:underline"
+            href="https://developers.google.com/terms/api-services-user-data-policy"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Política de Dados do Usuário dos Serviços de API do Google
+          </a>
+          , incluindo os requisitos de Uso Limitado.
+        </p>
+      </Secao>
+
+      <Secao id="compartilhamento" titulo="7. Com quem os dados são compartilhados">
+        <p>
+          Compartilhamos dados apenas com os prestadores necessários para o serviço funcionar, cada
+          um limitado ao que a sua função exige:
+        </p>
+        <Tabela
+          cabecalho={["Prestador", "Para quê", "Onde"]}
+          linhas={[
+            [
+              "Amazon Web Services (AWS)",
+              "Hospedagem da aplicação, do banco de dados e dos arquivos anexados.",
+              "Brasil (região de São Paulo)",
+            ],
+            [
+              "Anthropic",
+              "Processamento das funções de IA, com os dados já anonimizados.",
+              "Estados Unidos",
+            ],
+            [
+              "Google",
+              "Sincronização do Google Agenda e do Google Meet, quando você conecta a conta.",
+              "Estados Unidos",
+            ],
+            [
+              "Meta (WhatsApp Business Platform)",
+              "Envio e recebimento de mensagens, quando você usa a integração oficial.",
+              "Estados Unidos",
+            ],
+            [
+              "Asaas",
+              "Emissão de boletos e Pix das suas cobranças, quando o gateway está habilitado.",
+              "Brasil",
+            ],
+            [
+              "Provedor de e-mail transacional",
+              "Envio dos e-mails do sistema, como recuperação de senha.",
+              "Brasil / Estados Unidos",
+            ],
+          ]}
+        />
+        <p>
+          As transferências internacionais acima ocorrem com base em cláusulas contratuais e nas
+          demais garantias exigidas pelos arts. 33 e seguintes da LGPD. Também podemos divulgar
+          dados diante de ordem judicial ou requisição de autoridade competente e, nesse caso,
+          avisaremos você sempre que a lei permitir.
+        </p>
+      </Secao>
+
+      <Secao id="seguranca" titulo="8. Como os dados são protegidos">
+        <Lista>
+          <li>Todo o tráfego entre o seu navegador e o sistema é cifrado por HTTPS/TLS.</li>
+          <li>Senhas são guardadas apenas como hash; nem nós conseguimos lê-las.</li>
+          <li>
+            O banco de dados aplica isolamento por assinante em nível de linha (Row Level Security):
+            os dados de uma empresa são inalcançáveis a partir da sessão de outra por decisão do
+            próprio banco, e não apenas por filtro da aplicação.
+          </li>
+          <li>Sessões inativas são encerradas automaticamente após 30 minutos.</li>
+          <li>Acessos e ações sensíveis ficam registrados em trilha de auditoria.</li>
+          <li>Backups automáticos são mantidos, com cópia fora do servidor de produção.</li>
+        </Lista>
+        <p>
+          Nenhum sistema é imune a incidentes. Se ocorrer um incidente de segurança com risco
+          relevante aos seus dados, comunicaremos você e a Autoridade Nacional de Proteção de Dados
+          (ANPD), conforme o art. 48 da LGPD.
+        </p>
+      </Secao>
+
+      <Secao id="retencao" titulo="9. Por quanto tempo os dados ficam guardados">
+        <Lista>
+          <li>
+            <strong>Enquanto a sua conta existir</strong>, os dados do negócio permanecem
+            disponíveis para você.
+          </li>
+          <li>
+            <strong>Após o encerramento da conta</strong>, os dados são excluídos em até 30 dias,
+            salvo o que precisarmos reter por obrigação legal — registros fiscais e o registro de
+            acessos exigido pelo art. 15 do Marco Civil da Internet, mantido por 6 meses.
+          </li>
+          <li>
+            <strong>Backups</strong> têm ciclo próprio: até 7 dias no servidor e até 30 dias na
+            cópia externa. Um dado excluído desaparece das cópias ao fim desse ciclo.
+          </li>
+        </Lista>
+      </Secao>
+
+      <Secao id="direitos" titulo="10. Seus direitos">
+        <p>Pelo art. 18 da LGPD, você pode a qualquer momento pedir:</p>
+        <Lista>
+          <li>confirmação de que tratamos seus dados, e acesso a eles;</li>
+          <li>correção de dados incompletos, inexatos ou desatualizados;</li>
+          <li>anonimização, bloqueio ou eliminação de dados desnecessários ou excessivos;</li>
+          <li>portabilidade dos dados a outro fornecedor;</li>
+          <li>eliminação dos dados tratados com base no seu consentimento;</li>
+          <li>informação sobre com quem compartilhamos seus dados;</li>
+          <li>revogação do consentimento.</li>
+        </Lista>
+        <p>
+          Basta escrever para{" "}
+          <a className="text-primary-600 hover:underline" href={`mailto:${CONTROLADOR.email}`}>
+            {CONTROLADOR.email}
+          </a>
+          . Respondemos em até 15 dias. Podemos pedir uma confirmação de identidade antes de
+          atender — é uma proteção contra alguém se passar por você.
+        </p>
+        <p>
+          Se o seu pedido se referir a dados que uma empresa assinante inseriu no{" "}
+          {CONTROLADOR.produto} sobre você (por exemplo, você é cliente de quem usa o sistema),
+          encaminharemos o pedido a essa empresa, que é a controladora daqueles dados.
+        </p>
+      </Secao>
+
+      <Secao id="cookies" titulo="11. Cookies e armazenamento no navegador">
+        <p>
+          Usamos armazenamento local do navegador apenas para o essencial: manter você autenticado
+          entre telas e guardar preferências de exibição. Não há cookies de publicidade, de análise
+          comportamental ou de terceiros. Limpar os dados do site desconecta a sua sessão e não
+          apaga nada do seu negócio.
+        </p>
+      </Secao>
+
+      <Secao id="menores" titulo="12. Crianças e adolescentes">
+        <p>
+          O {CONTROLADOR.produto} é uma ferramenta profissional e não se destina a menores de 18
+          anos. Não coletamos conscientemente dados de crianças ou adolescentes como titulares de
+          conta. Se identificarmos um cadastro nessa condição, ele será removido.
+        </p>
+      </Secao>
+
+      <Secao id="mudancas" titulo="13. Mudanças nesta política">
+        <p>
+          Podemos atualizar este documento para refletir mudanças no sistema ou na legislação. A
+          data de última atualização, no topo da página, indica a versão vigente. Se a mudança
+          alterar de forma relevante como tratamos seus dados, avisaremos por e-mail ou dentro do
+          sistema antes de ela passar a valer.
+        </p>
+      </Secao>
+
+      <Secao id="foro" titulo="14. Lei aplicável">
+        <p>
+          Esta política é regida pela lei brasileira. Fica eleito o foro da comarca do domicílio do
+          titular para dirimir as controvérsias dela decorrentes.
+        </p>
+      </Secao>
+    </LegalLayout>
+  );
+}

--- a/apps/web/src/features/legal/TermosPage.tsx
+++ b/apps/web/src/features/legal/TermosPage.tsx
@@ -1,0 +1,239 @@
+import { Link } from "react-router-dom";
+import LegalLayout, { Lista, Secao } from "./LegalLayout";
+import { CONTROLADOR } from "./controlador";
+
+/**
+ * Termos de Serviço — página PÚBLICA em `/termos`.
+ *
+ * O Google não exige este documento para publicar o app OAuth (só a Política de Privacidade é
+ * obrigatória lá). Ele existe pelo motivo próprio: o e1p gera peças jurídicas, projeções
+ * financeiras e mensagens em nome do assinante, e é preciso estar escrito de quem é cada
+ * responsabilidade — especialmente a de que a IA não substitui profissional habilitado.
+ */
+export default function TermosPage() {
+  return (
+    <LegalLayout
+      titulo="Termos de Serviço"
+      subtitulo={`Condições de uso do ${CONTROLADOR.produto}.`}
+      outroDocumento={{ to: "/privacidade", label: "Política de Privacidade" }}
+    >
+      <Secao id="objeto" titulo="1. Objeto e aceitação">
+        <p>
+          Estes termos regem o uso do {CONTROLADOR.produto}, sistema de gestão para negócios
+          conduzidos por uma pessoa, fornecido por <strong>{CONTROLADOR.razaoSocial}</strong>, CNPJ
+          nº {CONTROLADOR.cnpj} ("nós"). Ao criar uma conta ou usar o sistema, você ("assinante")
+          concorda com estas condições e com a{" "}
+          <Link className="text-primary-600 hover:underline" to="/privacidade">
+            Política de Privacidade
+          </Link>
+          , que é parte integrante deste documento.
+        </p>
+        <p>Se você não concorda com algum ponto, não use o sistema.</p>
+      </Secao>
+
+      <Secao id="conta" titulo="2. Conta de acesso">
+        <Lista>
+          <li>
+            O acesso é nominal e destinado a maiores de 18 anos, com capacidade civil, agindo em
+            nome próprio ou de pessoa jurídica que representem.
+          </li>
+          <li>
+            Você é responsável pela guarda da sua senha e por tudo que for feito com as suas
+            credenciais. Suspeitando de acesso indevido, troque a senha e avise-nos.
+          </li>
+          <li>
+            Ao cadastrar sub-usuários, você responde pelas ações deles no sistema e pelos módulos
+            que lhes libera.
+          </li>
+          <li>Os dados de cadastro devem ser verdadeiros e mantidos atualizados.</li>
+        </Lista>
+      </Secao>
+
+      <Secao id="licenca" titulo="3. Licença de uso">
+        <p>
+          Enquanto a assinatura estiver ativa e adimplente, concedemos a você uma licença pessoal,
+          intransferível, não exclusiva e revogável para usar o {CONTROLADOR.produto} conforme estes
+          termos. A licença não transfere propriedade sobre o software.
+        </p>
+      </Secao>
+
+      <Secao id="seus-dados" titulo="4. Os dados que você insere continuam seus">
+        <p>
+          O conteúdo que você cadastra no sistema — clientes, contratos, documentos, lançamentos,
+          mensagens, arquivos — é seu. Não reivindicamos propriedade sobre ele e não o usamos para
+          finalidade alheia à prestação do serviço. Nós o tratamos como operadores, sob as suas
+          instruções, conforme a seção 2 da Política de Privacidade.
+        </p>
+        <p>
+          Em contrapartida, <strong>você é o controlador desses dados</strong> perante a LGPD. Cabe
+          a você ter base legal para coletar e tratar os dados dos seus clientes, atender aos
+          pedidos que eles fizerem e informá-los sobre o tratamento. Nós ajudamos com as
+          ferramentas; a responsabilidade legal é sua.
+        </p>
+      </Secao>
+
+      <Secao id="uso-aceitavel" titulo="5. Uso aceitável">
+        <p>Ao usar o {CONTROLADOR.produto}, você se compromete a não:</p>
+        <Lista>
+          <li>
+            enviar mensagens não solicitadas em massa, spam ou qualquer comunicação que viole as
+            políticas do WhatsApp, da Meta ou a legislação aplicável;
+          </li>
+          <li>
+            tratar dados de terceiros sem base legal, nem inserir no sistema dados sensíveis para
+            os quais você não tenha respaldo;
+          </li>
+          <li>
+            usar o sistema para atividade ilícita, fraudulenta, difamatória ou que viole direitos de
+            terceiros;
+          </li>
+          <li>
+            tentar burlar limites técnicos, acessar dados de outros assinantes, aplicar engenharia
+            reversa, revender ou sublicenciar o acesso;
+          </li>
+          <li>
+            sobrecarregar deliberadamente a infraestrutura, por automação abusiva ou de outro modo.
+          </li>
+        </Lista>
+        <p>
+          A violação destes itens autoriza a suspensão imediata da conta, com aviso sempre que for
+          possível dar aviso.
+        </p>
+      </Secao>
+
+      <Secao id="ia" titulo="6. Conteúdo gerado por inteligência artificial">
+        <p>
+          O {CONTROLADOR.produto} usa IA para redigir textos, sugerir análises, produzir minutas de
+          documentos e responder perguntas sobre o seu negócio. Esse conteúdo é gerado
+          automaticamente e <strong>pode conter erros, omissões ou imprecisões</strong>.
+        </p>
+        <p>
+          Nada do que a IA produz constitui aconselhamento jurídico, contábil, tributário, financeiro
+          ou de investimentos. Minutas de contratos, peças jurídicas, projeções de caixa e
+          diagnósticos são <strong>ponto de partida</strong>, não parecer profissional. Antes de
+          assinar, enviar ou decidir com base nesse material, revise-o e, quando o caso exigir,
+          consulte um profissional habilitado.
+        </p>
+        <p>
+          A revisão do conteúdo antes do uso é responsabilidade sua, e não respondemos por decisões
+          tomadas com base em saídas de IA não revisadas.
+        </p>
+      </Secao>
+
+      <Secao id="integracoes" titulo="7. Integrações com terceiros">
+        <p>
+          O sistema pode se conectar a serviços de terceiros — Google Agenda e Google Meet, WhatsApp,
+          gateway de pagamento, entre outros. Essas conexões são opcionais e você as ativa. Ao
+          ativá-las, você fica também sujeito aos termos do serviço correspondente, e a
+          disponibilidade e o comportamento deles não estão sob o nosso controle.
+        </p>
+        <p>
+          Você pode revogar qualquer integração a qualquer momento; a funcionalidade que dependia
+          dela deixa de operar, sem prejuízo do restante do sistema.
+        </p>
+      </Secao>
+
+      <Secao id="disponibilidade" titulo="8. Disponibilidade, manutenção e backups">
+        <Lista>
+          <li>
+            Trabalhamos para manter o serviço disponível de forma contínua, mas ele é fornecido
+            "como está", sem garantia de operação ininterrupta ou livre de falhas.
+          </li>
+          <li>
+            Podemos realizar manutenções programadas, avisando com antecedência razoável quando
+            houver indisponibilidade prevista, e manutenções emergenciais sem aviso prévio.
+          </li>
+          <li>
+            Mantemos backups automáticos com cópia externa, conforme a seção 9 da Política de
+            Privacidade. Backup é medida de continuidade do serviço, não substituto de exportação
+            própria: você pode exportar seus dados a qualquer momento e é prudente fazê-lo.
+          </li>
+          <li>
+            Podemos alterar, adicionar ou descontinuar funcionalidades. Se uma mudança reduzir de
+            forma relevante o que você contratou, avisaremos com antecedência.
+          </li>
+        </Lista>
+      </Secao>
+
+      <Secao id="pagamento" titulo="9. Assinatura, pagamento e cancelamento">
+        <Lista>
+          <li>
+            Os valores, a periodicidade e a forma de pagamento são os informados no ato da
+            contratação. Reajustes serão comunicados com pelo menos 30 dias de antecedência e valem
+            para o ciclo seguinte.
+          </li>
+          <li>
+            O atraso no pagamento pode levar à suspensão do acesso após aviso. Persistindo a
+            inadimplência, a conta pode ser encerrada nos termos da seção 12.
+          </li>
+          <li>
+            Você pode cancelar a assinatura quando quiser. O cancelamento vale para o fim do ciclo
+            já pago, sem devolução proporcional, salvo o caso do item seguinte.
+          </li>
+          <li>
+            Sendo você consumidor, tem direito de arrependimento em até 7 dias da contratação, com
+            devolução integral, na forma do art. 49 do Código de Defesa do Consumidor.
+          </li>
+        </Lista>
+      </Secao>
+
+      <Secao id="propriedade" titulo="10. Propriedade intelectual">
+        <p>
+          O software, a marca, a interface, a documentação e os demais elementos do
+          {" "}{CONTROLADOR.produto} pertencem a {CONTROLADOR.razaoSocial}. Estes termos não
+          transferem nenhum desses direitos. Sugestões e comentários que você nos enviar podem ser
+          usados para melhorar o produto, sem que isso gere obrigação de contrapartida.
+        </p>
+      </Secao>
+
+      <Secao id="responsabilidade" titulo="11. Limitação de responsabilidade">
+        <p>
+          Na máxima extensão permitida pela lei, não respondemos por lucros cessantes, perda de
+          oportunidade de negócio, danos indiretos ou por consequências de decisões que você tomar
+          com base em informações do sistema, inclusive as geradas por IA.
+        </p>
+        <p>
+          Nossa responsabilidade total, em qualquer hipótese, fica limitada ao valor que você pagou
+          pela assinatura nos 12 meses anteriores ao evento que originou a reclamação.
+        </p>
+        <p>
+          Esta limitação não afasta as garantias que a legislação consumerista brasileira torna
+          inafastáveis nem responsabilidade por dolo.
+        </p>
+      </Secao>
+
+      <Secao id="encerramento" titulo="12. Encerramento da conta">
+        <p>
+          Você pode encerrar a conta a qualquer momento. Nós podemos encerrá-la em caso de violação
+          destes termos, inadimplência persistente ou exigência legal, sempre com aviso prévio
+          quando o aviso for possível.
+        </p>
+        <p>
+          Após o encerramento, você tem <strong>30 dias</strong> para exportar seus dados. Passado
+          esse prazo, eles são excluídos conforme a seção 9 da Política de Privacidade.
+        </p>
+      </Secao>
+
+      <Secao id="mudancas" titulo="13. Mudanças nestes termos">
+        <p>
+          Podemos atualizar estes termos. A data no topo da página indica a versão vigente. Mudanças
+          relevantes serão comunicadas por e-mail ou dentro do sistema com pelo menos 30 dias de
+          antecedência; continuar usando o serviço depois desse prazo significa aceitá-las.
+        </p>
+      </Secao>
+
+      <Secao id="foro" titulo="14. Lei aplicável e foro">
+        <p>
+          Estes termos são regidos pela lei brasileira. Antes de qualquer medida judicial, procure-nos
+          em{" "}
+          <a className="text-primary-600 hover:underline" href={`mailto:${CONTROLADOR.email}`}>
+            {CONTROLADOR.email}
+          </a>
+          : quase tudo se resolve por conversa. Não havendo acordo, fica eleito o foro da comarca do
+          domicílio do assinante consumidor; nos demais casos, o da sede de{" "}
+          {CONTROLADOR.razaoSocial}.
+        </p>
+      </Secao>
+    </LegalLayout>
+  );
+}

--- a/apps/web/src/features/legal/controlador.ts
+++ b/apps/web/src/features/legal/controlador.ts
@@ -1,0 +1,19 @@
+/**
+ * Identificação de quem opera o e1p, em UM lugar só.
+ *
+ * Os dois documentos legais (`PrivacidadePage`, `TermosPage`) precisam repetir razão social,
+ * CNPJ e contato. Duplicar isso em dois arquivos é como um documento fica desatualizado sem
+ * ninguém perceber — e, num documento legal, divergir de si mesmo é pior do que estar velho.
+ */
+export const CONTROLADOR = {
+  razaoSocial: "FLAVIO KATO LTDA",
+  cnpj: "65.623.582/0001-08",
+  email: "flaviokato76@gmail.com",
+  produto: "e1p",
+} as const;
+
+/**
+ * Data da última revisão dos documentos legais. Atualize AO MUDAR o texto de qualquer um dos
+ * dois — a data é o que permite a uma pessoa saber se leu a versão vigente.
+ */
+export const VIGENCIA = "2 de setembro de 2026";


### PR DESCRIPTION
## Por quê

O app OAuth do Google está preso em **"Testando"** porque a aba Branding da tela de consentimento exige a URL de uma Política de Privacidade e o campo está vazio. Nesse modo o refresh token de cada pessoa expira a cada **7 dias**: a sincronização de agenda morre sozinha toda semana com cara de bug do produto. Não havia página nenhuma para apontar — `App.tsx` não tinha rota.

## O que muda

- **`/privacidade` e `/termos`** — rotas **públicas**, fora do `ProtectedLayout`. Quem precisa lê-las (o revisor do Google, alguém avaliando virar assinante) não tem sessão.
- **Links no rodapé da tela de login**, fora do cartão, visíveis nos três modos (entrar / recuperar / redefinir).
- **`controlador.ts`** — razão social, CNPJ e contato num lugar só. Dois documentos legais que divergem entre si é pior do que um documento velho.

## O texto descreve o sistema real, não um modelo genérico

| Ponto | O que está escrito |
|---|---|
| Papéis LGPD | Somos **controladores** dos dados de conta e **operadores** dos dados que o assinante insere sobre os clientes dele |
| IA | A anonimização de CPF/CNPJ/e-mail/telefone/cartão antes de qualquer chamada, e o desmascaramento local na volta |
| Google | Os dois escopos que o app realmente pede (`calendar.events`, `userinfo.email`) e nada além |
| Subprocessadores | AWS, Anthropic, Google, Meta, Asaas, e-mail transacional — com país |
| Retenção | 30 dias após encerramento + o ciclo próprio dos backups (7 dias local / 30 offsite), que é o que faz um dado excluído demorar a sumir de verdade |
| Segurança | HTTPS, hash de senha, RLS por assinante, logout em 30 min, trilha de auditoria |

Nos Termos, a cláusula que mais importa para este produto: **conteúdo de IA não é aconselhamento jurídico, contábil ou financeiro** — o módulo jurídico gera minutas, e é preciso estar escrito de quem é a revisão.

## Cláusula de Uso Limitado do Google

Está literal e **coberta por teste**. A Google API Services User Data Policy exige a frase para apps que usam escopos de usuário, e a revisão procura por ela. Apagá-la ao "melhorar a redação" reprovaria a publicação sem quebrar nada visível — por isso a asserção é pelo texto inteiro, e não por um `toContain("Uso Limitado")` que passaria com a frase mutilada.

## Verificação

- `pnpm lint` e `pnpm typecheck` limpos
- **1246 testes verdes** (96 arquivos), incluindo 9 novos em `PaginasLegais.test.tsx`
- `pnpm build` ok
- **Sem rolagem horizontal a 360px** — `scrollWidth == clientWidth` em `/privacidade`, `/termos` e `/login`, medido com Playwright a 360×740 e 1280×900

`LoginPage` passou a usar `<Link>`, então seus testes agora montam o componente dentro de um `MemoryRouter` — o componente real, e não uma versão sem links só para o teste não precisar de rota.

## Depois do merge

1. Deploy.
2. Colar `https://e1p.criativaeduca.com.br/privacidade` na aba Branding do Google Cloud Console (e, opcionalmente, `/termos`, que ali é opcional).
3. Publicar o app → acaba a expiração de 7 dias do refresh token.

> ⚠️ Os documentos foram redigidos a partir do que o sistema comprovadamente faz, mas **não substituem revisão por advogado** antes de valerem como contrato de adesão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
