### PR TITLE
fix(deploy): o guard do bundle parou de abortar deploy correto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
         run: |
           set -uo pipefail
           cd apps/api
-          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py tests/test_guarda_timeouts_mutacao.py tests/test_guarda_stryker_disable_deslocado.py --junitxml=infra-gates.xml
+          python -m pytest -q tests/test_caddyfile_blocos_opcionais.py tests/test_deploy_guarda_checkout_limpo.py tests/test_deploy_guarda_build_velho.py tests/test_guarda_timeouts_mutacao.py tests/test_guarda_stryker_disable_deslocado.py --junitxml=infra-gates.xml
           rc=$?
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
-          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=34; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 34 executados: 7 do Caddyfile + 4 da guarda do deploy.sh + 13 da guarda de timeouts da mutacao + 10 da guarda de diretiva Stryker deslocada). Eles dependem de infra/, scripts/, bash, git e node alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o do deploy.sh e a guarda que abortava 100% dos deploys na AWS, o de timeouts e a issue #213, o da diretiva deslocada e a issue #229."); sys.exit(0 if ok else 1)'
+          python -c 'import sys,xml.etree.ElementTree as ET; r=ET.parse("infra-gates.xml").getroot(); s=r if r.tag=="testsuite" else r.find("testsuite"); t=int(s.get("tests",0)); k=int(s.get("skipped",0)); ex=t-k; print(f"infra-gates: coletados={t} executados={ex} skipped={k}"); ok=ex>=43; ok or print("::error::Um gate de infra/ foi PULADO ou sumiu (esperado >= 43 executados: 7 do Caddyfile + 4 da guarda de checkout limpo do deploy.sh + 9 da guarda de build velho do deploy.sh + 13 da guarda de timeouts da mutacao + 10 da guarda de diretiva Stryker deslocada). Eles dependem de infra/, scripts/, bash, git e node alcancaveis; pulado, nao protege nada -- o do Caddyfile e a issue #151, o de checkout limpo e a guarda que abortava 100% dos deploys na AWS, o de build velho e o abort falso do deploy do #300, o de timeouts e a issue #213, o da diretiva deslocada e a issue #229."); sys.exit(0 if ok else 1)'
 
       # AMPLIADO (Story 7.1): filtra por PROPRIEDADE (o marker rls_e2e), NÃO por um arquivo nomeado.
       # Assim os 9 arquivos test_*_rls.py de hoje — e um 10º futuro — entram automaticamente, sem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3668,11 +3668,69 @@ derrubava**: o script morria antes de fazer qualquer coisa, em toda execução, 
   rodar compose à mão continua exposto. ⚠️ **Mas a issue #151 está FECHADA** (PRs #170 e #193, em
   produção desde 21/08): o `infra/Caddyfile` não tem mais o bloco wildcard incondicional, então
   esquecer o override deixou de derrubar o site. O override segue valendo pelo `Caddyfile.single`.
