### PR TITLE
docs: o app OAuth saiu de "Testing" — corrige 7 afirmações vivas do ciclo de 7 dias

### DIFF
--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -308,8 +308,12 @@ def _ensure_fresh_token(db: Session, cred: GoogleCredential) -> str | None:
     )
     if resp.status_code == 400 and "invalid_grant" in resp.text:
         # Refresh token revogado ou expirado. É TERMINAL: repetir não adianta, só reconectar.
-        # Acontece a cada 7 dias enquanto o app OAuth estiver em modo "Testing" no Google (ver
-        # docs/GO-LIVE-CHECKLIST.md §5, "Autocura da conexão morta").
+        # NÃO é rotina. O app OAuth está publicado ("Em produção" desde 2026-09-05), então o
+        # antigo ciclo de 7 dias do modo "Testing" ACABOU — não use mais essa explicação para
+        # encerrar uma investigação. Cair aqui hoje significa revogação de verdade: o dono
+        # removeu o acesso do e1p na conta Google, trocou a senha, ou passou ~6 meses sem usar a
+        # integração. É raro e merece ser investigado (ver docs/GO-LIVE-CHECKLIST.md §5,
+        # "Autocura da conexão morta").
         logger.warning(
             "[google:token:revogado] tenant=%s — refresh_token morto, precisa reconectar",
             cred.tenant_id,

--- a/apps/web/src/features/legal/PrivacidadePage.tsx
+++ b/apps/web/src/features/legal/PrivacidadePage.tsx
@@ -6,8 +6,9 @@ import { CONTROLADOR } from "./controlador";
  *
  * Existe por três exigências concretas, não por formalidade:
  *  1. LGPD (Lei 13.709/2018) art. 9º — informação clara sobre o tratamento.
- *  2. Google OAuth — a aba Branding da tela de consentimento exige a URL desta página para
- *     publicar o app; sem publicar, o refresh token morre a cada 7 dias.
+ *  2. Google OAuth — a aba Branding da tela de consentimento exige a URL desta página, e foi com
+ *     ela que o app foi publicado ("Em produção" desde 2026-09-05). Tirar esta rota do ar, ou
+ *     deixá-la de pé sem deploy, derruba o link que sustenta a publicação.
  *  3. Google API Services User Data Policy — a seção "Uso Limitado" abaixo é literal e
  *     obrigatória para qualquer app que leia escopos de usuário do Google.
  *

--- a/docs/GO-LIVE-CHECKLIST.md
+++ b/docs/GO-LIVE-CHECKLIST.md
@@ -50,7 +50,10 @@
 - [x] Criar projeto no Google Cloud Console + ativar Calendar API — projeto do fundador, Calendar
   API habilitada, OAuth consent screen em modo "Testing" com `flaviokato76@gmail.com` como test
   user (suficiente para uso próprio; sair de "Testing" exige verificação do Google só se/quando
-  precisar liberar para outras contas).
+  precisar liberar para outras contas). **Errata 2026-09-05:** o app **saiu de "Testing"** — o
+  status de publicação é **Em produção**, tipo **Externo**, branding **verificado**, conferido no
+  Console com o dono do projeto. O parêntese acima descreve o estado até 2026-09-04; publicar não
+  exigiu a verificação do Google. Ver "Estado verificado em 2026-09-05" abaixo.
 - [x] Gerar OAuth Client ID/Secret, configurar redirect URI — client Web `e1p` criado. **Resolvido
   em 2026-09-02:** as DUAS URIs estão cadastradas — `http://localhost:8000/integrations/google/callback`
   (dev) e `https://e1p.criativaeduca.com.br/api/integrations/google/callback` (produção AWS),
@@ -105,27 +108,49 @@
 | Escopos na tela de consentimento | `calendar.events` + `userinfo.email` registrados **e** concedidos (conferido pelo `scope=` devolvido no callback real). Bate com `DEFAULT_SCOPE` de `modules/google_calendar/models.py`. |
 | Redirect URIs | dev + produção AWS cadastradas; a de produção casa com o `.env.prod` da EC2. |
 | Tipo de usuário | **Externo** |
-| Status de publicação | **Testando** — 3 usuários de teste de 100. |
+| Status de publicação | **Testando** — 3 usuários de teste de 100. **(Errata 2026-09-05: virou "Em produção" — ver abaixo.)** |
 
-⚠️ **O modo "Testando" expira o refresh token em 7 dias.** Enquanto o app não for publicado, a
-sincronização de agenda de cada pessoa morre sozinha uma vez por semana e exige reconectar — o
-sintoma parece bug do produto e não é. Publicar (Público-alvo → "Publicar app") remove esse
-limite e **não** exige passar pela verificação do Google enquanto ficar abaixo de ~100 usuários;
-o custo é a tela "o Google não verificou este app", uma vez por pessoa.
+### Estado verificado em 2026-09-05 — o app foi publicado
 
