### PR TITLE
fix: fecha o furo da Regra de Ouro nº 2 e coloca um gate atrás dela

### DIFF
--- a/apps/api/app/core/anonymizer.py
+++ b/apps/api/app/core/anonymizer.py
@@ -26,6 +26,16 @@ _PATTERNS: list[tuple[str, str]] = [
 ]
 
 
+# Instrução de sistema que faz o `unmask` funcionar. Sem ela o modelo reescreve `[CPF_1]` como
+# "o CPF informado" e o valor real não tem mais onde voltar — o dado não vaza, mas a resposta
+# chega mutilada ao dono e ninguém entende por quê. Vive aqui, ao lado dos marcadores que
+# descreve, para não virar cinco redações diferentes espalhadas pelos chamadores.
+INSTRUCAO_PRESERVAR_MARCADORES = (
+    " Os trechos entre colchetes (ex.: [CPF_1], [EMAIL_1], [FONE_1]) são dados ocultados por "
+    "privacidade: repita-os EXATAMENTE como aparecem, sem traduzir, descrever ou inventar outros."
+)
+
+
 class Anonymizer:
     """Mascara/desmascara PII. Stateless entre chamadas: o mapping é retornado, não guardado."""
 

--- a/apps/api/app/modules/funnels/service.py
+++ b/apps/api/app/modules/funnels/service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core import ai, audit
+from app.core.anonymizer import INSTRUCAO_PRESERVAR_MARCADORES, anonymizer
 from app.modules.funnels.models import Funnel
 from app.modules.funnels.schemas import FunnelCreate, FunnelUpdate
 from app.modules.settings.service import hoje_do_tenant
@@ -263,20 +264,27 @@ def ai_compose(db: Session, *, tenant_id: str, kind: str, prompt: str) -> dict:
 
     `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
     não lê nem escreve nada de negócio.
+
+    Regra de Ouro nº 2: o `prompt` é texto livre do dono e pode trazer o contato de quem vai
+    receber a mensagem. Mascaramos os identificadores estruturais (CPF/CNPJ, e-mail, telefone,
+    cartão) antes de sair e reinserimos no texto final, já aqui dentro. Nomes ficam de fora do
+    mascaramento por decisão: o prompt existe para ser reescrito, e um marcador no lugar do nome
+    produziria uma mensagem de funil inútil.
     """
-    system = _COMPOSE_SYSTEM.get(kind, _COMPOSE_SYSTEM["generic"])
+    system = _COMPOSE_SYSTEM.get(kind, _COMPOSE_SYSTEM["generic"]) + INSTRUCAO_PRESERVAR_MARCADORES
     if not settings.anthropic_api_key:
         return _compose_fallback(kind, prompt)
+    seguro, mapa = anonymizer.mask(prompt)
     try:
         text = ai.complete(
             db=db, tenant_id=tenant_id, task="funnels.compose",
-            system=system, user_message=prompt, max_tokens=800,
+            system=system, user_message=seguro, max_tokens=800,
         ).text
         cleaned = re.sub(r"^```(?:json)?|```$", "", text.strip(), flags=re.MULTILINE).strip()
         data = json.loads(cleaned)
         return {
-            "subject": str(data.get("subject", ""))[:200],
-            "body": str(data.get("body", ""))[:4000],
+            "subject": anonymizer.unmask(str(data.get("subject", "")), mapa)[:200],
+            "body": anonymizer.unmask(str(data.get("body", "")), mapa)[:4000],
         }
     except Exception:
         return _compose_fallback(kind, prompt)

--- a/apps/api/app/modules/marketing/service.py
+++ b/apps/api/app/modules/marketing/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core import ai, audit
+from app.core.anonymizer import INSTRUCAO_PRESERVAR_MARCADORES, anonymizer
 from app.modules.marketing.models import Carousel
 from app.modules.marketing.schemas import CarouselCreate, CarouselUpdate
 
@@ -110,16 +111,24 @@ def generate_content(db: Session, *, tenant_id: str, topic: str, n: int, tone: s
 
     `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
     não lê nem escreve nada de negócio.
