### PR TITLE
feat(audit): a trilha do Google Calendar passa a dizer QUAL conta entrou e saiu

### DIFF
--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -19,12 +19,64 @@ class AuditEntry(Base, TenantMixin, TimestampMixin):
     is_ai: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     action: Mapped[str] = mapped_column(String(128), nullable=False)
     target: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    detail: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    """SNAPSHOT em texto livre do que o `target` sozinho não consegue recuperar depois.
+
+    MESMO raciocínio de `PlatformAuditEntry.actor_email` (abaixo): quando a linha apontada pelo
+    `target` é APAGADA na própria ação auditada, o id vira um ponteiro para o nada — não há
+    FK/join possível depois. Foi o caso que abriu esta coluna (issue #307): `google.credential.
+    disconnect` e `.revoked` gravavam `target=cred.id` e apagavam a `GoogleCredential` na mesma
+    transação, então QUAL conta Google saiu deixava de existir no banco.
+
+    POR QUE UMA COLUNA, e não compor no `target` (as duas opções que a #307 pesou):
+
+    1. O `target` já foi sobrecarregado antes, e machucou. Sem campo de detalhe, o módulo `dna`
+       enfiou três formas diferentes no mesmo campo — id, `f"{source}:{key}"`
+       (`dna/eventos.py::alvo_da_resposta`) e uma contagem crua (`dna/router.py`) — e
+       `scripts/nucleo_activation.py` precisou virar PARSER do campo (`target.split(":", 1)[0]`
+       e `int(e.target)`). Aquele parse só é seguro porque a query filtra
+       `action.startswith("dna.")` antes: o campo não tem contrato, tem convenção por ação.
+       Uma quarta forma (`id:email`) estenderia exatamente esse defeito.
+    2. NÃO CABE, e o estouro seria SILENCIOSO no teste e FATAL em produção. `target` é
+       `String(255)`; `cred.id` é um UUID de 36 chars e o e-mail vai a 254 (RFC 5321) — o
+       composto chega a 291. O Postgres de produção RECUSA (`value too long for type character
+       varying(255)`) e derrubaria justo o `disconnect`; o SQLite da suíte IGNORA o limite e
+       ficaria verde. Coluna própria dá 255 inteiros ao e-mail.
+
+    `default=""`/`NOT NULL` (não `nullable`) de propósito: os 121 `audit.record()` existentes
+    seguem sem passar nada e gravam `""`. Ausência de detalhe é "não se aplica", não é
+    desconhecido — não há semântica de NULL a preservar aqui (ao contrário da 0086).
+
+    ⚠️ LGPD: isto é dado pessoal e é PARA ficar em claro (a trilha existe para ser lida). Fica
+    do lado CERTO da linha por herdar `TenantMixin`: `platform/service.py::_business_table_names`
+    descobre a tabela por `issubclass(..., TenantMixin)`, então a coluna É purgada junto com o
+    tenant. É a diferença deliberada para `PlatformAuditEntry`, que fica FORA do `TenantMixin`
+    justamente para sobreviver à purga.
+    """
 
 
-def record(db, *, tenant_id: str, actor: str, action: str, target: str = "", is_ai: bool = False):
-    """Grava uma entrada de auditoria. Chame em toda mutação de dados de negócio."""
+def record(
+    db,
+    *,
+    tenant_id: str,
+    actor: str,
+    action: str,
+    target: str = "",
+    detail: str = "",
+    is_ai: bool = False,
+):
+    """Grava uma entrada de auditoria. Chame em toda mutação de dados de negócio.
+
+    Use `detail` para o SNAPSHOT que o `target` não recupera depois (ver o docstring da coluna):
+    quando a linha apontada pelo `target` morre na própria ação, o id não basta.
+    """
     entry = AuditEntry(
-        tenant_id=tenant_id, actor=actor, action=action, target=target, is_ai=is_ai
+        tenant_id=tenant_id,
+        actor=actor,
+        action=action,
+        target=target,
+        detail=detail,
+        is_ai=is_ai,
     )
     db.add(entry)
     return entry

