### PR TITLE
feat(audit): o `target` volta a ser só um id, e um gate impede a 4ª forma

### DIFF
--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -19,6 +19,30 @@ class AuditEntry(Base, TenantMixin, TimestampMixin):
     is_ai: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     action: Mapped[str] = mapped_column(String(128), nullable=False)
     target: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    """O **id** da entidade sobre a qual a ação aconteceu — ou `""` quando não há entidade.
+
+    **É contrato, e é fechado (issue #312).** `target` é um id, e só isso. NUNCA um composto
+    (`f"{source}:{key}"`), NUNCA um valor (uma contagem, um total, uma data). O que não é id vai
+    em `detail`, que é livre por definição — ver o docstring logo abaixo. Um id no `target` é o
+    que permite JOIN; qualquer outra coisa transforma o consumidor em parser.
+
+    **Por que isto precisou virar contrato escrito.** O campo não tinha nenhum, e por isso
+    acumulou TRÊS formas conforme a action: id nu (a esmagadora maioria das chamadas do repo),
+    `<source>:<pergunta>` no módulo `dna` e uma contagem crua (`str(exibidas)`) no `open` do
+    núcleo. A conta chegou no consumidor: `scripts/nucleo_activation.py` virou PARSER do campo
+    (`target.split(":", 1)[0]` e `int(target)`), e aquele parse só era seguro porque a query
+    filtrava `action.startswith("dna.")` antes. Não era contrato: era convenção por ação, e a
+    convenção morava no chamador. `wallet/models.py` documenta um abuso irmão, já corrigido
+    (`target=str(total)` — o VALOR, não um id).
+
+    ⚠️ **Docstring não contém nada sozinha** — foi exatamente uma docstring que descreveu o
+    defeito MNT-001 por semanas enquanto os 17 call sites continuavam lá. Quem segura ESTE
+    contrato é `tests/test_audit_target_e_id_gate.py`, que reprova por AST qualquer `target=`
+    que seja f-string, `str(...)` de valor, concatenação ou literal composto — inclusive quando
+    a composição está escondida atrás de uma variável ou de um helper que devolve f-string
+    (a forma que o `dna` usava).
+    """
+
     detail: Mapped[str] = mapped_column(String(255), default="", nullable=False)
     """SNAPSHOT em texto livre do que o `target` sozinho não consegue recuperar depois.
 
@@ -31,21 +55,30 @@ class AuditEntry(Base, TenantMixin, TimestampMixin):
     POR QUE UMA COLUNA, e não compor no `target` (as duas opções que a #307 pesou):
 
     1. O `target` já foi sobrecarregado antes, e machucou. Sem campo de detalhe, o módulo `dna`
-       enfiou três formas diferentes no mesmo campo — id, `f"{source}:{key}"`
-       (`dna/eventos.py::alvo_da_resposta`) e uma contagem crua (`dna/router.py`) — e
+       enfiou três formas diferentes no mesmo campo — id, `f"{source}:{key}"` (por um helper
+       `alvo_da_resposta`) e uma contagem crua (`dna/router.py`) — e
        `scripts/nucleo_activation.py` precisou virar PARSER do campo (`target.split(":", 1)[0]`
-       e `int(e.target)`). Aquele parse só é seguro porque a query filtra
-       `action.startswith("dna.")` antes: o campo não tem contrato, tem convenção por ação.
+       e `int(e.target)`). Aquele parse só era seguro porque a query filtra
+       `action.startswith("dna.")` antes: o campo não tinha contrato, tinha convenção por ação.
        Uma quarta forma (`id:email`) estenderia exatamente esse defeito.
+
+       ERRATA (2026-09-05, issue #312): o `dna` foi migrado para esta coluna e
+       `alvo_da_resposta` deixou de existir — hoje o `save`/`skip` grava `target=<id da
+       DnaAnswer>` e `detail=<source>`, e o `open` grava `target=""` e `detail=<exibidas>`.
+       O parse SOBREVIVE em `nucleo_activation.py`, mas só como leitura do LEGADO já gravado em
+       produção, marcada como tal e coberta por teste. O `target` ganhou o contrato que não
+       tinha (ver o docstring da coluna, acima); esta razão nº 1 continua sendo por que a
+       coluna existe, e não deixou de valer por ter sido paga.
     2. NÃO CABE, e o estouro seria SILENCIOSO no teste e FATAL em produção. `target` é
        `String(255)`; `cred.id` é um UUID de 36 chars e o e-mail vai a 254 (RFC 5321) — o
        composto chega a 291. O Postgres de produção RECUSA (`value too long for type character
        varying(255)`) e derrubaria justo o `disconnect`; o SQLite da suíte IGNORA o limite e
        ficaria verde. Coluna própria dá 255 inteiros ao e-mail.
 
-    `default=""`/`NOT NULL` (não `nullable`) de propósito: os 121 `audit.record()` existentes
-    seguem sem passar nada e gravam `""`. Ausência de detalhe é "não se aplica", não é
-    desconhecido — não há semântica de NULL a preservar aqui (ao contrário da 0086).
+    `default=""`/`NOT NULL` (não `nullable`) de propósito: a esmagadora maioria dos
+    `audit.record()` do repo não tem detalhe nenhum a dar, segue sem passar nada e grava `""`.
+    Ausência de detalhe é "não se aplica", não é desconhecido — não há semântica de NULL a
+    preservar aqui (ao contrário da 0086).
 
     ⚠️ LGPD: isto é dado pessoal e é PARA ficar em claro (a trilha existe para ser lida). Fica
     do lado CERTO da linha por herdar `TenantMixin`: `platform/service.py::_business_table_names`

--- a/apps/api/app/modules/dna/eventos.py
+++ b/apps/api/app/modules/dna/eventos.py
@@ -8,10 +8,18 @@ histórico de quem mudou o quê já é trabalho de `core/audit.py`". Até 2026-0
 `audit` aparecia UMA vez no módulo `dna`, dentro daquela frase, com zero chamadas. Este módulo é
 o que torna a frase verdadeira.
 
-**`source` vai no `target`, NUNCA no `action`.** Quatro actions × três sources (`nucleo｜gancho｜
+**`source` vai no `detail`, NUNCA no `action`.** Quatro actions × três sources (`nucleo｜gancho｜
 config`) seriam doze strings, e é assim que 117 actions distintas viram 200. O repo já tem
 `account_deleted` — sem pontos, fora do padrão `<entidade>.<entidade>.<verbo>` — provando que a
 convenção sozinha não segura o vocabulário.
+
+ERRATA (2026-09-05, issue #312): até esta data a frase acima dizia `target`, e o módulo gravava
+`target=f"{source}:{key}"` por um helper `alvo_da_resposta`. Era a segunda das três formas que o
+`target` acumulou sem contrato, e ela obrigava `scripts/nucleo_activation.py` a virar parser do
+campo. O `target` hoje é só id (`app/core/audit.py`, docstring da coluna) e quem carrega o
+`source` é o `detail`, livre por definição. O `key` NÃO precisa ser guardado: o `target` aponta
+para a `DnaAnswer`, e `question_key` é a chave do upsert — não muda. O que o upsert DESTRÓI é o
+`source`, e é exatamente ele que vai para o rastro.
 
 **Por que a validação é aqui e não uma convenção.** `facts.record` tem guarda mecânica (o `kind`
 tem de começar pelo `module`); `audit.record` não tem nenhuma. Esta função é a guarda equivalente
@@ -44,17 +52,13 @@ class VocabularioError(Exception):
     """Erro de programação, não de usuário: estoura na hora, como `FactError`."""
 
 
-def alvo_da_resposta(source: str, key: str) -> str:
-    """O `target` de uma resposta: `<source>:<pergunta>`.
-
-    É esta string que sobrevive ao upsert e distingue "respondeu no núcleo" de "editou no
-    `/config`" — as duas linhas de audit que o `dna_answers` não consegue guardar.
-    """
-    return f"{source}:{key}"
-
-
-def registrar(db, *, tenant_id: str, actor: str, action: str, target: str = ""):
+def registrar(db, *, tenant_id: str, actor: str, action: str, target: str = "", detail: str = ""):
     """Grava a trilha do DNA, validando o vocabulário AGORA.
+
+    `target` é o **id** da linha (contrato de `audit_entries.target`); `detail` é o `source` da
+    resposta (`nucleo｜gancho｜config`), que é o que o upsert de `dna_answers` destrói e o id não
+    recupera depois. No `open`/`abandon` do núcleo não existe entidade: `target=""`, e o `open`
+    leva o denominador visto no `detail`.
 
     ⚠️ Quem chama é responsável pelo `db.flush()` quando o `target` depende de uma linha recém
     adicionada — o `id` tem default Python-side e só existe depois do INSERT. Sem o flush o
@@ -72,6 +76,8 @@ def registrar(db, *, tenant_id: str, actor: str, action: str, target: str = ""):
         raise VocabularioError(
             f"'{action}' não é uma action do DNA. O vocabulário é fechado e mora em "
             f"`eventos.ACTIONS`: {ACTIONS}. Se o evento é novo, declare-o lá — e note que o "
-            "`source` vai no TARGET, nunca no action."
+            "`source` vai no DETAIL, nunca no action e nunca no target (que é só id)."
         )
-    return audit.record(db, tenant_id=tenant_id, actor=actor, action=action, target=target)
+    return audit.record(
+        db, tenant_id=tenant_id, actor=actor, action=action, target=target, detail=detail
+    )

--- a/apps/api/app/modules/dna/models.py
+++ b/apps/api/app/modules/dna/models.py
@@ -11,9 +11,14 @@ mais grave, porque **sustentava uma decisão de modelagem**: o upsert foi aceito
 rede que ninguém tinha tecido.
 
 Quem grava, hoje (verificável por `grep -rn "eventos.registrar" apps/api/app/modules/dna/`):