+
+    Regra de Ouro nº 2: o `topic` é texto livre, e "carrossel sobre o caso do cliente
+    fulano@email.com" é um tema plausível. Mascaramos os identificadores estruturais do texto
+    JÁ MONTADO — mascarar o `topic` isolado deixaria escapar o que o `tone` trouxesse — e
+    desfazemos a máscara ANTES de `_parse`, porque as truncagens de lá (`[:200]`, `[:600]`)
+    cortariam um marcador ao meio e o valor real não teria mais onde voltar.
     """
     if not settings.anthropic_api_key:
         return _fallback(topic, n)
     user = f"Tema: {topic}\nNúmero de slides: {n}\nTom: {tone}"
+    seguro, mapa = anonymizer.mask(user)
     try:
         text = ai.complete(
             db=db, tenant_id=tenant_id, task="marketing.carrossel",
-            system=_EDITORIAL_SYSTEM, user_message=user, max_tokens=2000,
+            system=_EDITORIAL_SYSTEM + INSTRUCAO_PRESERVAR_MARCADORES,
+            user_message=seguro, max_tokens=2000,
         ).text
-        return _parse(text, topic, n)
+        return _parse(anonymizer.unmask(text, mapa), topic, n)
     except Exception:
         return _fallback(topic, n)
 

--- a/apps/api/app/modules/quotes/service.py
+++ b/apps/api/app/modules/quotes/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core import ai, audit, facts
+from app.core.anonymizer import INSTRUCAO_PRESERVAR_MARCADORES, anonymizer
 from app.core.facts import (
     COM_ORCAMENTO_ACEITO,
     COM_ORCAMENTO_ENVIADO,
@@ -338,20 +339,29 @@ def generate_scope(db: Session, *, tenant_id: str, brief: str) -> str:
 
     `db`/`tenant_id` existem só para a contabilidade de IA (`core/ai_usage`) — esta função
     não lê nem escreve nada de negócio.
+
+    O `brief` é texto livre do dono e costuma trazer o contato de quem pediu o orçamento. Nomes
+    NÃO são mascarados aqui de propósito: o briefing existe para ser reescrito, e trocar o nome
+    do cliente por um marcador destruiria a função. O que sai são os identificadores estruturais
+    (CPF/CNPJ, e-mail, telefone, cartão), que não acrescentam nada à redação.
     """
     if not settings.anthropic_api_key:
         return brief.strip()
     system = (
         "Você é um redator comercial brasileiro. A partir do briefing, escreva UMA descrição "
         "de escopo profissional e enxuta (1-2 frases) para um orçamento. Responda só com o texto."
+        + INSTRUCAO_PRESERVAR_MARCADORES
     )
+    # Regra de Ouro nº 2: mascara ANTES de sair; desmascara a resposta localmente.
+    seguro, mapa = anonymizer.mask(brief)
     try:
-        return ai.complete(
+        texto = ai.complete(
             db=db, tenant_id=tenant_id, task="quotes.escopo",
-            system=system, user_message=brief, max_tokens=300,
-        ).text.strip()
+            system=system, user_message=seguro, max_tokens=300,
+        ).text
     except Exception:
         return brief.strip()
+    return anonymizer.unmask(texto, mapa).strip()
 
 
 # ── Link público (cliente abre sem login; lê da tabela GLOBAL) ──────────────

