### PR TITLE
fix: a tela para de dizer "conectado" com a conexão Google morta

### DIFF
--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.core import audit
 from app.core.security import sign_oauth_state
+from app.db.session import tenant_session
 from app.modules.google_calendar.models import DEFAULT_SCOPE, GoogleCredential
 
 logger = logging.getLogger("e1p.google_calendar")
@@ -173,6 +174,48 @@ def disconnect(db: Session, *, tenant_id: str, actor: str) -> bool:
     return True
 
 
+def _descartar_credencial_revogada(cred: GoogleCredential) -> None:
+    """Apaga a credencial morta numa sessão CURTA e INDEPENDENTE — nunca na sessão do chamador.
+
+    POR QUÊ a sessão própria: `_ensure_fresh_token` é chamado de dentro de quatro fluxos
+    (`create_meet_event`, `patch_meet_event`, `delete_meet_event` e o `pull_changes` do worker) e
+    em NENHUM deles ele é dono da transação — há um AgendaEvent recém-alterado e ainda sem commit
+    na sessão. Um `db.commit()` aqui persistiria TUDO o que estivesse pendente, no meio de uma
+    operação que ainda podia falhar. Esta sessão curta commita só o DELETE + a auditoria e fecha
+    (mesmo padrão de `funnels/automation.py` e `notifications/service.py::on_client_moved`).
+
+    POR QUÊ apagar: `/integrations/google/status` deduz "conectado" da existência da linha. Com o
+    refresh_token morto a linha sobrevivia e a tela mentia ("conectado como ...") enquanto nenhum
+    Meet era criado. Sem a linha, o status volta a `connected: false` sozinho e reconectar segue
+    funcionando pelo caminho normal (`upsert_credential` recria a linha) — sem coluna nova, sem
+    migration, sem mexer no router.
+
+    BEST-EFFORT (princípio de robustez do módulo, IV1/IV2): se a sessão curta falhar (banco fora,
+    RLS, o que for), loga e segue. Nenhuma exceção nova sai de `_ensure_fresh_token` — a Agenda
+    nunca cai por causa da integração Google.
+    """
+    # Lidos ANTES de abrir a outra sessão: `cred` pertence à sessão do chamador e não pode ser
+    # usado dentro dela (nem depois do delete, que o expiraria lá).
+    tenant_id = cred.tenant_id
+    cred_id = cred.id
+    try:
+        with tenant_session(tenant_id) as descarte:
+            morta = descarte.get(GoogleCredential, cred_id)
+            if morta is None:
+                return  # o usuário (ou outro fluxo) já desconectou — nada a fazer
+            descarte.delete(morta)
+            # Ação PRÓPRIA, deliberadamente distinta de `google.credential.disconnect`: quem
+            # apagou foi o sistema ao ver o token morto, não o usuário pedindo para desconectar.
+            # Confundir as duas no audit apagaria a diferença entre "revogado pelo Google" e
+            # "o dono clicou em Desconectar".
+            audit.record(
+                descarte, tenant_id=tenant_id, actor="google:token",
+                action="google.credential.revoked", target=cred_id,
+            )
+    except Exception:
+        logger.exception("[google:token:descarte_falhou] tenant=%s", tenant_id)
+
+
 # ── Geração de Meet ao criar evento ──────────────────────────────────────────
 def _ensure_fresh_token(db: Session, cred: GoogleCredential) -> str | None:
     """Retorna um access_token válido, renovando via refresh_token se já expirou. None se não
@@ -196,14 +239,17 @@ def _ensure_fresh_token(db: Session, cred: GoogleCredential) -> str | None:
     )
     if resp.status_code == 400 and "invalid_grant" in resp.text:
         # Refresh token revogado ou expirado. É TERMINAL: repetir não adianta, só reconectar.
-        # Acontece a cada 7 dias enquanto o app OAuth estiver em modo "Testing" no Google.
-        # ATENÇÃO: a credencial CONTINUA no banco, então `/integrations/google/status` segue
-        # dizendo "conectado como ..." enquanto nenhum Meet é criado — a tela mente. Este log
-        # é hoje o único sinal da falha; ver o TODO em docs/GO-LIVE-CHECKLIST.md §5.
+        # Acontece a cada 7 dias enquanto o app OAuth estiver em modo "Testing" no Google (ver
+        # docs/GO-LIVE-CHECKLIST.md §5, "Autocura da conexão morta").
         logger.warning(
             "[google:token:revogado] tenant=%s — refresh_token morto, precisa reconectar",
             cred.tenant_id,
         )
+        # A credencial morta é descartada aqui (em sessão própria, ver a função abaixo): sem a
+        # linha, `/integrations/google/status` volta a responder `connected: false` e a UI
+        # oferece "Conectar Google", em vez de exibir "conectado como ..." com a integração
+        # parada. O log acima deixa de ser o único sinal da falha.
+        _descartar_credencial_revogada(cred)
         return None
     resp.raise_for_status()
     token_data = resp.json()

--- a/apps/api/tests/test_google_calendar.py
+++ b/apps/api/tests/test_google_calendar.py
@@ -3,11 +3,15 @@
 Todas as chamadas HTTP ao Google são MOCKADAS (não batemos na API real). A validação
 ponta-a-ponta com um Google Cloud project real é manual, pós-deploy (ver Dev Agent Record).
 """
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.modules.google_calendar import service
@@ -297,7 +301,7 @@ def test_callback_exchange_failure_logs_traceback(
 
 
 def test_refresh_token_revogado_loga_reconexao(client: TestClient, headers, configured, db,
-                                               monkeypatch, caplog):
+                                               monkeypatch, caplog, sessao_curta):
     """`invalid_grant` na renovação é terminal: precisa sair no log como 'reconectar', não como
     um traceback genérico de create_meet — é o que diferencia 'token morto' de 'Google fora do ar'.
     """