--- a/apps/api/app/modules/google_calendar/service.py
+++ b/apps/api/app/modules/google_calendar/service.py
@@ -196,9 +196,14 @@ def upsert_credential(db: Session, *, tenant_id: str, email: str, token_data: di
             "[google:reconexao:conta_trocada] tenant=%s eventos_invalidados=%d",
             tenant_id, invalidados,
         )
+    # `detail=email`: QUAL conta entrou. Sem isso, nem reconstruindo a sequência de entradas dá
+    # para saber de qual conta para qual a reconexão trocou — o `connect` é a única ponta que
+    # sabe o e-mail novo, e o `target` (id da credencial) é o MESMO em toda troca do tenant.
+    # `email` vazio (userinfo falhou no callback, ver `handle_callback`) grava "" e é honesto:
+    # a conexão de fato aconteceu sem que soubéssemos quem é.
     audit.record(
         db, tenant_id=tenant_id, actor="google:oauth", action="google.credential.connect",
-        target=cred.id,
+        target=cred.id, detail=email,
     )
     db.commit()
 
@@ -234,10 +239,19 @@ def disconnect(db: Session, *, tenant_id: str, actor: str) -> bool:
             )
         except Exception:
             logger.exception("[google:revoke:failed] tenant=%s", tenant_id)
+    # Lidos ANTES do `delete`: depois dele `cred` está marcado para remoção e ler atributo de
+    # instância deletada depende de a sessão ainda não ter expirado o objeto. O `target=cred.id`
+    # que ficava DEPOIS do delete só funcionava por acidente de timing; agora nenhum dos dois
+    # valores depende disso. (Mesma disciplina de `_descartar_credencial_revogada`, que já lê
+    # `tenant_id`/`cred_id` antes de mexer na credencial.)
+    cred_id = cred.id
+    email_da_conta = cred.google_account_email
     db.delete(cred)
+    # `detail`: QUAL conta saiu. A linha morre nesta mesma transação, então o e-mail não é
+    # recuperável por join depois — é exatamente o caso que a coluna `detail` existe para cobrir.
     audit.record(
         db, tenant_id=tenant_id, actor=actor, action="google.credential.disconnect",
-        target=cred.id,
+        target=cred_id, detail=email_da_conta,
     )
     db.commit()
     return True
@@ -267,6 +281,7 @@ def _descartar_credencial_revogada(cred: GoogleCredential) -> None:
     # usado dentro dela (nem depois do delete, que o expiraria lá).
     tenant_id = cred.tenant_id
     cred_id = cred.id
+    email_da_conta = cred.google_account_email
     try:
         with tenant_session(tenant_id) as descarte:
             morta = descarte.get(GoogleCredential, cred_id)
@@ -277,9 +292,12 @@ def _descartar_credencial_revogada(cred: GoogleCredential) -> None:
             # apagou foi o sistema ao ver o token morto, não o usuário pedindo para desconectar.
             # Confundir as duas no audit apagaria a diferença entre "revogado pelo Google" e
             # "o dono clicou em Desconectar".
+            # `detail`: QUAL conta o Google revogou. Vem do `email_da_conta` lido lá em cima, na
+            # sessão do CHAMADOR — `morta` é outra instância, e ler dela também serviria, mas o
+            # snapshot já está na mão e não depende do estado da sessão curta.
             audit.record(
                 descarte, tenant_id=tenant_id, actor="google:token",
-                action="google.credential.revoked", target=cred_id,
+                action="google.credential.revoked", target=cred_id, detail=email_da_conta,
             )
     except Exception:
         logger.exception("[google:token:descarte_falhou] tenant=%s", tenant_id)

