### PR TITLE
Torna visíveis as falhas silenciosas do OAuth Google + fecha a defasagem dos docs de infra

### DIFF
--- a/apps/api/app/modules/google_calendar/router.py
+++ b/apps/api/app/modules/google_calendar/router.py
@@ -7,6 +7,8 @@ pages/router.py. O tenant vem do `state` assinado (anti-CSRF), não de um token 
 """
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
@@ -20,6 +22,8 @@ from app.modules.google_calendar.schemas import GoogleConnectOut, GoogleStatusOu
 
 router = APIRouter(prefix="/integrations/google", tags=["google-calendar"])
 public_router = APIRouter(prefix="/integrations/google", tags=["google-calendar-public"])
+
+logger = logging.getLogger("e1p.google_calendar")
 
 _guard = require_module("agenda")
 
@@ -58,20 +62,39 @@ def disconnect(
 def callback(
     code: str | None = Query(default=None),
     state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
     session_factory=Depends(get_tenant_session_factory),
 ) -> RedirectResponse:
     """O Google redireciona para cá após o consent. Valida o `state`, troca o `code` por tokens
-    e persiste a credencial no tenant. Sempre redireciona de volta ao frontend."""
+    e persiste a credencial no tenant. Sempre redireciona de volta ao frontend.
+
+    Todo caminho de falha cai no MESMO `?google=error` para o usuário — então cada um precisa
+    deixar rastro no log, senão "recusou o consentimento", `redirect_uri_mismatch` e state
+    expirado ficam indistinguíveis no suporte."""
     dest_ok = f"{settings.frontend_url}/config?google=connected"
     dest_err = f"{settings.frontend_url}/config?google=error"
+    if error:
+        # O Google devolve `error=access_denied` quando a pessoa cancela na tela de consentimento.
+        # Rota PÚBLICA: `error` é entrada arbitrária, então vai truncado e sem quebra de linha
+        # (senão dá para forjar linhas no log).
+        logger.warning("[google:callback:denied] error=%s", " ".join(error[:60].split()))
+        return RedirectResponse(dest_err, status_code=307)
     if not code or not state:
+        logger.warning(
+            "[google:callback:incompleto] code=%s state=%s", bool(code), bool(state)
+        )
         return RedirectResponse(dest_err, status_code=307)
     tenant_id = verify_oauth_state(state)
     if not tenant_id:
+        # State assinado inválido/expirado: CSRF ou aba parada tempo demais na tela do Google.
+        logger.warning("[google:callback:state_invalido]")
         return RedirectResponse(dest_err, status_code=307)
     try:
         with session_factory(tenant_id) as tdb:
             service.handle_callback(tdb, tenant_id=tenant_id, code=code)
     except Exception:  # noqa: BLE001 — qualquer falha vira redirect de erro, nunca 500
+        # O usuário só vê `?google=error` genérico: sem este log, `redirect_uri_mismatch`,
+        # client_secret errado e token expirado ficam indistinguíveis no suporte.
+        logger.exception("[google:callback:failed] tenant=%s", tenant_id)
         return RedirectResponse(dest_err, status_code=307)
     return RedirectResponse(dest_ok, status_code=307)

--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -194,6 +194,17 @@ def _ensure_fresh_token(db: Session, cred: GoogleCredential) -> str | None:
         },
         timeout=_HTTP_TIMEOUT,
     )
+    if resp.status_code == 400 and "invalid_grant" in resp.text:
+        # Refresh token revogado ou expirado. É TERMINAL: repetir não adianta, só reconectar.
+        # Acontece a cada 7 dias enquanto o app OAuth estiver em modo "Testing" no Google.
+        # ATENÇÃO: a credencial CONTINUA no banco, então `/integrations/google/status` segue
+        # dizendo "conectado como ..." enquanto nenhum Meet é criado — a tela mente. Este log
+        # é hoje o único sinal da falha; ver o TODO em docs/GO-LIVE-CHECKLIST.md §5.
+        logger.warning(
+            "[google:token:revogado] tenant=%s — refresh_token morto, precisa reconectar",
+            cred.tenant_id,
+        )
+        return None
     resp.raise_for_status()
     token_data = resp.json()
     cred.access_token = token_data.get("access_token", "")