@@ -333,3 +337,289 @@ def test_refresh_token_revogado_loga_reconexao(client: TestClient, headers, conf
     assert token is None  # nenhum call site tenta usar um token morto
     assert "[google:token:revogado]" in caplog.text
     assert "precisa reconectar" in caplog.text
+
+
+# ── Issue #294: conexão morta não pode continuar dizendo "conectado" ─────────
+#
+# Limite conhecido desta suíte (leia antes de acreditar no que os testes provam): o SQLite de
+# teste usa `StaticPool` (tests/conftest.py), ou seja TODAS as sessões compartilham a MESMA
+# conexão DBAPI. Logo é IMPOSSÍVEL provar aqui isolamento de transação física — um commit da
+# "sessão curta" roda na mesma transação da sessão do chamador. O que os testes abaixo provam é
+# isolamento ESTRUTURAL: QUAL objeto de sessão o código usa para apagar e para commitar, e que a
+# sessão do chamador não recebe `.commit()` nem `.delete()`. O isolamento físico é garantido em
+# produção por `app/db/session.py::tenant_session` (conexão dedicada) e é exercido no Postgres.
+
+
+@pytest.fixture()
+def sessao_curta(db, monkeypatch):
+    """Troca `service.tenant_session` por uma fábrica que devolve uma sessão SEPARADA.
+
+    Separada de verdade no sentido de objeto Python (identidade distinta da sessão do chamador),
+    ligada à mesma engine SQLite da suíte. Devolve a lista de sessões abertas, para os testes
+    conferirem por identidade quem foi usado no descarte.
+    """
+    abertas: list[Session] = []
+
+    @contextmanager
+    def _factory(_tenant_id: str):
+        curta = Session(bind=db.get_bind(), autoflush=False, expire_on_commit=False)
+        abertas.append(curta)
+        try:
+            yield curta
+            curta.commit()  # espelha `tenant_session` de produção: commita ao sair do `with`
+        finally:
+            curta.close()
+
+    monkeypatch.setattr(service, "tenant_session", _factory)
+    return abertas
+
+
+class _Revogado400:
+    """O que o Google devolve quando o refresh_token morreu: 400 + `invalid_grant`."""
+
+    status_code = 400
+    text = '{"error": "invalid_grant", "error_description": "expired or revoked"}'
+
+    def raise_for_status(self):
+        raise httpx.HTTPStatusError("400 invalid_grant", request=None, response=None)
+
+
+def _mock_invalid_grant(monkeypatch) -> None:
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Revogado400())
+
+
+def _tenant_id(db) -> str:
+    from app.modules.auth.models import Tenant
+
+    return db.scalars(select(Tenant)).first().id
+
+
+def _cred_morta(db, tenant_id: str):
+    """Credencial com token JÁ expirado — força a renovação (e portanto o `invalid_grant`)."""
+    from app.modules.google_calendar.models import GoogleCredential
+
+    cred = GoogleCredential(
+        tenant_id=tenant_id,
+        google_account_email="dono@gmail.com",
+        access_token="velho",
+        refresh_token="refresh-morto",
+        token_expiry=datetime.now(UTC) - timedelta(hours=1),
+    )
+    db.add(cred)
+    db.commit()
+    return cred
+
+
+def _evento(db, tenant_id: str, *, title: str = "Reunião com cliente"):
+    from app.modules.agenda.models import AgendaEvent
+
+    ev = AgendaEvent(
+        tenant_id=tenant_id,
+        title=title,
+        kind="reuniao",
+        starts_at=datetime.now(UTC) + timedelta(days=1),
+        ends_at=datetime.now(UTC) + timedelta(days=1, hours=1),
+        guests=[],
+    )
+    db.add(ev)
+    db.commit()
+    return ev
+
+
+class _SessaoEspia:
+    """Espelha a sessão do chamador, contando `commit()` e registrando `delete()`.
+
+    Delega tudo o mais por `__getattr__` — o código sob teste não percebe a diferença. É assim
+    que provamos que o descarte da credencial NÃO passa pela transação de quem chamou.
+    """
+
+    def __init__(self, real: Session):
+        self._real = real
+        self.commits = 0
+        self.deletados: list[object] = []
+
+    def __getattr__(self, nome):
+        return getattr(self._real, nome)
+
+    def commit(self):
+        self.commits += 1
+        return self._real.commit()
+
+    def delete(self, obj):
+        self.deletados.append(obj)
+        return self._real.delete(obj)
+
+
+def test_invalid_grant_descarta_credencial_e_status_volta_a_desconectado(
+    client: TestClient, headers, configured, db, monkeypatch, sessao_curta
+):
+    """AC1+AC2: com `invalid_grant`, a linha da credencial some e `/status` para de mentir.
+
+    Antes desta correção o `/status` respondia `connected: true` para sempre, porque deduz a
+    conexão da EXISTÊNCIA da linha — e a linha sobrevivia à morte do refresh_token.
+    """
+    from app.modules.google_calendar.models import GoogleCredential
+
+    tenant_id = _tenant_id(db)
+    _cred_morta(db, tenant_id)
+
+    antes = client.get("/integrations/google/status", headers=headers).json()
+    assert antes["connected"] is True
+    assert antes["email"] == "dono@gmail.com"
+
+    _mock_invalid_grant(monkeypatch)
+    assert service.create_meet_event(db, tenant_id=tenant_id, event=_evento(db, tenant_id)) is None
+
+    assert db.scalar(select(GoogleCredential)) is None
+    depois = client.get("/integrations/google/status", headers=headers).json()
+    assert depois["connected"] is False
+    assert depois["email"] is None
+
+
+def test_descarte_grava_audit_com_acao_propria(
+    client: TestClient, headers, configured, db, monkeypatch, sessao_curta
+):
+    """AC4: o descarte automático tem ação PRÓPRIA no audit.
+
+    `google.credential.revoked` (ator `google:token`) não pode se confundir com
+    `google.credential.disconnect` (ator = usuário): uma é o Google matando o token, a outra é o
+    dono clicando em Desconectar. Sem ações distintas, o audit não sabe dizer qual aconteceu.
+    """
+    from app.core.audit import AuditEntry
+
+    tenant_id = _tenant_id(db)
+    cred_id = _cred_morta(db, tenant_id).id
+
+    _mock_invalid_grant(monkeypatch)
+    service.create_meet_event(db, tenant_id=tenant_id, event=_evento(db, tenant_id))
+
+    acoes = [e.action for e in db.scalars(select(AuditEntry)).all()]
+    assert "google.credential.revoked" in acoes
+    assert "google.credential.disconnect" not in acoes  # não é um disconnect do usuário
+
+    entrada = db.scalar(
+        select(AuditEntry).where(AuditEntry.action == "google.credential.revoked")
+    )
+    assert entrada.actor == "google:token"
+    assert entrada.target == cred_id
+    assert entrada.tenant_id == tenant_id
+
+
+def test_descarte_nao_toca_a_transacao_de_create_meet_event(
+    client: TestClient, headers, configured, db, monkeypatch, sessao_curta
+):
+    """AC3, call site `create_meet_event`: a sessão do chamador não apaga nem commita.
+
+    Prova (estrutural, ver a nota do topo deste bloco): a sessão que o código recebeu não recebe
+    `.commit()` nem `.delete()`, o descarte usa OUTRO objeto de sessão, e uma alteração pendente
+    e não flushada no AgendaEvent continua NÃO persistida depois da chamada — que é exatamente o
+    risco que impedia um `db.commit()` aqui dentro (evento alterado pela metade).
+    """
+    from app.modules.agenda.models import AgendaEvent
+    from app.modules.google_calendar.models import GoogleCredential
+
+    tenant_id = _tenant_id(db)
+    _cred_morta(db, tenant_id)
+    ev = _evento(db, tenant_id, title="Título original")
+    ev_id = ev.id
+
+    ev.title = "ALTERADO PELA METADE"  # pendente na sessão, sem flush (autoflush=False)
+
+    _mock_invalid_grant(monkeypatch)
+    espia = _SessaoEspia(db)
+    assert service.create_meet_event(espia, tenant_id=tenant_id, event=ev) is None
+
+    assert espia.commits == 0, "a transação do chamador não pode ser commitada aqui"
+    assert espia.deletados == [], "a credencial não pode ser apagada pela sessão do chamador"
+    assert sessao_curta, "o descarte precisa abrir uma sessão própria"
+    assert sessao_curta[0] is not espia
+    assert sessao_curta[0] is not db
+
+    db.expire_all()  # descarta o que só existia em memória e relê do banco
+    assert db.get(AgendaEvent, ev_id).title == "Título original"
+    assert db.scalar(select(GoogleCredential)) is None  # o descarte aconteceu, na sessão certa
+
+
+def test_descarte_nao_toca_a_transacao_do_worker_pull_changes(
+    client: TestClient, headers, configured, db, monkeypatch, sessao_curta
+):
+    """AC3, call site do worker (`sync.pull_changes`): idem, na transação do sweep.
+
+    O worker é o pior caso: roda em lote, e um commit no meio persistiria eventos aplicados de
+    outros itens do mesmo sweep.
+    """
+    from app.modules.agenda.models import AgendaEvent
+    from app.modules.google_calendar import sync
+    from app.modules.google_calendar.models import GoogleCredential
+
+    tenant_id = _tenant_id(db)
+    _cred_morta(db, tenant_id)
+    ev = _evento(db, tenant_id, title="Título original")
+    ev_id = ev.id
+
+    ev.title = "ALTERADO PELA METADE"
+
+    _mock_invalid_grant(monkeypatch)
+    espia = _SessaoEspia(db)
+    assert sync.pull_changes(espia, tenant_id=tenant_id) == 0
+
+    assert espia.commits == 0
+    assert espia.deletados == []
+    assert sessao_curta
+    assert sessao_curta[0] is not espia
+    assert sessao_curta[0] is not db
+
+    db.expire_all()
+    assert db.get(AgendaEvent, ev_id).title == "Título original"
+    assert db.scalar(select(GoogleCredential)) is None
+
+
+def test_descarte_falho_nao_derruba_a_agenda(
+    client: TestClient, headers, configured, db, monkeypatch, caplog
+):
+    """Best-effort (IV1/IV2): sessão curta quebrada vira log, não exceção.
+
+    Se o descarte pudesse propagar, a integração Google passaria a derrubar a criação de evento
+    da Agenda — exatamente o que a docstring do módulo proíbe.
+    """
+    tenant_id = _tenant_id(db)
+    _cred_morta(db, tenant_id)
+
+    @contextmanager
+    def _explode(_tenant_id: str):
+        raise RuntimeError("banco fora do ar")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service, "tenant_session", _explode)
+    _mock_invalid_grant(monkeypatch)
+
+    with caplog.at_level("ERROR", logger="e1p.google_calendar"):
+        resultado = service.create_meet_event(
+            db, tenant_id=tenant_id, event=_evento(db, tenant_id)
+        )
+    assert resultado is None
+    assert "[google:token:descarte_falhou]" in caplog.text
+
+
+def test_reconectar_depois_do_descarte_volta_a_funcionar(
+    client: TestClient, headers, configured, db, monkeypatch, sessao_curta
+):
+    """AC5: apagar a linha não quebra o reconectar — `upsert_credential` recria do zero."""
+    from app.modules.google_calendar.models import GoogleCredential
+
+    tenant_id = _tenant_id(db)
+    _cred_morta(db, tenant_id)
+    _mock_invalid_grant(monkeypatch)
+    service.create_meet_event(db, tenant_id=tenant_id, event=_evento(db, tenant_id))
+    assert db.scalar(select(GoogleCredential)) is None
+
+    _mock_google(monkeypatch)  # Google volta a responder normalmente
+    url = client.get("/integrations/google/connect", headers=headers).json()["url"]
+    state = parse_qs(urlparse(url).query)["state"][0]
+    resp = client.get(
+        "/integrations/google/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 307
+    assert client.get("/integrations/google/status", headers=headers).json()["connected"] is True

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -122,6 +122,24 @@ fora do `ProtectedLayout`, em `apps/web/src/features/legal/`. Restam dois passos
 2. Colar `https://e1p.criativaeduca.com.br/privacidade` (e, se quiser, `/termos`) na aba
    Branding e então **Público-alvo → Publicar app**.
 
+### Autocura da conexão morta (issue #294, corrigido)
+
+Quando o refresh token morre (o caso semanal acima, ou uma revogação na conta Google), o e1p
+**descarta sozinho** a credencial do tenant: `_ensure_fresh_token` detecta o `400 invalid_grant`,
+loga `[google:token:revogado]` e apaga a linha `GoogleCredential` numa sessão curta e
+independente — sem tocar a transação de quem chamou (criar/remarcar/cancelar evento, ou o sweep
+do worker). Consequências operacionais:
+
+- `/integrations/google/status` volta a `connected: false` sozinho e a UI oferece "Conectar
+  Google". **Antes disso a tela mentia**: dizia "conectado como ..." indefinidamente enquanto
+  nenhum Meet era criado.
+- O descarte fica no audit do tenant como `google.credential.revoked` (ator `google:token`) —
+  deliberadamente distinto de `google.credential.disconnect`, que é o dono clicando em
+  Desconectar. Ao investigar "sumiu minha conexão", é esta ação que diz qual dos dois foi.
+- Reconectar segue o caminho normal (OAuth → `upsert_credential` recria a linha).
+- O descarte é best-effort: se a sessão curta falhar, sai `[google:token:descarte_falhou]` no log
+  e a operação de negócio continua — a integração Google nunca derruba a Agenda (IV1/IV2).
+
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [x] Instalar/configurar `rclone` com remote S3-compatível — validado em 2026-07-12 **localmente**
   (MinIO em Docker no lugar do S3 real — sem custo/conta externa) com o binário real do rclone.


### PR DESCRIPTION
## Contexto

O PR #295 tornou visível a falha do OAuth Google no log (`[google:token:revogado]`) e deixou
escrito, na seção "O que NÃO muda", que a tela continuava mentindo. Este PR fecha isso.

`GET /integrations/google/status` deduz "conectado" da **existência** da linha `GoogleCredential`.
Quando o refresh token morre (`400 invalid_grant`), o que morre é o token — a linha continua no
banco. Resultado: a tela diz "conectado como fulano@gmail.com" indefinidamente, nenhum Meet é
criado, e o usuário não tem como descobrir o motivo. Em modo "Testing" no Google Cloud, que é o
estado atual do projeto, isso acontece **toda semana, para cada pessoa conectada**.

## Por que não foi feito junto com o #295

Apagar a credencial exige `db.commit()`, e o ponto de detecção (`_ensure_fresh_token`) não é dono
da transação: é chamado de quatro fluxos, cada um com pendências diferentes na sessão.

| Chamador | Estado da transação |
|---|---|
| `create_meet_event` ← criar evento da Agenda | outras pendências na sessão |
| `patch_meet_event` ← remarcar | evento já alterado, sem commit |
| `delete_meet_event` ← cancelar | idem |
| `sync.pull_changes` ← worker | transação do sweep |

Um commit ali dentro persistiria **tudo** o que estivesse pendente — inclusive um evento de agenda
alterado pela metade, no meio de uma operação que ainda podia falhar.

## O que muda

### Descarte em sessão curta e independente

`_descartar_credencial_revogada` abre uma `tenant_session` própria, apaga a linha, grava a
auditoria, commita e fecha — sem tocar a transação de quem chamou. É o padrão que o repo já usa em
`funnels/automation.py` e `notifications/service.py::on_client_moved`, pelo mesmo motivo.

Com a linha fora, `/integrations/google/status` volta a `connected: false` **sozinho** e a UI já
sabe oferecer "Conectar Google" nesse estado. Sem migration, sem coluna nova, sem mexer no router.
Reconectar segue o caminho normal — `upsert_credential` recria a linha.

### Audit com ação própria

`google.credential.revoked` (ator `google:token`), deliberadamente distinta de
`google.credential.disconnect` (o dono clicando em Desconectar). Sem ações separadas, ao investigar
"sumiu minha conexão" não há como saber qual dos dois aconteceu.

### Best-effort, como o resto do módulo

Falha da sessão curta vira `[google:token:descarte_falhou]` no log. Nenhuma exceção nova sai de
`_ensure_fresh_token` — a integração Google nunca derruba a Agenda (IV1/IV2).

### Referência pendurada na documentação

O comentário no ponto de detecção mandava "ver o TODO em `docs/GO-LIVE-CHECKLIST.md` §5". Esse TODO
**nunca existiu** — `grep -n TODO` no arquivo inteiro volta vazio. §5 ganhou a subseção "Autocura
da conexão morta", posicionada depois das instruções de publicar (para não separar o aviso do modo
"Testando" do seu próprio "Para publicar:"), e o comentário passou a apontar para ela.

