### PR TITLE
fix: o mascaramento de nomes da Vima para de engolir português

### DIFF
--- a/apps/api/app/modules/vima/palavras_comuns.py
+++ b/apps/api/app/modules/vima/palavras_comuns.py
@@ -1,0 +1,140 @@
+"""Quais componentes de um nome de cliente podem virar marcador na pergunta do dono.
+
+O problema, medido: `_nomes_conhecidos` quebra cada nome da carteira em componentes de 3+ letras
+e manda mascarar todos. Num CRM de pequeno negócio brasileiro, **nome de cliente é palavra
+comum** — com "Bar do Porto", "Casa Nova Reformas" e "Sol Nascente Ltda" na carteira, a pergunta
+
+    quanto gastei no bar esse mes? preciso pagar a casa e comprar sol e sombra
+
+chegava à Claude assim:
+
+    quanto gastei no [PESSOA_3] esse mes? preciso pagar a [PESSOA_1] e comprar [PESSOA_2] e sombra
+
+A resposta piora e ninguém descobre por quê — não há erro, só uma pergunta que virou charada.
+`Ltda` era o caso mais caro: toda empresa na carteira fazia "ltda" virar marcador em QUALQUER
+pergunta.
+
+**A garantia não muda.** O nome COMPLETO ("Bar do Porto") continua sempre mascarado, por
+`mask_literals`, antes de qualquer componente. O que esta lista faz é decidir se o componente
+ISOLADO ("bar") também vira marcador — e a resposta é não, quando ele é palavra de todo dia.
+
+Por que uma lista, e não "mascarar só o que for incomum": decidir incomum exige um dicionário
+PT-BR (dependência nova) ou uma varredura do corpus do tenant a cada pergunta (latência, e mais
+consulta sob RLS). As duas são probabilísticas, e o docstring de `_nomes_conhecidos` já rejeitou
+o probabilístico ao escolher vocabulário determinístico em vez de NER. Uma lista versionada é
+auditável: dá para ver o que ela cobre, e o custo de errar é uma palavra a mais mascarada.
+
+A lista é um piso, não um teto — quem descobrir um falso positivo novo acrescenta a palavra aqui.
+"""
+from __future__ import annotations
+
+import unicodedata
+
+# ── Termos societários ────────────────────────────────────────────────────────────────────
+# O grupo de maior impacto: aparecem em quase todo nome de pessoa jurídica, então mascaravam a
+# palavra em TODA pergunta de quem tem empresas na carteira. (Os de 1-2 letras — "me", "sa",
+# "ss" — nunca chegaram aqui, porque o filtro de componentes já exige 3+ letras; ficam listados
+# para que a lista continue correta se aquele filtro mudar.)
+_SOCIETARIOS = """
+me sa ss ltda ltd epp mei eireli cia inc llc sociedade empresa empresas empreendimentos
+comercio comercial industria industrial servicos produtos solucoes assessoria consultoria
+representacoes distribuidora distribuicao atacado varejo filial matriz grupo holding
+participacoes associados associacao instituto fundacao cooperativa
+"""
+
+# ── Ramos de negócio ──────────────────────────────────────────────────────────────────────
+# Palavras que nomeiam o negócio E aparecem na pergunta com o sentido comum ("gastei no bar",
+# "passar na farmácia").
+_RAMOS = """
+bar restaurante lanchonete padaria mercado mercearia supermercado hortifruti acougue
+farmacia drogaria loja lojas oficina garagem salao barbearia estetica clinica consultorio
+escritorio academia escola colegio curso creche hotel pousada pizzaria hamburgueria
+sorveteria cafe cafeteria papelaria livraria floricultura petshop lavanderia imobiliaria
+construtora transportadora borracharia marcenaria serralheria grafica estudio atelie
+boutique joalheria otica banca quiosque buffet bufe eventos festa festas viagens turismo
+seguros contabilidade advocacia odontologia veterinaria
+"""
+
+# ── Vocabulário de todo dia ───────────────────────────────────────────────────────────────
+# Substantivos, adjetivos e advérbios de alta frequência que também batizam negócio ("Casa
+# Nova", "Sol Nascente", "Bom Preço"). Não entram aqui palavras que só um nome próprio
+# explicaria — "Porto" e "Nascente" continuam mascaráveis de propósito.
+_COTIDIANO = """
+casa lar sol lua mar campo centro cidade vila jardim parque praca rua avenida ponto lugar
+canto esquina porta janela mesa agua terra luz vida flor cor verde azul branco preto
+vermelho amarelo ouro prata bom boa bem mal melhor pior novo nova velho grande pequeno
+alto baixo forte fraco primeiro segundo terceiro ultimo proximo antigo real
+dia dias mes meses ano anos hoje ontem amanha semana semanas hora horas minuto tempo vez
+vezes manha tarde noite cedo agora ainda sempre nunca depois antes durante
+"""
+
+# ── Vocabulário do negócio ────────────────────────────────────────────────────────────────
+# O assunto das perguntas da Vima. "Conta", "Caixa", "Recanto" e afins também são nome de
+# empresa, e mascará-los apagava justamente o substantivo que dava sentido à pergunta.
+_NEGOCIO = """
+cliente clientes contato contatos fornecedor conta contas caixa banco saldo valor valores
+dinheiro preco custo custos despesa despesas receita receitas lucro prejuizo pagamento
+pagamentos cobranca cobrancas fatura faturas boleto nota notas pedido pedidos orcamento
+orcamentos proposta contrato contratos venda vendas compra compras produto servico trabalho
+trabalhos negocio projeto projetos obra obras reforma reformas entrega entregas estoque
+agenda compromisso compromissos reuniao reunioes consulta consultas horario prazo vencimento
+imposto impostos folha salario comissao meta metas relatorio resumo total mensal anual
+"""
+
+# ── Palavras funcionais e verbos frequentes ───────────────────────────────────────────────
+_FUNCIONAIS = """
+da das de do dos em na nas no nos ao aos com sem sob sobre para pelo pela pelos pelas por
+que quem qual quais quanto quantos quanta
+quantas como onde quando porque entao tambem apenas mesmo mesma outro outra outros outras
+cada algum alguma alguns algumas nenhum nenhuma nada tudo todo toda todos todas mais menos
+muito muita muitos muitas pouco pouca varios varias ambos ate desde entre contra
+ser sou somos sao esta estao estou estamos estava estavam esteve ter tem tenho temos tinha
+teve fazer faz faco fiz fez fazia ir vou vai vamos foi fui vir vem venho dar dou deu ver
+vejo viu saber sei sabe poder posso pode queria quero quer preciso precisa precisamos devo
+deve pagar pago paguei receber recebo recebi comprar compro comprei vender vendo
+vendi gastar gasto gastei ganhar ganho ganhei mandar mando mandei enviar envio enviei falar
+falo falei ligar ligo liguei marcar marco marquei agendar cancelar abrir fechar entrar sair
+ficar passar chegar levar trazer colocar pegar deixar achar olhar mostrar criar montar usar
+"""
+
+
+def _normalizar(palavra: str) -> str:
+    """Minúsculas, sem acento e sem pontuação de borda.
+
+    Sem isso a lista precisaria de "servicos" E "serviços", e `Cia.` (com o ponto que sobra do
+    `split()`) escaparia de `cia`.
+    """
+    sem_acento = "".join(
+        letra
+        for letra in unicodedata.normalize("NFD", palavra.casefold())
+        if unicodedata.category(letra) != "Mn"
+    )
+    return sem_acento.strip(".,;:!?()[]{}\"'“”‘’-–—/&")
+
+
+PALAVRAS_COMUNS: frozenset[str] = frozenset(
+    _normalizar(palavra)
+    for bloco in (_SOCIETARIOS, _RAMOS, _COTIDIANO, _NEGOCIO, _FUNCIONAIS)
+    for palavra in bloco.split()
+)
+
+# Comprimento mínimo do componente. Herdado do código anterior: abaixo disso a chance de o
+# componente ser palavra comum supera de longe a de ele identificar alguém.
+TAMANHO_MINIMO_DO_COMPONENTE = 3
+
+
+def componentes_mascaraveis(nomes: list[str]) -> set[str]:
+    """Componentes isolados que ainda vale a pena mascarar, dado o vocabulário da carteira.
+
+    Recebe os nomes COMPLETOS e devolve só as partes que não são palavra comum — "Porto" e
+    "Nascente" entram, "Bar", "Casa", "Sol" e "Ltda" não. Quem chama continua mascarando os
+    nomes completos separadamente; esta função não decide nada sobre eles.
+    """
+    return {
+        parte
+        for nome in nomes
+        for parte in nome.split()
+        if len(parte) >= TAMANHO_MINIMO_DO_COMPONENTE
+        and _normalizar(parte) not in PALAVRAS_COMUNS
+        and _normalizar(parte) != ""
+    }