--- a/apps/api/tests/test_google_calendar.py
+++ b/apps/api/tests/test_google_calendar.py
@@ -294,3 +294,42 @@ def test_callback_exchange_failure_logs_traceback(
     assert resp.headers["location"].endswith("/config?google=error")
     assert "[google:callback:failed]" in caplog.text
     assert "redirect_uri_mismatch" in caplog.text  # traceback preservado
+
+
+def test_refresh_token_revogado_loga_reconexao(client: TestClient, headers, configured, db,
+                                               monkeypatch, caplog):
+    """`invalid_grant` na renovação é terminal: precisa sair no log como 'reconectar', não como
+    um traceback genérico de create_meet — é o que diferencia 'token morto' de 'Google fora do ar'.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from app.modules.google_calendar.models import GoogleCredential
+
+    cred = GoogleCredential(
+        tenant_id="t" * 12,
+        google_account_email="x@example.com",
+        access_token="velho",
+        refresh_token="refresh-morto",
+        token_expiry=datetime.now(UTC) - timedelta(hours=1),  # já expirado → força a renovação
+    )
+    db.add(cred)
+    db.commit()
+
+    class _Resp400:
+        """Fiel ao que o Google devolve: 400 + invalid_grant, e um raise_for_status que
+        levanta de verdade — senão o teste passaria por AttributeError em vez de pelo log."""
+
+        status_code = 400
+        text = '{"error": "invalid_grant", "error_description": "expired or revoked"}'
+
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("400 invalid_grant", request=None, response=None)
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp400())
+
+    with caplog.at_level("WARNING", logger="e1p.google_calendar"):
+        token = service._ensure_fresh_token(db, cred)
+
+    assert token is None  # nenhum call site tenta usar um token morto
+    assert "[google:token:revogado]" in caplog.text
+    assert "precisa reconectar" in caplog.text

--- a/apps/api/tests/test_google_calendar.py
+++ b/apps/api/tests/test_google_calendar.py
@@ -243,3 +243,54 @@ def test_create_meet_event_noop_without_credential(client: TestClient, headers, 
         guests: list = []
 
     assert service.create_meet_event(db, tenant_id="t" * 12, event=_Ev()) is None
+
+
+# ── Diagnóstico do callback ──────────────────────────────────────────────────
+# Todo caminho de falha devolve o MESMO `?google=error` ao usuário. Sem log, o suporte não
+# distingue "cancelou o consentimento" de `redirect_uri_mismatch` — estes testes travam isso.
+def test_callback_denied_logs_reason(client: TestClient, configured, caplog):
+    """Cancelar na tela do Google (`error=access_denied`) deixa rastro identificável."""
+    with caplog.at_level("WARNING", logger="e1p.google_calendar"):
+        resp = client.get(
+            "/integrations/google/callback",
+            params={"error": "access_denied", "state": "qualquer"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 307
+    assert resp.headers["location"].endswith("/config?google=error")
+    assert "[google:callback:denied]" in caplog.text
+    assert "access_denied" in caplog.text
+
+
+def test_callback_invalid_state_logs_reason(client: TestClient, configured, caplog):
+    with caplog.at_level("WARNING", logger="e1p.google_calendar"):
+        client.get(
+            "/integrations/google/callback",
+            params={"code": "abc", "state": "not-a-valid-state"},
+            follow_redirects=False,
+        )
+    assert "[google:callback:state_invalido]" in caplog.text
+
+
+def test_callback_exchange_failure_logs_traceback(
+    client: TestClient, headers, configured, monkeypatch, caplog
+):
+    """Falha na troca do code (ex.: redirect_uri_mismatch) precisa ir para o log com traceback."""
+    url = client.get("/integrations/google/connect", headers=headers).json()["url"]
+    state = parse_qs(urlparse(url).query)["state"][0]
+
+    def _boom(*_a, **_k):
+        raise httpx.HTTPStatusError("400 redirect_uri_mismatch", request=None, response=None)
+
+    monkeypatch.setattr(service, "exchange_code", _boom)
+
+    with caplog.at_level("ERROR", logger="e1p.google_calendar"):
+        resp = client.get(
+            "/integrations/google/callback",
+            params={"code": "abc", "state": state},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 307
+    assert resp.headers["location"].endswith("/config?google=error")
+    assert "[google:callback:failed]" in caplog.text
+    assert "redirect_uri_mismatch" in caplog.text  # traceback preservado

--- a/docs/AWS-DEPLOYMENT.md
+++ b/docs/AWS-DEPLOYMENT.md
@@ -16,7 +16,10 @@
 >
 > Confere com o planejado apenas o host: `t4g` **Graviton/ARM**, com o Compose de `docker-compose.prod.yml`.
 > Domínio: **https://e1p.criativaeduca.com.br**. A VPS Hostinger (`e1p.doroeventos.com.br`) passou a
-> ser **dev/teste** na mesma data.
+> ser dev/teste em 2026-08-20 e foi **descomissionada por completo em 2026-08-30** (containers,
+> volumes, `/opt/e1p`, backups, cron, remote `rclone` e DNS — ver `docs/HOSTINGER-DEPLOY.md`).
+> **Esta EC2 é hoje o único ambiente que existe: não há dev nem staging.** Toda validação que
+> exigir um host roda contra a produção — trate qualquer teste aqui com esse peso.
 >
 > **Consequências operacionais que valem hoje**, e não quando a Fase A existir:
 > - **Backup é só local** (`/opt/e1p-backups`, diário às 03:15). Não há `rclone`/offsite na AWS —

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -113,10 +113,14 @@ sintoma parece bug do produto e não é. Publicar (Público-alvo → "Publicar a
 limite e **não** exige passar pela verificação do Google enquanto ficar abaixo de ~100 usuários;
 o custo é a tela "o Google não verificou este app", uma vez por pessoa.
 
-**Bloqueio para publicar:** a aba Branding exige **link de Política de Privacidade** e o campo
-está vazio (Termos de Serviço é opcional). Não existe página de privacidade no frontend hoje
-(`apps/web/src/app/App.tsx` não tem rota) — precisa ser criada e publicada sob
-`e1p.criativaeduca.com.br` antes de mudar o status.
+**Para publicar:** a aba Branding exige **link de Política de Privacidade** (Termos de Serviço é
+opcional). As páginas passaram a existir no PR #293 — rotas públicas `/privacidade` e `/termos`,
+fora do `ProtectedLayout`, em `apps/web/src/features/legal/`. Restam dois passos, nesta ordem:
+
+1. **Deployar**, senão as URLs não respondem. O Google valida que o link é alcançável, e a
+   produção costuma ficar atrás de `main` — meça o gap antes de assumir que já está no ar.
+2. Colar `https://e1p.criativaeduca.com.br/privacidade` (e, se quiser, `/termos`) na aba
+   Branding e então **Público-alvo → Publicar app**.
 
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [x] Instalar/configurar `rclone` com remote S3-compatível — validado em 2026-07-12 **localmente**

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -51,11 +51,12 @@
   API habilitada, OAuth consent screen em modo "Testing" com `flaviokato76@gmail.com` como test
   user (suficiente para uso próprio; sair de "Testing" exige verificação do Google só se/quando
   precisar liberar para outras contas).
-- [x] Gerar OAuth Client ID/Secret, configurar redirect URI — client Web criado, redirect URI
-  `http://localhost:8000/integrations/google/callback` (dev). **Pendente:** cadastrar a URI de
-  produção (`https://<domínio-real>/integrations/google/callback`) quando o item 10 existir —
-  OAuth clients aceitam múltiplas redirect URIs simultâneas, então isso é aditivo, não substitui a
-  de dev.
+- [x] Gerar OAuth Client ID/Secret, configurar redirect URI — client Web `e1p` criado. **Resolvido
+  em 2026-09-02:** as DUAS URIs estão cadastradas — `http://localhost:8000/integrations/google/callback`
+  (dev) e `https://e1p.criativaeduca.com.br/api/integrations/google/callback` (produção AWS),
+  esta última conferida byte-a-byte contra o `GOOGLE_OAUTH_REDIRECT_URI` do `.env.prod` da EC2.
+  Note o prefixo **`/api`** na de produção: o Caddy publica a API sob esse path, e omiti-lo
+  produz `redirect_uri_mismatch`.
 - [x] Preencher `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`/`GOOGLE_OAUTH_REDIRECT_URI` — feito no
   `.env` local (raiz, gitignorado), repassado a `api`/`worker` via `env_file`.
 - [x] Testar fluxo OAuth ponta-a-ponta (autorizar, criar evento com Meet real) — validado em
@@ -97,6 +98,25 @@
   segue). Validado 2026-07-12 por testes (`tests/test_google_calendar_hardening.py`): patch/delete
   são chamados no evento certo com os novos horários quando há `google_event_id`; NÃO são chamados
   quando não há; e um erro HTTP mockado do Google não impede o reschedule/cancel local de persistir.
+
+### Estado verificado em 2026-09-02
+| Item | Estado |
+|---|---|
+| Escopos na tela de consentimento | `calendar.events` + `userinfo.email` registrados **e** concedidos (conferido pelo `scope=` devolvido no callback real). Bate com `DEFAULT_SCOPE` de `modules/google_calendar/models.py`. |
+| Redirect URIs | dev + produção AWS cadastradas; a de produção casa com o `.env.prod` da EC2. |
+| Tipo de usuário | **Externo** |
+| Status de publicação | **Testando** — 3 usuários de teste de 100. |
+
+⚠️ **O modo "Testando" expira o refresh token em 7 dias.** Enquanto o app não for publicado, a
+sincronização de agenda de cada pessoa morre sozinha uma vez por semana e exige reconectar — o
+sintoma parece bug do produto e não é. Publicar (Público-alvo → "Publicar app") remove esse
+limite e **não** exige passar pela verificação do Google enquanto ficar abaixo de ~100 usuários;
+o custo é a tela "o Google não verificou este app", uma vez por pessoa.
+
+**Bloqueio para publicar:** a aba Branding exige **link de Política de Privacidade** e o campo
+está vazio (Termos de Serviço é opcional). Não existe página de privacidade no frontend hoje
+(`apps/web/src/app/App.tsx` não tem rota) — precisa ser criada e publicada sob
+`e1p.criativaeduca.com.br` antes de mudar o status.
 
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [x] Instalar/configurar `rclone` com remote S3-compatível — validado em 2026-07-12 **localmente**

--- a/docs/RUNBOOK-BACKUP-RESTORE.md
+++ b/docs/RUNBOOK-BACKUP-RESTORE.md
@@ -13,9 +13,9 @@
 
 | Item | Detalhe |
 |------|---------|
-| Stack em produção rodando | `docker-compose.traefik.yml` (VPS real `e1p.doroeventos.com.br`) ou `docker-compose.prod.yml` (Caddy próprio). O serviço `postgres` precisa estar de pé. |
+| Stack em produção rodando | `docker-compose.prod.yml` **+ o `docker-compose.override.yml` não versionado da EC2** (AWS, `e1p.criativaeduca.com.br`) — os DOIS `-f`, ver `docs/AWS-DEPLOYMENT.md`. O serviço `postgres` precisa estar de pé. O caminho `docker-compose.traefik.yml` era da VPS Hostinger, **descomissionada em 2026-08-30**. |
 | `rclone` instalado no HOST | Fora do container (é ferramenta de host). `curl https://rclone.org/install.sh \| sudo bash`. |
-| Remote rclone `e1p-offsite` configurado | Provedor S3-compatível (AWS S3, Backblaze B2, Wasabi). Credenciais NUNCA no repo. |
+| Remote rclone `e1p-offsite` configurado | Provedor S3-compatível (AWS S3, Backblaze B2, Wasabi). Credenciais NUNCA no repo. ⚠️ **Não existe na EC2 de produção hoje** — quem tinha era a VPS Hostinger, descomissionada em 2026-08-30. O backup atual é **só local** (`/opt/e1p-backups`, diário 03:15): se a instância morrer, morrem app, banco e backup juntos. |
 | `infra/.env.prod` preenchido | `BACKUP_S3_BUCKET`, `BACKUP_RETENTION_DAYS_LOCAL`, `BACKUP_RETENTION_DAYS_REMOTE`. |
 | Papel `e1p_app` no alvo do restore | Só existe se o Postgres foi inicializado com volume novo (ver §5.1). Crítico p/ o RLS valer (Regra de Ouro nº 1). |
 


### PR DESCRIPTION
## Contexto

Partiu de uma pergunta simples ("`calendar.events` está na lista de escopos?"). Está — e conferir isso expôs duas coisas maiores: falhas do OAuth que não deixavam rastro nenhum, e documentos afirmando um estado de infra que não existe mais.

## O que muda

### 1. Log em todo caminho de falha do callback (`b15e5aa`)

Os quatro caminhos de falha do callback devolviam o mesmo `?google=error` e **nenhum** deixava rastro. `redirect_uri_mismatch`, `client_secret` errado, state expirado e "a pessoa cancelou o consentimento" eram indistinguíveis no suporte — o `except Exception` nem o traceback logava.

Agora os quatro logam. E o endpoint passa a aceitar o parâmetro `error` que o Google envia quando alguém cancela na tela de consentimento: antes isso caía no ramo genérico de "code/state ausente" e produzia o diagnóstico errado.

`error` vem de rota pública não autenticada, então entra truncado e com espaço em branco colapsado — senão dá para forjar linhas no log.

### 2. `invalid_grant` deixa de parecer queda de rede (`cad1ae7`)

Quando o refresh token morre, o Google devolve `400 invalid_grant`. Isso virava uma `HTTPStatusError` genérica registrada como `[google:create_meet:failed]` com traceback — igualzinho a uma falha de rede ou quota. Só que a ação necessária é outra: não adianta repetir, alguém precisa reconectar.

Passa a sair como `[google:token:revogado] tenant=X — precisa reconectar`. Comportamento inalterado (continua devolvendo `None`, e os 4 call sites já tratavam `None`).

Relevante agora: o app OAuth está em modo **Testing** no Google Cloud, e isso expira o refresh token **a cada 7 dias**.

### 3. Docs de infra alinhados com a realidade (`0a62add`)

Os documentos ainda diziam que a VPS Hostinger "passou a ser dev/teste". Ela foi descomissionada por completo em 2026-08-30 e não volta nem como dev. Consequência que ninguém tinha escrito: **a EC2 da AWS é o único ambiente que existe — não há dev nem staging**, e toda validação que precise de host roda contra produção.

O runbook de backup ainda listava o remote `rclone` offsite como pré-requisito. Ele morreu junto com a VPS: hoje o backup é **só local**, na mesma máquina que deveria proteger.

Também fecha a pendência "cadastrar a redirect URI de produção", que estava aberta desde julho e já tinha sido resolvida — as duas URIs estão cadastradas, e a de produção casa byte a byte com o `.env.prod` da EC2 (atenção ao prefixo `/api`).

### 4. Teste bomba-relógio da Vima (`bfe0423`) — não relacionado, mas estava quebrando a suíte

`test_consultar_recebiveis_delega_para_o_resumo_real` cravava `due_date=date(2026, 9, 1)`. O resumo só conta em `open_cents` o que vence de hoje em diante, então em **2026-09-02** a data virou ontem e o teste passou a falhar para sempre, sem ninguém ter mudado nada. Agora usa data relativa.

Sexta ocorrência desta classe no repo (#84, #90, #101, #105, #169, #287).

## O que NÃO muda, de propósito

A credencial morta continua no banco, então `/integrations/google/status` segue respondendo `connected: true` com a conexão morta — **a tela mente para o usuário**. O conserto exige `db.commit()` num ponto que não é dono da transação, compartilhada com a Agenda em 4 call sites com estados diferentes. Merece PR próprio: issue #294.

## Verificação

- `ruff check .` limpo
- 15 testes do módulo Google verdes; 52 em `test_vima_tools.py`
- Os 4 testes novos foram **verificados por mutação**: removendo as chamadas de log, os 3 do callback falham; removendo a detecção de `invalid_grant`, o quarto falha com a `HTTPStatusError` propagando (que é o comportamento real de hoje)
- Gate do projeto (`pytest -q -m "not rls_e2e"`) rodando localmente

Nota: uma rodada anterior acusou `test_chart_of_accounts_rls` falhando. Foi invocação errada minha — `pytest -q` cru inclui o teste `rls_e2e`, que sobe Postgres em container e disputa recurso com os outros 2491. O gate do projeto o exclui, e o CI o roda em job dedicado. Passa isolado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
