### PR TITLE
docs(legal): os documentos publicados voltam a descrever a produção

### DIFF
--- a/apps/web/src/features/legal/PaginasLegais.test.tsx
+++ b/apps/web/src/features/legal/PaginasLegais.test.tsx
@@ -103,3 +103,48 @@ describe("Política de Privacidade — cláusula de Uso Limitado do Google", () 
     );
   });
 });
+
+// ── Afirmações que a auditoria de 03/09/2026 derrubou ─────────────────────────────────────
+//
+// As três frases abaixo estiveram publicadas e eram falsas. Nenhuma delas quebrava nada
+// visível: o site continuava de pé, os testes verdes, e só uma conferência contra a produção
+// mostrava a diferença. É exatamente a classe de erro que precisa de consumidor mecânico —
+// uma frase forte e falsa num documento legal é pior que uma frase fraca e verdadeira.
+//
+//  1. "cópia fora do servidor de produção" (§8) e "30 dias na cópia externa" (§9): a EC2 não
+//     tem rclone instalado nem BACKUP_S3_BUCKET preenchido. O offsite nunca existiu na AWS;
+//     o texto vinha do `.env.prod.example`, que descreve a Hostinger, descomissionada.
+//  2. "você pode exportar seus dados a qualquer momento" (Termos §8, e a mesma promessa no
+//     §12): não há endpoint de exportação — só `juridico/export.py::to_docx`, que exporta UM
+//     documento. A frase enfraquecia o direito de portabilidade do §10 da Política.
+//  3. Asaas e a WhatsApp Business Platform listados como prestadores em operação:
+//     `PAYMENT_GATEWAY_PROVIDER` e `WHATSAPP_TOKEN` estão vazios em produção.
+//
+// Se alguma voltar, o texto precisa de código atrás dela — não do contrário.
+describe("Os documentos não voltam a prometer o que o sistema não faz", () => {
+  it("não anuncia backup fora do servidor de produção", () => {
+    abrir("/privacidade");
+    const texto = textoDaPagina();
+    expect(texto).not.toContain("cópia fora do servidor");
+    expect(texto).not.toContain("cópia externa");
+    // E diz o que de fato acontece, incluindo o limite.
+    expect(texto).toContain("no próprio servidor de produção");
+  });
+
+  it("não promete exportação de dados que não existe", () => {
+    abrir("/termos");
+    const texto = textoDaPagina();
+    expect(texto).not.toContain("exportar seus dados a qualquer momento");
+    expect(texto).not.toContain("para exportar seus dados");
+  });
+
+  it("separa o prestador que opera hoje do que só entra se o assinante ativar", () => {
+    abrir("/privacidade");
+    const texto = textoDaPagina();
+    expect(texto).toContain("Ainda não em uso");
+    // Asaas e a plataforma oficial da Meta continuam citadas — mas do lado desligado.
+    const desligados = texto.slice(texto.indexOf("Ainda não em uso"));
+    expect(desligados).toContain("Asaas");
+    expect(desligados).toContain("WhatsApp Business Platform");
+  });
+});