--- a/apps/api/app/modules/vima/pergunta.py
+++ b/apps/api/app/modules/vima/pergunta.py
@@ -19,6 +19,7 @@ from app.core.tenancy import CurrentUser
 from app.modules.auth.models import Tenant, User
 from app.modules.crm import service as crm_service
 from app.modules.vima import tools
+from app.modules.vima.palavras_comuns import componentes_mascaraveis
 
 _SYSTEM = (
     "Você é a Vima, a assistente do dono deste negócio dentro do e1p. Responda perguntas sobre "
@@ -32,8 +33,6 @@ _SYSTEM = (
     "pediu. Para cancelar ou remarcar, use consultar_agenda primeiro para achar o compromisso "
     "certo; se houver mais de um compatível, pergunte qual antes de agir."
 )
-
-_NAME_CONNECTORS = {"da", "das", "de", "do", "dos", "e"}
 
 
 @dataclass
@@ -105,15 +104,11 @@ def _nomes_conhecidos(db: Session, user: CurrentUser) -> list[str]:
             break
         offset += len(pagina)
 
-    # Também protege menções pelo primeiro/último nome ("fale com João"), sem mascarar
-    # conectores portugueses que aparecem naturalmente em qualquer pergunta.
-    componentes = {
-        parte
-        for nome in nomes
-        for parte in nome.split()
-        if len(parte) >= 3 and parte.casefold() not in _NAME_CONNECTORS
-    }
-    return nomes + list(componentes)
+    # Também protege menções pelo primeiro/último nome ("fale com João"). O componente isolado
+    # só vira marcador quando não é palavra de todo dia — ver `palavras_comuns.py` para a
+    # medição que motivou o filtro. Os nomes COMPLETOS vão sempre, sem exceção: é deles que
+    # vem a garantia, e `mask_literals` os aplica antes dos componentes.
+    return nomes + list(componentes_mascaraveis(nomes))
 
 
 def _com_historico(pergunta: str, historico: list[Turno]) -> str:

--- a/apps/api/tests/test_vima_palavras_comuns.py
+++ b/apps/api/tests/test_vima_palavras_comuns.py
@@ -1,0 +1,82 @@
+"""O mascaramento de nomes da Vima não pode engolir o português.
+
+O caso medido antes da correção, com "Bar do Porto", "Casa Nova Reformas" e "Sol Nascente Ltda"
+na carteira:
+
+    pergunta : quanto gastei no bar esse mes? preciso pagar a casa e comprar sol e sombra
+    Claude ve: quanto gastei no [PESSOA_3] esse mes? preciso pagar a [PESSOA_1] e comprar
+               [PESSOA_2] e sombra
+
+Três marcadores numa pergunta que não fala de ninguém. O teste tem dois lados e os dois importam:
+as palavras comuns sobrevivem **e** os nomes continuam mascarados. Um lado sozinho deixaria passar
+a correção preguiçosa (desligar o mascaramento de componentes) ou a correção nula.
+"""
+from __future__ import annotations
+
+from app.core.anonymizer import AnonymizationContext
+from app.modules.vima.palavras_comuns import componentes_mascaraveis
+
+CARTEIRA = ["Bar do Porto", "Casa Nova Reformas", "Sol Nascente Ltda"]
+
+
+def _como_a_claude_ve(texto: str, nomes: list[str]) -> str:
+    """Reproduz o que `pergunta.responder` faz: nomes completos e depois componentes."""
+    privacy = AnonymizationContext()
+    return privacy.mask_literals(
+        texto, nomes + list(componentes_mascaraveis(nomes)), label="PESSOA"
+    )
+
+
+def test_palavra_comum_sobrevive_na_pergunta() -> None:
+    pergunta = "quanto gastei no bar esse mes? preciso pagar a casa e comprar sol e sombra"
+    visto = _como_a_claude_ve(pergunta, CARTEIRA)
+    assert visto == pergunta, f"a pergunta chegou mutilada: {visto}"
+
+
+def test_termo_societario_nao_vira_marcador() -> None:
+    """`Ltda` era o pior caso: uma empresa na carteira mascarava "ltda" em toda pergunta."""
+    pergunta = "preciso emitir nota para uma ltda ou posso emitir para o CNPJ direto?"
+    assert _como_a_claude_ve(pergunta, CARTEIRA) == pergunta
+
+
+def test_o_nome_completo_continua_sempre_mascarado() -> None:
+    """A garantia. Não depende da lista de palavras comuns e não pode depender."""
+    pergunta = "quanto o Bar do Porto me deve? e a Casa Nova Reformas?"
+    visto = _como_a_claude_ve(pergunta, CARTEIRA)
+    assert "Bar do Porto" not in visto
+    assert "Casa Nova Reformas" not in visto
+    assert "[PESSOA_" in visto
+
+
+def test_componente_incomum_continua_mascarado() -> None:
+    """Mencionar o cliente pelo sobrenome ainda protege — é para isso que os componentes existem."""
+    visto = _como_a_claude_ve("o Porto pagou? e o Nascente?", CARTEIRA)
+    assert "Porto" not in visto and "Nascente" not in visto
+
+
+def test_nome_de_pessoa_nao_e_afetado_pela_lista() -> None:
+    """O caso do docstring de `_nomes_conhecidos` ("fale com João") tem de continuar valendo."""
+    nomes = ["João da Silva Pereira"]
+    componentes = componentes_mascaraveis(nomes)
+    assert {"João", "Silva", "Pereira"} <= componentes
+    assert "da" not in componentes  # conector, e abaixo do tamanho mínimo
+    assert "fale com [PESSOA_1]" == _como_a_claude_ve("fale com joão", nomes)
+
+
+def test_acento_e_pontuacao_nao_escapam_da_lista() -> None:
+    """Sem normalizar, "Serviços" e "Cia." passariam por cima de "servicos" e "cia"."""
+    assert componentes_mascaraveis(["Alfa Serviços Ltda"]) == {"Alfa"}
+    assert componentes_mascaraveis(["Beta & Cia."]) == {"Beta"}
+
+
+def test_nome_inteiramente_comum_ainda_e_protegido_como_nome_completo() -> None:
+    """O limite honesto desta escolha, escrito.
+
+    Um cliente chamado "Casa Nova" perde a proteção do componente isolado — de propósito, porque
+    "casa" e "nova" numa pergunta quase nunca falam dele. O nome completo continua protegido, e é
+    essa a garantia que a Política de Privacidade descreve.
+    """
+    nomes = ["Casa Nova"]
+    assert componentes_mascaraveis(nomes) == set()
+    visto = _como_a_claude_ve("quanto a Casa Nova me deve?", nomes)
+    assert "Casa Nova" not in visto and "[PESSOA_1]" in visto


### PR DESCRIPTION
## O problema, medido

`_nomes_conhecidos` quebrava cada nome da carteira em componentes de 3+ letras e mandava mascarar todos, excluindo só conectores (`da/de/do/e`). Num CRM de pequeno negócio brasileiro, **nome de cliente é palavra comum**.

Com "Bar do Porto", "Casa Nova Reformas" e "Sol Nascente Ltda" na carteira:

```
pergunta : quanto gastei no bar esse mes? preciso pagar a casa e comprar sol e sombra
Claude ve: quanto gastei no [PESSOA_3] esse mes? preciso pagar a [PESSOA_1] e comprar [PESSOA_2] e sombra
```

Três marcadores numa pergunta que não fala de ninguém. **Não há erro** — o sistema não quebra, os testes ficam verdes, e a resposta só piora em silêncio. `Ltda` era o caso mais caro: uma única empresa na carteira bastava para mascarar "ltda" em *qualquer* pergunta, para sempre.

## A escolha, e por quê

Havia duas saídas. Fiquei com a **lista de palavras comuns**.

A alternativa — "mascarar componente isolado só quando ele for incomum" — exige um dicionário PT-BR (dependência nova) ou uma varredura do corpus do tenant a cada pergunta (latência, e mais consulta sob RLS). As duas são **probabilísticas**, e é exatamente isso que o docstring de `_nomes_conhecidos` já havia rejeitado ao escolher vocabulário determinístico em vez de NER:

> *NER não oferece garantia suficiente para privacidade.*

Uma lista versionada é auditável: dá para ler o que ela cobre, e o custo de errar para o lado errado é uma palavra a mais mascarada — não um vazamento.

`app/modules/vima/palavras_comuns.py` traz a lista em cinco blocos comentados (termos societários, ramos de negócio, vocabulário de todo dia, vocabulário do negócio, funcionais e verbos frequentes) e a função pura que filtra. Normaliza acento e pontuação de borda — sem isso "Serviços" passaria por cima de "servicos", e `Cia.` (com o ponto que sobra do `split()`) escaparia de `cia`.

## A garantia não muda

O nome **completo** continua sempre mascarado por `mask_literals`, antes de qualquer componente. Esta lista decide apenas se o componente *isolado* também vira marcador.

O teste cobre os dois lados, porque um lado sozinho deixaria passar a correção preguiçosa (desligar o mascaramento de componentes) ou a correção nula:

- "bar", "casa", "sol" e "ltda" **sobrevivem**;
- "Bar do Porto" e "Casa Nova Reformas" **continuam mascarados**;
- "Porto" e "Nascente" (incomuns) **seguem mascarados**;
- "fale com joão" continua virando `fale com [PESSOA_1]` — o caso que motivou os componentes.

E registra o limite em vez de escondê-lo: um cliente chamado **"Casa Nova"** perde a proteção do componente isolado, de propósito. O nome completo segue protegido, e é essa a garantia que a Política de Privacidade descreve.

## Verificação

```
ruff check .            -> All checks passed!
pytest -q               -> 2504 passed, 1 skipped, 0 failed, 0 errors
pytest -m rls_e2e       -> 71 passed (Postgres real em container)
```

Executado pelo venv de `apps/api` **com Docker disponivel**, entao os 71 testes de isolamento entre tenants rodaram de fato. Todo teste coletado executou e passou (coleta = 2504 + 1 skipped).

Bônus: o módulo novo já foi adotado sozinho por um gate que existia — `test_fuso_do_tenant.py::test_vima_nunca_deriva_hoje_do_relogio_do_servidor[palavras_comuns.py]` — e passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