-`service._gravar` → `dna.answer.save` / `dna.answer.skip`, com `target=<source>:<pergunta>`;
-`router.nucleo_evento` → `dna.nucleo.open` / `dna.nucleo.abandon`. **Se esta lista divergir do
-grep, é ela que está errada.**
+`service._gravar` → `dna.answer.save` / `dna.answer.skip`, com `target=<id desta linha>` e
+`detail=<source>`; `router.nucleo_evento` → `dna.nucleo.open` / `dna.nucleo.abandon`, com
+`target=""` (não há entidade) e o denominador visto no `detail` do `open`. **Se esta lista
+divergir do grep, é ela que está errada.**
+
+O `source` vai para o `detail` e não para o `target` porque `audit_entries.target` é id, e só
+(issue #312) — e porque o id JÁ devolve a pergunta: `question_key` é a chave do upsert e não
+muda. O que o upsert apaga é a coluna `source` abaixo, e é ela que o rastro guarda.
 
 `value` nulo NÃO é ausência de linha: é "o dono viu a pergunta e pulou". A distinção sustenta a
 quarentena de 7 dias em `cadencia.py` sem tabela nova.

--- a/apps/api/app/modules/dna/router.py
+++ b/apps/api/app/modules/dna/router.py
@@ -104,19 +104,23 @@ def nucleo_evento(
             detail=f"evento '{evento}' não existe; são {sorted(eventos.EVENTOS_DO_NUCLEO)}",
         )
 
-    alvo = ""
+    # `target=""` nos DOIS eventos do núcleo, e não é omissão: abrir e abandonar o núcleo não
+    # tocam entidade nenhuma — não há id a apontar (contrato de `audit_entries.target`).
+    # O denominador é gravado porque NÃO é derivável: `faltantes` devolve só as não respondidas
+    # (na 2ª visita são 4, não 6) e `catalog.NUCLEO` pode crescer. Ele é um VALOR, então vai no
+    # `detail`. Até a issue #312 ia no `target` (`str(corpo.exibidas)`) — a terceira forma que
+    # aquele campo acumulou sem contrato, e a que forçava `int(e.target)` no consumidor.
+    detalhe = ""
     if action == eventos.ACTION_OPEN:
-        # O denominador é gravado porque NÃO é derivável: `faltantes` devolve só as não
-        # respondidas (na 2ª visita são 4, não 6) e `catalog.NUCLEO` pode crescer.
         if corpo.exibidas is None or corpo.exibidas < 1:
             raise HTTPException(
                 status_code=422,
                 detail="'exibidas' é obrigatório no open: é a evidência do que a pessoa viu",
             )
-        alvo = str(corpo.exibidas)
+        detalhe = str(corpo.exibidas)
 
     eventos.registrar(
-        db, tenant_id=user.tenant_id, actor=user.user_id, action=action, target=alvo
+        db, tenant_id=user.tenant_id, actor=user.user_id, action=action, detail=detalhe
     )
     db.commit()
     return Response(status_code=204)

--- a/apps/api/app/modules/dna/service.py
+++ b/apps/api/app/modules/dna/service.py
@@ -124,16 +124,23 @@ def _gravar(
     """Upsert por `(tenant, pergunta)` — a unique constraint da migration é o que o garante.
 
     A trilha em `audit_entries` é o que faz o upsert deixar de apagar história: a linha guarda o
-    estado ATUAL, e as passagens ficam no rastro append. É o `target` (`<source>:<pergunta>`) que
-    distingue "respondeu no núcleo" de "editou no `/config`".
+    estado ATUAL, e as passagens ficam no rastro append. É o `detail` (o `source`) que distingue
+    "respondeu no núcleo" de "editou no `/config`" — a ÚNICA coisa que o upsert destrói e que o
+    `target` não recupera. `question_key` não precisa ir junto: ela é a chave do upsert, então
+    `target=linha.id` a devolve por join, para sempre.
 
-    ⚠️ **`db.flush()` ANTES de gravar a trilha, e a razão aqui NÃO é a do MNT-001.** O padrão do
-    repo (`bank.create_account`) existe porque o `target` costuma ser o `id` da linha, que tem
-    default Python-side e ainda é `None` antes do INSERT. Este `target` é `<source>:<pergunta>` e
-    não depende de `id` nenhum — mas o flush continua obrigatório pelo segundo motivo que
-    `bank.create_transaction` documenta: é nele que a unique constraint de `(tenant,
-    question_key)` fala. Sem ele, gravaríamos um rastro afirmando uma resposta que a constraint
-    ainda pode recusar — trilha que mente.
+    ⚠️ ERRATA (2026-09-05, issue #312): até esta data gravávamos
+    `target=eventos.alvo_da_resposta(source, key)`, isto é, `<source>:<pergunta>` — composto num
+    campo cujo contrato é "id, ou nada". Ver `app/core/audit.py`, docstring da coluna `target`.
+
+    ⚠️ **`db.flush()` ANTES de gravar a trilha, e agora pelas DUAS razões.** (1) MNT-001: o
+    `target` é o `id` da linha, que tem default Python-side e ainda é `None` antes do INSERT —
+    sem flush a trilha nasceria com `target=''`, em silêncio (`tests/
+    test_audit_target_flush_gate.py` reprova essa forma por AST). Até a #312 esta razão NÃO
+    valia aqui, porque o `target` era composto e não dependia de id nenhum; passou a valer.
+    (2) A que já valia, e que `bank.create_transaction` documenta: é no flush que a unique
+    constraint de `(tenant, question_key)` fala. Sem ele, gravaríamos um rastro afirmando uma
+    resposta que a constraint ainda pode recusar — trilha que mente.
     """
     linha = db.scalar(select(DnaAnswer).where(DnaAnswer.question_key == key))
     if linha is None:
@@ -149,7 +156,8 @@ def _gravar(
         tenant_id=tenant_id,
         actor=user_id or "",
         action=acao,
-        target=eventos.alvo_da_resposta(source, key),
+        target=linha.id,
+        detail=source,
     )
     db.commit()
     db.refresh(linha)

--- a/apps/api/app/scripts/nucleo_activation.py
+++ b/apps/api/app/scripts/nucleo_activation.py
@@ -54,7 +54,8 @@ logger = logging.getLogger("e1p.nucleo_activation")
 class Passagem:
     """Uma passagem pelo núcleo: de um `open` até o `abandon` (ou até o fim do rastro).
 
-    `exibidas` é o denominador VISTO, lido do `target` do `open` — não é `len(catalog.NUCLEO)`.
+    `exibidas` é o denominador VISTO, lido do `detail` do `open` (e do `target`, no rastro
+    legado — ver a nota de compatibilidade abaixo) — não é `len(catalog.NUCLEO)`.
     `faltantes` devolve só as não respondidas, então na segunda visita a pessoa vê 4 e não 6; e
     `catalog.NUCLEO` pode crescer, o que viraria todo "k de 6" histórico em "k de 7"
     retroativamente. O progresso (`respondidas`/`puladas`) é DERIVADO dos eventos, e nada de
@@ -90,9 +91,60 @@ def entradas_do_dna(db: Session) -> list[AuditEntry]:
     )
 
 
+# ⚠️ **Compatibilidade com o rastro LEGADO — não é opcional, e tem condição de saída medível.**
+#
+# Até 2026-09-05 (issue #312) o módulo `dna` gravava as suas três informações no `target`, que não
+# tinha contrato: `save`/`skip` iam como `f"{source}:{key}"` e o `open` como a contagem crua
+# (`str(exibidas)`). Hoje o `target` é só id — o `source` mora em `detail`, e o denominador do
+# `open` também. **As duas funções abaixo leem as DUAS formas, e a antiga primeiro.**
+#
+# Por que não é opcional: existe trilha JÁ GRAVADA em produção nas formas antigas, e ela é a única
+# evidência de ativação do núcleo que este script existe para ler. Ler só o `detail` devolveria
+# `origem=""` e `exibidas=0` para todo o histórico — zero passagens contadas, **sem erro nenhum**,
+# que é indistinguível de "ninguém abriu o núcleo ainda". É o modo de falha que o docstring do topo
+# chama de pior que ficar calado, e a razão de este script imprimir a contagem de tenants.
+#
+# Por que não uma migration de dados, que apagaria o problema: (a) `audit_entries` tem `FORCE ROW
+# LEVEL SECURITY`; um `UPDATE` de migration roda **sem** `app.current_tenant_id` e é filtrado a
+# ZERO linhas em silêncio — é exatamente o que a 0087 documenta ao recusar backfill por `UPDATE`;
+# (b) o rastro é EVIDÊNCIA, e reescrever evidência é o que o topo deste arquivo recusa ao não ter
+# `--fix`; (c) a conversão não é reversível: reconstruir `f"{source}:{key}"` exigiria o `source`
+# que o upsert de `dna_answers` já pode ter sobrescrito — o rastro existe precisamente porque
+# aquela coluna não guarda o passado.
+#
+# **Até quando importa:** enquanto existir uma linha antiga. `audit_entries` não tem retenção nem
+# poda — a única remoção é a purga do tenant inteiro (`platform/service._business_table_names`).
+# A condição de saída é medível, e é esta, por tenant, dentro de `tenant_session`:
+#
+#     SELECT count(*) FROM audit_entries
+#      WHERE action LIKE 'dna.%' AND (target LIKE '%:%' OR target ~ '^[0-9]+$');
+#
+# Zero em TODOS os tenants é o dia em que os dois ramos legados abaixo podem sair. Antes disso,
+# removê-los cega o histórico sem produzir um único sintoma.
+
+
 def _origem(entrada: AuditEntry) -> str:
-    """A porta de entrada da resposta, lida do `target` (`<source>:<pergunta>`)."""
-    return entrada.target.split(":", 1)[0]
+    """A porta de entrada da resposta (`nucleo｜gancho｜config`).
+
+    Forma atual: `detail` é o `source`, cru. Forma LEGADA: `target` era `<source>:<pergunta>`.
+    O `":"` no `target` é o discriminador e é seguro nos dois sentidos — o contrato novo só
+    admite um UUID ou `""` ali, e nenhum dos dois contém `":"`.
+    """
+    if ":" in entrada.target:
+        return entrada.target.split(":", 1)[0]  # LEGADO (ver a nota acima)
+    return entrada.detail
+
+
+def _exibidas(entrada: AuditEntry) -> int:
+    """O denominador VISTO no `open`. Zero quando não dá para saber — nunca um chute.
+
+    Forma atual: o número está no `detail` (o `open` não tem entidade, então `target=""`). Forma
+    LEGADA: o número ERA o `target`. Um `target` que é dígito só pode ser legado — o contrato
+    novo só admite UUID ou `""` ali —, então a ordem dos ramos não é ambígua nos dois sentidos.
+    """
+    if entrada.target.isdigit():
+        return int(entrada.target)  # LEGADO (ver a nota acima)
+    return int(entrada.detail) if entrada.detail.isdigit() else 0
 
 
 def _com(p: Passagem, **campos) -> Passagem:
@@ -111,7 +163,7 @@ def derivar(entradas: Sequence[AuditEntry]) -> list[Passagem]:
 
     Resposta fora de uma passagem aberta é ignorada de propósito: gancho e `/config` acontecem o
     tempo todo, e contá-los inventaria passagem onde não houve abertura. É esse recorte que faz o
-    `source` no `target` pagar a conta.
+    `source` no `detail` pagar a conta.
     """
     passagens: list[Passagem] = []
     aberta: Passagem | None = None
@@ -120,9 +172,7 @@ def derivar(entradas: Sequence[AuditEntry]) -> list[Passagem]:
         if e.action == eventos.ACTION_OPEN:
             if aberta is not None:
                 passagens.append(aberta)
-            aberta = Passagem(
-                abertura=e.created_at, exibidas=int(e.target) if e.target.isdigit() else 0
-            )
+            aberta = Passagem(abertura=e.created_at, exibidas=_exibidas(e))
         elif e.action == eventos.ACTION_ABANDON:
             if aberta is not None:
                 passagens.append(_com(aberta, fim=e.created_at))

--- a/apps/api/tests/test_audit_target_e_id_gate.py
+++ b/apps/api/tests/test_audit_target_e_id_gate.py
@@ -1,0 +1,421 @@
+"""#312 — `audit_entries.target` é um ID, e só. Nada de composto, nada de valor.
+
+O campo não tinha contrato: tinha **convenção por ação**, e a convenção morava no chamador. Foi
+assim que três formas diferentes couberam no mesmo lugar — id nu na esmagadora maioria das
+chamadas, `f"{source}:{key}"` no módulo `dna` e uma contagem crua (`str(exibidas)`) no `open` do
+núcleo — e o consumidor (`scripts/nucleo_activation.py`) precisou virar PARSER
+(`target.split(":", 1)[0]`, `int(target)`). Aquele parse só era seguro porque a query filtrava
+`action.startswith("dna.")` antes: um contrato que dependia de quem chamava.
+
+**Por que um gate, e não a docstring que a #312 escreveu.** Este repositório já provou duas vezes
+que documentar não contém: a docstring de `dna/eventos.py` nomeava o defeito MNT-001 **com
+contagem** desde 2026-08-11 e os 17 call sites continuaram lá até a #311; `wallet/models.py`
+documentava `target=str(total)` como abuso conhecido do mesmo campo. Conter é trabalho de teste.
+Este gate impede a QUARTA forma de nascer.
+
+**O que ele reprova** em `target=`: f-string, `str(...)` de um valor, concatenação/`%`/`.format`,
+literal já composto (com `":"`), constante que não é texto — e as mesmas coisas escondidas atrás
+de uma variável ou de um **helper do próprio projeto que devolve f-string**. Esta última é a
+forma histórica exata (`eventos.alvo_da_resposta`), e sem ela o gate deixaria passar o defeito
+que motivou a issue só por ele estar uma camada acima.
+
+**Controles positivos obrigatórios.** Um scanner AST que deixasse de encontrar as chamadas (glob
+quebrado, import renomeado, pasta movida) passaria **verde por vacuidade**. Por isso este arquivo
+prova, com fontes sintéticas parseadas por `ast`, que o gate MORDE cada forma proibida e que NÃO
+morde as formas corretas — e prova, contra o repo real, que ele de fato varreu código.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parents[1] / "app"
+
+#: Quem grava trilha. `registrar` é a porta do DNA (`dna/eventos.py`), que delega a `audit.record`.
+_GRAVADORES = {"record", "registrar"}
+
+#: Chamadas que produzem TEXTO a partir de um valor — o oposto de um id.
+_FABRICAS_DE_TEXTO = {"str", "format", "join", "repr"}
+
+
+class Ofensa:
+    def __init__(self, arquivo: str, linha: int, funcao: str, forma: str) -> None:
+        self.arquivo, self.linha, self.funcao, self.forma = arquivo, linha, funcao, forma
+
+    def __eq__(self, outro: object) -> bool:  # para comparar listas em asserção
+        return isinstance(outro, Ofensa) and repr(self) == repr(outro)
+
+    def __repr__(self) -> str:  # o que aparece na falha — tem de bastar para o conserto
+        return (
+            f"{self.arquivo}:{self.linha} em {self.funcao}(): `target=` recebeu {self.forma} "
+            "→ `target` é o ID da entidade (ou `\"\"` se não há entidade). O que não é id vai "
+            "em `detail`, que é livre — ver o docstring da coluna em `app/core/audit.py`"
+        )
+
+
+def _nome_da_chamada(call: ast.Call) -> str | None:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    if isinstance(f, ast.Name):
+        return f.id
+    return None
+
+
+def _devolve_texto_composto(no: ast.AST) -> bool:
+    """Um `return` que junta PARTES — a assinatura de uma compositora.
+
+    ⚠️ `str(...)` fica de FORA deste critério, e a exclusão foi medida: `db/base.py::_uuid`
+    devolve `str(uuid4())` e é a fábrica de ids do projeto inteiro. Indexá-la como compositora
+    reprovava `wallet/service.py::request_payout` (`target=payout_id`, com `payout_id = _uuid()`)
+    — um id perfeito. `str(x)` numa função que devolve id é o oposto de composição: é conversão
+    de UM valor. Junção precisa de DUAS partes, e é isso que f-string, `+`, `%`, `.format` e
+    `.join` têm em comum. Na CHAMADA, `str(...)` continua reprovado (`_FABRICAS_DE_TEXTO`): ali
+    o que se está convertendo é o valor que deveria ser um id.
+    """
+    if isinstance(no, ast.JoinedStr):
+        return True
+    if isinstance(no, ast.BinOp) and isinstance(no.op, ast.Add | ast.Mod):
+        return True
+    return isinstance(no, ast.Call) and _nome_da_chamada(no) in {"format", "join"}
+
+
+def compositoras(fontes: list[str]) -> set[str]:
+    """Funções do projeto que DEVOLVEM texto composto — `alvo_da_resposta` era uma delas.
+
+    Índice por NOME, sem resolver import: o gate prefere apontar um caso que talvez esteja certo
+    a deixar passar um que está errado, e a mesma escolha conservadora está no gate irmão
+    (`test_audit_target_flush_gate.py::_linearizar`). Uma função que devolve f-string e é usada
+    como `target` viola o contrato, venha de onde vier.
+    """
+    achadas: set[str] = set()
+    for fonte in fontes:
+        for no in ast.walk(ast.parse(fonte)):
+            if not isinstance(no, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for filho in ast.walk(no):
+                if isinstance(filho, ast.Return) and filho.value is not None:
+                    if _devolve_texto_composto(filho.value):
+                        achadas.add(no.name)
+    return achadas
+
+
+def _composicao(no: ast.AST, apelidos: dict[str, str], indice: set[str]) -> str | None:
+    """A razão pela qual esta expressão JUNTA partes em vez de ser um id — ou `None`."""
+    if isinstance(no, ast.JoinedStr):
+        return "uma f-string (composição)"
+    if isinstance(no, ast.BinOp) and isinstance(no.op, ast.Add | ast.Mod):
+        return "uma concatenação/formatação de texto"
+    if isinstance(no, ast.Call):
+        nome = _nome_da_chamada(no)
+        if nome in _FABRICAS_DE_TEXTO:
+            return f"`{nome}(...)` — texto fabricado de um VALOR, não um id"
+        if nome in indice:
+            return f"`{nome}(...)`, que devolve texto composto"
+        return None
+    if isinstance(no, ast.Constant):
+        if isinstance(no.value, str) and ":" in no.value:
+            return "um literal já composto (contém `:`)"
+        return None
+    if isinstance(no, ast.Name):
+        return apelidos.get(no.id)
+    if isinstance(no, ast.IfExp | ast.BoolOp):
+        # Um ramo composto contamina o todo: `x if c else f"{a}:{b}"` grava composto metade das
+        # vezes, e "metade das vezes" é exatamente como o campo perdeu o contrato.
+        ramos = (no.body, no.orelse) if isinstance(no, ast.IfExp) else tuple(no.values)
+        for ramo in ramos:
+            razao = _composicao(ramo, apelidos, indice)
+            if razao:
+                return razao
+    return None
+
+
+def _forma_proibida(no: ast.AST, apelidos: dict[str, str], indice: set[str]) -> str | None:
+    """A razão pela qual esta expressão não pode ser um `target` — ou `None` se pode.
+
+    Composição em qualquer profundidade, MAIS a regra que só vale na chamada: uma constante que
+    não é texto (`target=6`) é um valor, e o campo é `String(255)`.
+    """
+    razao = _composicao(no, apelidos, indice)
+    if razao:
+        return razao
+    if isinstance(no, ast.Constant) and not isinstance(no.value, str):
+        return f"a constante {no.value!r}, que não é texto"
+    return None
+
+
+def _apelidos_compostos(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, indice: set[str]
+) -> dict[str, str]:
+    """Nomes locais que guardam uma COMPOSIÇÃO — `alvo = f"{source}:{key}"`.
+
+    ⚠️ Passada PRÓPRIA, antes de olhar as chamadas, e é isto que a torna correta: `ast.walk` é
+    por nível, **não** por linha, então um `alvo = ...` dentro de um `if` é visitado DEPOIS de um
+    `record(...)` no topo da função. Resolver apelidos no mesmo laço perderia exatamente a forma
+    do `dna/router.py` (a atribuição vive dentro de um `if`).
+
+    ⚠️ Só atribuições que COMPÕEM entram, e nenhuma atribuição posterior perdoa um nome já
+    contaminado — o gate não faz análise de fluxo, e contaminar é o lado conservador. O outro
+    lado foi medido: guardar TODA atribuição fazia um `client_id = None` lá em cima reprovar
+    `target=client_id or "unidentified"` em `whatsapp_inbox/service.py`, que é um id legítimo.
+
+    Duas passadas resolvem cadeia curta (`a = f"..."` → `b = a` → `target=b`) sem virar
+    ponto-fixo: cadeia mais longa que isso num `target` é sintoma pior do que este gate mede.
+    """
+    apelidos: dict[str, str] = {}
+    for _ in range(2):
+        for st in ast.walk(fn):
+            if (
+                isinstance(st, ast.Assign)
+                and len(st.targets) == 1
+                and isinstance(st.targets[0], ast.Name)
+            ):
+                razao = _composicao(st.value, apelidos, indice)
+                if razao:
+                    apelidos.setdefault(st.targets[0].id, razao)
+    return apelidos
+
+
+def _analisar_funcao(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, arquivo: str, indice: set[str]
+) -> list[Ofensa]:
+    ofensas: list[Ofensa] = []
+    apelidos = _apelidos_compostos(fn, indice)
+    for st in ast.walk(fn):
+        if not isinstance(st, ast.Call) or _nome_da_chamada(st) not in _GRAVADORES:
+            continue
+        if not any(k.arg == "action" for k in st.keywords):
+            continue  # `facts.record(kind=...)` e afins não são a trilha de auditoria
+        for kw in st.keywords:
+            if kw.arg != "target":
+                continue
+            razao = _forma_proibida(kw.value, apelidos, indice)
+            if razao:
+                ofensas.append(Ofensa(arquivo, st.lineno, fn.name, razao))
+    return ofensas
+
+
+def varrer(
+    fonte: str, arquivo: str = "<sintetico>", indice: set[str] | None = None
+) -> list[Ofensa]:
+    """Todas as ofensas ao contrato do `target` num fonte Python."""
+    indice = compositoras([fonte]) if indice is None else indice
+    ofensas: list[Ofensa] = []
+    for no in ast.walk(ast.parse(fonte)):
+        if isinstance(no, ast.FunctionDef | ast.AsyncFunctionDef):
+            ofensas.extend(_analisar_funcao(no, arquivo, indice))
+    return ofensas
+
+
+def _alvos_analisados(fonte: str) -> int:
+    return sum(
+        1
+        for no in ast.walk(ast.parse(fonte))
+        if isinstance(no, ast.Call)
+        and _nome_da_chamada(no) in _GRAVADORES
+        and any(k.arg == "action" for k in no.keywords)
+        and any(k.arg == "target" for k in no.keywords)
+    )
+
+
+# ── Controles positivos: o gate MORDE cada forma proibida ────────────────────
+
+def test_o_gate_reprova_a_f_string():
+    """A 2ª forma histórica, na própria chamada."""
+    fonte = (
+        "\nfrom app.core import audit\n"
+        "\n"
+        "def salvar(db, *, tenant_id, actor, source, key):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="dna.answer.save",\n'
+        '                 target=f"{source}:{key}")\n'
+    )
+    [o] = varrer(fonte, "sintetico.py")
+    assert o.linha == 5 and o.funcao == "salvar"
+    assert "f-string" in repr(o)
+    # A mensagem tem de bastar para consertar sem abrir o gate.
+    assert "sintetico.py:5" in repr(o) and "detail" in repr(o)
+
+
+def test_o_gate_reprova_str_de_um_valor():
+    """A 3ª forma histórica: `target=str(corpo.exibidas)` — uma CONTAGEM no campo do id."""
+    fonte = (
+        "\nfrom app.modules.dna import eventos\n"
+        "\n"
+        "def nucleo_evento(db, *, tenant_id, actor, corpo):\n"
+        '    eventos.registrar(db, tenant_id=tenant_id, actor=actor, action="dna.nucleo.open",\n'
+        "                      target=str(corpo.exibidas))\n"
+    )
+    [o] = varrer(fonte)
+    assert "`str(...)`" in repr(o)
+
+
+def test_o_gate_reprova_concatenacao_e_format():
+    concat = (
+        "\ndef f(db, *, tenant_id, actor, source, key):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.y",\n'
+        '                 target=source + ":" + key)\n'
+    )
+    formatado = (
+        "\ndef f(db, *, tenant_id, actor, source, key):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.y",\n'
+        '                 target="{}:{}".format(source, key))\n'
+    )
+    assert len(varrer(concat)) == 1
+    assert len(varrer(formatado)) == 1
+
+
+def test_o_gate_reprova_o_literal_ja_composto():
+    """`target="nucleo:oferta"` é a mesma forma, escrita à mão — o `:` é o que denuncia."""
+    fonte = (
+        "\ndef f(db, *, tenant_id, actor):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.y",\n'
+        '                 target="nucleo:oferta.o_que_vende")\n'
+    )
+    assert len(varrer(fonte)) == 1
+
+
+def test_o_gate_reprova_a_composicao_escondida_numa_variavel():
+    """Dar um nome à composição não a desfaz — a lição do gate irmão da #311."""
+    fonte = (
+        "\ndef nucleo_evento(db, *, tenant_id, actor, corpo, source, key):\n"
+        '    alvo = f"{source}:{key}"\n'
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.y", target=alvo)\n'
+    )
+    [o] = varrer(fonte)
+    assert "f-string" in repr(o)
+
+
+def test_o_gate_reprova_a_composicao_atribuida_DENTRO_de_um_if():
+    """**A forma exata de `dna/router.py`**: `alvo = str(...)` num ramo, `record` lá embaixo.
+
+    É o caso que obriga a passada própria de apelidos: `ast.walk` visita por NÍVEL, então a
+    atribuição dentro do `if` sai DEPOIS da chamada no topo da função. Um gate que resolvesse
+    apelidos no mesmo laço passaria verde justamente sobre a terceira forma da issue.
+    """
+    fonte = (
+        "\ndef nucleo_evento(db, *, tenant_id, actor, action, corpo):\n"
+        '    alvo = ""\n'
+        '    if action == "dna.nucleo.open":\n'
+        "        alvo = str(corpo.exibidas)\n"
+        "    eventos.registrar(db, tenant_id=tenant_id, actor=actor, action=action, target=alvo)\n"
+    )
+    [o] = varrer(fonte)
+    assert "`str(...)`" in repr(o) and o.linha == 6
+
+
+def test_o_gate_reprova_a_composicao_escondida_num_HELPER_do_projeto():
+    """**A forma histórica exata**: `eventos.alvo_da_resposta(source, key)`.
+
+    A composição acontecia uma CAMADA ACIMA da chamada, noutro arquivo — nenhuma inspeção da
+    chamada sozinha a enxergaria. Sem este caso o gate deixaria passar justamente o defeito que
+    abriu a issue #312.
+    """
+    helper = (
+        "\ndef alvo_da_resposta(source, key):\n"
+        '    return f"{source}:{key}"\n'
+    )
+    call_site = (
+        "\nfrom app.modules.dna import eventos\n"
+        "\n"
+        "def _gravar(db, *, tenant_id, actor, source, key):\n"
+        '    eventos.registrar(db, tenant_id=tenant_id, actor=actor, action="dna.answer.save",\n'
+        "                      target=eventos.alvo_da_resposta(source, key))\n"
+    )
+    indice = compositoras([helper, call_site])
+    assert "alvo_da_resposta" in indice
+
+    [o] = varrer(call_site, "dna/service.py", indice)
+    assert "alvo_da_resposta" in repr(o)
+    # E o controle do controle: sem o índice cross-file, a chamada passa. É por isso que o gate
+    # real (abaixo) monta o índice com o repo INTEIRO antes de varrer qualquer arquivo.
+    assert varrer(call_site, "dna/service.py", set()) == []
+
+
+def test_o_gate_reprova_a_constante_que_nao_e_texto():
+    fonte = (
+        "\ndef f(db, *, tenant_id, actor):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.y", target=6)\n'
+    )
+    assert len(varrer(fonte)) == 1
+
+
+# ── Controles negativos: o gate NÃO morde o que está certo ───────────────────
+
+def test_o_gate_aprova_o_id_da_entidade():
+    fonte = (
+        "\ndef criar(db, *, tenant_id, actor):\n"
+        "    w = Widget(tenant_id=tenant_id)\n"
+        "    db.add(w)\n"
+        "    db.flush()\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="w.create", target=w.id)\n'
+    )
+    assert varrer(fonte) == []
+
+
+def test_o_gate_aprova_target_vazio_e_id_em_variavel():
+    """`""` é o contrato para "não há entidade" — e um id guardado numa variável é um id."""
+    fonte = (
+        "\ndef f(db, *, tenant_id, actor, chat):\n"
+        "    chat_id = chat.id\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="a.b", target=chat_id)\n'
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="a.c", target="")\n'
+    )
+    assert varrer(fonte) == []
+
+
+def test_o_gate_aprova_id_com_sentinela_sem_dois_pontos():
+    """A forma real de `whatsapp_inbox.service`: id, ou uma palavra quando não há cliente.
+
+    Continua sendo "um alvo", não uma composição — e o `:` é o que separa os dois casos.
+    """
+    fonte = (
+        "\ndef f(db, *, tenant_id, client_id):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor="x", action="a.b",\n'
+        '                 target=client_id or "unidentified")\n'
+    )
+    assert varrer(fonte) == []
+
+
+def test_o_gate_ignora_facts_record_que_nao_e_auditoria():
+    """`facts.record(kind=...)` não tem `action` e não grava `audit_entries` — fora do escopo."""
+    fonte = (
+        "\ndef f(db, *, tenant_id, a, b):\n"
+        '    facts.record(db, tenant_id=tenant_id, kind="x.y", ref_id=f"{a}:{b}")\n'
+    )
+    assert varrer(fonte) == []
+
+
+# ── O gate contra o repo real ────────────────────────────────────────────────
+
+def _fontes_do_app() -> dict[str, str]:
+    return {
+        a.relative_to(_APP.parent).as_posix(): a.read_text(encoding="utf-8")
+        for a in sorted(_APP.rglob("*.py"))
+    }
+
+
+def test_a_varredura_realmente_leu_o_repo():
+    """Controle antivacuidade: sem isto, um glob quebrado aprovaria o projeto inteiro."""
+    fontes = _fontes_do_app()
+    assert len(fontes) > 100, f"a varredura leu só {len(fontes)} arquivos — glob quebrado?"
+    alvos = sum(_alvos_analisados(f) for f in fontes.values())
+    assert alvos > 50, (
+        f"só {alvos} chamadas de auditoria COM `target=` encontradas. O gate abaixo passaria "
+        "verde sobre um repo que ele não está enxergando (import renomeado? pasta movida?)."
+    )
+
+
+def test_nenhum_target_do_repo_e_composto_ou_valor():
+    fontes = _fontes_do_app()
+    # O índice de compositoras é montado com o repo INTEIRO antes da varredura: a composição
+    # pode morar noutro arquivo (era o caso de `dna/eventos.py` → `dna/service.py`).
+    indice = compositoras(list(fontes.values()))
+    ofensas: list[Ofensa] = []
+    for rel, fonte in fontes.items():
+        ofensas.extend(varrer(fonte, rel, indice))
+    assert not ofensas, (
+        "`audit_entries.target` é o ID da entidade da ação, ou `\"\"` quando não há entidade — "
+        "nunca um composto, nunca um valor. Estas chamadas gravam outra coisa, e é assim que o "
+        "campo perde o contrato e o consumidor vira parser (issue #312).\n  "
+        + "\n  ".join(repr(o) for o in ofensas)
+    )

