### PR TITLE
fix(agenda): 200 do Google sem id parava de virar evento com link e sem espelho

### DIFF
--- a/apps/api/app/modules/agenda/service.py
+++ b/apps/api/app/modules/agenda/service.py
@@ -5,6 +5,7 @@ queries (Regra de Ouro nº 1). O tenant_id só é usado para CARIMBAR novas linh
 """
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from sqlalchemy import and_, func, select
@@ -23,6 +24,8 @@ from app.modules.agenda.models import (
     AgendaEvent,
 )
 from app.modules.agenda.schemas import EventCreate, EventUpdate
+
+logger = logging.getLogger(__name__)
 
 # Estados terminais: não podem ser cancelados de novo nem remarcados.
 TERMINAL_STATUSES = {STATUS_CANCELLED, STATUS_DONE}
@@ -117,14 +120,52 @@ def create_event(
         result = gcal.create_meet_event(db, tenant_id=tenant_id, event=event)
         if result is not None:
             meeting_url, google_event_id, google_account_email = result
-            if meeting_url:
-                event.meeting_url = meeting_url
-            event.google_event_id = google_event_id
-            # De QUAL conta Google é este id (migration 0086). Vem junto do retorno, e não de um
-            # `get_credential` novo, porque é a credencial que REALMENTE escreveu o evento lá.
-            # Sem este carimbo, reconectar com outra conta deixaria o id apontando para um
-            # calendário alheio — ver `google_calendar/service.py::upsert_credential`.
-            event.google_account_email = google_account_email
+            # O ESPELHO É TUDO-OU-NADA (issue #306). Os três campos abaixo são UMA unidade e
+            # entram juntos ou não entram; `google_event_id` é a chave que dá sentido aos
+            # outros dois. Um 200 do Google sem `id` (a chave é opcional em `data.get("id")`)
+            # existia e era gravado como `None` — meio espelho, o pior dos estados:
+            #
+            # - sem id, `patch_meet_event`/`delete_meet_event` saem em `if not
+            #   event.google_event_id: return False` — remarcar e cancelar param de propagar em
+            #   silêncio, e fica evento fantasma no calendário do dono;
+            # - `sync.py::_apply_item` casa por `google_event_id`; sem ele o pull DUPLICA o
+            #   evento em vez de atualizá-lo;
+            # - e o `meeting_url` carimbado sozinho escapa PARA SEMPRE da invalidação de
+            #   `_invalidar_vinculos_de_outra_conta`, que filtra por `google_event_id IS NOT
+            #   NULL` — na troca de conta Google o card fica com o link do Meet de uma conta
+            #   que não é mais a conectada, e ninguém limpa. A #302 já decidiu que esse link
+            #   é pior que card nenhum.
+            #
+            # Por isso o link também é DESCARTADO junto: aqui não há trabalho do usuário em
+            # risco — este ramo só roda quando `not data.meeting_url` (link manual de Zoom nem
+            # chama o Google). Perde-se um link que ninguém digitou e que o sistema não
+            # conseguiria mais remarcar, cancelar nem invalidar.
+            #
+            # Falsy, e não `is not None`, de propósito: id `""` também não endereça evento
+            # nenhum e ainda ocuparia o índice único parcial `ix_agenda_events_tenant_google_
+            # event_id` (migration 0081, `WHERE google_event_id IS NOT NULL`), fazendo o
+            # SEGUNDO evento nesse estado estourar unicidade. Esta é a mesma guarda que
+            # `google_calendar/sync.py::_apply_item` já aplica no caminho de PULL
+            # (`if not google_event_id: return False`) — os dois pontos de escrita da coluna
+            # discordavam entre si, e a decisão registrada agora é: recusar meio espelho.
+            if google_event_id:
+                if meeting_url:
+                    event.meeting_url = meeting_url
+                event.google_event_id = google_event_id
+                # De QUAL conta Google é este id (migration 0086). Vem junto do retorno, e não
+                # de um `get_credential` novo, porque é a credencial que REALMENTE escreveu o
+                # evento lá. Sem este carimbo, reconectar com outra conta deixaria o id
+                # apontando para um calendário alheio — ver
+                # `google_calendar/service.py::upsert_credential`.
+                event.google_account_email = google_account_email
+            else:
+                # Não derruba a criação (IV1, mesmo princípio do `return None` em falha de rede):
+                # o evento local nasce igual, só sem espelho. O log é o único sinal de que o
+                # Google respondeu 200 com um corpo inservível.
+                logger.warning(
+                    "[google:create_meet:sem_id] tenant=%s hangout_link_recebido=%s",
+                    tenant_id, bool(meeting_url),
+                )
     db.add(event)
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="agenda.event.create",

--- a/apps/api/tests/test_agenda.py
+++ b/apps/api/tests/test_agenda.py
@@ -303,7 +303,16 @@ def test_meet_not_generated_without_google(client: TestClient, headers):
     assert ev["google_event_id"] is None
 
 
-def test_meet_generated_when_google_connected(client: TestClient, headers, monkeypatch):
+def test_meet_generated_when_google_connected(
+    client: TestClient, headers, monkeypatch, db: Session
+):
+    """Caminho feliz: com id de verdade, os TRÊS campos do espelho são carimbados juntos.
+
+    O `google_account_email` é lido do banco porque não está em `EventOut` (é metadado de
+    procedência, não dado de tela) — e sem esta asserção nada distinguiria a guarda da #306
+    de uma guarda que engole o carimbo de conta.
+    """
+    from app.modules.agenda.models import AgendaEvent
     from app.modules.google_calendar import service as gcal
 
     monkeypatch.setattr(
@@ -315,6 +324,67 @@ def test_meet_generated_when_google_connected(client: TestClient, headers, monke
     ev = resp.json()["event"]
     assert ev["meeting_url"] == "https://meet.google.com/abc-defg-hij"
     assert ev["google_event_id"] == "gcal-evt-1"
+    assert db.get(AgendaEvent, ev["id"]).google_account_email == "dono@gmail.com"
+
+
+def test_google_200_sem_id_nao_grava_meio_espelho(
+    client: TestClient, headers, monkeypatch, db: Session, caplog
+):
+    """200 do Google com `hangoutLink` e SEM `id`: nenhum dos três campos é carimbado (#306).
+
+    O estado que esta guarda impede é "link de Meet sem espelho rastreável": `patch_meet_event`
+    e `delete_meet_event` sairiam em `if not event.google_event_id`, o pull de `sync.py`
+    duplicaria o evento, e o link escaparia para sempre da invalidação por troca de conta
+    (`_invalidar_vinculos_de_outra_conta` filtra por `google_event_id IS NOT NULL`).
+
+    O link vai junto de propósito: neste ramo não existe link digitado pelo usuário (ele só
+    roda quando `not data.meeting_url`), então descartar não destrói trabalho de ninguém.
+    """
+    import logging
+
+    from app.modules.agenda.models import AgendaEvent
+    from app.modules.google_calendar import service as gcal
+
+    monkeypatch.setattr(
+        gcal, "create_meet_event",
+        lambda *a, **k: ("https://meet.google.com/orf-anho-xyz", None, "dono@gmail.com"),
+    )
+    with caplog.at_level(logging.WARNING, logger="app.modules.agenda.service"):
+        resp = client.post("/agenda/events", json=_event(kind="reuniao"), headers=headers)
+
+    assert resp.status_code == 201, resp.text  # a criação local NUNCA cai por causa do Google
+    ev = resp.json()["event"]
+    assert ev["meeting_url"] is None, "link de Meet sem id é órfão: não pode ser gravado"
+    assert ev["google_event_id"] is None
+    linha = db.get(AgendaEvent, ev["id"])
+    assert linha.google_account_email is None, (
+        "carimbar a conta sem id deixa a linha fora do WHERE da invalidação do #305"
+    )
+    assert "[google:create_meet:sem_id]" in caplog.text
+
+
+def test_google_200_com_id_vazio_e_recusado_como_ausente(
+    client: TestClient, headers, monkeypatch, db: Session
+):
+    """`id == ""` é recusado igual a `None` — a guarda é falsy, não `is not None`.
+
+    String vazia não endereça evento nenhum no Google E é `NOT NULL` para o índice único
+    parcial `ix_agenda_events_tenant_google_event_id` (migration 0081): dois eventos assim
+    estourariam unicidade. Mesma escolha de `sync.py::_apply_item` (`if not google_event_id`).
+    """
+    from app.modules.agenda.models import AgendaEvent
+    from app.modules.google_calendar import service as gcal
+
+    monkeypatch.setattr(
+        gcal, "create_meet_event",
+        lambda *a, **k: ("https://meet.google.com/vaz-io-xyz", "", "dono@gmail.com"),
+    )
+    resp = client.post("/agenda/events", json=_event(kind="reuniao"), headers=headers)
+    assert resp.status_code == 201, resp.text
+    ev = resp.json()["event"]
+    assert ev["meeting_url"] is None
+    assert not ev["google_event_id"]
+    assert db.get(AgendaEvent, ev["id"]).google_account_email is None
 
 
 def test_manual_meeting_url_preserved_google_not_called(client: TestClient, headers, monkeypatch):

--- a/apps/api/tests/test_google_calendar_reconexao.py
+++ b/apps/api/tests/test_google_calendar_reconexao.py
@@ -149,10 +149,13 @@ def test_link_de_evento_sem_espelho_no_google_sobrevive_a_troca_de_conta(db: Ses
        apagar trabalho digitado à mão. Note que aqui a cláusula `google_account_email IS NOT
        NULL` também protege: só derrubando as DUAS cláusulas esta linha é destruída.
 
-    b) ESPELHO PARCIAL: procedência conhecida, id ausente. Estado real e alcançável — `create_
-       event` grava `event.google_event_id = data.get("id")`, então um 200 do Google trazendo
-       `hangoutLink` mas sem `id` produz exatamente isto. Aqui a cláusula do id é a ÚNICA
+    b) ESPELHO PARCIAL: procedência conhecida, id ausente. Aqui a cláusula do id é a ÚNICA
        proteção, e é por esta linha que a remoção dela, sozinha, mata este teste.
+       ⚠️ ATUALIZADO (#306): `create_event` deixou de PRODUZIR este estado — um 200 do Google
+       com `hangoutLink` e sem `id` agora não carimba nada (ver `agenda/service.py::create_
+       event` e `test_agenda.py::test_google_200_sem_id_nao_grava_meio_espelho`). A linha
+       continua ALCANÇÁVEL como legado: quem foi gravado antes da guarda segue no banco, e
+       é exatamente quem esta cláusula protege de ser varrido numa troca de conta.
     """
     _conectar(db, CONTA_ANTIGA)
     manual = _evento(


### PR DESCRIPTION
## Contexto

`create_event` gravava `meeting_url` **sob guarda** e `google_event_id` **sem nenhuma**. Um `200`
do Google sem `id` no corpo (`create_meet_event` devolve `data.get("id")`) produzia um evento com
link de Meet e sem espelho rastreável — estado que o resto do módulo não sabe tratar.

## Os dois pontos de escrita discordavam entre si

O outro ponto de escrita da mesma coluna já recusava o caso. Não havia decisão registrada em lugar
nenhum; era assimetria.

| Ponto de escrita | Item sem `id` |
|---|---|
| `google_calendar/sync.py::_apply_item` (pull) | `if not google_event_id: return False` — **recusa** |
| `agenda/service.py::create_event` (push) | gravava `None` e seguia — **aceitava** |

## O estado ruim escapava também da limpeza do #305

A issue mediu 1 call site, e é 1 mesmo. Mas o `google_account_email` (migration 0086, do #305)
era carimbado no mesmo bloco, **também sem guarda** — e a invalidação por troca de conta filtra
por `google_event_id IS NOT NULL`:

```sql
WHERE google_event_id IS NOT NULL AND google_account_email IS NOT NULL AND google_account_email <> :novo
```

Ou seja, a linha defeituosa ficava carimbada com o e-mail de uma conta que podia deixar de ser a
conectada, e **`_invalidar_vinculos_de_outra_conta` nunca a alcançava**. O card ficaria para sempre
com o link do Meet de outra pessoa — exatamente o dano que o #305 existe para evitar. Isto não
estava na issue; apareceu ao medir.

## A decisão: o espelho é tudo-ou-nada

Sem `id`, **nenhum** dos três campos é carimbado — o `meeting_url` vai junto. Registrada em
comentário no ponto de escrita, porque a assimetria anterior não estava registrada em lugar nenhum.

Descartar o link não destrói trabalho de ninguém: **este ramo só roda quando `not
data.meeting_url`**. Quem colou um Zoom ou um Meet à mão nunca chega aqui. O link descartado é um
link que ninguém digitou, que o sistema não conseguiria remarcar, cancelar nem invalidar — e a #302
já julgou que esse link é pior que card nenhum.

A criação local **não** cai (IV1): o evento nasce igual, só sem espelho, e emite
`[google:create_meet:sem_id]`. Antes era silêncio total.

### A guarda é falsy, não `is not None` — e isso é material

`if google_event_id:` e não `if google_event_id is not None:`. Um id `""` é `NOT NULL` para o
índice único parcial `ix_agenda_events_tenant_google_event_id` (migration 0081,
`WHERE google_event_id IS NOT NULL`), então o **segundo** evento nesse estado estouraria
unicidade. É a mesma guarda que `_apply_item` já aplica no pull — os dois pontos voltam a
concordar.

## Prova por mutação

Sete mutantes, sete mortos. Cada mutação foi validada com `ast.parse` antes de rodar (mutante que
não compila mata o teste pelo módulo, não pela asserção) e revertida por cópia de arquivo.

| Mutação | Teste que morreu | Mensagem |
|---|---|---|
| guarda removida (comportamento de hoje) | `test_google_200_sem_id_nao_grava_meio_espelho` | `AssertionError: link de Meet sem id é órfão: não pode ser gravado` |
| `google_account_email` **fora** da guarda | `test_google_200_sem_id_nao_grava_meio_espelho` | `AssertionError: carimbar a conta sem id deixa a linha fora do WHERE da invalidação do #305` |
| `meeting_url` fora da guarda (decisão do link revertida) | `test_google_200_sem_id_nao_grava_meio_espelho` | `assert 'https://meet.google.com/orf-anho-xyz' is None` |
| `is not None` no lugar do falsy | `test_google_200_com_id_vazio_e_recusado_como_ausente` | `assert 'https://meet.google.com/vaz-io-xyz' is None` |
| guarda sempre falsa (espelho nunca carimbado) | `test_meet_generated_when_google_connected` + 2 de `test_google_calendar_reconexao.py` | `assert None == 'https://meet.google.com/abc-defg-hij'` |
| `logger.warning(...)` → `pass` | `test_google_200_sem_id_nao_grava_meio_espelho` | `assert '[google:create_meet:sem_id]' in ''` |
| carimbo da conta apagado do caminho feliz | `test_meet_generated_when_google_connected` | `assert None == 'dono@gmail.com'` |

**Mutante equivalente documentado:** o `if meeting_url:` interno (pré-existente) só se distingue
com o input exótico `meeting_url == ""`, que este ramo nunca vê. Fica como está, **sem** teste
inventado para fixar o literal.

## A mudança no teste do #305 é só docstring — provado por parse

`test_google_calendar_reconexao.py` afirmava que o "espelho parcial" é alcançável porque
`create_event` grava `data.get("id")` sem condição. Este PR torna isso falso: a linha segue
alcançável, mas **como legado**. Só a prosa mudou.

Provado comparando a AST com as docstrings removidas de todos os nós: **idêntica**, 28525 chars nos
dois lados. Controle negativo (negar uma asserção) faz o método acusar diff — 29281 chars.

## O que este PR não faz

- **Não mediu produção.** A issue sugere `SELECT count(*) FROM agenda_events WHERE
  google_event_id IS NULL AND meeting_url LIKE '%meet.google.com%'`. Não foi rodada — a guarda é
  correta com `0` linhas, e o número mudaria só a prioridade e a necessidade de um backfill.
- **Não faz backfill.** Linhas legadas nesse estado, se existirem, continuam nele. Um `UPDATE …
  SET meeting_url = NULL` seria coerente com a decisão daqui, mas é destrutivo e depende da
  medição acima.

## Gates

```
ruff check .                     All checks passed!
pytest -q -m "not rls_e2e"       2471 passed, 1 skipped, 72 deselected
```

Closes #306
