### PR TITLE
fix(agenda): reconectar com outra conta Google não deixa evento apontando pro calendário alheio

### DIFF
--- a/apps/api/app/modules/agenda/models.py
+++ b/apps/api/app/modules/agenda/models.py
@@ -80,6 +80,16 @@ class AgendaEvent(Base, TenantMixin, TimestampMixin):
     # máximo documentado pela Google para o campo `id` do evento.
     google_event_id: Mapped[str | None] = mapped_column(String(1024), nullable=True)
 
+    # De QUAL conta Google veio o `google_event_id` acima (migration 0086). Carimbado nos dois
+    # pontos de escrita do id: `agenda/service.py::create_event` (a credencial que criou o
+    # espelho lá) e `google_calendar/sync.py::_apply_item` (a credencial que puxou o evento).
+    #
+    # NULL tem SIGNIFICADO: procedência DESCONHECIDA — ou a linha é legada (gravada antes da
+    # 0086, que não fez backfill de propósito), ou o `userinfo` do Google falhou e nunca
+    # soubemos o e-mail. Em ambos os casos a limpeza de reconexão
+    # (`google_calendar/service.py::_invalidar_vinculos_de_outra_conta`) NÃO toca a linha.
+    google_account_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
     # Dinheiro SEMPRE em centavos inteiros (evita erro de float). Opcional (cobranças).
     amount_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Referência à entidade de origem (id do processo, fatura, contrato...).