--- a/apps/api/migrations/versions/0087_audit_entries_detail.py
+++ b/apps/api/migrations/versions/0087_audit_entries_detail.py
@@ -1,0 +1,49 @@
+"""audit_entries ganha `detail` — o SNAPSHOT que o `target` não recupera depois
+
+Revision ID: 0087
+Revises: 0086
+Create Date: 2026-09-05
+
+Por quê (issue #307): os três `audit.record()` do Google Calendar
+(`google_calendar/service.py`) gravavam só `target=cred.id` — e os DOIS caminhos de saída
+apagam a `GoogleCredential` na MESMA transação (`disconnect` faz `db.delete(cred)`;
+`_descartar_credencial_revogada` idem). O id sobrevive apontando para uma linha que não existe
+mais, então QUAL conta Google entrou ou saiu não era recuperável por nenhum join. A 0086 tinha
+deixado a procedência em `agenda_events.google_account_email`, mas a própria invalidação de
+reconexão ZERA essa coluna — o último rastro morria exatamente no evento que se queria auditar.
+
+É o mesmo raciocínio que `platform_audit_entries` já aplica (`actor_email`,
+`target_tenant_slug`): guardar SNAPSHOT quando o alvo é apagado logo em seguida.
+
+`String(255)` + `NOT NULL` + `server_default=""`: a coluna cabe um e-mail inteiro (254, RFC
+5321), que NÃO caberia composto no `target` (`String(255)` já ocupado por um UUID de 36).
+
+O `server_default=""` é o que BACKFILLA as linhas existentes — e é DDL puro, sem `UPDATE`,
+mantendo a disciplina das 0084/0085/0086: um `UPDATE` aqui rodaria sob FORCE RLS sem
+`app.current_tenant_id`, seria filtrado a ZERO linhas e "passaria" em silêncio. Aqui o valor
+das linhas antigas é `""` e isso é CORRETO, não uma lacuna: aquelas ações não tinham detalhe.
+
+Diferente da 0086, `NULL` NÃO tem significado semântico nesta coluna — "sem detalhe" é `""`,
+não "detalhe desconhecido". Por isso `NOT NULL`, espelhando o irmão `target`.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0087"
+down_revision: str | None = "0086"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_entries",
+        sa.Column("detail", sa.String(255), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("audit_entries", "detail")

--- a/apps/api/tests/test_google_calendar_audit_conta.py
+++ b/apps/api/tests/test_google_calendar_audit_conta.py
@@ -1,0 +1,275 @@
+"""A trilha do Google Calendar tem de dizer QUAL conta entrou e QUAL saiu (issue #307).
+
+Antes disto, os três `audit.record()` de `google_calendar/service.py` gravavam só
+`target=cred.id`. Como os DOIS caminhos de saída APAGAM a `GoogleCredential` na mesma transação
+(`disconnect` → `db.delete(cred)`; `_descartar_credencial_revogada` → idem), o id sobrevivia
+apontando para uma linha inexistente: o e-mail deixava de existir no banco e nenhum join o
+trazia de volta. A `agenda_events.google_account_email` da 0086 também não salvava, porque a
+invalidação de reconexão ZERA aquela coluna — o último rastro morria justo no evento auditado.
+
+A correção é a coluna `audit_entries.detail` (migration 0087), o mesmo SNAPSHOT que
+`platform_audit_entries.actor_email` já usava pelo mesmo motivo.
+
+UM TESTE POR CALL SITE, de propósito. Os três chamam a mesma função e é fácil escrever uma
+asserção só que passa a cobrir os três por acidente — aí quebrar dois deles não mata teste
+nenhum e a cobertura é ilusória. Cada teste abaixo morre com a mutação do SEU call site,
+verificado uma a uma.
+
+Todas as chamadas HTTP ao Google são MOCKADAS.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.audit import AuditEntry
+from app.modules.google_calendar import service
+from app.modules.google_calendar.models import GoogleCredential
+
+REGISTER = {
+    "legal_name": "Clínica Maria",
+    "document": "98765432000198",
+    "slug": "clinicamaria",
+    "email": "maria@example.com",
+    "name": "Maria",
+    "password": "uma-senha-bem-forte",
+}
+
+CONTA = "dono.da.clinica@gmail.com"
+OUTRA_CONTA = "socio@empresa.com.br"
+
+_TOKEN_DATA = {
+    "access_token": "ya29.fake-access",
+    "refresh_token": "1//fake-refresh",
+    "expires_in": 3600,
+}
+
+
+@pytest.fixture()
+def tenant_id(client: TestClient, db: Session) -> str:
+    from app.modules.auth.models import Tenant
+
+    client.post("/auth/register", json=REGISTER)
+    return db.scalars(select(Tenant)).first().id
+
+
+def _conectar(db: Session, tenant_id: str, email: str) -> GoogleCredential:
+    """Credencial VIVA (token no futuro), como depois de um callback bem-sucedido."""
+    cred = GoogleCredential(
+        tenant_id=tenant_id,
+        google_account_email=email,
+        access_token="access-valido",
+        refresh_token="refresh-valido",
+        token_expiry=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db.add(cred)
+    db.commit()
+    return cred
+
+
+def _entrada(db: Session, action: str) -> AuditEntry:
+    entrada = db.scalar(select(AuditEntry).where(AuditEntry.action == action))
+    assert entrada is not None, f"nenhuma entrada de audit para '{action}'"
+    return entrada
+
+
+# ── Call site 1: `upsert_credential` → google.credential.connect ─────────────
+def test_connect_grava_a_conta_que_entrou(db: Session, tenant_id: str):
+    """O `connect` é a ÚNICA ponta que sabe o e-mail novo.
+
+    Sem ele não adianta ter os dois de saída: o `target` é o id da credencial, que o upsert
+    REAPROVEITA entre reconexões — o mesmo id serve a todas as contas que o tenant já usou, e
+    portanto não distingue nenhuma. Só o `detail` diz de qual conta para qual a troca foi.
+    """
+    service.upsert_credential(db, tenant_id=tenant_id, email=CONTA, token_data=_TOKEN_DATA)
+
+    assert _entrada(db, "google.credential.connect").detail == CONTA
+
+
+def test_connect_sem_userinfo_grava_vazio_e_nao_quebra(db: Session, tenant_id: str):
+    """`handle_callback` segue com `email=""` quando o userinfo falha (robustez do módulo).
+
+    O audit grava "" e isso é HONESTO: a conexão aconteceu sem que soubéssemos quem é. O que
+    não pode é a ausência de e-mail derrubar o `connect` — os tokens já foram obtidos.
+    """
+    service.upsert_credential(db, tenant_id=tenant_id, email="", token_data=_TOKEN_DATA)
+
+    assert _entrada(db, "google.credential.connect").detail == ""
+
+
+# ── Call site 2: `disconnect` → google.credential.disconnect ─────────────────
+def test_disconnect_grava_a_conta_que_saiu(db: Session, tenant_id: str, monkeypatch):
+    """A conta tem de sobreviver ao `db.delete(cred)` da MESMA transação."""
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: None)
+    _conectar(db, tenant_id, CONTA)
+
+    assert service.disconnect(db, tenant_id=tenant_id, actor="user-1") is True
+
+    assert db.scalar(select(GoogleCredential)) is None  # a linha REALMENTE sumiu
+    assert _entrada(db, "google.credential.disconnect").detail == CONTA
+
+
+def test_disconnect_grava_a_conta_mesmo_se_a_revogacao_falhar(
+    db: Session, tenant_id: str, monkeypatch
+):
+    """Best-effort na revogação não pode custar o rastro: o delete acontece de qualquer jeito."""
+
+    def explode(*a, **k):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx, "post", explode)
+    _conectar(db, tenant_id, CONTA)
+
+    assert service.disconnect(db, tenant_id=tenant_id, actor="user-1") is True
+
+    assert _entrada(db, "google.credential.disconnect").detail == CONTA
+
+
+# ── Call site 3: `_descartar_credencial_revogada` → google.credential.revoked ─
+@pytest.fixture()
+def sessao_curta(db: Session, monkeypatch):
+    """`service.tenant_session` → sessão SEPARADA na mesma engine (espelha produção)."""
+
+    @contextmanager
+    def _factory(_tenant_id: str):
+        curta = Session(bind=db.get_bind(), autoflush=False, expire_on_commit=False)
+        try:
+            yield curta
+            curta.commit()
+        finally:
+            curta.close()
+
+    monkeypatch.setattr(service, "tenant_session", _factory)
+
+
+class _Revogado400:
+    status_code = 400
+    text = '{"error": "invalid_grant", "error_description": "expired or revoked"}'
+
+    def raise_for_status(self):
+        raise httpx.HTTPStatusError("400 invalid_grant", request=None, response=None)
+
+
+def test_revoked_grava_a_conta_que_o_google_matou(
+    db: Session, tenant_id: str, monkeypatch, sessao_curta
+):
+    """O descarte automático roda em sessão CURTA e não tem o `cred` do chamador na mão.
+
+    O e-mail é lido ANTES de abrir a outra sessão, junto de `tenant_id`/`cred_id` — mesma
+    disciplina que a função já aplicava para os outros dois.
+    """
+    from app.modules.agenda.models import AgendaEvent
+
+    cred = GoogleCredential(
+        tenant_id=tenant_id,
+        google_account_email=OUTRA_CONTA,
+        access_token="velho",
+        refresh_token="refresh-morto",
+        token_expiry=datetime.now(UTC) - timedelta(hours=1),  # força a renovação
+    )
+    db.add(cred)
+    ev = AgendaEvent(
+        tenant_id=tenant_id,
+        title="Reunião",
+        kind="reuniao",
+        starts_at=datetime.now(UTC) + timedelta(days=1),
+        ends_at=datetime.now(UTC) + timedelta(days=1, hours=1),
+    )
+    db.add(ev)
+    db.commit()
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _Revogado400())
+    assert service.create_meet_event(db, tenant_id=tenant_id, event=ev) is None
+
+    assert _entrada(db, "google.credential.revoked").detail == OUTRA_CONTA
+
+
+# ── A pergunta da issue, ponta a ponta ───────────────────────────────────────
+def test_a_trilha_sozinha_reconstroi_a_troca_de_conta(
+    db: Session, tenant_id: str, monkeypatch
+):
+    """O caso que abriu a issue: "de QUAL conta para qual?".
+
+    Depois da troca, NENHUMA linha do banco guarda a conta antiga — a `GoogleCredential` foi
+    apagada e a invalidação de reconexão zerou `agenda_events.google_account_email`. A trilha
+    tem de bastar sozinha.
+
+    E note o `target`: os três registros carregam ids que já não endereçam nada (a credencial
+    velha morreu). É o `detail` que responde.
+    """
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: None)
+    service.upsert_credential(db, tenant_id=tenant_id, email=CONTA, token_data=_TOKEN_DATA)
+    service.disconnect(db, tenant_id=tenant_id, actor="user-1")
+    service.upsert_credential(db, tenant_id=tenant_id, email=OUTRA_CONTA, token_data=_TOKEN_DATA)
+
+    trilha = sorted(
+        (e.action, e.detail)
+        for e in db.scalars(
+            select(AuditEntry).where(AuditEntry.action.startswith("google.credential."))
+        ).all()
+    )
+
+    # `sorted`, e NÃO ordem cronológica, de propósito: `created_at` é `server_default=func.now()`
+    # — o timestamp da TRANSAÇÃO. Aqui as três ações caem na mesma transação de teste, então os
+    # carimbos EMPATAM e o desempate por `id` (UUID aleatório) daria uma ordem que muda entre
+    # execuções. É a mesma armadilha documentada em `scripts/nucleo_activation.entradas_do_dna`.
+    # Em produção cada ação é uma request própria e a cronologia existe; o que este teste precisa
+    # provar é o CONTEÚDO — que cada entrada carrega a sua conta.
+    assert trilha == sorted(
+        [
+            ("google.credential.connect", CONTA),
+            ("google.credential.disconnect", CONTA),  # a conta que SAIU, nomeada
+            ("google.credential.connect", OUTRA_CONTA),  # a conta que ENTROU, nomeada
+        ]
+    )
+
+
+# ── A coluna em si ──────────────────────────────────────────────────────────
+def test_detail_e_vazio_por_padrao_nunca_nulo(db: Session, tenant_id: str):
+    """Os 121 `audit.record()` que não passam `detail` seguem gravando — com "" , não NULL.
+
+    A coluna é `NOT NULL default ""` de propósito: "sem detalhe" é "não se aplica", não é
+    "desconhecido". Um `None` aqui obrigaria todo leitor futuro a tratar NULL sem ganhar nada.
+    """
+    from app.core import audit
+
+    audit.record(db, tenant_id=tenant_id, actor="user-1", action="teste.sem.detalhe")
+    db.commit()
+
+    entrada = _entrada(db, "teste.sem.detalhe")
+    assert entrada.detail == ""
+    assert entrada.detail is not None
+
+
+def test_detail_cabe_um_email_inteiro_que_nao_caberia_composto_no_target(
+    db: Session, tenant_id: str
+):
+    """A razão TÉCNICA de ser coluna, e não `target=f"{id}:{email}"`.
+
+    `target` é `String(255)` e já carrega um UUID de 36 chars; o e-mail vai a 254 (RFC 5321).
+    Composto dá 291 — o Postgres de produção RECUSA e derrubaria o `disconnect`, enquanto o
+    SQLite da suíte ignoraria o limite e ficaria verde. Em coluna própria os 254 cabem.
+    """
+    from app.core import audit
+
+    email_no_limite = "a" * 64 + "@" + "b" * 185 + ".com"  # 254 chars
+    assert len(email_no_limite) == 254
+
+    audit.record(
+        db,
+        tenant_id=tenant_id,
+        actor="google:oauth",
+        action="teste.email.longo",
+        target="x" * 36,
+        detail=email_no_limite,
+    )
+    db.commit()
+    db.expire_all()  # força reler do banco, não devolver o objeto da identity map
+
+    assert _entrada(db, "teste.email.longo").detail == email_no_limite