-- **Dívida:** o `deploy.sh` **nunca completou uma execução de verdade** — o `--dry-run` da AWS
-  parava na guarda, e o primeiro caminho feliz ainda não aconteceu. Os passos 3 em diante (gate de
-  CI, backup, `up -d`, prova do bundle) seguem exercitados só por leitura.
+- ~~**Dívida:** o `deploy.sh` **nunca completou uma execução de verdade**.~~ **Rodou em produção
+  pela primeira vez em 04/09/2026** (deploy do #300, na AWS): gate de CI, backup, `up -d --build`,
+  health e alembic passaram todos. Ele **abortou na última asserção**, e o abort era falso — ver
+  logo abaixo. Os passos 3 em diante deixaram de ser exercitados só por leitura.
 - **Dívida:** o `CLOUDFLARE_API_TOKEN` segue vazio na AWS. Correto hoje (sem wildcard, sem DNS-01);
   vira problema no dia em que subdomínio por tenant entrar em uso.
+
+#### O guard do bundle abortou um deploy que estava CORRETO (2026-09-04)
+
+O primeiro caminho feliz do script terminou em `ABORTADO: o diff mexe no front mas o bundle
+servido continua '/assets/index-BEyo_MpB.js'`. **A produção estava perfeita.** O commit que subiu
+era o `c2fd483` (#300), de **um arquivo só**: `apps/web/public/google43f12893cae1f247.html`.
+
+- **O Vite copia `public/` VERBATIM para a raiz do `dist/`** — é assim que `sw.js` e
+  `manifest.webmanifest` chegam lá. Um arquivo em `public/` **não pode**, por construção, mudar o
+  hash do `index-*.js`. A classificação `FRONT` olhava só o CAMINHO (`apps/web`, `packages`), e a
+  asserção que ela liga (*"o bundle DEVE mudar"*) pedia o impossível.
+- **A evidência que fechou o diagnóstico, e a ordem importa:** o `Last-Modified` do `index.html`
+  servido era de 4 minutos antes (o container **foi** reconstruído); não há CDN na frente
+  (`Via: 1.1 Caddy`, `Server: nginx`, sem `cf-cache-status`); e `GET /google43f12893cae1f247.html`
+  devolvia o conteúdo certo. ⚠️ **`curl -I` MENTE nessa URL** — o `try_files $uri $uri/ /index.html`
+  do `apps/web/nginx.conf` responde **200 com o index.html** para arquivo inexistente. Só o
+  CONTEÚDO prova.
+- [x] **`FORA_DO_BUNDLE`** (`infra/scripts/deploy.sh`) — pathspecs de exclusão no `git diff` da
+  classificação: `apps/web/public`, `apps/web/e2e` e `apps/web/**/*.test.*`. Nenhum dos três vira
+  JS de bundle; os 96 `*.test.tsx` do vitest e os `*.spec.ts` do Playwright não são importados pela
+  entrada. **Não apaga nada** — só deixa o script de PREVER mudança de hash onde ela é impossível.
+- [x] **`imagem_do_web_esta_atual`** — a exclusão acima, sozinha, abriria um ponto cego pior que o
+  falso alarme: com `FRONT=0` o script cai em *"bundle inalterado, como esperado"* e **nada** mais
+  verificaria que o web foi reconstruído. A checagem nova roda SEMPRE e não depende de conteúdo
+  mudar: compara a imagem que o container em pé roda com a imagem `<projeto>-web` recém-construída.
+  - ⚠️ **A pergunta certa é "o container está na imagem mais nova?", nunca "a imagem mudou?".**
+    Imagem do Docker é content-addressed: build que não muda o `dist/` produz a MESMA imagem e o
+    compose nem recria o container — *"mudou?"* acusaria um deploy correto.
+  - **Inconclusivo NÃO é reprovação.** Se o nome da imagem ou o container não resolverem neste
+    host, o script **avisa e segue**. Inventar um jeito novo de bloquear produção por suposição de
+    nomenclatura já custou ~40 min fora do ar aqui (issue #151).
+- **O gate é `tests/test_deploy_guarda_build_velho.py`** (9 testes), irmão do de checkout limpo e
+  no mesmo molde: **EXTRAI as linhas reais do `deploy.sh` e as EXECUTA**, nunca uma cópia escrita
+  no teste. Dois controles positivos (`apps/web/src/**` e `packages/**` TÊM de marcar `FRONT=1`) —
+  sem eles, uma classificação que devolvesse 0 para tudo passaria nos três casos de exclusão.
+  Provado por mutação: devolver a linha antiga mata 3 testes; tirar a guarda de vazio mata o 4º.
+- ⚠️ **Duas armadilhas do harness custaram a maior parte do tempo, e as duas falham para o MESMO
+  lado — o script "roda", sai 0, e o stdout parece plausível:**
+  1. **`bash -c` não serve nesta máquina.** O `bash` que o `subprocess` acha é o do WSL, e o
+     interop Windows→WSL **expande os `$` do argumento** antes de o bash parsear: as atribuições
+     rodam e toda referência a variável chega VAZIA. Com `set -x`, a linha virava
+     `git diff --name-only .. -- apps/web packages ''`.
+  2. **`text=True` não serve.** No Windows ele traduz `\n` em `\r\n` ao escrever no pipe, e o CR
+     entra no script: `set -uo pipefail\r` vira *"invalid option name"*, `HEAD~1\r..HEAD\r` vira
+     *"bad revision"*.
+  `_bash()` entrega o script por **stdin em BYTES** (`bash -s`), e o chamador **confere o stderr**:
+  sem isso um `fatal:` do git faz o `grep -q` não achar nada, `FRONT` fica 0, e os três testes de
+  *"NÃO marca front"* passam VERDES sem a guarda ter sido exercitada. No Linux do CI as duas
+  escolhas são indiferentes — é a família do §5.2 (o teste que não tem como falhar), agora na
+  camada do processo.
+- **O gate de infra do `ci.yml` foi de `>= 34` para `>= 43` executados**, com a decomposição
+  atualizada na mensagem de erro. A guarda anti-vacuidade só vale enquanto o número acompanha os
+  arquivos da lista.
+- **Dívida:** a checagem de imagem deriva o nome `<projeto>-web` do label
+  `com.docker.compose.project` do `infra-api-1`. Se um host futuro nomear a imagem de outro jeito,
+  a checagem fica **inconclusiva** (avisa, não reprova) — deliberado, mas significa que ela pode
+  estar calada num host sem ninguém notar. Só o primeiro deploy real dirá.
 
 ## 6.0 Correções importantes
 - **[CORRIGIDO 2026-08-05] O sistema inteiro passou a viver no fuso do tenant (era UTC).** O sintoma que o fundador viu foi a linha do tempo do Funil exibindo `Aguardando até 2026-08-05T11:11:32.812731+00:00` — formato de máquina e 3h adiantado. A investigação achou **três** defeitos com a mesma raiz: existia infra de fuso (`core/tz.py` + `tenant.timezone`, migration 0044) mas só 3 módulos a consumiam.

--- a/apps/api/tests/test_deploy_guarda_build_velho.py
+++ b/apps/api/tests/test_deploy_guarda_build_velho.py
@@ -1,0 +1,219 @@
+"""As duas guardas do `deploy.sh` contra "o web está servindo build velho".
+
+⚠️ Como o gate irmão (`test_deploy_guarda_checkout_limpo.py`), este teste EXECUTA as linhas que
+estão no `deploy.sh`, extraídas dele em tempo de teste — nunca uma cópia escrita aqui. Cópia passa
+a concordar consigo mesma no dia em que alguém edita o script (§5.1).
+
+O defeito que a primeira guarda fecha: a classificação `FRONT` olhava só o CAMINHO (`apps/web`,
+`packages`) e, com ela ligada, o script exigia que o hash do bundle mudasse. Mas `apps/web/public/`
+é copiado VERBATIM pelo Vite para o `dist/` — por construção não pode mudar o `index-*.js`. O
+deploy do #300 (um único arquivo em `public/`, a verificação de propriedade do Google) subiu
+inteiro e correto e mesmo assim ABORTOU na última asserção, com a produção já saudável. Mesma
+classe: `apps/web/e2e/` e os 96 `*.test.tsx`, que não entram no bundle.
+
+O defeito que a segunda guarda fecha é o oposto — o ponto cego que a primeira abriria sozinha: com
+`FRONT=0`, NADA mais verificava que o web havia sido reconstruído. A checagem de imagem não depende
+de conteúdo mudar: compara a imagem que o container em pé roda com a imagem recém-construída. Se o
+`up -d --build` construiu e não recriou o container, as duas divergem — que é exatamente "servindo
+build velho", e vale para `public/`, para e2e e para código real.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+def _acha_infra() -> pathlib.Path | None:
+    """Sobe procurando o `infra/`.
+
+    A suíte também roda DENTRO da imagem da API, onde só `apps/api` foi copiado. Resolver a raiz
+    por índice fixo (`parents[3]`) estoura `IndexError` na COLETA e derruba o job inteiro.
+    """
+    for pai in pathlib.Path(__file__).resolve().parents:
+        candidato = pai / "infra"
+        if (candidato / "scripts" / "deploy.sh").is_file():
+            return candidato
+    return None
+
+
+INFRA = _acha_infra()
+
+pytestmark = pytest.mark.skipif(
+    INFRA is None or shutil.which("bash") is None or shutil.which("git") is None,
+    reason=(
+        "precisa de infra/, bash e git — o job cross-tenant-rls tem os três, "
+        "e lá o SKIP é reprovado pela guarda anti-vacuidade"
+    ),
+)
+
+
+def _fonte() -> str:
+    assert INFRA is not None
+    return (INFRA / "scripts" / "deploy.sh").read_text(encoding="utf-8")
+
+
+def _bash(
+    script: str, *args: str, cwd: pathlib.Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Roda `script` no bash entregando-o por STDIN em BYTES, nunca por `bash -c` e nunca em texto.
+
+    ⚠️ Nenhuma das duas escolhas é estilo; cada uma fecha uma falha SILENCIOSA medida aqui:
+
+    1. `bash -c` não serve. Nesta máquina de dev o `bash` do PATH é o do WSL, e o interop
+       Windows→WSL EXPANDE os `$` do argumento antes de o bash parsear: as atribuições rodam, mas
+       toda referência a variável chega vazia. Com `set -x`, a linha da classificação virava
+       `git diff --name-only .. -- apps/web packages ''`.
+
+    2. `text=True` não serve. No Windows ele traduz `\\n` em `\\r\\n` ao escrever no pipe, e o CR
+       entra no script: `set -uo pipefail\\r` vira "invalid option name" e `HEAD~1\\r..HEAD\\r`
+       vira "bad revision". Bytes passam intactos.
+
+    Os dois defeitos falham para o MESMO lado — o script sai 0, o stdout vem plausível e a guarda
+    parece ter respondido. Por isso quem chama esta função confere o stderr: um erro do git aqui
+    não pode virar "FRONT=0, teste verde". No Linux do CI as duas escolhas são indiferentes.
+    """
+    r = subprocess.run(
+        ["bash", "-s", "--", *args],
+        input=script.encode("utf-8"),
+        cwd=cwd,
+        capture_output=True,
+    )
+    return subprocess.CompletedProcess(
+        r.args,
+        r.returncode,
+        r.stdout.decode("utf-8", "replace"),
+        r.stderr.decode("utf-8", "replace"),
+    )
+
+
+def _linha_unica(agulha: str) -> str:
+    """A ÚNICA linha não-comentada do deploy.sh que contém `agulha`."""
+    linhas = [
+        linha.strip()
+        for linha in _fonte().splitlines()
+        if agulha in linha and not linha.lstrip().startswith("#")
+    ]
+    assert len(linhas) == 1, f"esperava UMA linha com {agulha!r}, achei {len(linhas)}: {linhas}"
+    return linhas[0]
+
+
+# --------------------------------------------------------------- guarda 1: classificação FRONT
+
+
+def _classificacao_front() -> str:
+    """As linhas REAIS que decidem se o diff mexe no que vira bundle."""
+    return _linha_unica("FORA_DO_BUNDLE=(") + "\n" + _linha_unica("FRONT=1") + "\n"
+
+
+def _front_para(tmp_path: pathlib.Path, caminho: str) -> int:
+    """Cria um repo cujo último commit mexe SÓ em `caminho`, e roda a classificação real nele."""
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-q", ".")
+    git("config", "user.email", "teste@e1p")
+    git("config", "user.name", "teste")
+    # Mesmo motivo do gate irmão: o `bash` desta máquina é o do WSL e traz um git PRÓPRIO, com
+    # `core.autocrlf` diferente do git que cria o repo aqui. Sem fixar, o repo nasce sujo.
+    git("config", "core.autocrlf", "false")
+    (tmp_path / "base.txt").write_text("base\n", encoding="utf-8")
+    git("add", "base.txt")
+    git("commit", "-q", "-m", "base")
+
+    alvo = tmp_path / caminho
+    alvo.parent.mkdir(parents=True, exist_ok=True)
+    alvo.write_text("conteudo\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-q", "-m", "mudanca")
+
+    script = (
+        "set -uo pipefail\n"
+        'SHA_ANTES="HEAD~1"\n'
+        'SHA_ALVO="HEAD"\n'
+        "FRONT=0\n"
+        + _classificacao_front()
+        + 'echo "$FRONT"\n'
+    )
+    r = _bash(script, cwd=tmp_path)
+    assert r.returncode == 0, f"a classificação estourou: {r.stderr}"
+    # Sem esta linha o teste mente: um `fatal:` do git faz o `grep -q` não achar nada, FRONT fica
+    # 0 e os três testes de "NÃO marca front" passam VERDES sem a guarda ter sido exercitada.
+    assert not r.stderr.strip(), f"a classificação escreveu em stderr (git falhou?): {r.stderr}"
+    return int(r.stdout.strip())
+
+
+def test_arquivo_em_public_NAO_marca_front(tmp_path):
+    """O caso do #300: um arquivo em `public/` é copiado verbatim, o bundle NÃO pode mudar."""
+    assert _front_para(tmp_path, "apps/web/public/google43f12893cae1f247.html") == 0, (
+        "`apps/web/public/` marcou FRONT=1. O Vite copia essa pasta verbatim para o `dist/`: com "
+        "FRONT=1 o script exige uma mudança de hash do bundle que é impossível por construção, e "
+        "aborta um deploy que subiu inteiro e correto (medido em 04/09/2026, deploy do #300)."
+    )
+
+
+def test_e2e_NAO_marca_front(tmp_path):
+    """Os `*.spec.ts` do Playwright não são importados pela entrada — não entram no bundle."""
+    assert _front_para(tmp_path, "apps/web/e2e/alcance-360.spec.ts") == 0
+
+
+def test_teste_de_unidade_NAO_marca_front(tmp_path):
+    """Os 96 `*.test.tsx` do vitest também não: mesma classe de falso alarme."""
+    assert _front_para(tmp_path, "apps/web/src/features/legal/PaginasLegais.test.tsx") == 0
+
+
+def test_codigo_do_front_MARCA_front(tmp_path):
+    """Controle positivo. Sem ele, uma classificação que devolve 0 para TUDO passaria acima."""
+    assert _front_para(tmp_path, "apps/web/src/features/legal/PrivacidadePage.tsx") == 1, (
+        "código-fonte do front não marcou FRONT=1 — a guarda do bundle deixou de existir"
+    )
+
+
+def test_packages_MARCA_front(tmp_path):
+    """O bundle também come `packages/` (o Dockerfile copia os dois para o build)."""
+    assert _front_para(tmp_path, "packages/tipos/src/index.ts") == 1
+
+
+def test_backend_NAO_marca_front(tmp_path):
+    """Controle: o que nunca foi front continua fora."""
+    assert _front_para(tmp_path, "apps/api/app/main.py") == 0
+
+
+# ------------------------------------------------------ guarda 2: o container roda a imagem nova
+
+
+def _imagem_atual(em_pe: str, construida: str) -> bool:
+    """Roda a função REAL do deploy.sh. True = o container roda a imagem recém-construída."""
+    partes = _fonte().split("imagem_do_web_esta_atual()", 1)
+    assert len(partes) == 2, "não achei a função `imagem_do_web_esta_atual` no deploy.sh"
+    linhas = partes[1].splitlines()
+    fim = next(i for i, linha in enumerate(linhas) if linha.startswith("}"))
+    funcao = "imagem_do_web_esta_atual()" + "\n".join(linhas[: fim + 1])
+    script = funcao + '\nimagem_do_web_esta_atual "$1" "$2"\n'
+    return _bash(script, em_pe, construida).returncode == 0
+
+
+SHA_A = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+SHA_B = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+
+def test_container_na_imagem_recem_construida_PASSA():
+    assert _imagem_atual(SHA_A, SHA_A)
+
+
+def test_container_em_imagem_ANTIGA_reprova():
+    """O caso que a guarda existe para pegar: construiu a nova e não recriou o container."""
+    assert not _imagem_atual(SHA_A, SHA_B), (
+        "o container em pé roda uma imagem DIFERENTE da recém-construída e a guarda aceitou — "
+        "é literalmente 'o web está servindo build velho'"
+    )
+
+
+def test_valor_vazio_reprova():
+    """Um `docker inspect` que falha devolve string vazia; vazio == vazio não pode virar OK."""
+    assert not _imagem_atual("", ""), "duas strings vazias passaram pela guarda"
+    assert not _imagem_atual(SHA_A, ""), "imagem construída vazia passou pela guarda"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -48,6 +48,10 @@ LABEL_CHAVE='{{index .Config.Labels "com.docker.compose.project.config_files"}}'
 LABELS="$(docker inspect infra-api-1 --format "$LABEL_CHAVE" 2>/dev/null || true)"
 [[ -n "$LABELS" ]] || morre "nao achei o container infra-api-1. A stack esta de pe neste host?"
 
+# O project name do compose, lido do MESMO container (nao cravado): e ele que da nome tanto a
+# imagem construida (`<projeto>-web`) quanto ao label pelo qual achamos o container do web.
+PROJETO="$(docker inspect infra-api-1 --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null || true)"
+
 tem_traefik=0
 tem_prod=0
 [[ "$LABELS" == *docker-compose.traefik.yml* ]] && tem_traefik=1
@@ -103,6 +107,14 @@ bundle_servido() {
   curl -sS --max-time 20 "https://$DOMINIO/" 2>/dev/null \
     | grep -oE '/assets/index-[A-Za-z0-9_-]+[.]js' | head -1 || true
 }
+# Imagens do Docker sao content-addressed: se o build nao mudou o `dist/`, a imagem continua sendo
+# a MESMA e o compose nem recria o container -- entao "a imagem mudou?" seria a pergunta errada,
+# ela acusaria um deploy correto. A pergunta certa e "o container em pe esta na imagem mais nova?",
+# e essa nao depende de conteudo nenhum mudar: vale para uma mudanca em `public/` (que muda a
+# imagem sem tocar no bundle), para e2e (que nao muda nem uma nem outra) e para codigo real.
+imagem_do_web_esta_atual() { # $1 = imagem do container em pe, $2 = imagem recem-construida
+  [[ -n "$1" && -n "$2" && "$1" == "$2" ]]
+}
 
 # --- 2. O checkout esta limpo? ------------------------------------------------
 # --untracked-files=no NAO e frouxidao: e o que torna a guarda APLICAVEL neste parque. A AWS
@@ -140,7 +152,14 @@ echo "  ($(git rev-list --count "$SHA_ANTES..$SHA_ALVO") commits)"
 MIGRATION=0
 FRONT=0
 git diff --name-only "$SHA_ANTES..$SHA_ALVO" -- apps/api/migrations/versions | grep -q . && MIGRATION=1
-git diff --name-only "$SHA_ANTES..$SHA_ALVO" -- apps/web packages | grep -q . && FRONT=1
+# Caminhos que moram sob apps/web mas NUNCA viram JS do bundle. Sem esta exclusao a asserção do
+# passo 7 pede o impossivel: o Vite copia `public/` VERBATIM para a raiz do `dist/` (e assim que
+# `sw.js` e `manifest.webmanifest` chegam la), e nem os `*.spec.ts` do Playwright nem os
+# `*.test.tsx` do vitest sao importados pela entrada. Foi exatamente assim que o deploy do #300 --
+# um unico arquivo em `public/`, a verificacao de propriedade do dominio no Google -- ABORTOU
+# depois de ter subido inteiro e correto, com a producao ja saudavel (medido em 04/09/2026).
+FORA_DO_BUNDLE=(':(exclude)apps/web/public' ':(exclude)apps/web/e2e' ':(exclude,glob)apps/web/**/*.test.*')
+git diff --name-only "$SHA_ANTES..$SHA_ALVO" -- apps/web packages "${FORA_DO_BUNDLE[@]}" | grep -q . && FRONT=1
 if (( MIGRATION )); then aviso "traz migration - backup obrigatorio"; else ok "sem migration"; fi
 if (( FRONT )); then ok "mexe no front - o bundle DEVE mudar"; else ok "nao mexe no front - o bundle deve permanecer igual"; fi
 
@@ -253,6 +272,26 @@ if [[ "$ALEMBIC_DEPOIS" == "$HEAD_REPO" ]]; then
   ok "alembic: $ALEMBIC_ANTES -> $ALEMBIC_DEPOIS (head do repo)"
 else
   morre "alembic ficou em '$ALEMBIC_DEPOIS' mas o repo pede '$HEAD_REPO' - a migration nao aplicou."
+fi
+
+# O web esta rodando a imagem que o `up -d --build` acabou de construir? Esta checagem nao
+# depende de o conteudo mudar, entao ela cobre o buraco que a exclusao do `FORA_DO_BUNDLE` abriria
+# sozinha: um deploy que so mexe em `public/` cai no ramo "bundle inalterado, como esperado" e
+# passaria SEM NINGUEM ter verificado que o web foi reconstruido.
+#
+# Inconclusivo NAO e reprovacao. Se o nome da imagem ou o container nao resolverem neste host, o
+# script avisa e segue: a alternativa seria inventar um jeito novo de bloquear producao por uma
+# suposicao de nomenclatura -- e derrubar deploy por engano ja custou ~40 min de fora do ar aqui
+# uma vez (issue #151).
+CID_WEB="$(docker ps -q --filter "label=com.docker.compose.project=$PROJETO" --filter "label=com.docker.compose.service=web" 2>/dev/null | head -1)"
+IMG_EM_PE="$(docker inspect "$CID_WEB" --format '{{.Image}}' 2>/dev/null || true)"
+IMG_CONSTRUIDA="$(docker image inspect "${PROJETO}-web" --format '{{.Id}}' 2>/dev/null || true)"
+if [[ -z "$IMG_EM_PE" || -z "$IMG_CONSTRUIDA" ]]; then
+  aviso "nao consegui comparar a imagem do web (em pe: ${IMG_EM_PE:-?} | construida: ${IMG_CONSTRUIDA:-?}) - checagem inconclusiva, nao e reprovacao"
+elif imagem_do_web_esta_atual "$IMG_EM_PE" "$IMG_CONSTRUIDA"; then
+  ok "web na imagem recem-construida (${IMG_EM_PE:7:12})"
+else
+  morre "o container do web roda a imagem ${IMG_EM_PE:7:12} mas a construida agora e ${IMG_CONSTRUIDA:7:12} - o container nao foi recriado e esta servindo build velho."
 fi
 
 BUNDLE_DEPOIS="$(bundle_servido)"


### PR DESCRIPTION
## O que aconteceu

O `deploy.sh` rodou seu **primeiro caminho feliz em produção** (04/09/2026, AWS, deploy do #300) e terminou em:

```
ABORTADO: o diff mexe no front mas o bundle servido continua
'/assets/index-BEyo_MpB.js' - o web esta servindo build velho.
```

**A produção estava correta.** O commit que subiu era o `c2fd483` (#300), de um arquivo só: `apps/web/public/google43f12893cae1f247.html`.

## Diagnóstico

O Vite copia `public/` **verbatim** para a raiz do `dist/` — é assim que `sw.js` e `manifest.webmanifest` chegam lá. Um arquivo em `public/` **não pode**, por construção, mudar o hash do `index-*.js`.

A classificação `FRONT` marcava por CAMINHO (`apps/web`, `packages`), e a asserção que ela liga (*"o bundle DEVE mudar"*) passou a pedir o impossível. Mesma classe de falso alarme: `apps/web/e2e/` e os 96 `*.test.tsx` do vitest — nenhum é importado pela entrada.

**Evidência colhida antes de tocar em código** (a produção não foi alterada por esta investigação):

| Verificação | Resultado |
|---|---|
| `Last-Modified` do `index.html` servido | 4 min antes → o container **foi** reconstruído |
| CDN na frente? | Não (`Via: 1.1 Caddy`, `Server: nginx`, sem `cf-cache-status`) |
| `GET /google43f12893cae1f247.html` | 200, 54 bytes, conteúdo idêntico ao repo |
| Bundle servido contém o #299? | Sim (3 trechos de `PrivacidadePage.tsx`) → o range era só o #300 |

⚠️ **`curl -I` mente nessa URL** — o `try_files $uri $uri/ /index.html` do nginx responde 200 com o index.html para arquivo inexistente. A verificação acima foi por CONTEÚDO.

## As duas mudanças, e por que as duas

**1. `FORA_DO_BUNDLE`** — pathspecs de exclusão no `git diff` que decide `FRONT`: `apps/web/public`, `apps/web/e2e`, `apps/web/**/*.test.*`. Não apaga nada de lugar nenhum; só deixa o script de PREVER mudança de hash onde ela é impossível.

**2. `imagem_do_web_esta_atual`** — a exclusão sozinha abriria um ponto cego **pior que o falso alarme**: com `FRONT=0` o script cai em *"bundle inalterado, como esperado"* e **nada** mais verificaria que o web foi reconstruído. A checagem nova roda SEMPRE e não depende de conteúdo mudar: compara a imagem que o container em pé roda com a `<projeto>-web` recém-construída.

- A pergunta certa é *"o container está na imagem mais nova?"*, nunca *"a imagem mudou?"* — imagem do Docker é content-addressed, e um build que não muda o `dist/` produz a MESMA imagem sem recriar o container. *"Mudou?"* acusaria um deploy correto.
- **Inconclusivo não é reprovação**: se o nome ou o container não resolverem no host, o script avisa e segue. Inventar um jeito novo de bloquear produção por suposição de nomenclatura já custou ~40 min fora do ar (issue #151).

## O gate

`apps/api/tests/test_deploy_guarda_build_velho.py` (9 testes), irmão do de checkout limpo e no mesmo molde: **extrai as linhas reais do `deploy.sh` e as executa**, nunca uma cópia escrita no teste.

- Dois **controles positivos** (`apps/web/src/**` e `packages/**` TÊM de marcar `FRONT=1`) — sem eles, uma classificação que devolvesse 0 para tudo passaria nos três casos de exclusão.
- **Provado por mutação:** devolver a linha antiga mata 3 testes; tirar a guarda de valor vazio mata o 4º.

⚠️ **Duas armadilhas do harness custaram a maior parte do tempo, e as duas falham para o MESMO lado** — o script "roda", sai 0, e o stdout parece plausível:

1. **`bash -c` não serve nesta máquina.** O `bash` que o `subprocess` acha é o do WSL, e o interop Windows→WSL expande os `$` do argumento antes de o bash parsear: as atribuições rodam e toda referência a variável chega **vazia**. Com `set -x`, a linha virava `git diff --name-only .. -- apps/web packages ''`.
2. **`text=True` não serve.** No Windows ele traduz `\n` em `\r\n` ao escrever no pipe: `set -uo pipefail\r` vira *"invalid option name"* e `HEAD~1\r..HEAD\r` vira *"bad revision"*.

`_bash()` entrega o script por **stdin em bytes** (`bash -s`), e o chamador **confere o stderr**: sem isso um `fatal:` do git faz o `grep -q` não achar nada, `FRONT` fica 0, e os três testes de *"NÃO marca front"* passam verdes sem a guarda ter sido exercitada. No Linux do CI as duas escolhas são indiferentes.

## CI

O gate de infra foi de `>= 34` para `>= 43` executados, com a decomposição atualizada na mensagem de erro. Medido localmente: **43 passed**, `ruff check .` limpo.

## Escopo

3 arquivos + 1 novo. Nenhuma mudança de comportamento fora do `deploy.sh`. Não altera nada em produção — o #300 já está no ar e correto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