--- a/apps/api/tests/test_audit_target_e_id_gate.py
+++ b/apps/api/tests/test_audit_target_e_id_gate.py
@@ -15,9 +15,11 @@ Este gate impede a QUARTA forma de nascer.
 
 **O que ele reprova** em `target=`: f-string, `str(...)` de um valor, concatenação/`%`/`.format`,
 literal já composto (com `":"`), constante que não é texto — e as mesmas coisas escondidas atrás
-de uma variável ou de um **helper do próprio projeto que devolve f-string**. Esta última é a
-forma histórica exata (`eventos.alvo_da_resposta`), e sem ela o gate deixaria passar o defeito
-que motivou a issue só por ele estar uma camada acima.
+de (a) uma variável, mesmo atribuída dentro de um `if`; (b) um **helper do projeto que devolve
+f-string**, que é a forma histórica exata (`eventos.alvo_da_resposta`); (c) uma **cadeia de
+funções que repassam um parâmetro `target`** até a gravação. Sem (b) e (c) o gate deixaria passar
+o defeito só por ele estar uma ou duas camadas acima da chamada — e (c) achou uma quarta forma
+VIVA em produção que a issue não tinha visto (ver `_DIVIDA_CONHECIDA`, no fim do arquivo).
 
 **Controles positivos obrigatórios.** Um scanner AST que deixasse de encontrar as chamadas (glob
 quebrado, import renomeado, pasta movida) passaria **verde por vacuidade**. Por isso este arquivo