### PR DESCRIPTION
## Contexto

A trilha de auditoria do Google Calendar registrava **que** a conexão mudou, mas nunca **qual
conta**. Os dois caminhos de saída apagam a `GoogleCredential` na mesma transação (`disconnect`
faz `db.delete(cred)`; `_descartar_credencial_revogada` idem), então o e-mail deixava de existir
no banco e **não havia como recuperá-lo por nenhum join**.

O `connect` importa tanto quanto os dois de saída: sem ele, nem reconstruindo a sequência dá para
saber de qual conta **para qual** a reconexão trocou. O log `[google:reconexao:conta_trocada]` do
#305 carrega só a contagem.

Desde o #305 os eventos guardam `agenda_events.google_account_email` — mas a invalidação **zera
essa coluna** ao trocar de conta. O último rastro morria exatamente no evento que se queria
auditar.

## O repo já tinha resolvido esse problema — no outro log

`PlatformAuditEntry`, no mesmo arquivo, guarda `actor_email` e `target_tenant_slug` como
snapshots, e a docstring diz o porquê:

> Guarda SNAPSHOTS (`actor_email`, `target_tenant_slug`) porque o tenant-alvo é apagado logo em
> seguida: não há como fazer FK/join depois.

É o mesmo raciocínio. A trilha do Google Calendar só não tinha recebido o mesmo tratamento.