-**Para publicar:** a aba Branding exige **link de Política de Privacidade** (Termos de Serviço é
-opcional). As páginas passaram a existir no PR #293 — rotas públicas `/privacidade` e `/termos`,
-fora do `ProtectedLayout`, em `apps/web/src/features/legal/`. Restam dois passos, nesta ordem:
+| Item | Estado |
+|---|---|
+| Tipo de usuário | **Externo** (inalterado) |
+| Status de publicação | **Em produção** — o modo "Testando" acabou. |
+| Branding | **Verificado** |
+| *Data access status* | **Em análise** — é OUTRA coisa, ver o aviso abaixo. |
 
-1. **Deployar**, senão as URLs não respondem. O Google valida que o link é alcançável, e a
-   produção costuma ficar atrás de `main` — meça o gap antes de assumir que já está no ar.
-2. Colar `https://e1p.criativaeduca.com.br/privacidade` (e, se quiser, `/termos`) na aba
-   Branding e então **Público-alvo → Publicar app**.
+⚠️ **O limite de 7 dias acabou — o que segue é registro do que valia até 2026-09-04.** Enquanto o
+app esteve em "Testando", o Google expirava o refresh token em 7 dias: a sincronização de agenda
+de cada pessoa morria sozinha uma vez por semana e exigia reconectar, e o sintoma parecia bug do
+produto sem ser.
+
+**Resolvido em 2026-09-05:** o app foi publicado (Público-alvo → "Publicar app") e o refresh token
+deixou de ter prazo — ele passa a valer até ser revogado. **Consequência para quem investiga uma
+sincronização parada:** um `400 invalid_grant` hoje **não** é o ciclo semanal de antes. Significa
+revogação de verdade — a pessoa removeu o acesso do e1p na conta Google, trocou a senha, ou passou
+~6 meses sem usar a integração. É evento raro e digno de investigação, não "é o de sempre".
+
+Publicar **não** exigiu passar pela verificação do Google (o app fica abaixo de ~100 usuários); o
+custo é a tela "o Google não verificou este app", uma vez por pessoa. **Não confunda dois campos
+do Console:** o **status de publicação** é "Em produção" (concluído, é o campo que governava o
+prazo do refresh token) enquanto o ***Data access status*** segue "em análise" — esse outro campo
+é a revisão dos escopos solicitados, corre em separado e não reabre o limite de 7 dias.
+
+**Como foi publicado (concluído em 2026-09-05):** a aba Branding exige **link de Política de
+Privacidade** (Termos de Serviço é opcional). As páginas passaram a existir no PR #293 — rotas
+públicas `/privacidade` e `/termos`, fora do `ProtectedLayout`, em `apps/web/src/features/legal/`.
+Os dois passos que restavam foram executados, nesta ordem:
+
+1. **Deploy** das páginas — sem ele as URLs não respondem, e o Google valida que o link é
+   alcançável. (A produção costuma ficar atrás de `main`; foi preciso medir o gap.)
+2. `https://e1p.criativaeduca.com.br/privacidade` colada na aba Branding e então **Público-alvo →
+   Publicar app**.
 
 ### Autocura da conexão morta (issue #294, corrigido)
 
-Quando o refresh token morre (o caso semanal acima, ou uma revogação na conta Google), o e1p
-**descarta sozinho** a credencial do tenant: `_ensure_fresh_token` detecta o `400 invalid_grant`,
+Quando o refresh token morre (hoje só por revogação na conta Google; até 2026-09-04 também pelo
+ciclo semanal do modo "Testando", extinto com a publicação), o e1p **descarta sozinho** a
+credencial do tenant: `_ensure_fresh_token` detecta o `400 invalid_grant`,
 loga `[google:token:revogado]` e apaga a linha `GoogleCredential` numa sessão curta e
 independente — sem tocar a transação de quem chamou (criar/remarcar/cancelar evento, ou o sweep
 do worker). Consequências operacionais:


### PR DESCRIPTION
## Contexto

O app OAuth do Google **saiu do modo "Testing"**. O Console mostra status de publicação **Em
produção**, tipo **Externo**, branding **verificado** — conferido com o dono do projeto em
2026-09-05.

A consequência que a documentação descrevia — o refresh token morrendo a cada 7 dias — **deixou de
valer**. São afirmações **vivas**: orientam decisão futura, não são registro histórico.

## Onde isso machuca

O comentário de `_ensure_fresh_token` fica no ponto exato onde alguém investiga "por que a agenda
parou de sincronizar". Lendo que isso "acontece a cada 7 dias", a pessoa conclui que é o ciclo
normal do modo Testing e **para de investigar** — quando hoje um `400 invalid_grant` significa
revogação de verdade: o dono removeu o acesso, trocou a senha, ou passou ~6 meses sem usar. É
evento raro e digno de atenção.