--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -116,10 +116,15 @@ def create_event(
 
         result = gcal.create_meet_event(db, tenant_id=tenant_id, event=event)
         if result is not None:
-            meeting_url, google_event_id = result
+            meeting_url, google_event_id, google_account_email = result
             if meeting_url:
                 event.meeting_url = meeting_url
             event.google_event_id = google_event_id
+            # De QUAL conta Google é este id (migration 0086). Vem junto do retorno, e não de um
+            # `get_credential` novo, porque é a credencial que REALMENTE escreveu o evento lá.
+            # Sem este carimbo, reconectar com outra conta deixaria o id apontando para um
+            # calendário alheio — ver `google_calendar/service.py::upsert_credential`.
+            event.google_account_email = google_account_email
     db.add(event)
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="agenda.event.create",

--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -16,13 +16,14 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode
 
 import httpx
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.core import audit
 from app.core.security import sign_oauth_state
 from app.db.session import tenant_session
+from app.modules.agenda.models import AgendaEvent
 from app.modules.google_calendar.models import DEFAULT_SCOPE, GoogleCredential
 
 logger = logging.getLogger("e1p.google_calendar")
@@ -113,6 +114,66 @@ def get_credential(db: Session) -> GoogleCredential | None:
     return db.scalars(select(GoogleCredential)).first()
 
 
+def _invalidar_vinculos_de_outra_conta(db: Session, *, novo_email: str) -> int:
+    """Zera os vínculos com o Google dos eventos que vieram de OUTRA conta. Retorna quantos.
+
+    POR QUE NA RECONEXÃO, e não ao desconectar: enquanto o tenant está sem credencial, os três
+    consumidores de `google_event_id` (`patch_meet_event`, `delete_meet_event` e o
+    `pull_changes` do worker) já retornam cedo em `get_credential(db) is None` — nenhum id velho
+    chega ao Google. A janela de dano abre só quando uma credencial volta. Limpar no
+    `disconnect` seria cedo demais: ainda não se sabe qual conta vai voltar, e destruiria o
+    vínculo no caso DOMINANTE, que é reconectar com a MESMA conta.
+
+    Roda na sessão do chamador de propósito (ao contrário de `_descartar_credencial_revogada`,
+    que precisa de sessão própria): `upsert_credential` É a dona da transação e commita logo em
+    seguida — a limpeza e a nova credencial entram juntas ou não entram.
+
+    Cada cláusula do WHERE é deliberada:
+
+    - `google_event_id IS NOT NULL` — PROTEGE O `meeting_url` DIGITADO À MÃO. Quem colou um link
+      de Zoom nunca teve `google_event_id` (`agenda/service.py::create_event` só chama o Google
+      quando `not data.meeting_url`). Sem esta cláusula, apagaríamos links que o usuário digitou.
+
+    - `google_account_email IS NOT NULL` — LINHA LEGADA FICA INTACTA. `NULL` é procedência
+      desconhecida (gravada antes da migration 0086, que não fez backfill). Apagar às cegas
+      reintroduziria a duplicação de eventos no próximo sync para os dados que já existem. Elas
+      se autocuram no ramo de update de `sync.py::_apply_item`.
+      ⚠️ Esta cláusula é REDUNDANTE **hoje**, e isso foi MEDIDO (prova por mutação da #302:
+      removê-la sozinha não muda nenhum comportamento observável): pela lógica de três valores
+      do SQL, `NULL != 'alguem@gmail.com'` já avalia a NULL, não a TRUE, e a linha legada
+      escapa do `WHERE` sozinha. Ela fica porque a proteção não pode depender de um efeito
+      colateral de NULL que ninguém lê: trocar o `!=` por qualquer coisa NULL-tolerante
+      (`IS DISTINCT FROM`, `coalesce(..., '') !=`) apagaria TODA a base legada em silêncio — e
+      a mutação que faz exatamente isso mata o teste da linha legada.
+
+    - `!= novo_email` — RECONECTAR COM A MESMA CONTA É NO-OP. É a razão de existir de todo este
+      desenho: o caso comum (token expirou, dono reconecta a mesma conta) não pode perder nada.
+
+    `novo_email` vazio ("" quando o `userinfo` falhou no callback) também é no-op: sem saber
+    QUEM está conectando não dá para afirmar que a conta mudou, e na dúvida não se destrói.
+
+    TRADE-OFF ASSUMIDO: `meeting_url` vai junto. Um link de Meet da conta antiga PODE continuar
+    funcionando, e apagá-lo é irreversível. É o que a issue #302 pede explicitamente — um link
+    que abre o Meet de outra pessoa é pior que um card sem link.
+
+    UPDATE em MASSA (uma query), não laço Python: a RLS já isola a sessão no tenant (Regra de
+    Ouro nº 1) e o `WHERE` não precisa — nem pode — repetir o filtro de tenant.
+    """
+    if not novo_email:
+        return 0
+    resultado = db.execute(
+        update(AgendaEvent)
+        .where(
+            AgendaEvent.google_event_id.is_not(None),
+            AgendaEvent.google_account_email.is_not(None),
+            AgendaEvent.google_account_email != novo_email,
+        )
+        .values(google_event_id=None, meeting_url=None, google_account_email=None)
+        .execution_options(synchronize_session=False)
+    )
+    return resultado.rowcount or 0
+
+
 def upsert_credential(db: Session, *, tenant_id: str, email: str, token_data: dict) -> None:
     """Cria/atualiza a credencial do tenant (uma por tenant). Preserva o refresh_token antigo
     se o Google não devolver um novo (ele só vem na 1ª autorização com prompt=consent)."""
@@ -127,6 +188,14 @@ def upsert_credential(db: Session, *, tenant_id: str, email: str, token_data: di
         cred.refresh_token = new_refresh
     cred.token_expiry = _expiry_from(token_data)
     cred.scope = token_data.get("scope", DEFAULT_SCOPE)
+    # ANTES do commit abaixo (mesma transação): se a conta que está conectando não é a que
+    # gerou os `google_event_id` guardados, esses ids apontam para o calendário de OUTRA pessoa.
+    invalidados = _invalidar_vinculos_de_outra_conta(db, novo_email=email)
+    if invalidados:
+        logger.warning(
+            "[google:reconexao:conta_trocada] tenant=%s eventos_invalidados=%d",
+            tenant_id, invalidados,
+        )
     audit.record(
         db, tenant_id=tenant_id, actor="google:oauth", action="google.credential.connect",
         target=cred.id,
@@ -261,10 +330,10 @@ def _ensure_fresh_token(db: Session, cred: GoogleCredential) -> str | None:
 
 def create_meet_event(
     db: Session, *, tenant_id: str, event
-) -> tuple[str | None, str | None] | None:
+) -> tuple[str | None, str | None, str | None] | None:
     """Cria o evento espelho no Google Calendar (com link de Meet) para um AgendaEvent.
 
-    Retorna (hangout_link, google_event_id) em caso de sucesso, ou None se:
+    Retorna (hangout_link, google_event_id, google_account_email) em caso de sucesso, ou None se:
     - o tenant não tem Google conectado (no-op — preserva AC3/IV1); ou
     - a chamada ao Google falhou (rede/token/quota) — a exceção é capturada e logada, NUNCA
       propagada, para não derrubar a criação do evento da Agenda (IV1/IV2).
@@ -298,7 +367,12 @@ def create_meet_event(
         )
         resp.raise_for_status()
         data = resp.json()
-        return data.get("hangoutLink"), data.get("id")
+        # A conta vem da MESMA `cred` que acabou de autenticar a chamada — é a verdade sobre
+        # quem escreveu o evento lá, e não uma releitura posterior de `get_credential` (que
+        # poderia já ser outra conta se o dono reconectasse no meio). `or None` porque
+        # `google_account_email` fica "" quando o `userinfo` falhou no callback: string vazia
+        # não é um e-mail, é procedência desconhecida — mesma semântica do NULL da coluna.
+        return data.get("hangoutLink"), data.get("id"), cred.google_account_email or None
     except Exception:
         # Falha de integração externa não derruba a Agenda (IV1). Não logamos o token.
         logger.exception("[google:create_meet:failed] tenant=%s", tenant_id)

--- a/apps/api/app/modules/google_calendar/sync.py
+++ b/apps/api/app/modules/google_calendar/sync.py
@@ -104,8 +104,13 @@ def _parse_google_datetime(node: dict, *, all_day: bool) -> datetime | None:
     return datetime.fromisoformat(raw)
 
 
-def _apply_item(db: Session, *, tenant_id: str, item: dict) -> bool:
-    """Aplica UM item da resposta do Google na Agenda local. Retorna True se algo mudou."""
+def _apply_item(db: Session, *, tenant_id: str, item: dict, account_email: str | None) -> bool:
+    """Aplica UM item da resposta do Google na Agenda local. Retorna True se algo mudou.
+
+    `account_email` é a conta Google de onde ESTE item veio (a credencial usada em
+    `pull_changes`). Carimbá-la junto do `google_event_id` é o que permite invalidar o vínculo
+    depois, se o dono reconectar com outra conta — ver `service.py::upsert_credential`.
+    """
     google_event_id = item.get("id")
     if not google_event_id:
         return False
@@ -149,6 +154,7 @@ def _apply_item(db: Session, *, tenant_id: str, item: dict) -> bool:
             meeting_url=meeting_url,
             guests=guests,
             google_event_id=google_event_id,
+            google_account_email=account_email,
         )
     else:
         existing.title = title
@@ -159,6 +165,11 @@ def _apply_item(db: Session, *, tenant_id: str, item: dict) -> bool:
         existing.location = location
         existing.meeting_url = meeting_url
         existing.guests = guests
+        # Carimbo TAMBÉM no ramo de update, e não só no INSERT: é ele que AUTOCURA as linhas
+        # legadas (`google_account_email IS NULL`, gravadas antes da migration 0086, que de
+        # propósito não fez backfill). No primeiro sync bem-sucedido a procedência deixa de ser
+        # desconhecida e a linha passa a ser protegida/invalidável como qualquer outra.
+        existing.google_account_email = account_email
     db.add(existing)
     return True
 
@@ -182,9 +193,12 @@ def pull_changes(db: Session, *, tenant_id: str) -> int:
             cred.sync_token = None
             items, next_sync_token = _fetch_all_pages(access_token, _list_params(None))
 
+        # `or None`: `google_account_email` fica "" quando o `userinfo` falhou no callback —
+        # string vazia não é um e-mail, é procedência desconhecida (mesma semântica do NULL).
+        account_email = cred.google_account_email or None
         touched = 0
         for item in items:
-            if _apply_item(db, tenant_id=tenant_id, item=item):
+            if _apply_item(db, tenant_id=tenant_id, item=item, account_email=account_email):
                 touched += 1
 
         if next_sync_token:

--- a/apps/api/migrations/versions/0086_agenda_google_account_email.py
+++ b/apps/api/migrations/versions/0086_agenda_google_account_email.py
@@ -1,0 +1,44 @@
+"""agenda_events ganha google_account_email — de QUAL conta Google veio o vínculo
+
+Revision ID: 0086
+Revises: 0085
+Create Date: 2026-09-05
+
+Por quê: `agenda_events.google_event_id` é escrito em dois lugares — o espelho criado por
+`agenda/service.py::create_event` e o pull de `google_calendar/sync.py::_apply_item` — e nunca
+registrou de QUAL conta Google aquele id veio. Quando o tenant desconecta (o `disconnect`
+manual ou o descarte automático do token revogado, ambos em `google_calendar/service.py`) e
+depois reconecta com OUTRA conta, os ids antigos sobrevivem apontando para um calendário que
+não é mais dele.
+
+`nullable=True` e SEM `server_default`, DE PROPÓSITO — `NULL` aqui tem SIGNIFICADO SEMÂNTICO:
+PROCEDÊNCIA DESCONHECIDA (linha legada, gravada antes desta coluna existir). É o que permite à
+limpeza de reconexão (`google_calendar/service.py::_invalidar_vinculos_de_outra_conta`) deixar
+as linhas legadas INTACTAS em vez de apagá-las às cegas — apagar às cegas reintroduziria a
+duplicação de eventos no próximo sync para os dados que já existem.
+
+SEM BACKFILL, mesma disciplina das migrations 0084/0085: DDL puro. Um `UPDATE` aqui rodaria
+sob FORCE RLS sem `app.current_tenant_id` definido, seria filtrado a ZERO linhas e "passaria"
+em silêncio — o modo de falha que já mordeu este repo. As linhas legadas se AUTOCURAM sozinhas
+no primeiro sync bem-sucedido: o ramo de update de `_apply_item` carimba a conta.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0086"
+down_revision: str | None = "0085"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agenda_events", sa.Column("google_account_email", sa.String(255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agenda_events", "google_account_email")

--- a/apps/api/tests/test_agenda.py
+++ b/apps/api/tests/test_agenda.py
@@ -308,7 +308,7 @@ def test_meet_generated_when_google_connected(client: TestClient, headers, monke
 
     monkeypatch.setattr(
         gcal, "create_meet_event",
-        lambda *a, **k: ("https://meet.google.com/abc-defg-hij", "gcal-evt-1"),
+        lambda *a, **k: ("https://meet.google.com/abc-defg-hij", "gcal-evt-1", "dono@gmail.com"),
     )
     resp = client.post("/agenda/events", json=_event(kind="reuniao"), headers=headers)
     assert resp.status_code == 201
@@ -324,7 +324,7 @@ def test_manual_meeting_url_preserved_google_not_called(client: TestClient, head
 
     def _spy(*a, **k):
         calls["n"] += 1
-        return ("https://meet.google.com/should-not-win", "x")
+        return ("https://meet.google.com/should-not-win", "x", "dono@gmail.com")
 
     monkeypatch.setattr(gcal, "create_meet_event", _spy)
     resp = client.post(

--- a/apps/api/tests/test_google_calendar_reconexao.py
+++ b/apps/api/tests/test_google_calendar_reconexao.py
@@ -1,0 +1,365 @@
+"""Reconectar o Google não pode deixar evento apontando para o calendário de outra pessoa.
+
+Issue #302. `agenda_events.google_event_id` era escrito em dois lugares e limpo em NENHUM. Com o
+tenant desconectado nada quebrava — os três consumidores do id (`patch_meet_event`,
+`delete_meet_event`, `pull_changes`) já retornam cedo sem credencial. O dano abria na
+RECONEXÃO: se o dono voltasse com OUTRA conta Google, aqueles ids passavam a endereçar eventos
+de um calendário que não é mais dele (remarcar/cancelar mexendo na agenda alheia; e o pull
+importando de novo os mesmos compromissos, já que o `existing` nunca casava).
+
+A correção carimba a PROCEDÊNCIA (`google_account_email`, migration 0086) nos dois pontos de
+escrita e invalida, na reconexão, só o que veio de outra conta. Todas as chamadas HTTP ao Google
+são MOCKADAS.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.agenda.models import AgendaEvent
+from app.modules.google_calendar import service, sync
+from app.modules.google_calendar.models import GoogleCredential
+
+TENANT = "t" * 12
+CONTA_ANTIGA = "antiga@gmail.com"
+CONTA_NOVA = "nova@gmail.com"
+
+_TOKEN_DATA = {
+    "access_token": "ya29.novo-access",
+    "refresh_token": "1//novo-refresh",
+    "expires_in": 3600,
+}
+
+
+def _conectar(db: Session, email: str, *, sync_token: str | None = None) -> GoogleCredential:
+    cred = GoogleCredential(
+        tenant_id=TENANT,
+        google_account_email=email,
+        access_token="access-valido",
+        refresh_token="refresh-valido",
+        token_expiry=datetime.now(UTC) + timedelta(hours=1),
+        sync_token=sync_token,
+    )
+    db.add(cred)
+    db.commit()
+    return cred
+
+
+def _evento(
+    db: Session,
+    *,
+    titulo: str,
+    google_event_id: str | None,
+    google_account_email: str | None,
+    meeting_url: str | None,
+) -> str:
+    ev = AgendaEvent(
+        tenant_id=TENANT,
+        title=titulo,
+        kind="reuniao",
+        starts_at=datetime(2026, 9, 10, 13, 0, tzinfo=UTC),
+        ends_at=datetime(2026, 9, 10, 14, 0, tzinfo=UTC),
+        guests=[],
+        google_event_id=google_event_id,
+        google_account_email=google_account_email,
+        meeting_url=meeting_url,
+    )
+    db.add(ev)
+    db.commit()
+    return ev.id
+
+
+def _reler(db: Session, ev_id: str) -> AgendaEvent:
+    """Relê do BANCO. O UPDATE em massa usa `synchronize_session=False`: sem expirar a sessão,
+    o objeto em memória mentiria o estado anterior e o teste passaria por acidente."""
+    db.expire_all()
+    return db.get(AgendaEvent, ev_id)
+
+
+# ── A limpeza na reconexão ───────────────────────────────────────────────────
+def test_reconectar_com_a_mesma_conta_preserva_o_vinculo(db: Session):
+    """O caso DOMINANTE (token expirou, o dono reconecta a mesma conta) não pode perder nada.
+
+    É o teste que justifica o desenho inteiro: limpar no `disconnect` — quando ainda não se sabe
+    qual conta vai voltar — destruiria o vínculo justamente aqui.
+    """
+    _conectar(db, CONTA_ANTIGA)
+    ev_id = _evento(
+        db, titulo="Reunião no Meet", google_event_id="gcal-1",
+        google_account_email=CONTA_ANTIGA, meeting_url="https://meet.google.com/abc-defg-hij",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_ANTIGA, token_data=_TOKEN_DATA)
+
+    ev = _reler(db, ev_id)
+    assert ev.google_event_id == "gcal-1"
+    assert ev.meeting_url == "https://meet.google.com/abc-defg-hij"
+    assert ev.google_account_email == CONTA_ANTIGA
+
+
+def test_reconectar_com_outra_conta_zera_o_vinculo(db: Session):
+    """Conta diferente: o id endereça o calendário de OUTRA pessoa — some, junto com o link."""
+    _conectar(db, CONTA_ANTIGA)
+    ev_id = _evento(
+        db, titulo="Reunião no Meet", google_event_id="gcal-1",
+        google_account_email=CONTA_ANTIGA, meeting_url="https://meet.google.com/abc-defg-hij",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_NOVA, token_data=_TOKEN_DATA)
+
+    ev = _reler(db, ev_id)
+    assert ev.google_event_id is None
+    assert ev.meeting_url is None
+    assert ev.google_account_email is None
+    # O evento em si continua na agenda: some o VÍNCULO com o Google, não o compromisso.
+    assert ev.title == "Reunião no Meet"
+
+
+def test_linha_legada_sem_procedencia_nao_e_tocada_na_troca_de_conta(db: Session):
+    """`google_account_email IS NULL` = procedência DESCONHECIDA (gravada antes da 0086).
+
+    Apagar às cegas reintroduziria a duplicação de eventos no próximo sync para os dados que já
+    existem — que é a consequência nº 3 da issue. Elas se autocuram pelo sync (teste abaixo).
+    """
+    _conectar(db, CONTA_ANTIGA)
+    ev_id = _evento(
+        db, titulo="Evento legado", google_event_id="gcal-legado",
+        google_account_email=None, meeting_url="https://meet.google.com/leg-ado-xyz",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_NOVA, token_data=_TOKEN_DATA)
+
+    ev = _reler(db, ev_id)
+    assert ev.google_event_id == "gcal-legado"
+    assert ev.meeting_url == "https://meet.google.com/leg-ado-xyz"
+    assert ev.google_account_email is None
+
+
+def test_link_de_evento_sem_espelho_no_google_sobrevive_a_troca_de_conta(db: Session):
+    """`meeting_url` só é apagado de quem TEM espelho no Google (`google_event_id IS NOT NULL`).
+
+    Duas linhas, ambas sem id, pelas quais a cláusula responde:
+
+    a) LINK MANUAL (Zoom): `create_event` só chama o Google quando `not data.meeting_url`, então
+       quem digitou um link nunca teve id nem procedência. É o caso que a issue mais teme —
+       apagar trabalho digitado à mão. Note que aqui a cláusula `google_account_email IS NOT
+       NULL` também protege: só derrubando as DUAS cláusulas esta linha é destruída.
+
+    b) ESPELHO PARCIAL: procedência conhecida, id ausente. Estado real e alcançável — `create_
+       event` grava `event.google_event_id = data.get("id")`, então um 200 do Google trazendo
+       `hangoutLink` mas sem `id` produz exatamente isto. Aqui a cláusula do id é a ÚNICA
+       proteção, e é por esta linha que a remoção dela, sozinha, mata este teste.
+    """
+    _conectar(db, CONTA_ANTIGA)
+    manual = _evento(
+        db, titulo="Call no Zoom", google_event_id=None,
+        google_account_email=None, meeting_url="https://zoom.us/j/12345",
+    )
+    parcial = _evento(
+        db, titulo="Espelho sem id", google_event_id=None,
+        google_account_email=CONTA_ANTIGA, meeting_url="https://meet.google.com/par-cial-xyz",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_NOVA, token_data=_TOKEN_DATA)
+
+    assert _reler(db, manual).meeting_url == "https://zoom.us/j/12345"
+    assert _reler(db, manual).google_event_id is None
+    assert _reler(db, parcial).meeting_url == "https://meet.google.com/par-cial-xyz"
+    assert _reler(db, parcial).google_account_email == CONTA_ANTIGA
+
+
+def test_primeira_conexao_nao_apaga_nada(db: Session):
+    """Conectar pela 1ª vez (sem credencial anterior) não pode varrer a agenda existente."""
+    ev_id = _evento(
+        db, titulo="Call no Zoom", google_event_id=None,
+        google_account_email=None, meeting_url="https://zoom.us/j/12345",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_NOVA, token_data=_TOKEN_DATA)
+
+    assert _reler(db, ev_id).meeting_url == "https://zoom.us/j/12345"
+    assert db.scalar(select(GoogleCredential)).google_account_email == CONTA_NOVA
+
+
+def test_conta_desconhecida_no_callback_nao_apaga_nada(db: Session):
+    """`userinfo` falhou (`email=""`): sem saber QUEM conectou, não dá para afirmar que mudou.
+
+    `handle_callback` segue em frente com e-mail vazio de propósito (uma falha de exibição não
+    pode descartar tokens válidos). Na dúvida, não se destrói.
+    """
+    _conectar(db, CONTA_ANTIGA)
+    ev_id = _evento(
+        db, titulo="Reunião no Meet", google_event_id="gcal-1",
+        google_account_email=CONTA_ANTIGA, meeting_url="https://meet.google.com/abc-defg-hij",
+    )
+
+    service.upsert_credential(db, tenant_id=TENANT, email="", token_data=_TOKEN_DATA)
+
+    ev = _reler(db, ev_id)
+    assert ev.google_event_id == "gcal-1"
+    assert ev.meeting_url == "https://meet.google.com/abc-defg-hij"
+
+
+# ── O carimbo da procedência, nos dois pontos de escrita do id ───────────────
+def test_create_event_carimba_a_conta_conectada(db: Session, monkeypatch):
+    """Ponto de escrita nº 1 (e1p → Google). Sem o carimbo, a linha nasce "legada" e imune."""
+    from app.modules.agenda import service as agenda
+    from app.modules.agenda.schemas import EventCreate
+
+    _conectar(db, CONTA_ANTIGA)
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"id": "gcal-novo", "hangoutLink": "https://meet.google.com/nov-oooo-xyz"}
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp())
+
+    event, _ = agenda.create_event(
+        db,
+        tenant_id=TENANT,
+        actor="user-1",
+        by_ai=False,
+        data=EventCreate(
+            title="Reunião nova",
+            kind="reuniao",
+            starts_at=datetime(2026, 9, 11, 13, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 9, 11, 14, 0, tzinfo=UTC),
+        ),
+    )
+    assert event.google_event_id == "gcal-novo"
+    assert event.google_account_email == CONTA_ANTIGA
+
+
+def test_create_event_sem_conta_conhecida_carimba_none(db: Session, monkeypatch):
+    """Credencial sem e-mail (`userinfo` falhou) grava NULL, não string vazia.
+
+    "" na coluna passaria em `google_account_email IS NOT NULL` e a linha seria APAGADA na
+    próxima reconexão, sem que ninguém jamais tivesse provado de qual conta ela veio.
+    """
+    from app.modules.agenda import service as agenda
+    from app.modules.agenda.schemas import EventCreate
+
+    _conectar(db, "")
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"id": "gcal-anonimo"}
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Resp())
+
+    event, _ = agenda.create_event(
+        db,
+        tenant_id=TENANT,
+        actor="user-1",
+        by_ai=False,
+        data=EventCreate(
+            title="Reunião anônima",
+            kind="reuniao",
+            starts_at=datetime(2026, 9, 12, 13, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 9, 12, 14, 0, tzinfo=UTC),
+        ),
+    )
+    assert event.google_event_id == "gcal-anonimo"
+    assert event.google_account_email is None
+
+
+class _FakeGet:
+    def __init__(self, payload: dict):
+        self.status_code = 200
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.mark.parametrize("ja_existe", [False, True], ids=["insert", "update-autocura"])
+def test_sync_carimba_a_conta_no_insert_e_no_update(db: Session, monkeypatch, ja_existe: bool):
+    """Ponto de escrita nº 2 (Google → e1p), nos DOIS ramos de `_apply_item`.
+
+    O ramo de UPDATE é o que AUTOCURA as linhas legadas: uma linha com `google_account_email`
+    NULL (imune à limpeza, por desenho) ganha procedência no primeiro sync bem-sucedido e passa
+    a ser invalidável como qualquer outra. Sem o carimbo nesse ramo, a linha legada ficaria
+    legada para sempre.
+    """
+    _conectar(db, CONTA_ANTIGA)
+    if ja_existe:
+        ev_id = _evento(
+            db, titulo="Título antigo", google_event_id="gcal-sync-1",
+            google_account_email=None, meeting_url=None,
+        )
+
+    payload = {
+        "items": [
+            {
+                "id": "gcal-sync-1",
+                "summary": "Título do Google",
+                "start": {"dateTime": "2026-09-12T13:00:00-03:00"},
+                "end": {"dateTime": "2026-09-12T14:00:00-03:00"},
+            }
+        ],
+        "nextSyncToken": "token-v1",
+    }
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _FakeGet(payload))
+
+    assert sync.pull_changes(db, tenant_id=TENANT) == 1
+
+    db.expire_all()
+    ev = db.scalars(
+        select(AgendaEvent).where(AgendaEvent.google_event_id == "gcal-sync-1")
+    ).one()
+    if ja_existe:
+        assert ev.id == ev_id, "o sync deve ATUALIZAR a linha existente, não criar outra"
+        assert ev.title == "Título do Google"
+    assert ev.google_account_email == CONTA_ANTIGA
+
+
+def test_linha_autocurada_pelo_sync_passa_a_ser_invalidada_na_troca_de_conta(
+    db: Session, monkeypatch
+):
+    """O ciclo completo: legada → sync carimba → reconexão com outra conta agora a limpa.
+
+    É a razão de o carimbo no ramo de UPDATE existir. Sem ele este teste falha na última
+    asserção e a linha legada permanece apontando para um calendário alheio para sempre.
+    """
+    _conectar(db, CONTA_ANTIGA)
+    ev_id = _evento(
+        db, titulo="Legada", google_event_id="gcal-sync-1",
+        google_account_email=None, meeting_url=None,
+    )
+
+    payload = {
+        "items": [
+            {
+                "id": "gcal-sync-1",
+                "summary": "Legada",
+                "start": {"dateTime": "2026-09-12T13:00:00-03:00"},
+                "end": {"dateTime": "2026-09-12T14:00:00-03:00"},
+            }
+        ],
+        "nextSyncToken": "token-v1",
+    }
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _FakeGet(payload))
+    sync.pull_changes(db, tenant_id=TENANT)
+
+    service.upsert_credential(db, tenant_id=TENANT, email=CONTA_NOVA, token_data=_TOKEN_DATA)
+
+    ev = _reler(db, ev_id)
+    assert ev.google_event_id is None
+    assert ev.google_account_email is None

--- a/apps/api/tests/test_google_calendar_reconexao_rls.py
+++ b/apps/api/tests/test_google_calendar_reconexao_rls.py
@@ -1,0 +1,208 @@
+"""A limpeza de reconexão (issue #302) é um UPDATE EM MASSA — contra Postgres REAL, sob RLS.
+
+Por que este teste é obrigatório e não pode viver na suíte SQLite: o `UPDATE agenda_events ...`
+de `_invalidar_vinculos_de_outra_conta` não traz filtro de tenant no `WHERE` (Regra de Ouro
+nº 1 — quem isola é a RLS). Se a política não permitisse a escrita, o Postgres NÃO levantaria
+erro: filtraria a ZERO linhas e o commit "passaria". É o modo de falha silenciosa que já mordeu
+este repo, e SQLite (que não tem RLS) aprovaria os dois casos igualmente.
+
+Por isso as asserções são de CONTAGEM, não de ausência de exceção: provamos que N linhas
+REALMENTE mudaram no tenant que reconectou, e que ZERO mudaram no tenant vizinho.
+
+Mesmo bootstrap de test_google_calendar_sync_rls.py: engine "cru" da URL do container,
+migrations aplicadas com `alembic upgrade head` como `e1p_app`. Marcado `rls_e2e`: NÃO roda no
+`pytest -q`, só no job `cross-tenant-rls` do CI ou manualmente com Docker (`pytest -m rls_e2e`).
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("testcontainers.postgres")
+
+from sqlalchemy import create_engine, func, select, text  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+pytestmark = pytest.mark.rls_e2e
+
+_ROOT_USER = "e1p_root"
+_ROOT_PASS = "rootpass"  # noqa: S105 (senha efêmera do container de teste)
+_APP_PASS = "e1ppass"  # noqa: S105 (senha efêmera do papel de app no container de teste)
+_DB_NAME = "e1pdb"
+_API_DIR = Path(__file__).resolve().parents[1]
+
+CONTA_ANTIGA = "antiga@gmail.com"
+CONTA_NOVA = "nova@gmail.com"
+
+
+def _bootstrap_rls_role(super_url: str) -> None:
+    engine = create_engine(super_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(f"CREATE ROLE e1p_app WITH LOGIN PASSWORD '{_APP_PASS}' NOSUPERUSER"))
+            conn.execute(text(f"GRANT ALL PRIVILEGES ON DATABASE {_DB_NAME} TO e1p_app"))
+            conn.execute(text("GRANT ALL ON SCHEMA public TO e1p_app"))
+    finally:
+        engine.dispose()
+
+
+def _run_migrations_as_app(app_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    from app.config import settings
+
+    original_url = settings.database_url
+    settings.database_url = app_url
+    try:
+        cfg = Config(str(_API_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(_API_DIR / "migrations"))
+        command.upgrade(cfg, "head")
+    finally:
+        settings.database_url = original_url
+
+
+@contextmanager
+def _tenant_session(app_url: str, tenant_id: str):
+    engine = create_engine(app_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, false)"), {"tid": tenant_id}
+            )
+            conn.commit()
+            session = Session(bind=conn)
+            try:
+                yield session
+            finally:
+                session.close()
+    finally:
+        engine.dispose()
+
+
+def _semear(session: Session, tenant_id: str, *, prefixo: str) -> None:
+    """Dois eventos com procedência da conta ANTIGA + um legado (procedência desconhecida)."""
+    from app.modules.agenda.models import AgendaEvent
+
+    for i in (1, 2):
+        session.add(
+            AgendaEvent(
+                tenant_id=tenant_id,
+                title=f"Reunião {prefixo}-{i}",
+                kind="reuniao",
+                starts_at=datetime(2026, 9, 10, 10, 0, tzinfo=UTC),
+                ends_at=datetime(2026, 9, 10, 11, 0, tzinfo=UTC),
+                google_event_id=f"{prefixo}-evt-{i}",
+                google_account_email=CONTA_ANTIGA,
+                meeting_url=f"https://meet.google.com/{prefixo}-{i}",
+            )
+        )
+    session.add(
+        AgendaEvent(
+            tenant_id=tenant_id,
+            title=f"Legado {prefixo}",
+            kind="reuniao",
+            starts_at=datetime(2026, 9, 11, 10, 0, tzinfo=UTC),
+            ends_at=datetime(2026, 9, 11, 11, 0, tzinfo=UTC),
+            google_event_id=f"{prefixo}-evt-legado",
+            google_account_email=None,  # procedência desconhecida: imune por desenho
+            meeting_url=f"https://meet.google.com/{prefixo}-legado",
+        )
+    )
+    session.commit()
+
+
+def _com_vinculo(session: Session) -> int:
+    from app.modules.agenda.models import AgendaEvent
+
+    return session.scalar(
+        select(func.count()).select_from(AgendaEvent).where(
+            AgendaEvent.google_event_id.is_not(None)
+        )
+    )
+
+
+def test_limpeza_de_reconexao_atinge_o_proprio_tenant_e_nao_o_vizinho() -> None:
+    from app.modules.google_calendar.service import (
+        _invalidar_vinculos_de_outra_conta,
+        upsert_credential,
+    )
+
+    with PostgresContainer(
+        "postgres:16-alpine",
+        username=_ROOT_USER,
+        password=_ROOT_PASS,
+        dbname=_DB_NAME,
+        driver="psycopg",
+    ) as pg:
+        host = pg.get_container_host_ip()
+        port = pg.get_exposed_port(5432)
+        super_url = f"postgresql+psycopg://{_ROOT_USER}:{_ROOT_PASS}@{host}:{port}/{_DB_NAME}"
+        app_url = f"postgresql+psycopg://e1p_app:{_APP_PASS}@{host}:{port}/{_DB_NAME}"
+
+        _bootstrap_rls_role(super_url)
+        _run_migrations_as_app(app_url)
+
+        tenant_a = str(uuid4())
+        tenant_b = str(uuid4())
+        with _tenant_session(app_url, tenant_a) as sa_:
+            _semear(sa_, tenant_a, prefixo="a")
+            assert _com_vinculo(sa_) == 3
+        with _tenant_session(app_url, tenant_b) as sb:
+            _semear(sb, tenant_b, prefixo="b")
+            assert _com_vinculo(sb) == 3
+
+        # (a) O UPDATE em massa AFETA as linhas do tenant que está reconectando. A contagem
+        #     devolvida pelo próprio UPDATE é a prova contra o modo de falha silenciosa: uma
+        #     política de RLS que barrasse a escrita devolveria 0 aqui, sem erro nenhum.
+        with _tenant_session(app_url, tenant_a) as sa_:
+            afetadas = _invalidar_vinculos_de_outra_conta(sa_, novo_email=CONTA_NOVA)
+            assert afetadas == 2, (
+                "o UPDATE em massa não alcançou as linhas do próprio tenant — sob FORCE RLS "
+                "isso é falha SILENCIOSA (zero linhas, zero erro)"
+            )
+            sa_.commit()
+
+        with _tenant_session(app_url, tenant_a) as sa_:
+            from app.modules.agenda.models import AgendaEvent
+
+            assert _com_vinculo(sa_) == 1  # sobra só o legado
+            legado = sa_.scalars(
+                select(AgendaEvent).where(AgendaEvent.google_event_id.is_not(None))
+            ).one()
+            assert legado.google_event_id == "a-evt-legado"
+            assert legado.meeting_url == "https://meet.google.com/a-legado"
+            assert legado.google_account_email is None
+            # As duas invalidadas perderam id, link e procedência — as três colunas.
+            limpas = sa_.scalars(
+                select(AgendaEvent).where(AgendaEvent.google_event_id.is_(None))
+            ).all()
+            assert len(limpas) == 2
+            assert all(e.meeting_url is None and e.google_account_email is None for e in limpas)
+
+        # (b) O tenant vizinho NÃO foi tocado — as 3 linhas dele seguem intactas.
+        with _tenant_session(app_url, tenant_b) as sb:
+            from app.modules.agenda.models import AgendaEvent
+
+            assert _com_vinculo(sb) == 3
+            vizinhas = sb.scalars(select(AgendaEvent)).all()
+            assert len(vizinhas) == 3
+            assert all(e.meeting_url is not None for e in vizinhas)
+
+        # (c) O caminho REAL (`upsert_credential`, com credencial + auditoria na mesma
+        #     transação) também escreve de verdade sob FORCE RLS — não só a query isolada.
+        with _tenant_session(app_url, tenant_b) as sb:
+            upsert_credential(
+                sb,
+                tenant_id=tenant_b,
+                email=CONTA_NOVA,
+                token_data={"access_token": "a", "refresh_token": "r", "expires_in": 3600},
+            )
+        with _tenant_session(app_url, tenant_b) as sb:
+            assert _com_vinculo(sb) == 1  # só o legado de B sobreviveu

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -148,7 +148,7 @@ calendário de outra pessoa. Desde a migration 0086 cada evento guarda de qual c
 (`agenda_events.google_account_email`) e o `upsert_credential` invalida, na reconexão, só o que
 veio de outra conta: zera `google_event_id`, `meeting_url` e a própria procedência, e loga
 `[google:reconexao:conta_trocada]` com quantos eventos foram afetados. Reconectar com a **mesma**
-conta — o caso comum, o token de 7 dias — não perde nada. Eventos com link digitado à mão (Zoom)
+conta — o caso comum — não perde nada. Eventos com link digitado à mão (Zoom)
 não são tocados, e os anteriores à 0086 (procedência desconhecida) ficam intactos até o primeiro
 sync bem-sucedido, que carimba a conta neles. Ao investigar "sumiu o link do Meet dos meus
 eventos", é esse log que diz se foi troca de conta.

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -140,6 +140,19 @@ do worker). Consequências operacionais:
 - O descarte é best-effort: se a sessão curta falhar, sai `[google:token:descarte_falhou]` no log
   e a operação de negócio continua — a integração Google nunca derruba a Agenda (IV1/IV2).
 
+**Reconexão com outra conta (issue #302, corrigido).** Os `google_event_id` guardados nos eventos
+sobreviviam ao descarte acima. Ficar sem credencial nunca fez mal — os três consumidores do id
+(`patch_meet_event`, `delete_meet_event` e o `pull_changes` do worker) já param cedo sem
+credencial —, mas reconectar com uma conta **diferente** deixava esses ids endereçando o
+calendário de outra pessoa. Desde a migration 0086 cada evento guarda de qual conta veio
+(`agenda_events.google_account_email`) e o `upsert_credential` invalida, na reconexão, só o que
+veio de outra conta: zera `google_event_id`, `meeting_url` e a própria procedência, e loga
+`[google:reconexao:conta_trocada]` com quantos eventos foram afetados. Reconectar com a **mesma**
+conta — o caso comum, o token de 7 dias — não perde nada. Eventos com link digitado à mão (Zoom)
+não são tocados, e os anteriores à 0086 (procedência desconhecida) ficam intactos até o primeiro
+sync bem-sucedido, que carimba a conta neles. Ao investigar "sumiu o link do Meet dos meus
+eventos", é esse log que diz se foi troca de conta.
+
 ## 6. Backup automatizado + offsite (Story 3.3)
 - [x] Instalar/configurar `rclone` com remote S3-compatível — validado em 2026-07-12 **localmente**
   (MinIO em Docker no lugar do S3 real — sem custo/conta externa) com o binário real do rclone.


### PR DESCRIPTION
## Contexto

`agenda_events.google_event_id` é escrito em dois lugares e, até aqui, **limpo em nenhum**:

| Papel | Local |
|---|---|
| escreve | `agenda/service.py::create_event` — evento criado no e1p, espelhado no Google |
| escreve | `google_calendar/sync.py::_apply_item` — evento puxado do Google |
| limpa | *(nenhum)* — nem o `disconnect` manual, nem o descarte automático do #303 |

Quando a credencial some e a pessoa reconecta com **outra** conta Google, esses ids passam a
endereçar um calendário que não é mais dela.

## A correção não fica onde a issue supunha

A #302 propunha limpar no ponto em que a credencial é apagada. Medindo os consumidores, isso é o
lugar errado — pelos dois lados:

**Ficar sem credencial nunca fez mal.** Os três consumidores do id já retornam cedo em
`get_credential(db) is None`:

| Consumidor | Guarda |
|---|---|
| `patch_meet_event` (remarcar) | `if cred is None: return False` |
| `delete_meet_event` (cancelar) | `if cred is None: return False` |
| `sync.pull_changes` (worker) | `if cred is None: return 0` |

Enquanto o tenant está desconectado, **nenhum id velho chega ao Google**. A janela de dano abre
só quando uma credencial volta.

**E no `disconnect` ainda não se sabe a resposta.** Qual conta vai reconectar é informação que só
existe no callback. Limpar antes disso destrói o vínculo no caso **dominante** — reconectar com a
mesma conta, onde os ids continuam perfeitamente válidos.

Por isso a limpeza mora em `upsert_credential`, o único ponto que conhece as duas pontas.

## O que muda

### Cada evento passa a registrar de qual conta veio

`agenda_events.google_account_email` (migration **0086**), carimbado nos dois pontos de escrita.
`create_meet_event` devolve a conta junto do id — é a credencial que *realmente* escreveu o evento
lá, e não uma releitura posterior que já poderia ser outra.

`NULL` tem **significado**: procedência desconhecida. Ou a linha é anterior à 0086, ou o `userinfo`
do Google falhou no callback e nunca soubemos o e-mail.

### A migration não faz backfill — de propósito

Mesma disciplina das 0084/0085: DDL puro. Um `UPDATE` ali rodaria sob FORCE RLS sem
`app.current_tenant_id`, seria filtrado a **zero linhas** e "passaria" em silêncio. As linhas
legadas se autocuram sozinhas: o ramo de *update* de `_apply_item` carimba a conta no primeiro
sync bem-sucedido.

### A invalidação, e por que cada cláusula do `WHERE` existe

```sql
UPDATE agenda_events
   SET google_event_id = NULL, meeting_url = NULL, google_account_email = NULL
 WHERE google_event_id       IS NOT NULL
   AND google_account_email  IS NOT NULL
   AND google_account_email <> :novo_email
```

| Cláusula | Protege |
|---|---|
| `google_event_id IS NOT NULL` | o `meeting_url` **digitado à mão**. Quem colou um Zoom nunca teve `google_event_id` — `create_event` só chama o Google quando `not data.meeting_url`. Sem ela, apagaríamos links do usuário. |
| `google_account_email IS NOT NULL` | a **linha legada**. Apagá-la às cegas reintroduziria a duplicação de eventos no próximo sync, justamente para os dados que já existem. |
| `<> :novo_email` | **reconectar com a mesma conta é no-op.** É a razão de existir do desenho inteiro. |

`novo_email` vazio (o `userinfo` falhou) também é no-op: sem saber quem está conectando não dá para
afirmar que a conta mudou, e na dúvida não se destrói.

Roda na sessão do chamador — ao contrário do `_descartar_credencial_revogada` do #303, aqui
`upsert_credential` **é** dona da transação: a limpeza e a credencial nova entram juntas ou não
entram. Quando invalida algo, loga `[google:reconexao:conta_trocada]` com a contagem: é o que
responde "sumiu o link do Meet dos meus eventos".

### Trade-off assumido: `meeting_url` vai junto

Um link de Meet da conta antiga **pode** continuar funcionando, e apagá-lo é irreversível. É o que
a issue pede explicitamente, e a troca é deliberada: um card sem link é melhor que um link que abre
o Meet de outra pessoa. Fica registrado aqui porque é uma perda real, não um detalhe.

## Uma cláusula é redundante, e isso foi medido

`google_account_email IS NOT NULL` **não muda nenhum comportamento observável hoje** — removê-la
sozinha deixa os 11 testes verdes. Pela lógica de três valores do SQL, `NULL <> 'alguem@gmail.com'`
avalia a `NULL`, não a `TRUE`, e a linha legada já escapa do `WHERE` pela cláusula seguinte.

Ela fica assim mesmo, porque a proteção não pode depender de um efeito colateral de `NULL` que
ninguém lê. Trocar o `<>` por qualquer coisa NULL-tolerante — `IS DISTINCT FROM`,
`coalesce(..., '') <>` — varreria **toda** a base legada em silêncio. A mutação que faz exatamente
isso mata o teste da linha legada, e está na tabela abaixo.

## Prova por mutação

Cada asserção nova foi verificada desfazendo a linha correspondente na produção:

| Mutação | Teste que morreu | Mensagem |
|---|---|---|
| remove `<> novo_email` | `test_reconectar_com_a_mesma_conta_preserva_o_vinculo` | `assert None == 'gcal-1'` |
| `coalesce(...,'') <>` no lugar das duas cláusulas | `test_linha_legada_sem_procedencia_nao_e_tocada_na_troca_de_conta` | `assert None == 'gcal-legado'` |
| remove a invalidação inteira | `test_reconectar_com_outra_conta_zera_o_vinculo` | `assert 'gcal-sync-1' is None` |
| idem, contra Postgres real | `test_limpeza_de_reconexao_atinge_o_proprio_tenant_e_nao_o_vizinho` | tenant B ficou com 3 vínculos, esperado 1 |
| remove o carimbo no ramo de **update** | `test_sync_carimba_a_conta_no_insert_e_no_update[update-autocura]` | `assert None == 'antiga@gmail.com'` |
| remove o carimbo no ramo de **insert** | `test_sync_carimba_a_conta_no_insert_e_no_update[insert]` | `assert None == 'antiga@gmail.com'` |
| remove o carimbo em `create_event` | `test_create_event_carimba_a_conta_conectada` | `assert None == 'antiga@gmail.com'` |
| remove `google_event_id IS NOT NULL` | `test_link_de_evento_sem_espelho_no_google_sobrevive_a_troca_de_conta` | `assert None == 'https://meet.google.com/par-cial-xyz'` |
| remove `google_account_email IS NOT NULL` | **nenhum — mutante equivalente**, ver seção acima | — |

O caso do link manual precisou de uma segunda linha para ser honesto: com o Zoom puro (id `NULL`
*e* procedência `NULL`), a cláusula da procedência também o protegia, e a mutação sobrevivia. O
teste ganhou um **espelho parcial** — procedência conhecida, id ausente, estado alcançável porque
`create_event` grava `data.get("id")` sem condição — onde a cláusula do id é a única proteção.

## O que os testes provam — e o que não provam

O `UPDATE` em massa **não traz filtro de tenant no `WHERE`**: quem isola é a RLS (Regra de Ouro
nº 1). Se a política barrasse a escrita, o Postgres não levantaria erro — filtraria a zero linhas
e o commit "passaria". SQLite, que não tem RLS, aprovaria os dois casos igualmente.

Por isso há um teste `rls_e2e` contra Postgres real cujas asserções são de **contagem**, não de
ausência de exceção: `afetadas == 2` no tenant que reconecta, `3` linhas intactas no vizinho, e o
caminho real (`upsert_credential`, com credencial e auditoria na mesma transação) exercido ao lado
da query isolada.

O que ele **não** prova: nada sobre isolamento de transação física na suíte SQLite, que usa
`StaticPool` — todas as sessões dividem a mesma conexão DBAPI.

## O que este PR não toca

- **`ix_agenda_events_tenant_google_event_id`** (0081) fica como está. A limpeza acontece *antes*
  do primeiro sync com a conta nova, então não existe caminho em que dois ids iguais coexistam.
- **`agenda/schemas.py`** não muda: `google_account_email` é procedência interna, sem consumidor no
  front (`google_event_id`, que já é exposto, tem zero usos em `apps/web/src` fora de fixture).
  `packages/shared-types/src/generated.ts` fica intacto.
- **As afirmações "Testing"/"7 dias" do OAuth** em `GO-LIVE-CHECKLIST.md` §5, `PrivacidadePage.tsx`
  e no comentário de `_ensure_fresh_token` estão desatualizadas — o app saiu de "Testing" e o
  Console mostra "Em produção". São **4 afirmações vivas em 3 arquivos**, medidas, e viraram a
  issue #304 em vez de carona aqui. O parágrafo que este PR adiciona ao mesmo §5 foi escrito sem
  a premissa vencida.

## Gates

```
ruff check .                     All checks passed!
pytest -q -m "not rls_e2e"       2469 passed, 1 skipped, 72 deselected
pytest -q -m rls_e2e             72 passed, 2470 deselected      (eram 71; o 72º é o novo)
```

Closes #302