## Migration, e não composição no `target` — o argumento é aritmético

A issue deixava a escolha em aberto: compor no `target` (barato, sem migration) ou criar um campo
de detalhe. **Compor não cabe:**

| | |
|---|---|
| `target` é | `String(255)`, já ocupado por um UUID de **36** |
| e-mail vai a | **254** (RFC 5321) |
| composto | 36 + 1 + 254 = **291** |

Contra Postgres real, com controle positivo:

```
INSERT ... repeat('a',291)  →  ERROR: value too long for type character varying(255)
INSERT ... repeat('a',255)  →  INSERT 0 1
```

Derrubaria o próprio `disconnect` em produção. E o **SQLite da suíte aceita 291 chars num
`varchar(255)` sem erro** — a suíte ficaria verde enquanto prod quebra. É a divergência
suíte↔produção que o repo já paga em outros lugares, e não vale reintroduzir por economia de uma
migration.

### A contagem que sustentava a outra metade do argumento

Medida por **AST**, não por grep: `apps/api/app/` tem **121** chamadas reais de `audit.record()` em
31 arquivos. O grep devolve 125-126 porque conta prosa — docstrings e comentários citando
`audit.record(` em `core/ai.py`, `financial_intelligence/ai_narrator.py` e `wallet/models.py`.