--- a/apps/web/src/features/legal/PrivacidadePage.tsx
+++ b/apps/web/src/features/legal/PrivacidadePage.tsx
@@ -146,6 +146,14 @@ export default function PrivacidadePage() {
           identificadores.
         </p>
         <p>
+          Na <strong>Vima</strong> — a assistente que consulta os seus dados para responder às suas
+          perguntas — a proteção vai além disso. Também são substituídos por marcadores os nomes já
+          conhecidos pelo sistema (a sua empresa, os seus usuários e os seus clientes) e o resultado
+          de cada consulta ao banco de dados feita para montar a resposta. A IA raciocina sobre os
+          marcadores; os valores reais só reaparecem no texto que você lê, já dentro da nossa
+          infraestrutura.
+        </p>
+        <p>
           O conteúdo enviado à Anthropic não é usado para treinar os modelos dela. As respostas de
           IA são geradas automaticamente e podem conter erros: elas não substituem orientação
           jurídica, contábil ou financeira profissional. Ver a cláusula correspondente nos Termos de
@@ -201,7 +209,7 @@ export default function PrivacidadePage() {
 
       <Secao id="compartilhamento" titulo="7. Com quem os dados são compartilhados">
         <p>
-          Compartilhamos dados apenas com os prestadores necessários para o serviço funcionar, cada
+          Esta é a lista dos prestadores que <strong>hoje</strong> tratam dados a nosso pedido, cada
           um limitado ao que a sua função exige:
         </p>
         <Tabela
@@ -223,14 +231,9 @@ export default function PrivacidadePage() {
               "Estados Unidos",
             ],
             [
-              "Meta (WhatsApp Business Platform)",
-              "Envio e recebimento de mensagens, quando você usa a integração oficial.",
+              "Meta (WhatsApp)",
+              "Trânsito das mensagens enviadas e recebidas pelo número que você conectar.",
               "Estados Unidos",
-            ],
-            [
-              "Asaas",
-              "Emissão de boletos e Pix das suas cobranças, quando o gateway está habilitado.",
-              "Brasil",
             ],
             [
               "Provedor de e-mail transacional",
@@ -239,6 +242,22 @@ export default function PrivacidadePage() {
             ],
           ]}
         />
+        <p>
+          <strong>Sobre a conexão de WhatsApp.</strong> A ligação com o WhatsApp é feita hoje por um
+          componente que roda na nossa própria infraestrutura, usando o mesmo protocolo do WhatsApp
+          Web — não pela plataforma oficial de negócios da Meta. As suas mensagens continuam
+          trafegando pelos servidores do WhatsApp, como em qualquer conversa do aplicativo, mas o
+          intermediário entre o {CONTROLADOR.produto} e o WhatsApp somos nós, e não um serviço
+          contratado de terceiro.
+        </p>
+        <p>
+          <strong>Ainda não em uso.</strong> O sistema tem integrações prontas que só passam a
+          tratar dados se você as ativar, e nenhuma delas está ativa hoje: a plataforma oficial de
+          negócios da Meta (WhatsApp Business Platform), o gateway de pagamentos{" "}
+          <strong>Asaas</strong> para boletos e Pix, e o armazenamento de arquivos em serviço externo
+          — enquanto ele não é ativado, os anexos ficam no mesmo banco de dados do resto das suas
+          informações. Se você ativar alguma, ela passa a valer como prestador desta lista.
+        </p>
         <p>
           As transferências internacionais acima ocorrem com base em cláusulas contratuais e nas
           demais garantias exigidas pelos arts. 33 e seguintes da LGPD. Também podemos divulgar
@@ -258,7 +277,13 @@ export default function PrivacidadePage() {
           </li>
           <li>Sessões inativas são encerradas automaticamente após 30 minutos.</li>
           <li>Acessos e ações sensíveis ficam registrados em trilha de auditoria.</li>
-          <li>Backups automáticos são mantidos, com cópia fora do servidor de produção.</li>
+          <li>
+            O banco de dados é copiado automaticamente todos os dias. Essas cópias ficam{" "}
+            <strong>no próprio servidor de produção</strong>: hoje não há réplica em outro provedor,
+            de modo que um incidente que destrua o servidor destrói também as cópias. Estamos
+            dizendo isso porque preferimos que você saiba do limite a supor uma proteção que não
+            existe.
+          </li>
         </Lista>
         <p>
           Nenhum sistema é imune a incidentes. Se ocorrer um incidente de segurança com risco
@@ -279,8 +304,8 @@ export default function PrivacidadePage() {
             acessos exigido pelo art. 15 do Marco Civil da Internet, mantido por 6 meses.
           </li>
           <li>
-            <strong>Backups</strong> têm ciclo próprio: até 7 dias no servidor e até 30 dias na
-            cópia externa. Um dado excluído desaparece das cópias ao fim desse ciclo.
+            <strong>Backups</strong> têm ciclo próprio: a cópia diária do banco fica até 7 dias no
+            servidor e é apagada depois. Um dado excluído desaparece das cópias ao fim desse ciclo.
           </li>
         </Lista>
       </Secao>

--- a/apps/web/src/features/legal/TermosPage.tsx
+++ b/apps/web/src/features/legal/TermosPage.tsx
@@ -144,9 +144,9 @@ export default function TermosPage() {
             houver indisponibilidade prevista, e manutenções emergenciais sem aviso prévio.
           </li>
           <li>
-            Mantemos backups automáticos com cópia externa, conforme a seção 9 da Política de
-            Privacidade. Backup é medida de continuidade do serviço, não substituto de exportação
-            própria: você pode exportar seus dados a qualquer momento e é prudente fazê-lo.
+            Mantemos backups automáticos diários no servidor de produção, conforme as seções 8 e 9
+            da Política de Privacidade — sem cópia em outro provedor. Backup é medida de
+            continuidade do serviço e não é garantia de recuperação em qualquer cenário.
           </li>
           <li>
             Podemos alterar, adicionar ou descontinuar funcionalidades. Se uma mudança reduzir de
@@ -209,8 +209,9 @@ export default function TermosPage() {
           quando o aviso for possível.
         </p>
         <p>
-          Após o encerramento, você tem <strong>30 dias</strong> para exportar seus dados. Passado
-          esse prazo, eles são excluídos conforme a seção 9 da Política de Privacidade.
+          Após o encerramento, os seus dados permanecem por <strong>30 dias</strong> antes de serem
+          excluídos, conforme a seção 9 da Política de Privacidade. Dentro desse prazo você pode
+          pedir uma cópia deles pelo canal e nas condições da seção 10 da Política.
         </p>
       </Secao>
 

--- a/apps/web/src/features/legal/controlador.ts
+++ b/apps/web/src/features/legal/controlador.ts
@@ -16,4 +16,4 @@ export const CONTROLADOR = {
  * Data da última revisão dos documentos legais. Atualize AO MUDAR o texto de qualquer um dos
  * dois — a data é o que permite a uma pessoa saber se leu a versão vigente.
  */
-export const VIGENCIA = "2 de setembro de 2026";
+export const VIGENCIA = "3 de setembro de 2026";


### PR DESCRIPTION
> **Estes documentos estão no ar.** Uma frase forte e falsa numa política de privacidade é pior que uma frase fraca e verdadeira.

Auditoria confrontou `apps/web/src/features/legal/` com o código e com a EC2 de produção. Quatro afirmações não se sustentavam.

## §5 — Inteligência artificial

A frase *"antes de qualquer texto sair do sistema em direção à IA, ele passa por um anonimizador"* estava errada **nas duas direções**: falsa para cinco chamadas (orçamento, funil, carrossel e as duas cobranças) e, ao mesmo tempo, subestimando a Vima.

Com o #297, ela passa a ser verdadeira para PII estrutural — e agora tem um gate de AST atrás dela, não só boa vontade. Acrescentado o parágrafo que faltava: na Vima, os nomes já conhecidos pelo sistema e o resultado de cada consulta ao banco também são mascarados, e os valores reais só reaparecem dentro da nossa infraestrutura.

## §7 — Subprocessadores

A tabela descrevia o `.env.example`, não a produção. Medido na EC2:

| Variável | Estado | Consequência |
|---|---|---|
| `WHATSAPP_TOKEN` | vazio | **Meta oficial não está em uso** |
| `PAYMENT_GATEWAY_PROVIDER` | vazio | **Asaas não está em uso** |
| `S3_BUCKET` | vazio | anexos são `bytea` no Postgres, não S3 |
| `SMTP_HOST` | preenchido | e-mail transacional é real |

Quem faz a ponte com o WhatsApp hoje é um container na **nossa própria EC2** (`infra-evolution-1`, no ar há 13 dias), usando o protocolo do WhatsApp Web. Para o titular a diferença é material: *"vai para a Meta sob contrato de plataforma"* não é a mesma coisa que *"passa por um transporte hospedado por nós"*.

A tabela passa a listar só quem opera hoje. Os desligados ganham um parágrafo próprio, marcado como tal — a informação não se perde, mas para de sugerir operação.

## §8 e §9 — Backups

*"Cópia fora do servidor de produção"* e *"30 dias na cópia externa"* **nunca existiram na AWS**:

```
rclone            → não instalado
BACKUP_S3_BUCKET  → vazio
/etc/cron.d/      → só e1p-backup (03:15), BACKUP_RETENTION_DAYS_LOCAL=7
/opt/e1p-backups/ → 19 dumps, o mais antigo de 27/08 (consistente com 7 dias)
```

`docs/AWS-DEPLOYMENT.md` já dizia: *"Backup é só local. Se a instância morrer, morrem app e banco juntos."* O texto herdado vinha do `infra/.env.prod.example`, que descreve a **Hostinger** — descomissionada em 30/08/2026.

Escolha do dono entre corrigir o texto e instalar o offsite: **corrigir**. O texto agora diz o que existe e diz o limite em voz alta, porque o titular tem mais a ganhar sabendo do risco do que supondo uma proteção que não tem.

## Termos §8 e §12 — Exportação

*"Você pode exportar seus dados a qualquer momento"* (§8) e *"30 dias para exportar"* (§12). Não há endpoint de exportação — só `juridico/export.py::to_docx`, que exporta **um** documento.

O §12 tinha a mesma promessa e não estava no diagnóstico inicial. As duas saem.

O direito de portabilidade do §10 da Política (LGPD art. 18, V) **não dependia delas**: é atendido pelo canal de e-mail com prazo de 15 dias, que continua escrito. Sai a promessa de um botão que não existe; fica o direito que existe.

## Guardas

`PaginasLegais.test.tsx` ganha três testes contra o retorno das afirmações derrubadas — pelo mesmo motivo do gate do #297: nenhuma delas quebrava nada visível, e só uma conferência contra a produção mostrava a diferença.

**Verificados por mutação:** repor a frase antiga do §8 deixa o teste vermelho. O guarda literal da cláusula de Uso Limitado do Google segue verde e intocado.

## Verificação

```
pnpm lint       → limpo
pnpm typecheck  → limpo
pnpm test       → 96 arquivos, 1249 testes, todos verdes
```

## Nota

`VIGENCIA` subiu para **3 de setembro de 2026**. Se o merge/deploy escorregar de dia, a data precisa acompanhar.

Prod está em `d49dd9a` e o #296 ainda não subiu: até deployar, o que vale para o titular é a versão antiga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)