Os pontos do `GO-LIVE-CHECKLIST.md` estão num **checklist operacional**, o gênero de documento que
precisa estar certo — não é plano datado nem story fechada, que se corrigiriam só com errata no pé.

## A issue dizia 4 afirmações. São 7

O alcance foi medido três vezes: a issue listou 4, a varredura de abertura achou 6, e a
implementação achou a 7ª. As três últimas linhas da tabela não estavam no enunciado.

| # | Local | O que afirmava |
|---|---|---|
| 1 | `GO-LIVE-CHECKLIST.md:51-54` | consent screen em modo "Testing" com test user; "sair de Testing exige verificação do Google" |
| 2 | `GO-LIVE-CHECKLIST.md:108` | linha de tabela: `Status de publicação \| **Testando** — 3 usuários de teste de 100` |
| 3 | `GO-LIVE-CHECKLIST.md:110-114` | ⚠️ "expira o refresh token em 7 dias… morre sozinha uma vez por semana" |
| 4 | `PrivacidadePage.tsx:10` | comentário: "sem publicar, o refresh token morre a cada 7 dias" |
| 5 | `google_calendar/service.py:311` | comentário: "Acontece a cada 7 dias enquanto o app OAuth estiver em modo Testing" |
| 6 | `GO-LIVE-CHECKLIST.md:116-123` | "**Para publicar:** … Restam dois passos" — descrevia como pendente um trabalho já concluído |
| 7 | `GO-LIVE-CHECKLIST.md:127` | "Quando o refresh token morre (**o caso semanal acima**…)" — referência cruzada ao ciclo |

A 7ª é a que mostra por que contar importa: corrigir o item 3 sem ela deixaria o §5 apontando para
um "caso semanal" que o próprio documento acabou de declarar extinto.

Os ~80 outros hits de "7 dias" no repo foram descartados um a um: são JWT (`jwt_expire_minutes`),
fila de pagamentos, retenção de backup e quarentena do DNA. Os de "Testing" restantes são
`@testing-library`, `jsdom` e "CI testando a imagem Docker".

## O tratamento é diferente por gênero de texto

**Checklist → errata datada**, no padrão que o próprio §5 já usa (`**Resolvido em 2026-09-02:**`).
O texto original fica de pé; a errata diz o que mudou e quando. O registro de que o app já esteve
em Testing é história real e vale preservar — inclusive a tabela "Estado verificado em 2026-09-02",
que ganhou uma irmã de 2026-09-05 em vez de ser sobrescrita.

**Comentário de código → reescrita direta.** Comentário orienta decisão futura, não guarda história.
O de `_ensure_fresh_token` passa a dizer o que a pessoa precisa saber no momento em que está lendo:
o ciclo acabou, e cair ali hoje é revogação de verdade.

## Uma distinção que o texto novo faz de propósito

O Console tem **dois** campos que é fácil confundir:

| Campo | Valor hoje | O que é |
|---|---|---|
| Status de publicação | **Em produção** | concluído — é o campo que governava o prazo do refresh token |
| *Data access status* | **Em análise** | revisão dos escopos solicitados; corre em separado e **não** reabre o limite de 7 dias |

Sem essa distinção, quem ler "em análise" pode concluir que a publicação não valeu e que o ciclo
de 7 dias continua — que é exatamente o erro que este PR está desfazendo.

## Prova de que os dois arquivos de código só mudaram comentário

Ausência de diff visual não é prova. Os dois foram provados por **parse**, e cada método passou
por um controle negativo que confirma que ele detecta mudança real:

| Arquivo | Método | Antes x depois | Controle negativo |
|---|---|---|---|
| `google_calendar/service.py` | AST do Python (comentário não entra na AST) | idêntica, 40202 chars nos dois lados | renomear a função → AST acusa diff |
| `PrivacidadePage.tsx` | `esbuild` (parser de verdade) | idêntica, 20084 bytes nos dois lados | trocar um literal → `esbuild` acusa diff |

O controle negativo não é zelo: a primeira tentativa de prova rodou um `esbuild` que **falhou em
silêncio**, os dois lados saíram vazios e o `diff` deu vazio — aprovação aparente sobre nada. É o
mesmo desenho de falsa confiança que a prova deveria eliminar.

## O que este PR não toca

- **`TermosPage.tsx:8`** — "O Google não exige este documento para publicar o app OAuth". A
  afirmação continua **verdadeira** (Termos de Serviço segue opcional na aba Branding) e não
  menciona modo Testing nem o ciclo de 7 dias. O único desgaste é de tempo verbal. Fica.
- **Nenhum comportamento.** Provado acima: as duas mudanças de código são comentário.

## Gates

```
eslint . --max-warnings 0        exit 0, sem saída
tsc --noEmit                     exit 0, sem saída
vitest                           96 arquivos, 1249 testes passando
ruff check .                     All checks passed!
pytest -q -m "not rls_e2e"       2469 passed, 1 skipped, 72 deselected
```

Closes #304
