### PR TITLE
chore(web): torna permanente a verificação de propriedade do Google

### DIFF
--- a/apps/web/public/google43f12893cae1f247.html
+++ b/apps/web/public/google43f12893cae1f247.html
@@ -1,0 +1,1 @@
+google-site-verification: google43f12893cae1f247.html


### PR DESCRIPTION
## Contexto

A verificação do branding do OAuth estava reprovando com *"O site do URL da sua página inicial `https://e1p.criativaeduca.com.br/` não está registrado para você"*. O Google exige a posse do domínio verificada no Search Console pela mesma conta do projeto GCP — não existe campo de "proprietário" para corrigir, a prova é o Search Console.

A verificação foi feita pelo método de arquivo HTML e **já passou**: o branding está aprovado e o formulário completo entrou em análise (4 a 6 semanas).

## O problema que este PR resolve

Para destravar na hora, o token foi escrito à mão dentro do container que já rodava:

```
docker exec infra-web-1 sh -c 'echo "google-site-verification: ..." > /usr/share/nginx/html/...'
```

Isso vive na **camada gravável do container**: sobrevive a `restart`, mas **morre no próximo `up --build`**. E o Google revalida a posse do domínio ao longo de toda a análise — um rebuild no meio das próximas semanas derrubaria a verificação em silêncio, no meio do processo.

O arquivo em `apps/web/public/` passa a nascer dentro de toda imagem. O Vite copia essa pasta para a raiz do `dist/` sem configuração extra — é assim que `icon-192.png`, `sw.js` e `manifest.webmanifest` já chegam lá hoje.

## Nota para quem for testar a URL

`curl -I` **mente** aqui. O `try_files $uri $uri/ /index.html` de `apps/web/nginx.conf` devolve **200 com o index.html** para arquivo inexistente. Só o conteúdo prova:

```bash
curl -s https://e1p.criativaeduca.com.br/google43f12893cae1f247.html
# tem de imprimir a linha google-site-verification:, não HTML
```

## Escopo

1 arquivo, 1 linha, sem código. O blob foi commitado em LF (o repo só fixa `eol=lf` para `*.sh`, e o build roda do checkout Linux em `/opt/e1p`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)