Das 121, **nenhuma** compõe informação no `target` na própria chamada. Mas a falta de campo de
detalhe **já machucou**, por fora da chamada:

- O módulo `dna` enfia **três formas** no mesmo campo: id, `f"{source}:{key}"`
  (`dna/eventos.py::alvo_da_resposta`) e uma contagem crua (`dna/router.py:117`). O código diz
  isso com todas as letras — *"o `source` vai no TARGET, nunca no action"*.
- `wallet/models.py:83` documenta um abuso passado: `audit.record(target=str(total))`, *"o VALOR,
  não um id"*, corrigido criando uma entidade.

E existe um **parser** do campo: `app/scripts/nucleo_activation.py` faz `target.split(":", 1)[0]` e
`int(e.target)`, seguro só porque filtra `action.startswith("dna.")` antes. Um teste existente
também espera id puro (`test_google_calendar.py:502`).

## A migration 0087

`String(255)` + `NOT NULL` + `server_default=""`, espelhando o irmão `target`. DDL puro, **sem
`UPDATE`** — mantendo a disciplina das 0084/0085/0086: um `UPDATE` aqui rodaria sob FORCE RLS sem
`app.current_tenant_id`, seria filtrado a zero linhas e "passaria" em silêncio.

Diferente da 0086, `NULL` **não** tem significado semântico nesta coluna: "sem detalhe" é `""`.
Linha antiga fica `""` e isso é **correto**, não lacuna — aquelas ações não tinham detalhe.