## O que os testes provam — e o que não provam

A suíte usa SQLite com `StaticPool`: **todas** as sessões compartilham a mesma conexão DBAPI. Logo
isolamento de transação **física** é indemonstrável aqui, e nenhum teste finge o contrário. O que
os 6 testes novos provam:

| AC | Prova |
|---|---|
| `invalid_grant` descarta a credencial | a linha some depois de `create_meet_event` |
| `/status` responde `connected: false` | resposta real da rota, antes e depois |
| a transação do chamador não é afetada | isolamento **estrutural**, por call site: a sessão do chamador não recebe `.commit()` nem `.delete()`, o descarte usa outro objeto de sessão, e um `AgendaEvent` alterado e não flushado continua não persistido |
| audit com ação distinta | `google.credential.revoked` presente, `...disconnect` ausente |
| reconectar volta a funcionar | OAuth completo pós-descarte, `connected: true` no fim |

O isolamento físico é garantido em produção por `tenant_session` (conexão dedicada, exigida pela
RLS) e exercido no Postgres.

## Verificação

Prova por mutação — refeita **à mão** sobre o código de produção, revertida por cópia de arquivo, e
cada mutante passou por `ruff check` antes dos testes (mutante que não compila mata o teste pelo
motivo errado):

| Mutação | Resultado |
|---|---|
| remove a chamada de descarte | `6 failed, 15 passed` — morre em `assert ... is None` (credencial sobreviveu) |
| descarte usa a sessão do chamador (`Session.object_session(cred)`) | `3 failed, 18 passed` — morre em `assert sessao_curta` |
| remove o `audit.record` do descarte | `assert 'google.credential.revoked' in []` |
| reusa `action="google.credential.disconnect"` | `assert 'google.credential.revoked' in ['google.credential.disconnect']` |

Gates rodados localmente:

- `ruff check .` → `All checks passed!`
- 4 arquivos do módulo Google → `41 passed`
- Suíte backend, `pytest -q -m "not rls_e2e"` → `2449 passed, 1 skipped, 71 deselected` em 12min46s

`pytest -q` cru não vale como gate neste repo: ele inclui os `rls_e2e`, que sobem Postgres em
container, disputam recurso e falham em falso.

Nada fora de `google_calendar/service.py`, `tests/test_google_calendar.py` e
`docs/GO-LIVE-CHECKLIST.md` foi tocado — conferido por `git diff --name-only origin/main`.

## Achado fora do escopo → #302

`google_event_id` é escrito em 2 lugares e limpo em **nenhum** — nem pelo `disconnect` manual, nem
por este descarte. Quem reconectar com **outra** conta Google fica com eventos apontando para o
calendário antigo. Não é regressão (o `disconnect` já produzia isso), mas este PR torna o descarte
**semanal**, então o caminho raro virou rotina. Está em #302, fora deste PR.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