@@ -176,16 +178,65 @@ def _apelidos_compostos(
     return apelidos
 
 
+def _parametros(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    a = fn.args
+    return {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+
+
+def encaminhadoras(fontes: list[str]) -> set[str]:
+    """Funções que REPASSAM um parâmetro `target` até `audit.record` — o ponto cego do gate.
+
+    Um gate que só olha a chamada de `record` não enxerga composição feita DOIS saltos acima.
+    Foi assim que `financial_intelligence/router.py` passou a gravar um intervalo de datas
+    (`f"{start}..{end}"` — um VALOR) sem que nada reclamasse: quem compõe é o router, quem grava
+    é `ai_narrator.narrate_with_source`, e entre os dois há só um parâmetro chamado `target`.
+
+    O índice é por NOME e cobre a cadeia: primeiro quem grava direto, depois quem chama essas.
+    Três passadas cobrem `router → narrate_signals → narrate_with_source → record`; cadeia mais
+    longa que isso para carregar um id é sintoma pior do que este gate mede.
+    """
+    arvores = [ast.parse(f) for f in fontes]
+    achadas: set[str] = set()
+    for _ in range(3):
+        for arv in arvores:
+            for fn in ast.walk(arv):
+                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                params = _parametros(fn)
+                for call in ast.walk(fn):
+                    if not isinstance(call, ast.Call):
+                        continue
+                    nome = _nome_da_chamada(call)
+                    grava = nome in _GRAVADORES and any(k.arg == "action" for k in call.keywords)
+                    if not grava and nome not in achadas:
+                        continue
+                    for kw in call.keywords:
+                        if (
+                            kw.arg == "target"
+                            and isinstance(kw.value, ast.Name)
+                            and kw.value.id in params
+                        ):
+                            achadas.add(fn.name)
+    return achadas
+
+
 def _analisar_funcao(
-    fn: ast.FunctionDef | ast.AsyncFunctionDef, arquivo: str, indice: set[str]
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+    arquivo: str,
+    indice: set[str],
+    repassadoras: set[str] = frozenset(),
 ) -> list[Ofensa]:
     ofensas: list[Ofensa] = []
     apelidos = _apelidos_compostos(fn, indice)
     for st in ast.walk(fn):
-        if not isinstance(st, ast.Call) or _nome_da_chamada(st) not in _GRAVADORES:
+        if not isinstance(st, ast.Call):
             continue
-        if not any(k.arg == "action" for k in st.keywords):
-            continue  # `facts.record(kind=...)` e afins não são a trilha de auditoria
+        nome = _nome_da_chamada(st)
+        grava = nome in _GRAVADORES and any(k.arg == "action" for k in st.keywords)
+        # `facts.record(kind=...)` e afins não são a trilha de auditoria — daí a exigência de
+        # `action`. Uma repassadora não tem `action` nenhum: ela só carrega o `target` adiante.
+        if not grava and nome not in repassadoras:
+            continue
         for kw in st.keywords:
             if kw.arg != "target":
                 continue
@@ -196,14 +247,18 @@ def _analisar_funcao(
 
 
 def varrer(
-    fonte: str, arquivo: str = "<sintetico>", indice: set[str] | None = None
+    fonte: str,
+    arquivo: str = "<sintetico>",
+    indice: set[str] | None = None,
+    repassadoras: set[str] | None = None,
 ) -> list[Ofensa]:
     """Todas as ofensas ao contrato do `target` num fonte Python."""
     indice = compositoras([fonte]) if indice is None else indice
+    repassadoras = encaminhadoras([fonte]) if repassadoras is None else repassadoras
     ofensas: list[Ofensa] = []
     for no in ast.walk(ast.parse(fonte)):
         if isinstance(no, ast.FunctionDef | ast.AsyncFunctionDef):
-            ofensas.extend(_analisar_funcao(no, arquivo, indice))
+            ofensas.extend(_analisar_funcao(no, arquivo, indice, repassadoras))
     return ofensas
 
 
@@ -331,6 +386,39 @@ def test_o_gate_reprova_a_composicao_escondida_num_HELPER_do_projeto():
     assert varrer(call_site, "dna/service.py", set()) == []
 
 
+def test_o_gate_reprova_a_composicao_DOIS_SALTOS_acima_da_gravacao():
+    """O ponto cego que só a cadeia de repassadoras enxerga.
+
+    Quem compõe é o router; quem grava é o narrador, dois saltos abaixo; entre eles há apenas um
+    parâmetro chamado `target`. Nenhuma inspeção da chamada de `record` vê isso. É a forma real
+    de `financial_intelligence/router.py`, e ela já estava em produção — este gate a NOMEIA (ver
+    `_DIVIDA_CONHECIDA`) em vez de deixá-la invisível atrás de um verde.
+    """
+    fonte = (
+        "\nfrom app.core import audit\n"
+        "\n"
+        "def narrate(signals, *, db, tenant_id, actor, target=''):\n"
+        '    audit.record(db, tenant_id=tenant_id, actor=actor, action="x.narrated",\n'
+        "                 target=target)\n"
+        "\n"
+        "def narrate_with_source(signals, *, db, tenant_id, actor, target=''):\n"
+        "    return narrate(signals, db=db, tenant_id=tenant_id, actor=actor, target=target)\n"
+        "\n"
+        "def diagnostics(db, *, user, start, end):\n"
+        "    narrate_with_source([], db=db, tenant_id=user.tenant_id, actor=user.user_id,\n"
+        '                        target=f"{start.isoformat()}..{end.isoformat()}")\n'
+    )
+    repassadoras = encaminhadoras([fonte])
+    assert {"narrate", "narrate_with_source"} <= repassadoras
+
+    [o] = varrer(fonte, "router.py", set(), repassadoras)
+    assert o.funcao == "diagnostics" and "f-string" in repr(o)
+
+    # O controle do controle: sem a cadeia, o defeito é INVISÍVEL — e é por isso que o gate real
+    # monta `encaminhadoras` com o repo inteiro antes de varrer.
+    assert varrer(fonte, "router.py", set(), set()) == []
+
+
 def test_o_gate_reprova_a_constante_que_nao_e_texto():
     fonte = (
         "\ndef f(db, *, tenant_id, actor):\n"
@@ -405,14 +493,58 @@ def test_a_varredura_realmente_leu_o_repo():
     )
 
 
+#: Dívida CONHECIDA, herdada, fora do escopo da #312 — `arquivo::função`.
+#:
+#: `financial_intelligence/router.py::diagnostics` grava um INTERVALO DE DATAS
+#: (`f"{start.isoformat()}..{end.isoformat()}"`) no `target` da action
+#: `financial_diagnostics.narrated`. É a mesma família de `wallet` (`target=str(total)` — o
+#: VALOR, não um id) e já estava em produção antes desta issue; um diagnóstico não tem entidade,
+#: então o certo é `target=""` com o intervalo no `detail`. Corrigir aqui mudaria a trilha de
+#: OUTRO módulo, com os testes dele, sem relação com o `dna` — vira issue própria.
+#:
+#: A allowlist tem UM membro, e é esse o ponto (mesmo padrão de `_PODE_CHAMAR_AUDIT` em
+#: `test_dna_vocabulario_gate.py`): quem entrar aqui entra COM justificativa escrita, e é isso
+#: que faz a revisão acontecer. O valor de estar na lista, e não invisível, é que a próxima
+#: pessoa lê o defeito em vez de acreditar num verde limpo.
+_DIVIDA_CONHECIDA = {"app/modules/financial_intelligence/router.py::diagnostics"}
+
+
+def test_a_divida_conhecida_continua_sendo_UM_defeito_de_verdade():
+    """Controle da allowlist: se o defeito for consertado, esta linha tem de SAIR da lista.
+
+    Sem isto, a allowlist vira depósito — uma entrada morta que ninguém remove e que passaria a
+    perdoar silenciosamente um call site futuro no mesmo arquivo e função.
+    """
+    fontes = _fontes_do_app()
+    indice = compositoras(list(fontes.values()))
+    repassadoras = encaminhadoras(list(fontes.values()))
+    # A cadeia real tem DOIS saltos: `get_diagnostics` → `narrate_with_source` → `record`.
+    assert "narrate_with_source" in repassadoras
+
+    achadas = {
+        f"{rel}::{o.funcao}"
+        for rel, fonte in fontes.items()
+        for o in varrer(fonte, rel, indice, repassadoras)
+    }
+    assert achadas == _DIVIDA_CONHECIDA, (
+        "a dívida conhecida mudou. Se um defeito foi CONSERTADO, remova-o de "
+        f"`_DIVIDA_CONHECIDA`; se apareceu um novo, ele não entra na lista sem justificativa "
+        f"escrita.\n  esperado: {sorted(_DIVIDA_CONHECIDA)}\n  encontrado: {sorted(achadas)}"
+    )
+
+
 def test_nenhum_target_do_repo_e_composto_ou_valor():
     fontes = _fontes_do_app()
     # O índice de compositoras é montado com o repo INTEIRO antes da varredura: a composição
     # pode morar noutro arquivo (era o caso de `dna/eventos.py` → `dna/service.py`).
     indice = compositoras(list(fontes.values()))
-    ofensas: list[Ofensa] = []
-    for rel, fonte in fontes.items():
-        ofensas.extend(varrer(fonte, rel, indice))
+    repassadoras = encaminhadoras(list(fontes.values()))
+    ofensas = [
+        o
+        for rel, fonte in fontes.items()
+        for o in varrer(fonte, rel, indice, repassadoras)
+        if f"{rel}::{o.funcao}" not in _DIVIDA_CONHECIDA
+    ]
     assert not ofensas, (
         "`audit_entries.target` é o ID da entidade da ação, ou `\"\"` quando não há entidade — "
         "nunca um composto, nunca um valor. Estas chamadas gravam outra coisa, e é assim que o "

--- a/apps/api/tests/test_dna_audit.py
+++ b/apps/api/tests/test_dna_audit.py
@@ -31,25 +31,37 @@ def headers(client: TestClient) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _alvos(db: Session, action: str) -> list[str]:
+def _alvos(db: Session, action: str) -> list[tuple[str, str]]:
+    """Os `(target, detail)` da trilha daquela action — o contrato da #312, nos dois campos."""
     return [
-        e.target for e in db.scalars(select(AuditEntry).where(AuditEntry.action == action)).all()
+        (e.target, e.detail)
+        for e in db.scalars(select(AuditEntry).where(AuditEntry.action == action)).all()
     ]
 
 
-def test_responder_grava_trilha_com_o_source_no_target(
+def _id_da_linha(db: Session, key: str) -> str:
+    return db.scalars(select(DnaAnswer).where(DnaAnswer.question_key == key)).one().id
+
+
+def test_responder_grava_trilha_com_o_source_no_detail(
     client: TestClient, headers: dict[str, str], db: Session
 ):
-    """§6.1. A asserção é o VALOR do target, não `!= ""`.
+    """§6.1, na forma da #312: o `target` é o ID da linha e o `source` vai no `detail`.
 
-    `target != ""` passaria com qualquer string — inclusive com a errada. Afirmar o valor exato é
-    o que faz este teste morrer se alguém trocar o `source` de lugar (para o `action`, que é a
-    forma proibida) ou esquecer a chave da pergunta.
+    A asserção é o VALOR dos dois campos, não `!= ""` — `!= ""` passaria com qualquer string,
+    inclusive com a errada. Afirmar o id EXATO é o que prova o contrato de `audit_entries.
+    target` ("um id, e só"), e afirmar o `detail` exato é o que faz este teste morrer se alguém
+    devolver o `source` para o `target` (composto, a forma proibida) ou para o `action`.
+
+    E o id não é decoração: é o que devolve `question_key` por JOIN, sem guardá-la no rastro.
     """
     r = client.put(f"/dna/{TICKET}", json={"valor": "2k_10k", "source": "nucleo"}, headers=headers)
     assert r.status_code == 200
 
-    assert _alvos(db, "dna.answer.save") == [f"nucleo:{TICKET}"]
+    linha_id = _id_da_linha(db, TICKET)
+    assert _alvos(db, "dna.answer.save") == [(linha_id, "nucleo")]
+    # O id é um id de verdade (36 chars de UUID), não um composto disfarçado.
+    assert ":" not in linha_id and len(linha_id) == 36
 
 
 def test_pular_uma_pergunta_grava_trilha(
@@ -58,7 +70,7 @@ def test_pular_uma_pergunta_grava_trilha(
     r = client.post(f"/dna/{TICKET}/pular", json={"source": "gancho"}, headers=headers)
     assert r.status_code == 200
 
-    assert _alvos(db, "dna.answer.skip") == [f"gancho:{TICKET}"]
+    assert _alvos(db, "dna.answer.skip") == [(_id_da_linha(db, TICKET), "gancho")]
     # Não-membro: pular não é salvar.
     assert _alvos(db, "dna.answer.save") == []
 
@@ -81,5 +93,13 @@ def test_editar_no_config_nao_apaga_a_historia_do_nucleo(
     assert linhas[0].value == "10k_50k"
     assert linhas[0].source == "config"
 
-    # E a história das DUAS passagens sobrevive.
-    assert sorted(_alvos(db, "dna.answer.save")) == [f"config:{TICKET}", f"nucleo:{TICKET}"]
+    # E a história das DUAS passagens sobrevive, no `detail` — que é justamente a coluna que o
+    # upsert destruiu acima (`linhas[0].source` já diz só "config").
+    alvos = _alvos(db, "dna.answer.save")
+    assert sorted(d for _, d in alvos) == ["config", "nucleo"]
+
+    # E o `target` das DUAS aponta para a MESMA linha, a que sobreviveu ao upsert. É esta
+    # asserção que prova que o id no `target` não perdeu a pergunta: `question_key` é a chave do
+    # upsert e volta por JOIN, sem precisar viajar composta no rastro.
+    assert {t for t, _ in alvos} == {linhas[0].id}
+    assert db.get(DnaAnswer, linhas[0].id).question_key == TICKET

--- a/apps/api/tests/test_dna_nucleo_eventos.py
+++ b/apps/api/tests/test_dna_nucleo_eventos.py
@@ -56,9 +56,16 @@ def headers_sub_crm(tenant_id: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _do_dna(db: Session) -> list[tuple[str, str]]:
+def _do_dna(db: Session) -> list[tuple[str, str, str]]:
+    """`(action, target, detail)` — a trilha do DNA nos três campos que a issue #312 fixou.
+
+    O `target` entra na tupla apesar de ser SEMPRE `""` nos eventos do núcleo, e é por isso que
+    ele entra: abrir e abandonar o núcleo não tocam entidade nenhuma, então não há id a apontar.
+    Até a #312 era ali que o denominador visto ia parar (`str(exibidas)`), e afirmar `""` é o que
+    faz este teste morrer se alguém devolver um VALOR para o campo que só aceita id.
+    """
     return [
-        (e.action, e.target)
+        (e.action, e.target, e.detail)
         for e in db.scalars(select(AuditEntry).where(AuditEntry.action.like("dna.%"))).all()
     ]
 
@@ -78,14 +85,14 @@ def test_open_grava_o_denominador_que_a_pessoa_VIU(
     assert r.status_code == 204
     assert r.content == b""
 
-    assert _do_dna(db) == [("dna.nucleo.open", "4")]
+    assert _do_dna(db) == [("dna.nucleo.open", "", "4")]
 
 
 def test_abandon_grava_sem_alvo(client: TestClient, headers: dict[str, str], db: Session):
     r = client.post("/dna/nucleo/abandon", json={}, headers=headers)
     assert r.status_code == 204
 
-    assert _do_dna(db) == [("dna.nucleo.abandon", "")]
+    assert _do_dna(db) == [("dna.nucleo.abandon", "", "")]
 
 
 def test_evento_fora_da_tupla_nao_existe(client: TestClient, headers: dict[str, str], db: Session):
@@ -118,4 +125,4 @@ def test_403_do_sub_usuario_nao_produz_evento_nenhum(
 
     # Controle positivo: o MEMBRO, na mesma sessão, produz evento.
     assert client.post("/dna/nucleo/open", json={"exibidas": 6}, headers=headers).status_code == 204
-    assert _do_dna(db) == [("dna.nucleo.open", "6")]
+    assert _do_dna(db) == [("dna.nucleo.open", "", "6")]

--- a/apps/api/tests/test_nucleo_activation.py
+++ b/apps/api/tests/test_nucleo_activation.py
@@ -24,8 +24,11 @@ REGISTER = {
 }
 
 
-def _e(action: str, target: str, minuto: int) -> AuditEntry:
-    """Uma entrada com `created_at` EXPLÍCITO.
+def _e(action: str, minuto: int, *, target: str = "", detail: str = "") -> AuditEntry:
+    """Uma entrada na forma ATUAL (issue #312), com `created_at` EXPLÍCITO.
+
+    `target` é id (ou `""` quando não há entidade) e `detail` carrega o `source` da resposta ou o
+    denominador do `open` — o contrato de `app/core/audit.py`.
 
     ⚠️ Não semeie pela rota HTTP aqui: `created_at` vem de `server_default=func.now()`, que no
     SQLite tem resolução de SEGUNDO — quatro chamadas no mesmo segundo saem com o mesmo carimbo e
@@ -36,19 +39,33 @@ def _e(action: str, target: str, minuto: int) -> AuditEntry:
         actor="u",
         action=action,
         target=target,
+        detail=detail,
         created_at=datetime(2026, 8, 11, 12, minuto, tzinfo=UTC),
     )
+
+
+def _legado(action: str, target: str, minuto: int) -> AuditEntry:
+    """Uma entrada na forma ANTIGA — a que está GRAVADA em produção e não vai mudar.
+
+    Até 2026-09-05 o `dna` escrevia tudo no `target`: `<source>:<pergunta>` no `save`/`skip` e a
+    contagem crua no `open`. `detail` fica `""` porque a coluna nasceu depois (migration 0087,
+    `server_default=""` — DDL puro, sem backfill).
+
+    Existe para que a compatibilidade seja TESTADA e não apenas alegada: `audit_entries` não tem
+    retenção nem poda, então estas linhas sobrevivem enquanto o tenant existir.
+    """
+    return _e(action, minuto, target=target)
 
 
 def test_uma_passagem_completa_com_k_maior_que_zero():
     """O controle positivo: `respondidas` PRECISA ser > 0 em algum caso."""
     passagens = na.derivar(
         [
-            _e("dna.nucleo.open", "6", 0),
-            _e("dna.answer.save", "nucleo:oferta.o_que_vende", 1),
-            _e("dna.answer.save", "nucleo:oferta.em_uma_frase", 2),
-            _e("dna.answer.skip", "nucleo:oferta.como_cobra", 3),
-            _e("dna.nucleo.abandon", "", 4),
+            _e("dna.nucleo.open", 0, detail="6"),
+            _e("dna.answer.save", 1, target="id-o_que_vende", detail="nucleo"),
+            _e("dna.answer.save", 2, target="id-em_uma_frase", detail="nucleo"),
+            _e("dna.answer.skip", 3, target="id-como_cobra", detail="nucleo"),
+            _e("dna.nucleo.abandon", 4),
         ]
     )
 
@@ -62,7 +79,7 @@ def test_uma_passagem_completa_com_k_maior_que_zero():
 
 
 def test_resposta_de_outra_origem_nao_conta_como_progresso_do_nucleo():
-    """É PARA ISSO que o `source` vive no `target`.
+    """É PARA ISSO que o `source` vive no `detail`.
 
     O não-membro: uma pergunta respondida na aba de `/config` no meio de uma passagem do núcleo
     não é progresso do núcleo. Sem o recorte por prefixo, ela seria contada e o denominador
@@ -70,10 +87,10 @@ def test_resposta_de_outra_origem_nao_conta_como_progresso_do_nucleo():
     """
     [p] = na.derivar(
         [
-            _e("dna.nucleo.open", "6", 0),
-            _e("dna.answer.save", "config:oferta.ticket_tipico", 1),
-            _e("dna.answer.save", "gancho:dinheiro.cobranca_antecedencia_dias", 2),
-            _e("dna.answer.save", "nucleo:oferta.o_que_vende", 3),
+            _e("dna.nucleo.open", 0, detail="6"),
+            _e("dna.answer.save", 1, target="id-ticket", detail="config"),
+            _e("dna.answer.save", 2, target="id-antecedencia", detail="gancho"),
+            _e("dna.answer.save", 3, target="id-o_que_vende", detail="nucleo"),
         ]
     )
 
@@ -86,11 +103,11 @@ def test_duas_passagens_do_mesmo_dono_nao_se_misturam():
     """Um dono que abandonou no celular e depois abriu no desktop deixa DOIS `open` (§7)."""
     passagens = na.derivar(
         [
-            _e("dna.nucleo.open", "6", 0),
-            _e("dna.answer.save", "nucleo:oferta.o_que_vende", 1),
-            _e("dna.nucleo.abandon", "", 2),
-            _e("dna.nucleo.open", "5", 10),
-            _e("dna.answer.save", "nucleo:oferta.em_uma_frase", 11),
+            _e("dna.nucleo.open", 0, detail="6"),
+            _e("dna.answer.save", 1, target="id-o_que_vende", detail="nucleo"),
+            _e("dna.nucleo.abandon", 2),
+            _e("dna.nucleo.open", 10, detail="5"),
+            _e("dna.answer.save", 11, target="id-em_uma_frase", detail="nucleo"),
         ]
     )
 
@@ -102,22 +119,85 @@ def test_duas_passagens_do_mesmo_dono_nao_se_misturam():
 
 def test_resposta_antes_de_qualquer_open_nao_inventa_passagem():
     """Gancho e `/config` acontecem fora do núcleo o tempo todo, e não são passagem nenhuma."""
-    assert na.derivar([_e("dna.answer.save", "gancho:oferta.como_cobra", 0)]) == []
+    assert na.derivar([_e("dna.answer.save", 0, target="id-como_cobra", detail="gancho")]) == []
 
 
 def test_respostas_por_origem_separa_as_tres_portas():
     """A evidência sobre a quarentena de 7 dias e o "uma por dia" (a meia dívida da §0.1)."""
     contagem = na.respostas_por_origem(
         [
-            _e("dna.nucleo.open", "6", 0),
-            _e("dna.answer.save", "nucleo:a", 1),
-            _e("dna.answer.skip", "gancho:b", 2),
-            _e("dna.answer.save", "config:c", 3),
-            _e("dna.answer.save", "config:d", 4),
+            _e("dna.nucleo.open", 0, detail="6"),
+            _e("dna.answer.save", 1, target="id-a", detail="nucleo"),
+            _e("dna.answer.skip", 2, target="id-b", detail="gancho"),
+            _e("dna.answer.save", 3, target="id-c", detail="config"),
+            _e("dna.answer.save", 4, target="id-d", detail="config"),
         ]
     )
 
     assert contagem == {"nucleo": 1, "gancho": 1, "config": 2}
+
+
+def test_o_rastro_LEGADO_continua_sendo_lido_inteiro():
+    """⚠️ **A asserção mais importante da issue #312.**
+
+    Há trilha JÁ GRAVADA em produção na forma antiga: `target="6"` no `open` e
+    `target="nucleo:<pergunta>"` no `save`/`skip`. Ler só o `detail` devolveria `exibidas=0` e
+    `origem=""` para todas essas linhas — o histórico inteiro de ativação do núcleo viraria zero
+    **sem levantar um único erro**, que é o mesmo silêncio que este script existe para não
+    produzir (ver a nota de compatibilidade em `nucleo_activation.py`).
+
+    Trocar um parser tolerado por uma leitura que cega o histórico seria piorar. Por isso a
+    compatibilidade é asserção, e não alegação de docstring.
+    """
+    passagens = na.derivar(
+        [
+            _legado("dna.nucleo.open", "6", 0),
+            _legado("dna.answer.save", "nucleo:oferta.o_que_vende", 1),
+            _legado("dna.answer.skip", "nucleo:oferta.como_cobra", 2),
+            # O não-membro, na forma legada também: `/config` no meio não é progresso do núcleo.
+            _legado("dna.answer.save", "config:oferta.ticket_tipico", 3),
+            _legado("dna.nucleo.abandon", "", 4),
+        ]
+    )
+
+    assert len(passagens) == 1
+    p = passagens[0]
+    assert p.exibidas == 6  # veio do `target`, não do `detail` (que é `""` nas linhas antigas)
+    assert p.respondidas == 1
+    assert p.puladas == 1
+    assert p.abandonou is True
+
+
+def test_respostas_por_origem_le_o_rastro_LEGADO():
+    """A outra leitura do campo, com o mesmo risco: `_origem` de linha antiga sai do `target`."""
+    contagem = na.respostas_por_origem(
+        [
+            _legado("dna.answer.save", "nucleo:a", 1),
+            _legado("dna.answer.skip", "gancho:b", 2),
+            _legado("dna.answer.save", "config:c", 3),
+        ]
+    )
+
+    assert contagem == {"nucleo": 1, "gancho": 1, "config": 1}
+
+
+def test_uma_passagem_pode_ATRAVESSAR_o_deploy_e_ser_lida_inteira():
+    """O caso real do dia do deploy: abriu antes, respondeu depois.
+
+    As duas formas convivem na MESMA passagem, e nenhuma das duas é lida como zero. Sem este
+    caso, um fallback que só funcionasse para trilhas inteiramente antigas passaria verde e
+    perderia exatamente a passagem que o deploy cortou ao meio.
+    """
+    [p] = na.derivar(
+        [
+            _legado("dna.nucleo.open", "6", 0),  # antes do deploy
+            _legado("dna.answer.save", "nucleo:oferta.o_que_vende", 1),
+            _e("dna.answer.save", 2, target="id-em_uma_frase", detail="nucleo"),  # depois
+            _e("dna.answer.skip", 3, target="id-como_cobra", detail="nucleo"),
+        ]
+    )
+
+    assert (p.exibidas, p.respondidas, p.puladas) == (6, 2, 1)
 
 
 def test_o_fim_da_passagem_e_dito_por_extenso():

--- a/apps/api/tests/test_nucleo_activation_rls.py
+++ b/apps/api/tests/test_nucleo_activation_rls.py
@@ -98,19 +98,25 @@ def _seed(app_url: str, *, slug: str, exibidas: str, pergunta: str) -> str:
             session = Session(bind=conn)
             session.add(Tenant(id=tenant_id, slug=slug, legal_name=slug, document=f"{slug}-doc"))
             session.flush()
+            # Contrato de `audit_entries.target` (issue #312): id, ou `""` quando não há
+            # entidade. O `open` do núcleo não toca entidade nenhuma — o denominador visto é um
+            # VALOR e vai no `detail`. A resposta aponta para a `DnaAnswer`; aqui o id é
+            # sintético (não há linha de DNA a criar para exercer RLS de `audit_entries`), e é o
+            # `detail` que distingue a origem, como em produção.
             eventos.registrar(
                 session,
                 tenant_id=tenant_id,
                 actor="u",
                 action=eventos.ACTION_OPEN,
-                target=exibidas,
+                detail=exibidas,
             )
             eventos.registrar(
                 session,
                 tenant_id=tenant_id,
                 actor="u",
                 action=eventos.ACTION_SAVE,
-                target=eventos.alvo_da_resposta("nucleo", pergunta),
+                target=f"id-{pergunta}",
+                detail="nucleo",
             )
             eventos.registrar(
                 session, tenant_id=tenant_id, actor="u", action=eventos.ACTION_ABANDON, target=""
@@ -122,8 +128,12 @@ def _seed(app_url: str, *, slug: str, exibidas: str, pergunta: str) -> str:
     return tenant_id
 
 
-def _entradas_como(app_url: str, tenant_id: str | None) -> list[str]:
-    """Os `target`s da trilha do DNA vistos por esta sessão.
+def _entradas_como(app_url: str, tenant_id: str | None) -> list[tuple[str, str]]:
+    """Os pares `(target, detail)` da trilha do DNA vistos por esta sessão.
+
+    Os DOIS campos, porque desde a issue #312 a informação de uma entrada do DNA mora nos dois:
+    `target` é id (ou `""`) e `detail` carrega o `source` da resposta ou o denominador do `open`.
+    Ler só um deles deixaria metade do vazamento invisível a este teste.
 
     ⚠️ **Sem ordem prometida.** As três chamadas de `_seed` correm na MESMA transação, e
     `AuditEntry.created_at` usa `server_default=func.now()` — em Postgres isso é o instante da
@@ -144,7 +154,7 @@ def _entradas_como(app_url: str, tenant_id: str | None) -> list[str]:
             session = Session(bind=conn)
             entradas = entradas_do_dna(session)
             session.close()
-            return [e.target for e in entradas]
+            return [(e.target, e.detail) for e in entradas]
     finally:
         engine.dispose()
 
@@ -173,15 +183,19 @@ def test_a_ativacao_enxerga_a_propria_trilha_e_nao_a_do_vizinho() -> None:
         # por transação — a mesma razão que `test_investment_audit_rls` não tem aqui, porque lá
         # a ordem nunca era afirmada).
         alvos_a = _entradas_como(app_url, a)
-        assert sorted(alvos_a) == sorted(["6", "nucleo:oferta.o_que_vende", ""])
+        assert sorted(alvos_a) == sorted(
+            [("", "6"), ("id-oferta.o_que_vende", "nucleo"), ("", "")]
+        )
 
         # (3) — e não vê nada do vizinho. Se a leitura trocasse A por B (em vez de vazar as duas),
         # o roteiro distinto de cada tenant denuncia: o relatório de ativação de A citaria a
         # pergunta de B — o modo de falha que o épico chama de "pior do que ficar calado".
         alvos_b = _entradas_como(app_url, b)
-        assert sorted(alvos_b) == sorted(["5", "nucleo:oferta.como_cobra", ""])
-        assert "nucleo:oferta.como_cobra" not in alvos_a
-        assert "nucleo:oferta.o_que_vende" not in alvos_b
+        assert sorted(alvos_b) == sorted(
+            [("", "5"), ("id-oferta.como_cobra", "nucleo"), ("", "")]
+        )
+        assert ("id-oferta.como_cobra", "nucleo") not in alvos_a
+        assert ("id-oferta.o_que_vende", "nucleo") not in alvos_b
 
         # (4) — sem GUC: ZERO linhas, sem erro. É este silêncio que `main()` não pode confundir com
         # "nenhum tenant abriu o núcleo ainda", e por isso o script imprime a contagem de tenants.

--- a/docs/superpowers/plans/2026-08-11-vima-v2-medicao-de-ativacao.md
+++ b/docs/superpowers/plans/2026-08-11-vima-v2-medicao-de-ativacao.md
@@ -1,5 +1,15 @@
 # Vima V2 — medição de ativação do núcleo: plano de implementação
 
+> **ERRATA (2026-09-05, issue #312) — este plano está FECHADO e não foi reescrito.** Ele
+> descreve, corretamente, o que foi executado em 2026-08-11. Uma decisão sua mudou depois: o
+> `source` ia no **`target`** e hoje vai no **`detail`** (coluna criada pela issue #307), porque
+> `audit_entries.target` ganhou contrato — id, ou `""` quando não há entidade. O helper
+> `eventos.alvo_da_resposta` (citado abaixo) não existe mais; `service._gravar` grava
+> `target=<id da DnaAnswer>` + `detail=<source>` e o `open` grava `target=""` +
+> `detail=<exibidas>`. O rastro gravado ANTES desta data continua na forma antiga e continua
+> sendo lido — ver a nota de compatibilidade em `app/scripts/nucleo_activation.py`. A fonte da
+> verdade sobre a forma atual é o docstring da coluna em `app/core/audit.py`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
 > plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 


### PR DESCRIPTION
## Contexto

`AuditEntry.target` não tinha contrato: carregava **três formas** conforme a ação, e havia um
**parser em produção** dependendo disso.

| Forma | Onde | Exemplo |
|---|---|---|
| id nu | a esmagadora maioria das 121 chamadas | `target=cred.id` |
| composto | `dna/eventos.py::alvo_da_resposta` | `f"{source}:{key}"` |
| valor cru | `dna/router.py` (o `open`) | `str(corpo.exibidas)` — uma contagem |

`scripts/nucleo_activation.py` lia o campo como **estrutura**: `target.split(":", 1)[0]` e
`int(e.target)`. Só era seguro porque a query filtra `action.startswith("dna.")` antes — o campo não
tinha contrato, tinha **convenção por ação**, e a convenção morava no chamador. Com o
`AuditEntry.detail` que o #310 criou, dá para devolver ao `target` o papel único de id, o que torna
o parser **desnecessário** em vez de apenas tolerado.

> **Nasceu empilhada sobre a #311** e foi rebaseada em `main` depois que o #315 entrou (squash, por
> isso `--onto` descartando o commit da mãe). O rebase está provado por **hash de árvore**:
> `bb725c6f` antes e depois — o squash em `main` carregava exatamente o conteúdo da mãe, e nada foi
> trazido nem perdido. O único arquivo que as duas tocam é `dna/eventos.py`, e a errata do MNT-001
> que a #311 escreveu lá está **intacta**: esta PR acrescenta uma segunda errata abaixo dela.

## Alcance medido

**121** chamadas de `audit.record()` em **31** arquivos (AST; o grep devolve mais porque conta prosa
em docstring): 104 `X.id`, 14 variável, 2 `''`, 1 `BoolOp`. As 14 variáveis foram inspecionadas uma
a uma — **todas são ids**. Zero composições na própria chamada, como a issue dizia.

**Consumidores: 1** (`nucleo_activation.py`). Verificado que nenhum `response_model` da API expõe
`target` e que `apps/web` não o lê.

**Testes dependentes: 5, não 1** — a issue subestimou, e a lista que eu tinha levantado também. Além
de `test_dna_audit.py`, `test_dna_nucleo_eventos.py`, `test_nucleo_activation_rls.py` e
`test_google_calendar.py:504` (que **não precisou mudar**: assere `target == cred_id`, exatamente o
que o contrato novo preserva), o mais afetado era `test_nucleo_activation.py` — o teste unitário do
próprio parser, com 9 testes construindo `AuditEntry(target=...)`.

## A forma nova, e por que só o `source` viaja

`target` = o **id** da entidade da ação, ou `""` quando não há entidade. `detail` = snapshot livre.
Escrito na docstring da coluna, onde é definível.

No `dna`: `target=linha.id` (a `DnaAnswer`, que já existe porque `_gravar` faz `db.flush()` antes,
por outro motivo já documentado lá) e `detail=source`. No `open` do núcleo não há entidade —
`target=""` e o denominador visto vai no `detail`.

**Só o `source`, não `source:key`.** O `key` não precisa viajar: `question_key` é a chave do upsert,
então `target=linha.id` o devolve por JOIN, para sempre. O que o upsert **destrói** é o `source`, e
é só ele que o rastro precisa guardar. Consequência: `_origem` **deixou de fazer `split`** — o parse
de campo não foi migrado para outro campo, foi **eliminado**. Sobra `int(detail)` no `open`, num
campo livre por definição.

`alvo_da_resposta` deixou de existir. As frases que a citavam (`dna/eventos.py`, `dna/models.py`,
`core/audit.py`) foram corrigidas; o plano datado de 2026-08-11 levou **errata datada** no topo em
vez de reescrita, porque ele descrevia a forma antiga como decisão viva.

## Os dados legados: retrocompatibilidade, e a migration foi recusada com motivo

Existe trilha **já gravada em produção** nas formas antigas, e ela é a única evidência de ativação
do núcleo que este script existe para ler. Ler só o `detail` devolveria `origem=""` e `exibidas=0`
para todo o histórico — **zero passagens contadas, sem erro nenhum**, indistinguível de "ninguém
abriu o núcleo ainda".

As duas funções leem as duas formas, a antiga primeiro. **Migration de dados foi recusada, por três
razões escritas no código:**

1. `audit_entries` tem `FORCE ROW LEVEL SECURITY`. Um `UPDATE` de migration roda **sem**
   `app.current_tenant_id` e é filtrado a **zero linhas em silêncio** — é exatamente o que a
   migration `0087` já documenta ao recusar backfill por `UPDATE`.
2. O topo do próprio script recusa ter `--fix` porque *"o rastro é evidência, e corrigir evidência é
   reescrever história"*. Uma migration de dados na trilha é isso.
3. **Não é reversível:** o `downgrade` teria de reconstruir `f"{source}:{key}"` a partir do id, o
   que exige o `source` da `DnaAnswer` — que o upsert já pode ter sobrescrito. O rastro existe
   precisamente porque aquela coluna não guarda o passado.

**O discriminador não é "o `detail` está preenchido"** (frágil: `RespostaIn.source` não é validado).
É a forma do próprio `target`: `":" in target` ⇒ legado; `target.isdigit()` ⇒ legado. O contrato
novo só admite UUID ou `""` ali, e nenhum dos dois contém `:` nem é dígito — inequívoco nos dois
sentidos.

**Condição de saída medível, escrita no código**, porque `audit_entries` não tem retenção nem poda
(a única remoção é a purga do tenant):

```sql
SELECT count(*) FROM audit_entries
 WHERE action LIKE 'dna.%' AND (target LIKE '%:%' OR target ~ '^[0-9]+$');
```

Zero em **todos** os tenants é o dia em que os dois ramos legados podem sair. Antes disso, removê-los
cega o histórico sem produzir um único sintoma.

## O gate contra a 4ª forma

`tests/test_audit_target_e_id_gate.py` reprova por AST `target=` que receba f-string, `str(...)` de
valor ou concatenação — e prova contra fontes sintéticas que morde. Duas decisões que ele forçou, e
que viraram documentação em vez de exceção: `_uuid()` (`str(uuid4())`) é **fábrica de id**, não
compositora (indexá-la reprovava `wallet::request_payout`); e resolver apelidos na ordem do
`ast.walk` (que é por nível, não por linha) reprovava `target=client_id or "unidentified"`.

## Prova por mutação

| Mutação | Teste que morreu | Mensagem |
|---|---|---|
| `dna/service.py` volta a `target=f"{source}:{key}"` | `test_dna_audit` (3) + gate | `assert [('nucleo:ofe..._tipico', '')] == [('c77e88c9-…', 'nucleo')]` · gate: `service.py:154 em _gravar(): target= recebeu uma f-string (composição)` |
| **o parser passa a ler SÓ o `detail`** | `test_o_rastro_LEGADO_continua_sendo_lido_inteiro`, `test_respostas_por_origem_le_o_rastro_LEGADO`, `test_uma_passagem_pode_ATRAVESSAR_o_deploy_e_ser_lida_inteira` | `assert 0 == 6` · `assert {'': 3} == {'config': 1, 'gancho': 1, 'nucleo': 1}` · `assert (0, 1, 1) == (6, 2, 1)` |
| 4ª forma sintética (`target=f"{product_id}:{actor}"` em `products`) | gate | `products/service.py:196 em sell(): target= recebeu uma f-string (composição)` |
| `dna/router.py`: denominador volta ao `target` | `test_dna_nucleo_eventos` (2) + gate | `assert [('dna.nucleo.open', '4', '')] == [('dna.nucleo.open', '', '4')]` |
| `eventos.registrar` deixa de repassar `detail` | `test_nucleo_activation_rls` (**Postgres real**) | `At index 1 diff: ('', '') != ('', '6')` |
| a dívida conhecida é *consertada* | `test_a_divida_conhecida_continua_sendo_UM_defeito_de_verdade` | `esperado: ['…router.py::diagnostics'] / encontrado: []` |

A segunda linha é a que sustenta esta PR: sem ela, a retrocompatibilidade seria uma alegação. O
teste que **atravessa o deploy** (um `open` na forma antiga, respostas na nova, dentro da mesma
passagem) é o caso que o dia do deploy vai produzir de verdade.

`rls_e2e` **foi rodado**, não pulado: Docker 29.6.1, testcontainers com Postgres 16 real, migrations
aplicadas — `1 passed in 24.13s` — e a mutação nº 5 o mata através do Postgres real, provando que
não é vácuo.

## Uma 4ª forma VIVA que a issue não viu — medida, não consertada aqui

`financial_intelligence/router.py:407` grava um **intervalo de datas** no `target`:
`f"{start.isoformat()}..{end.isoformat()}"`, na action `financial_diagnostics.narrated`. É a família
do abuso que `wallet/models.py:83` documenta (`target=str(total)` — o VALOR).

Ela é invisível a qualquer gate ingênuo de call site: **quem compõe é o router, quem grava é
`ai_narrator.narrate_with_source` dois saltos abaixo**, e entre eles há só um parâmetro chamado
`target`. O gate foi estendido para enxergar composição repassada por parâmetro (indexando a cadeia
de encaminhadoras), e a ocorrência entrou em `_DIVIDA_CONHECIDA` com justificativa escrita — o mesmo
padrão de `_PODE_CHAMAR_AUDIT` que esta casa já usa. A allowlist tem controle **nos dois sentidos**
(mutação nº 6): consertar sem esvaziar a lista falha, e defeito novo não entra escondido.

O conserto certo (`target=""` + intervalo no `detail`) é de outro módulo, com testes próprios e sem
relação com o `dna`. **Vira issue própria.**

## O que ficou de fora

- **`whatsapp_inbox:545`: `target=client_id or "unidentified"`** — sentinela textual onde o contrato
  pede `""`. O gate a aceita **de propósito** (é "um alvo", não composição), com controle negativo
  escrito. Mudar isso altera a trilha de outro módulo.
- **`RespostaIn.source`/`PularIn.source` são `str` livres**, sem validação contra
  `SOURCE_NUCLEO|GANCHO|CONFIG`. Não é regressão desta PR, mas agora é o `detail` que carrega a
  semântica de origem — merece a mesma porta estreita que `_validar` dá ao catálogo. Issue própria.

Closes #312