Provado contra Postgres 16 descartável, com uma linha legada inserida **antes** do upgrade:

```
upgrade   0086 → 0087   OK   linha legada: detail_null = f, detail = []
downgrade 0087 → 0086   OK   coluna sumiu (count = 0)
forma:  detail | varying(255) | NOT NULL | ''::character varying   (idêntica a target)
```

## LGPD — conferido, sem conflito

O gate `test_regra_de_ouro_gate.py` mira chamada de IA sem `mask`; auditoria não é chamada de IA.
`AuditEntry` herda `TenantMixin`, então `_business_table_names()` descobre a tabela e o e-mail **é
purgado junto com o tenant** — o lado certo da linha, e a diferença deliberada para
`PlatformAuditEntry`, que fica fora do mixin justamente para sobreviver à purga. Nenhuma categoria
nova de dado: o mesmo e-mail já está em `google_credentials` e `agenda_events`, no mesmo escopo.

## Prova por mutação

Cada call site foi mutado **sozinho**. Se um só morresse com os três quebrados juntos, a cobertura
dos outros dois seria ilusória.

| Mutação | Teste que morreu | Mensagem |
|---|---|---|
| `connect` sem `detail` | `test_connect_grava_a_conta_que_entrou` | `assert '' == 'dono.da.clinica@gmail.com'` |
| `disconnect` sem `detail` | `test_disconnect_grava_a_conta_que_saiu` | `assert '' == 'dono.da.clinica@gmail.com'` |
| `revoked` sem `detail` | `test_revoked_grava_a_conta_que_o_google_matou` | `assert '' == 'socio@empresa.com.br'` |
| `record()` não repassa `detail` | 6 testes | `assert '' == 'aaaa…@bbbb.com'` |
| coluna sem `default=""` | `test_nucleo_activation`, `test_ai` (pré-existentes) | `sqlite3.IntegrityError: NOT NULL constraint failed: audit_entries.detail` |

**Dois mutantes equivalentes, documentados em vez de contornados com teste inventado:**

- `default=""` → `default="MUTANTE"`: inobservável. `record()` tem `detail: str = ""` na assinatura
  e sempre passa explícito, então o default da coluna nunca dispara. Foi trocado por
  **remover** o default, que é load-bearing e mata testes pré-existentes.
- Ler o e-mail **depois** do `db.delete(cred)`: equivalente — `delete()` só marca a instância, os
  atributos seguem carregados até o flush, e o código original já dependia disso
  (`target=cred.id` vinha depois do delete). A reordenação fica como **remoção de risco latente**;
  este PR não afirma que teste algum a prove.

## Gates

```
ruff check .                   All checks passed!
pytest -q -m "not rls_e2e"     2477 passed, 1 skipped, 72 deselected
pytest -q -m rls_e2e           72 passed, 2478 deselected
```

Os `rls_e2e` rodaram em comando separado, contra Postgres real via testcontainers: a 0087 mexe em
tabela sob RLS e foi exercida ali.

Closes #307