--- a/apps/api/app/modules/receivables/service.py
+++ b/apps/api/app/modules/receivables/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core import ai, audit, facts, payment_gateway
+from app.core.anonymizer import INSTRUCAO_PRESERVAR_MARCADORES, anonymizer
 from app.core.facts import (
     FIN_COBRANCA_PROTESTADA,
     FIN_PAGAMENTO_RECEBIDO,
@@ -1220,7 +1221,10 @@ def _compose_dunning(
 ) -> str:
     """Mensagem de cobrança amigável. Usa a IA (Claude) se houver chave; senão, template.
 
-    PII: enviamos o placeholder [NOME] ao Claude e reinserimos o nome real localmente.
+    PII: o nome vira `[NOME]` na montagem e volta no fim. A **descrição** não tinha esse
+    tratamento e é campo livre — "consulta de fulano, CPF 123.456.789-00" é uma descrição de
+    cobrança inteiramente plausível, e ela ia crua. Por isso o texto montado passa pelo
+    `anonymizer` antes de sair: `[NOME]` é convenção deste chamador, o `mask` é a garantia.
     """
     valor = _money(amount_cents)
     venc = due.strftime("%d/%m/%Y")
@@ -1235,14 +1239,16 @@ def _compose_dunning(
         "Escreva UMA mensagem curta de WhatsApp (2-3 frases) cobrando um pagamento em atraso, "
         "em tom cordial e respeitoso, em português do Brasil. Nunca ameace. Use o placeholder "
         "[NOME] onde aparecer o nome do cliente. Responda só com a mensagem."
+        + INSTRUCAO_PRESERVAR_MARCADORES
     )
     user = f"Valor: {valor}\nVencimento: {venc}\nDescrição: {desc}\nNome do cliente: [NOME]"
+    seguro, mapa = anonymizer.mask(user)
     try:
         result = ai.complete(
             db=db, tenant_id=tenant_id, task="receivables.cobranca",
-            system=system, user_message=user, max_tokens=300,
+            system=system, user_message=seguro, max_tokens=300,
         )
-        return result.text.strip().replace("[NOME]", name)
+        return anonymizer.unmask(result.text, mapa).strip().replace("[NOME]", name)
     except Exception:
         return (
             f"Olá {name}, tudo bem? Notamos que {desc} no valor de {valor} venceu em {venc}. "
@@ -1271,14 +1277,16 @@ def _compose_dunning_phrase(
         "aparece em outras partes da mensagem) explicando o motivo da cobrança em tom cordial e "
         "respeitoso, em português do Brasil. Nunca ameace. Use o placeholder [NOME] se precisar "
         "se referir ao cliente. Responda só com a frase."
+        + INSTRUCAO_PRESERVAR_MARCADORES
     )
     user = f"Valor: {valor}\nVencimento: {venc}\nDescrição: {desc}\nNome do cliente: [NOME]"
+    seguro, mapa = anonymizer.mask(user)
     try:
         result = ai.complete(
             db=db, tenant_id=tenant_id, task="receivables.cobranca",
-            system=system, user_message=user, max_tokens=100,
+            system=system, user_message=seguro, max_tokens=100,
         )
-        return result.text.strip().replace("[NOME]", name)
+        return anonymizer.unmask(result.text, mapa).strip().replace("[NOME]", name)
     except Exception:
         return "Notamos que sua cobrança está em aberto."
 

--- a/apps/api/tests/test_regra_de_ouro_chamadores.py
+++ b/apps/api/tests/test_regra_de_ouro_chamadores.py
@@ -1,0 +1,146 @@
+"""O que cada chamador de IA REALMENTE manda para a Anthropic.
+
+`test_regra_de_ouro_gate.py` prova a forma: existe um `mask`, e o que vai em `user_message` saiu
+dele. Isso não é o mesmo que provar o efeito — um `mask` pode ser chamado sobre o texto errado, ou
+o `unmask` pode ficar para trás e o dono receber `[CPF_1]` na tela. Aqui a prova é comportamental,
+uma por chamador, na forma que `test_financial_intelligence_narrator.py` estabeleceu: mocka-se
+`ai.complete`, captura-se o `user_message`, e a IA "responde" ecoando o que recebeu.
+
+O eco é o detalhe que faz o teste valer: se o chamador esquecer o `unmask`, o marcador chega
+íntegro ao texto final e a asserção de volta reprova.
+
+As funções cobertas mandavam texto livre do dono sem nenhum tratamento até este PR: `quotes`
+(o `brief`), `funnels` (o `prompt`), `marketing` (o `topic`) e as DUAS de `receivables` (a
+descrição da cobrança).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core import ai
+from app.modules.funnels import service as funnels_service
+from app.modules.marketing import service as marketing_service
+from app.modules.quotes import service as quotes_service
+from app.modules.receivables import service as receivables_service
+
+CPF = "123.456.789-09"
+EMAIL = "ana.souza@exemplo.com"
+FONE = "(11) 98765-4321"
+
+
+@dataclass
+class _Resultado:
+    text: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class _Espiao:
+    """Substitui `ai.complete`: guarda o que recebeu e ecoa de volta o texto seguro.
+
+    `envelope` deixa cada chamador receber a resposta na FORMA que ele espera (JSON, no caso de
+    `funnels` e `marketing`) sem perder o eco — o texto seguro continua sendo o que volta.
+    """
+
+    def __init__(self) -> None:
+        self.user_message = ""
+        self.system = ""
+        self.envelope = lambda eco: eco
+
+    def __call__(self, *, system: str, user_message: str, **_kwargs) -> _Resultado:
+        self.system = system
+        self.user_message = user_message
+        return _Resultado(text=self.envelope(user_message))
+
+
+@pytest.fixture()
+def espiao(monkeypatch: pytest.MonkeyPatch) -> _Espiao:
+    """Liga a IA e troca `ai.complete` pelo espião.
+
+    Um `setattr` só: os quatro módulos importam `from app.core import ai`, então compartilham o
+    MESMO objeto de módulo — e `settings` idem. O `monkeypatch` desfaz ao fim do teste, o que
+    importa porque `app.core.ai` é global à suíte.
+    """
+    espiao = _Espiao()
+    monkeypatch.setattr(ai, "complete", espiao)
+    monkeypatch.setattr(
+        quotes_service.settings, "anthropic_api_key", "sk-ant-teste", raising=False
+    )
+    return espiao
+
+
+def _nada_de_pii(texto: str) -> None:
+    assert CPF not in texto, "CPF saiu do sistema em claro"
+    assert EMAIL not in texto, "e-mail saiu do sistema em claro"
+    assert FONE not in texto, "telefone saiu do sistema em claro"
+    assert "[CPF_1]" in texto and "[EMAIL_1]" in texto and "[FONE_1]" in texto
+
+
+# ── quotes: o `brief` que o dono digita ────────────────────────────────────────────────────
+def test_quotes_nao_manda_o_brief_cru_e_devolve_os_valores(db: Session, espiao: _Espiao) -> None:
+    brief = f"Reforma para Ana, CPF {CPF}, e-mail {EMAIL}, fone {FONE}."
+    final = quotes_service.generate_scope(db, tenant_id="t1", brief=brief)
+
+    _nada_de_pii(espiao.user_message)
+    assert final == brief.strip(), "o dono tem de receber os valores reais de volta"
+
+
+# ── funnels: o `prompt` livre do nó ────────────────────────────────────────────────────────
+def test_funnels_nao_manda_o_prompt_cru_e_devolve_os_valores(db: Session, espiao: _Espiao) -> None:
+    prompt = f"Mensagem para Ana, CPF {CPF}, e-mail {EMAIL}, fone {FONE}."
+    espiao.envelope = lambda eco: json.dumps({"subject": "Assunto", "body": eco})
+
+    saida = funnels_service.ai_compose(db, tenant_id="t1", kind="email", prompt=prompt)
+
+    _nada_de_pii(espiao.user_message)
+    assert CPF in saida["body"] and EMAIL in saida["body"] and FONE in saida["body"]
+
+
+# ── marketing: o `topic` livre do carrossel ────────────────────────────────────────────────
+def test_marketing_nao_manda_o_topic_cru_e_devolve_os_valores(
+    db: Session, espiao: _Espiao
+) -> None:
+    topic = f"Caso da cliente Ana, CPF {CPF}, e-mail {EMAIL}, fone {FONE}"
+    espiao.envelope = lambda eco: json.dumps(
+        {
+            "slides": [
+                {"kind": "cover", "heading": "Capa", "body": eco, "secondary": "",
+                 "highlight": ""}
+            ],
+            "caption": eco,
+            "hashtags": "#x",
+        }
+    )
+
+    saida = marketing_service.generate_content(db, tenant_id="t1", topic=topic, n=3, tone="direto")
+
+    _nada_de_pii(espiao.user_message)
+    assert CPF in saida["caption"] and EMAIL in saida["caption"] and FONE in saida["caption"]
+
+
+# ── receivables: a descrição da cobrança ───────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "compor",
+    [receivables_service._compose_dunning, receivables_service._compose_dunning_phrase],
+    ids=["mensagem_inteira", "so_a_frase"],
+)
+def test_receivables_nao_manda_a_descricao_crua(db: Session, espiao: _Espiao, compor) -> None:
+    """As DUAS composições de cobrança, não só a primeira.
+
+    O nome já virava `[NOME]` na montagem — mas a descrição, que é campo livre, ia inteira.
+    """
+    descricao = f"Consulta de Ana, CPF {CPF}, e-mail {EMAIL}, fone {FONE}"
+    final = compor(
+        db, tenant_id="t1", name="Ana Souza", amount_cents=15000,
+        due=date(2026, 1, 10), description=descricao,
+    )
+
+    _nada_de_pii(espiao.user_message)
+    assert "Ana Souza" not in espiao.user_message, "o nome nunca sai — vira [NOME] na montagem"
+    assert CPF in final and EMAIL in final and FONE in final
+    assert "[NOME]" not in final, "o nome real volta no texto entregue ao dono"

--- a/apps/api/tests/test_regra_de_ouro_gate.py
+++ b/apps/api/tests/test_regra_de_ouro_gate.py
@@ -1,0 +1,293 @@
+"""Gate estrutural: nenhuma chamada de IA sai sem passar pelo anonimizador.
+
+`core/ai.py` é o ponto único de acesso à Anthropic e seu docstring declara a Regra de Ouro nº 2:
+*"todo texto que entra aqui DEVE já estar anonimizado (ver anonymizer.py)"*. **A camada não
+verifica nada** — `ai.complete` recebe `user_message` e envia. A regra vive na cabeça de quem
+escreve o chamador, e foi assim que cinco chamadas nasceram sem anonimização nenhuma
+(`quotes`, `funnels`, `marketing` e as DUAS de `receivables`): o `brief` que o dono digita, o
+`prompt` livre do funil, o `topic` do carrossel e a descrição da cobrança iam crus para os
+Estados Unidos, e a suíte ficava verde.
+
+Por que um gate, e não só a correção: o repositório já protege invariantes MENORES com gate
+(`test_ancora_de_hoje.py`, `test_invariante_do_trilho.py`, `test_dna_vocabulario_gate.py`).
+A Regra de Ouro nº 2 é a única com consequência jurídica — a Política de Privacidade em
+`/privacidade` afirma ao titular que a anonimização acontece — e era a única sem consumidor
+mecânico. Sem ele, o sexto furo nasce igual aos cinco primeiros: sem ninguém ver.
+
+São duas asserções, porque a primeira sozinha não basta:
+
+1. **Presença** — a função que contém a chamada usa `anonymizer`/`AnonymizationContext` e chama
+   algum `mask*`. Pega o esquecimento total.
+2. **Destino** — o que vai em `user_message=` é o resultado de um `mask*`, não um parâmetro cru.
+   Pega o furo mais sutil, que a primeira deixaria passar: mascarar UMA coisa e mandar OUTRA.
+   `receivables._compose_dunning` era exatamente isso — trocava o nome por `[NOME]` na mão e
+   mandava a descrição inteira sem tocar.
+
+Ambas olham a ÁRVORE, não o texto: este arquivo cita `ai.complete` uma dúzia de vezes ao
+explicar-se, e uma varredura textual acusaria justamente quem já está correto.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[1] / "app"
+
+_MODULO_IA = "app.core.ai"
+_FUNCOES_IA = {"complete", "complete_with_tools"}
+_MASCARADORES = {"mask", "mask_literals", "mask_value", "mask_tool_result"}
+_SIMBOLOS_DE_ANONIMIZACAO = {"anonymizer", "Anonymizer", "AnonymizationContext"}
+
+# Exceções explícitas. Uma entrada aqui é uma DECISÃO registrada, não um silenciamento: quem
+# adicionar precisa escrever por que aquele chamador legitimamente não anonimiza. Fica no gate,
+# onde a próxima pessoa lê, e não na cabeça de quem passou por aqui.
+#
+# Formato: "app/caminho/relativo.py::nome_da_funcao": "motivo"
+EXCECOES: dict[str, str] = {
+    # (vazia de propósito — todos os chamadores atuais anonimizam)
+}
+
+# `core/ai.py` é quem DEFINE `complete`; não é chamador.
+ARQUIVOS_IGNORADOS = {"core/ai.py"}
+
+
+def _arquivos_do_app() -> list[Path]:
+    return sorted(
+        arquivo
+        for arquivo in APP_DIR.rglob("*.py")
+        if arquivo.relative_to(APP_DIR).as_posix() not in ARQUIVOS_IGNORADOS
+    )
+
+
+def _importa_direto(arvore: ast.Module) -> set[str]:
+    """Nomes de `complete`/`complete_with_tools` trazidos por `from app.core.ai import ...`.
+
+    `juridico/service.py` importa assim, e um gate que só procurasse `ai.complete` daria verde
+    para o módulo cujo dado é o mais sensível do produto (segredo de justiça).
+    """
+    importados: set[str] = set()
+    for no in ast.walk(arvore):
+        if isinstance(no, ast.ImportFrom) and no.module == _MODULO_IA:
+            for alias in no.names:
+                if alias.name in _FUNCOES_IA:
+                    importados.add(alias.asname or alias.name)
+    return importados
+
+
+def _e_chamada_de_ia(no: ast.Call, importados: set[str]) -> bool:
+    func = no.func
+    if isinstance(func, ast.Attribute) and func.attr in _FUNCOES_IA:
+        return isinstance(func.value, ast.Name) and func.value.id == "ai"
+    return isinstance(func, ast.Name) and func.id in importados
+
+
+def _cadeia_de_funcoes(arvore: ast.Module) -> dict[ast.AST, list[ast.AST]]:
+    """Para cada nó, a pilha de funções que o contêm (da mais interna para a mais externa).
+
+    A pilha, e não só a função imediata: em `vima/pergunta.py` o `mask_tool_result` mora numa
+    closure e o `mask` da pergunta mora na função de fora. Olhar só uma das duas erraria.
+    """
+    pilhas: dict[ast.AST, list[ast.AST]] = {}
+
+    def _descer(no: ast.AST, pilha: list[ast.AST]) -> None:
+        pilhas[no] = pilha
+        proxima = [no, *pilha] if isinstance(no, ast.FunctionDef | ast.AsyncFunctionDef) else pilha
+        for filho in ast.iter_child_nodes(no):
+            _descer(filho, proxima)
+
+    _descer(arvore, [])
+    return pilhas
+
+
+def _anonimiza(funcoes: list[ast.AST]) -> bool:
+    """Alguma função da pilha referencia o anonimizador E chama um `mask*`."""
+    tem_simbolo = False
+    tem_mascaramento = False
+    for funcao in funcoes:
+        for no in ast.walk(funcao):
+            if isinstance(no, ast.Name) and no.id in _SIMBOLOS_DE_ANONIMIZACAO:
+                tem_simbolo = True
+            elif isinstance(no, ast.Call):
+                alvo = no.func
+                if isinstance(alvo, ast.Attribute) and alvo.attr in _MASCARADORES:
+                    tem_mascaramento = True
+    return tem_simbolo and tem_mascaramento
+
+
+def _nomes_mascarados(funcoes: list[ast.AST]) -> set[str]:
+    """Variáveis que RECEBEM o resultado de um `mask*` — `x = anon.mask(t)` e `x, m = ...`."""
+    seguros: set[str] = set()
+    for funcao in funcoes:
+        for no in ast.walk(funcao):
+            if not isinstance(no, ast.Assign) or not isinstance(no.value, ast.Call):
+                continue
+            alvo = no.value.func
+            if not (isinstance(alvo, ast.Attribute) and alvo.attr in _MASCARADORES):
+                continue
+            for destino in no.targets:
+                if isinstance(destino, ast.Name):
+                    seguros.add(destino.id)
+                elif isinstance(destino, ast.Tuple):
+                    seguros.update(
+                        elemento.id for elemento in destino.elts if isinstance(elemento, ast.Name)
+                    )
+    return seguros
+
+
+def _parametros(funcoes: list[ast.AST]) -> set[str]:
+    nomes: set[str] = set()
+    for funcao in funcoes:
+        args = funcao.args  # type: ignore[attr-defined]
+        for grupo in (args.posonlyargs, args.args, args.kwonlyargs):
+            nomes.update(arg.arg for arg in grupo)
+        for solto in (args.vararg, args.kwarg):
+            if solto is not None:
+                nomes.add(solto.arg)
+    return nomes
+
+
+def _destino_e_seguro(chamada: ast.Call, funcoes: list[ast.AST]) -> bool:
+    """O que vai em `user_message=` saiu de um `mask*` e não é um parâmetro cru.
+
+    Um `user_message` construído inline (f-string com o texto do usuário) reprova aqui de
+    propósito: mascarar depois de montar é o único jeito de garantir que nada escapou.
+    """
+    argumento = next((kw.value for kw in chamada.keywords if kw.arg == "user_message"), None)
+    if argumento is None:
+        return False  # posicional/desconhecido: o gate não consegue provar, então reprova.
+
+    seguros = _nomes_mascarados(funcoes)
+    crus = _parametros(funcoes) - seguros
+    referenciados = {no.id for no in ast.walk(argumento) if isinstance(no, ast.Name)}
+    if referenciados & crus:
+        return False
+    return bool(referenciados & seguros)
+
+
+def _infratores(fonte: str, rotulo: str, *, checar_destino: bool) -> list[str]:
+    arvore = ast.parse(fonte)
+    importados = _importa_direto(arvore)
+    pilhas = _cadeia_de_funcoes(arvore)
+
+    achados: list[str] = []
+    for no in ast.walk(arvore):
+        if not isinstance(no, ast.Call) or not _e_chamada_de_ia(no, importados):
+            continue
+        funcoes = pilhas.get(no, [])
+        if not funcoes:
+            achados.append(f"{rotulo}:{no.lineno} — chamada de IA fora de qualquer função")
+            continue
+        nome = funcoes[0].name  # type: ignore[attr-defined]
+        if f"{rotulo}::{nome}" in EXCECOES:
+            continue
+        ok = _destino_e_seguro(no, funcoes) if checar_destino else _anonimiza(funcoes)
+        if not ok:
+            achados.append(f"{rotulo}:{no.lineno} — def {nome}()")
+    return achados
+
+
+def _varrer(*, checar_destino: bool) -> list[str]:
+    achados: list[str] = []
+    for arquivo in _arquivos_do_app():
+        rotulo = f"app/{arquivo.relative_to(APP_DIR).as_posix()}"
+        achados.extend(
+            _infratores(arquivo.read_text(encoding="utf-8"), rotulo, checar_destino=checar_destino)
+        )
+    return achados
+
+
+def test_toda_chamada_de_ia_esta_numa_funcao_que_anonimiza() -> None:
+    culpados = _varrer(checar_destino=False)
+    assert not culpados, (
+        "Regra de Ouro nº 2: `core/ai.py` exige texto já anonimizado e não verifica nada. "
+        "Estes chamadores não usam `anonymizer`/`AnonymizationContext` — mascare ANTES de "
+        "`ai.complete` e desmascare a resposta localmente (padrão em "
+        "`modules/juridico/service.py`):\n  " + "\n  ".join(culpados)
+    )
+
+
+def test_o_texto_que_vai_para_a_ia_e_o_texto_mascarado() -> None:
+    culpados = _varrer(checar_destino=True)
+    assert not culpados, (
+        "`user_message=` não recebe o resultado de um `mask*`. Anonimizar alguma coisa e enviar "
+        "outra é o furo que `receivables._compose_dunning` tinha (nome virava [NOME] na mão, "
+        "descrição ia crua). Monte o texto inteiro, mascare o texto montado, envie o "
+        "mascarado:\n  " + "\n  ".join(culpados)
+    )
+
+
+# ── Instanciação obrigatória ──────────────────────────────────────────────────────────────
+#
+# Sem um infrator o gate poderia não estar varrendo nada; sem um inocente, poderia estar
+# acusando todo mundo. Os pares abaixo são o mínimo para que "verde" signifique alguma coisa —
+# foi o que `test_ancora_de_hoje.py` ensinou quando a primeira versão do gate dele passou verde
+# sobre um arquivo que continuava quebrado.
+
+_INFRATOR = """
+from app.core import ai
+
+def gerar(db, tenant_id, brief):
+    return ai.complete(db=db, tenant_id=tenant_id, task="x", system="s", user_message=brief)
+"""
+
+_CORRETO = """
+from app.core import ai
+from app.core.anonymizer import anonymizer
+
+def gerar(db, tenant_id, brief):
+    seguro, mapa = anonymizer.mask(brief)
+    r = ai.complete(db=db, tenant_id=tenant_id, task="x", system="s", user_message=seguro)
+    return anonymizer.unmask(r.text, mapa)
+"""
+
+# Importa `complete` direto, como `juridico/service.py`. Um gate que só procurasse `ai.complete`
+# daria verde aqui.
+_INFRATOR_IMPORT_DIRETO = """
+from app.core.ai import complete
+
+def gerar(db, tenant_id, brief):
+    return complete(db=db, tenant_id=tenant_id, task="x", system="s", user_message=brief)
+"""
+
+# Anonimiza — mas manda outra coisa. Passa na primeira asserção e reprova na segunda.
+_INFRATOR_MANDA_OUTRA_COISA = """
+from app.core import ai
+from app.core.anonymizer import anonymizer
+
+def gerar(db, tenant_id, brief, descricao):
+    seguro, mapa = anonymizer.mask(brief)
+    return ai.complete(db=db, tenant_id=tenant_id, task="x", system="s", user_message=descricao)
+"""
+
+
+def test_o_gate_reconhece_o_infrator_e_ignora_quem_esta_correto() -> None:
+    assert _infratores(_INFRATOR, "x.py", checar_destino=False)
+    assert _infratores(_INFRATOR_IMPORT_DIRETO, "x.py", checar_destino=False), (
+        "não pegaria `from app.core.ai import complete` — o padrão do módulo Jurídico"
+    )
+    assert not _infratores(_CORRETO, "x.py", checar_destino=False)
+
+
+def test_o_gate_de_destino_pega_quem_mascara_uma_coisa_e_manda_outra() -> None:
+    assert not _infratores(_INFRATOR_MANDA_OUTRA_COISA, "x.py", checar_destino=False), (
+        "este infrator TEM anonimizador; quem tem de pegá-lo é a asserção de destino"
+    )
+    assert _infratores(_INFRATOR_MANDA_OUTRA_COISA, "x.py", checar_destino=True)
+    assert not _infratores(_CORRETO, "x.py", checar_destino=True)
+
+
+def test_a_varredura_encontra_os_chamadores_reais() -> None:
+    """Se um refactor mover `core/ai.py` ou renomear as funções, o gate fica verde por vacuidade.
+
+    Esta asserção é o cinto: o app TEM chamadas de IA, e o gate tem de enxergá-las.
+    """
+    vistas = 0
+    for arquivo in _arquivos_do_app():
+        arvore = ast.parse(arquivo.read_text(encoding="utf-8"))
+        importados = _importa_direto(arvore)
+        vistas += sum(
+            1
+            for no in ast.walk(arvore)
+            if isinstance(no, ast.Call) and _e_chamada_de_ia(no, importados)
+        )
+    assert vistas >= 5, f"o gate só enxergou {vistas} chamadas de IA — está varrendo o quê?"


### PR DESCRIPTION
## O problema

`core/ai.py` é o ponto único de acesso à Anthropic e seu docstring declara a Regra de Ouro nº 2 — *"todo texto que entra aqui DEVE já estar anonimizado"*. **A camada não verifica nada.** A regra vivia na cabeça de quem escrevia o chamador, e cinco chamadas nasceram sem anonimização alguma:

| Arquivo | O que ia cru para os Estados Unidos |
|---|---|
| `modules/quotes/service.py:349` | o `brief` inteiro que o dono digitou |
| `modules/funnels/service.py:271` | o `prompt` livre do nó |
| `modules/marketing/service.py:118` | o `topic` livre do carrossel |
| `modules/receivables/service.py:1241` | a descrição da cobrança |
| `modules/receivables/service.py:1277` | idem, na composição só-da-frase |

**As duas últimas são a mesma classe.** O diagnóstico inicial só tinha a primeira; `_compose_dunning_phrase` tem o furo idêntico. Nos dois, o nome já virava `[NOME]` na montagem — mas a descrição é campo livre, e *"consulta de fulano, CPF 123.456.789-00"* é uma descrição de cobrança inteiramente plausível.

A Política de Privacidade **em produção** afirma ao titular, no §5, que a anonimização acontece antes de qualquer texto sair. Era falso para estes cinco.

## O gate

`tests/test_regra_de_ouro_gate.py` varre a AST de `app/**` e reprova quem chama IA sem anonimizar. **Duas asserções, porque a primeira sozinha não basta:**

1. **Presença** — a função que contém a chamada usa `anonymizer`/`AnonymizationContext` e chama algum `mask*`.
2. **Destino** — o que vai em `user_message=` é o resultado de um `mask*`, não um parâmetro cru.

`_compose_dunning` passaria só na primeira: tinha tratamento de PII (o `[NOME]` na mão) e mandava a descrição inteira. Mascarar uma coisa e enviar outra é o furo sutil, e é a segunda asserção que o pega.

O gate também enxerga `from app.core.ai import complete` — a forma que `juridico/service.py` usa. Um gate que só procurasse `ai.complete` daria verde justamente para o módulo cujo dado é o mais sensível do produto (segredo de justiça).

Tem lista de exceções explícita e comentada (hoje vazia): quem precisar de uma escreve o motivo no gate, não na própria memória.

## Verificação — nas três direções

O gate foi provado **vermelho, verde e vermelho de novo**:

- **Vermelho no estado atual**, antes da correção, nomeando arquivo e linha das 5 chamadas.
- **Verde depois** da correção.
- **Vermelho sob mutação** (`user_message=brief` reintroduzido em `quotes`). Nessa mutação a asserção de *presença* passou e só a de *destino* pegou — que é a prova de que a segunda não é redundante.

`tests/test_regra_de_ouro_chamadores.py` acrescenta a prova comportamental, uma por chamador: o espião ecoa o texto seguro de volta, então **esquecer o `unmask` também reprova** — o marcador chegaria íntegro ao texto final.

```
ruff check .            -> All checks passed!
pytest -q               -> 2506 passed, 1 skipped, 0 failed, 0 errors
pytest -m rls_e2e       -> 71 passed (Postgres real em container)
```

Executado pelo venv de `apps/api` **com Docker disponivel**, entao os 71 testes de isolamento entre tenants rodaram de fato. Todo teste coletado executou e passou (coleta = 2506 + 1 skipped).

## Decisão de escopo

Nomes **não** são mascarados nestes cinco. O texto do dono é o insumo criativo — o `brief` de um orçamento existe para ser reescrito — e trocar o nome do cliente por um marcador destruiria a função sem ganho proporcional. O que sai são os identificadores estruturais: CPF, CNPJ, e-mail, telefone e cartão.

`INSTRUCAO_PRESERVAR_MARCADORES` entrou em `core/anonymizer.py` porque sem ela o modelo reescreve `[CPF_1]` como "o CPF informado" e o `unmask` não tem onde voltar: o dado não vaza, mas a resposta chega mutilada ao dono e ninguém entende por quê.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

